### PR TITLE
Fix to TypeError: Cannot call method 'forEach' of undefined in runner.js

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -71,9 +71,11 @@ Runner.prototype.grep = function(re){
  */
 
 Runner.prototype.globals = function(arr){
+  if (typeof arr != "undefined") {
   arr.forEach(function(arr){
     this._globals.push(arr);
   }, this);
+  }
   return this;
 };
 


### PR DESCRIPTION
If no --globals are given mocha fails. This failure was being masked by the fact that the mocha tests were all using globals defined in test/mocha.opts
