### PR TITLE
add a flag to ignore global var leaks #82

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -46,8 +46,8 @@ program
   .option('-C, --no-colors', 'force disabling of colors')
   .option('-c, --colors', 'force enabling of colors')
   .option('-G, --growl', 'enable growl notification support')
-  .option('-gl, --leaks', 'ignore Global Leaks')
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
+  .option('--leaks', 'ignore var global leaks')
   .option('--interfaces', 'display available interfaces')
   .option('--reporters', 'display available reporters')
 
@@ -177,7 +177,7 @@ function run(suite) {
   var reporter = new Reporter(runner);
   runner.globals(program.globals);
   if(program.leaks)
-    runner.check_global_leaks = false
+    runner.check_global_leaks = false;
   if (program.grep) runner.grep(new RegExp(program.grep));
   if (program.growl) growl(runner, reporter)
   runner.run();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -37,10 +37,8 @@ function Runner(suite) {
   this._globals = [];
   this.suite = suite;
   this.total = suite.total();
-  if(this.check_global_leaks){
-    this.on('test end', function(test){ self.checkGlobals(test); });
-    this.on('hook end', function(hook){ self.checkGlobals(hook); });
-  }
+  this.on('test end', function(test){ self.checkGlobals(test); });
+  this.on('hook end', function(hook){ self.checkGlobals(hook); });
   this.grep(/.*/);
   this.globals(Object.keys(global).concat(['errno']));
   this.check_global_leaks = true
@@ -87,6 +85,9 @@ Runner.prototype.globals = function(arr){
  */
 
 Runner.prototype.checkGlobals = function(test){
+  if(!this.check_global_leaks){
+    return;
+  }
   var leaks = Object.keys(global).filter(function(key){
     return !~this._globals.indexOf(key);
   }, this);


### PR DESCRIPTION
#82 add a flag to ignore global var leaks

I'm not sure if this is how you'd like to implement it.

uses the flag `--leaks` to ignore var global leaks.

Also associated tests needs to be written...

feel free to reject or comment/edit as you please...

Edit:

it's funny, my tests, after I _fixed it_ doesn't have leaks anymore, maybe it's better practice not to use this...
