### PR TITLE
Fix for require under CWD

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -80,8 +80,10 @@ program.on('interfaces', function(){
   process.exit();
 });
 
+// Push the module paths for the current directory onto mochas own, to allow lookups under cwd
+module.paths = require('module')._nodeModulePaths(process.cwd()).concat(module.paths);
+
 // -r, --require
-module.paths.push(path.join(process.cwd(), 'node_modules'));
 program.on('require', function(mod){
   require(mod);
 });


### PR DESCRIPTION
This patch pushes process.cwd onto module.paths to allow mocha to require modules under the current directory (issue #93).

To be honest I'm not sure if this is the right way to do it, as I know why require.paths was removed in 0.6 and don't want to be doing anything "wrong".  But it works..
