### PR TITLE
Update suite background color to default terminal background color

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -34,7 +34,7 @@ exports.colors = {
   , 'bright fail': 91
   , 'bright yellow': 93
   , 'pending': 36
-  , 'suite': 39
+  , 'suite': 0 
   , 'error title': 0
   , 'error message': 31
   , 'error stack': 90


### PR DESCRIPTION
Currently, reporting a suite message on the terminal shows always black as background color. Users using different terminal background than black cannot see the output.

It updates the suite color to use the default terminal background.
