### PR TITLE
Added support for `window.onerror`.

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -2318,8 +2318,16 @@ module.exports = function(paths, fn){
 
 process = {};
 process.nextTick = function(fn){ setTimeout(fn, 0); };
-process.removeListener = function(fn){};
-process.on = function(){};
+process.removeListener = function(ev){
+  if ('uncaughtException' == ev) {
+    window.onerror = null;
+  }
+};
+process.on = function(ev, fn){
+  if ('uncaughtException' == ev) {
+    window.onerror = fn;
+  }
+};
 process.exit = function(status){};
 process.stdout = {};
 global = this;


### PR DESCRIPTION
This gets us closer to complete browser support. The only gotcha is that timeouts seem to still be firing (but I'm wondering if that's the case in CLI mocha too now), therefore reporting twice for each test.

I have a tentative solution which is keeping track of the current `done` function on `Runnable#run` and have the uncaughtException handler fire that instead.
