### PR TITLE
TAP spec doesn't allow hashmark in the title.

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -37,11 +37,23 @@ function TAP(runner) {
   });
 
   runner.on('pass', function(test){
-    console.log('ok %d %s', n, test.fullTitle());
+    console.log('ok %d %s', n, title(test));
   });
 
   runner.on('fail', function(test, err){
-    console.log('not ok %d %s', n, test.fullTitle());
+    console.log('not ok %d %s', n, title(test));
     console.log(err.stack.replace(/^/gm, '  '));
   });
+}
+
+/**
+ * Return a TAP-safe title of `test`
+ *
+ * @param {Object} test
+ * @return {String}
+ * @api private
+ */
+
+function title(test) {
+  return test.fullTitle().replace(/#/g, '');
 }


### PR DESCRIPTION
Trivial patch to remove hashmark(s) from the title.
