### PR TITLE
Mark pending tests as skipped in TAP report

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -36,6 +36,10 @@ function TAP(runner) {
     ++n;
   });
 
+  runner.on('pending', function(test){
+    console.log('ok %d %s # SKIP -', n, title(test));
+  });
+
   runner.on('pass', function(test){
     console.log('ok %d %s', n, title(test));
   });


### PR DESCRIPTION
With TAP we can use directives, so it is good to mark pending tests as skipped.
These tests will be yellow in Jenkins. :)

(The other directive can be used is TODO, but the currently Jenkins TAP plugin doesn't recognize it.)
