### PR TITLE
make output visible against solarized theme

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -28,7 +28,7 @@ exports.useColors = isatty;
  */
 
 exports.colors = {
-    'pass': 90
+    'pass': 38
   , 'fail': 31
   , 'bright pass': 92
   , 'bright fail': 91
@@ -37,13 +37,13 @@ exports.colors = {
   , 'suite': 0
   , 'error title': 0
   , 'error message': 31
-  , 'error stack': 90
+  , 'error stack': 38
   , 'checkmark': 32
-  , 'fast': 90
+  , 'fast': 38
   , 'medium': 33
   , 'slow': 31
   , 'green': 32
-  , 'light': 90
+  , 'light': 38
 };
 
 /**


### PR DESCRIPTION
this is a workaround for #122 (unreadable tests with solarized dark terminal theme): the issue is specifically with color code 90 (dark gray, eg stack traces), which blends with the background. this patch changes it to 38 (light gray).
