### PR TITLE
Add `say` notification support

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -47,6 +47,7 @@ program
   .option('-C, --no-colors', 'force disabling of colors')
   .option('-c, --colors', 'force enabling of colors')
   .option('-G, --growl', 'enable growl notification support')
+  .option('-S, --say [voice]', 'enable say notification support')
   .option('-d, --debug', "enable node's debugger")
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--ignore-leaks', 'ignore global variable leaks')
@@ -237,6 +238,7 @@ function run(suite, fn) {
   if (program.ignoreLeaks) runner.ignoreLeaks = true;
   if (program.grep) runner.grep(new RegExp(program.grep));
   if (program.growl) growl(runner, reporter);
+  if (program.say) say(runner, reporter);
   runner.run(fn);
 }
 
@@ -256,6 +258,22 @@ function growl(runner, reporter) {
         , image: images.pass
       });
     }
+  });
+}
+
+function say(runner, reporter) {
+  var say = require('say');
+
+  runner.on('end', function(){
+    var stats = reporter.stats
+      , msg;
+
+    if (stats.failures) {
+      msg = stats.failures + ' of ' + runner.total + ' tests failed';
+    } else {
+      msg = stats.passes + ' tests passed in ' + stats.duration + 'ms';
+    }
+    say.speak('string' == typeof program.say ? program.say : 'Alex', msg);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "commander": "0.3.2"
     , "growl": "1.4.x"
     , "debug": "*"
+    , "say": "0.5.x"
   }
   , "devDependencies": {
     "should": "0.3.x"


### PR DESCRIPTION
When you run `mocha` with `-S` or `--say` parameter, it'll `say` test
status message. When you give `-S` a parameter (like `mocha -S Bruce`),
it'll use voice from the parameter.

Status message is similar to one used by `growl` notifications.

This pulls one additional dependency - `say`.
