### PR TITLE
Rewrite the 'mocha' wrapper script as a node script.

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -1,15 +1,19 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
 
-DEBUG=0
+/**
+ * This tiny wrapper file checks for known node flags and appends them
+ * when found, before invoking the "real" _mocha executable.
+ */
 
-for arg in $@; do
-  case $arg in
-    -d|--debug) DEBUG=1 ;;
-  esac
-done
+var spawn = require('child_process').spawn
+  , args = process.argv.slice(2)
 
-if test $DEBUG -eq 1; then
-  node debug $(dirname $0)/_mocha $@
-else
-  node $(dirname $0)/_mocha $@
-fi
+args.unshift(__dirname + '/_mocha');
+
+process.argv.forEach(function (arg) {
+  if (/^(-d|--debug)$/.test(arg)) {
+    args.unshift('debug');
+  }
+});
+
+spawn(process.argv[0], args, { customFds: [0,1,2] });


### PR DESCRIPTION
For Windows (there's obviously no Bash), so this node script does the same thing (sniffs for node-specific args before launching a subprocess with the node args appended).

It would be cool to get some of the other flags in as well I suppose at some point (`--expose-gc` specifically I use in node-weak).
