### PR TITLE
[reporters/base] fixed max call stack error handling

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -128,8 +128,8 @@ exports.list = function(failures){
 
     // msg
     var err = test.err
-      , stack = err.stack || err.message
       , message = err.message || ''
+      , stack = err.stack || message
       , index = stack.indexOf(message) + message.length
       , msg = stack.slice(0, index);
 


### PR DESCRIPTION
`Max call stack size exceeded` error instance doesn't have `stack` property.
