### PR TITLE
should use 'self.currentRunnable' or 'self.test' instead of 'test'? 

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -312,13 +312,13 @@ Runner.prototype.runTests = function(suite, fn){
       self.runTest(function(err){
         if (err) {
           self.fail(test, err);
-          self.emit('test end', test);
+          self.emit('test end', self.currentRunnable);
           return self.hookUp('afterEach', next);
         }
 
-        test.passed = true;
-        self.emit('pass', test);
-        self.emit('test end', test);
+        self.currentRunnable.passed = true;
+        self.emit('pass', self.currentRunnable);
+        self.emit('test end', self.currentRunnable);
         self.hookUp('afterEach', next);
       });
     });


### PR DESCRIPTION
should use 'self.currentRunnable' or 'self.test' instead of 'test'? I'm not sure use which one, but 'test' may be covered when the callback function is called.
