### PR TITLE
Browser example

### DIFF
--- a/index.md
+++ b/index.md
@@ -385,21 +385,31 @@ Testing asynchronous code with Mocha could not be simpler! Simply invoke the cal
 ## Browser support
 
  Mocha runs in the browser. Every release of Mocha will have new builds of _./mocha.js_ and _./mocha.css_ for use in the browser. To setup Mocha for browser use all you have to do is include the script, stylesheet, tell Mocha which interface you wish to use, and then run the tests. A typical setup might look something like the following, where we call `mocha.setup('bdd')` to use the __BDD__ interface before loading the test scripts, running them `onload` with `mocha.run()`.
- 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="mocha.css" />
-    <script src="mocha.js"></script>
-    <script>mocha.setup('bdd')</script>
-    <script src="test.array.js"></script>
-    <script src="test.object.js"></script>
-    <script src="test.xhr.js"></script>
-    <script>
-      onload = function(){
-        mocha
-          .run()
-          .globals(['foo', 'bar']) // acceptable globals 
-      };
-    </script>
+
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <title>Mocha Tests</title>
+      <link rel="stylesheet" href="https://raw.github.com/visionmedia/mocha/master/mocha.css" />
+      <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+      <script src="https://raw.github.com/LearnBoost/expect.js/d2440da086bf8dc38c6085641f23b968a0f48b29/expect.js"></script>
+      <script src="https://raw.github.com/visionmedia/mocha/master/mocha.js"></script>
+      <script>mocha.setup('bdd')</script>
+      <script src="test.array.js"></script>
+      <script src="test.object.js"></script>
+      <script src="test.xhr.js"></script>
+      <script>
+        $(function () {
+          mocha
+            .run()
+            .globals(['foo', 'bar']) // acceptable globals
+        })
+      </script>
+    </head>
+    <body>
+      <div id="mocha"></div>
+    </body>
+    </html>
 
   Feel free to hot-link the [mocha.css](https://raw.github.com/visionmedia/mocha/master/mocha.css) and [mocha.js](https://raw.github.com/visionmedia/mocha/master/mocha.js) from GitHub.
 


### PR DESCRIPTION
If it helps, I added a more explicit browser example. I found I had to add the `<div id="mocha">` and also the expect.js include to get mocha to work in the browser.
