### PR TITLE
Add support for -gc / --expose-gc.

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -6,15 +6,20 @@
  */
 
 var spawn = require('child_process').spawn
-  , args = process.argv.slice(2)
+  , args = [ __dirname + '/_mocha' ];
 
-args.unshift(__dirname + '/_mocha');
-
-process.argv.forEach(function (arg) {
+process.argv.slice(2).forEach(function (arg) {
   switch (arg) {
     case '-d':
     case '--debug':
       args.unshift('debug');
+      break;
+    case '-gc':
+    case '--expose-gc':
+      args.unshift('--expose-gc');
+      break;
+    default:
+      args.push(arg);
       break;
   }
 });


### PR DESCRIPTION
This also changes the technique of passing args to the _mocha child process by now building up an 'args' object from scratch.

The '-gc' / '--expose-gc' flags are undocumented in _mocha currently...
