### PR TITLE
Changing the 0 based error counter to 1

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -137,7 +137,7 @@ exports.list = function(failures){
     stack = stack.slice(index + 1)
       .replace(/^/gm, '  ');
 
-    console.error(fmt, i, test.fullTitle(), msg, stack);
+    console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
   });
 };
 

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -51,7 +51,7 @@ function List(runner) {
 
   runner.on('fail', function(test, err){
     cursor.CR();
-    console.log(color('fail', '  %d) %s'), n++, test.fullTitle());
+    console.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.on('end', self.epilogue.bind(self));


### PR DESCRIPTION
Whenever I had an error in my specs the index of the error started with 0 and not 1. I "humanized" the reporting a bit.

Instead of seeing this:

``` code
0) Suite when initialized is initialized with a title
```

You now have this:

``` code
1) Suite when initialized is initialized with a title
```

I also changed the list reporter, I noticed the numbering of the error started from 0 instead of 1.
