### PR TITLE
Improve error reporting when a test finishes after it has timed out.

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -26,6 +26,7 @@ function Runnable(title, fn) {
   this.async = fn && fn.length;
   this.sync = ! this.async;
   this._timeout = 2000;
+  this.timedOut = false;
   this.context = this;
 }
 
@@ -87,6 +88,7 @@ Runnable.prototype.resetTimeout = function(){
   if (ms) {
     this.timer = setTimeout(function(){
       self.callback(new Error('timeout of ' + ms + 'ms exceeded'));
+      self.timedOut = true;
     }, ms);
   }
 };
@@ -111,6 +113,7 @@ Runnable.prototype.run = function(fn){
     if (ms) {
       this.timer = setTimeout(function(){
         done(new Error('timeout of ' + ms + 'ms exceeded'));
+        self.timedOut = true;
       }, ms);
     }
   }
@@ -124,6 +127,7 @@ Runnable.prototype.run = function(fn){
 
   // finished
   function done(err) {
+    if (self.timedOut) return;
     if (finished) return multiple();
     self.clearTimeout();
     self.duration = new Date - start;


### PR DESCRIPTION
When a test exceeds the timeout time but still finishes, Mocha displays TWO stacktraces with the error "done() called multiple times". This patch makes Mocha display a single error that simply mentions that the timeout has been exceeded.
