### PR TITLE
No semantic change. Just using a standard (ECMAScript 5) alternative.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -50,7 +49,7 @@ function Runner(suite) {
  * Inherit from `EventEmitter.prototype`.
  */
 
-Runner.prototype.__proto__ = EventEmitter.prototype;
+Runner.prototype = Object.create(EventEmitter.prototype);
 
 /**
  * Run tests with full titles matching `re`.


### PR DESCRIPTION
**proto** is not standard. For this particular case, a standard alternative can be written.
