### PR TITLE
Fixing a failing spec

### DIFF
--- a/test/runner.js
+++ b/test/runner.js
@@ -18,10 +18,8 @@ describe('Runner', function(){
 
     it('should white-list globals', function(){
       runner.globals(['foo', 'bar']);
-      var globals = runner.globals();
-      var globalsLength = globals.length;
-      globals[globalsLength - 2].should.equal('foo');
-      globals[globalsLength - 1].should.equal('bar');
+      runner.globals().should.contain('foo');
+      runner.globals().should.contain('bar');
     })
   })
 


### PR DESCRIPTION
I received this error when I executed mocha's own tests:

```
  ✖ 1 of 98 tests failed:

  1) Runner .globals() should white-list globals:
     TypeError: Property 'include' of object #<Object> is not a function
```

I see that should.js has a matcher for [].should.include('xyz') but the test failed for me.

Attempting to fix it.
