### PR TITLE
Updated xunit reporter.

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -35,6 +35,7 @@ function XUnit(runner) {
         name: 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
+      , errors: stats.failures
       , skip: stats.tests - stats.failures - stats.passes
       , timestamp: (new Date).toUTCString()
       , time: stats.duration / 1000
@@ -57,7 +58,7 @@ XUnit.prototype.__proto__ = Base.prototype;
 
 function test(test) {
   var attrs = {
-      classname: test.fullTitle()
+      classname: test.parent.fullTitle()
     , name: test.title
     , time: test.duration / 1000
   };


### PR DESCRIPTION
Updated xunit reporter:
- an errors attribute is emitted. 
- changed classname to report the test's parent's title to avoid repetition

so e.g. in Jenkins the tests will be grouped by "Foo" rather than individually as "Foo should do something" and "Foo should do something else"
