### PR TITLE
Fixing the spec reporter's numbering

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -74,7 +74,7 @@ function Spec(runner) {
 
   runner.on('fail', function(test, err){
     cursor.CR();
-    console.log(indent() + color('fail', '  %d) %s'), n++, test.title);
+    console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.on('end', self.epilogue.bind(self));


### PR DESCRIPTION
I've recently [fixed](https://github.com/visionmedia/mocha/commit/9b038f59b7a0c966e8398537016f05b819f8a7ce) the numbering of reported errors in lib/reporters.

I missed the spec reporter (sorry), now that should be taken care of as well.
