### PR TITLE
Ability to require local files, -r ./local_file

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -103,9 +103,15 @@ program.on('require', function(mod){
 
   if (mod[0] == '/' && !mod.match(/\.(js|coffee)$/)) {
 
-    try { 
-      if(fs.statSync(mod+'.coffee').isFile()) mod += '.coffee';
-    } catch (err) {}  // ignores file does not exist error 
+    // .js modules takes precedence over .coffee
+
+    try {
+      fs.statSync(mod+'.js').isFile() == true;
+    } catch(err){
+      try {
+        if(fs.statSync(mod+'.coffee').isFile()) mod += '.coffee';
+      } catch (err) {}  // ignores file does not exist errors
+    }
 
   }
 


### PR DESCRIPTION
`-r` option can already load local node_modules, it be cool if it could load local files as well.

```
mocha test.js -r ./utils
```

... gonna get it to work with coffee-script next... 

---

currently d177952 doesn't default to `.js`, example

```
$> ls
spec.coffee
tools.js
tools.coffee

$> mocha spec.coffee -r ./tools

// Loads tools.coffee, but should load tools.js
```

also... might be good to add support for absolute coffee-script file modules 0ca6ca8

```
$> mocha spec.coffee -r /home/qv/test.coffee
```

---

**Edit:** .js now takes precedence over .coffee 6406472 
