### PR TITLE
Watch option does not reload the actual changed file

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -207,10 +207,11 @@ if (program.watch) {
 
   play(frames);
 
-  utils.watch(utils.files(cwd), function(){
-    stop()
+  utils.watch(utils.files(cwd), function(file){
+    stop();
     suite = suite.clone();
     ui = interfaces[program.ui](suite);
+    delete require.cache[file];
     load(files, function(){
       run(suite, function(){
         play(frames);


### PR DESCRIPTION
Running mocha with the --watch option will only reload the tests sources, and never reload changes in the application's source files. It means that it is actually impossible to fix the offending application code while running in watch mode. I assume this is not the desired behavior :-)

Attached commit fixes this by removing the changed file from the require-cache before re-running the suite.
