### PR TITLE
Remove uncaughtException listener from process

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -413,7 +412,7 @@ Runner.prototype.run = function(fn){
   // callback
   this.on('end', function(){
     debug('end');
-    process.removeListener('uncaughtException', this.uncaught);
+    process.removeListener('uncaughtException', self.uncaught);
     fn(self.failures);
   });
 
@@ -425,9 +424,7 @@ Runner.prototype.run = function(fn){
   });
 
   // uncaught exception
-  process.on('uncaughtException', function(err){
-    self.uncaught(err);
-  });
+  process.on('uncaughtException', self.uncaught);
 
   return this;
 };


### PR DESCRIPTION
In line 415, the listener from process is removed, but uses `this.uncaught` while in line 427 a new function is added as listener. Thus, the listener could never be removed..
