### PR TITLE
allow --require'd modules to register runner hooks

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -18,7 +18,8 @@ var program = require('commander')
   , vm = require('vm')
   , fs = require('fs')
   , join = path.join
-  , cwd = process.cwd();
+  , cwd = process.cwd()
+  , require_injected_hooks = [];
 
 /**
  * Files.
@@ -102,7 +103,10 @@ program.on('require', function(mod){
     || path.existsSync(mod + '.js');
 
   if (abs) mod = join(cwd, mod);
-  require(mod);
+  var loaded = require(mod);
+  if(loaded.hasOwnProperty('mocha_hooks')) {
+    require_injected_hooks.push(loaded.mocha_hooks);
+  };
 });
 
 // mocha.opts support
@@ -243,11 +247,21 @@ function load(files, fn) {
   });
 }
 
+function add_require_injected_hooks(runner) {
+  require_injected_hooks.forEach(function(hooks) {
+    collection.each(hooks, function(hook, event) {
+      runner.on(event, hook);
+    });
+  });
+};
+
+
 // run the given suite
 
 function run(suite, fn) {
   suite.emit('run');
   var runner = new Runner(suite);
+  add_require_injected_hooks(runner);
   var reporter = new Reporter(runner);
   runner.globals(program.globals);
   if (program.ignoreLeaks) runner.ignoreLeaks = true;


### PR DESCRIPTION
There may be a better way of doing this, but I needed a way for a --require to be able to hook into the runner's emitted events.
