### PR TITLE
add 'test verify' hook

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -25,6 +25,7 @@ module.exports = Runner;
  *   - `suite`  (suite) test suite execution started
  *   - `suite end`  (suite) all tests (and sub-suites) have finished
  *   - `test`  (test) test execution started
+ *   - `test verify` (test) test body complete but status not yet decided
  *   - `test end`  (test) test completed
  *   - `hook`  (hook) hook execution started
  *   - `hook end`  (hook) hook complete
@@ -262,16 +263,26 @@ Runner.prototype.parents = function(){
 
 Runner.prototype.runTest = function(fn){
   var test = this.test
-    , self = this;
+    , self = this
+    , continue_fn;
+
+  continue_fn = function(test_err) {
+    try {
+      self.emit('test verify');
+    } catch (e) {
+      if(!test_err) test_err = e;
+    }
+    fn(test_err);
+  };
 
   try {
     test.ctx.test(test);
     test.on('error', function(err){
       self.fail(test, err);
     });
-    test.run(fn);
+    test.run(continue_fn);
   } catch (err) {
-    fn(err);
+    continue_fn(err);
   }
 };
 


### PR DESCRIPTION
for use by frameworks to _always_ perform verification / teardown after a test has run (but before it is declared successful or failed).
