### PR TITLE
add optional "additional_context" field & cleaned up logic in error formatting

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -38,6 +38,7 @@ exports.colors = {
   , 'error title': 0
   , 'error message': 31
   , 'error stack': 90
+  , 'error context': 90
   , 'checkmark': 32
   , 'fast': 90
   , 'medium': 33
@@ -126,18 +127,27 @@ exports.list = function(failures){
       + color('error message', '     %s')
       + color('error stack', '\n%s\n');
 
+    var indent = function(str) {
+      return str.replace(/^/gm, '  ');
+    };
+
     // msg
     var err = test.err
-      , message = err.message || ''
-      , stack = err.stack || message
-      , index = stack.indexOf(message) + message.length
-      , msg = stack.slice(0, index);
+      , msg = err.message || ''
+      , stack = err.stack || msg
+      , context = err.additional_context || null
+      , stack_idx = stack.indexOf(msg);
+  
+    if(stack_idx != -1 && stack != msg) {
+      stack = stack.slice(stack_idx) + msg.length;
+      msg = stack.slice(0, stack_idx);
+    }
 
-    // indent stack trace without msg
-    stack = stack.slice(index + 1)
-      .replace(/^/gm, '  ');
+    console.error(fmt, (i + 1), test.fullTitle(), indent(msg).trim(), indent(stack));
 
-    console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
+    if(context != null) {
+      console.error(color('error context', '\n%s'), indent(context));
+    }
   });
 };
 


### PR DESCRIPTION
"additional_context" field added to the test for reporting e.g log output

Logic cleanup is for when stack does not actually contain error message, which otherwise results in nonsense reporting. Apologies for putting two things in the one commit, but I only did the cleanup after adding the new field.
