### PR TITLE
Don't escape source output from jscoverage

### DIFF
--- a/lib/reporters/templates/coverage.jade
+++ b/lib/reporters/templates/coverage.jade
@@ -37,14 +37,14 @@ html
                     tr.hit 
                       td.line= number
                       td.hits= line.coverage
-                      td.source= line.source
+                      td.source!= line.source
                   else if 0 === line.coverage
                     tr.miss 
                       td.line= number
                       td.hits 0
-                      td.source= line.source
+                      td.source!= line.source
                   else
                     tr
                       td.line= number
                       td.hits
-                      td.source= line.source || ' '
+                      td.source!= line.source || ' '


### PR DESCRIPTION
Using jscoverage 0.5.1 (installed via Homebrew), the `html-cov` reporter outputs escaped source lines. This updates the template to not escape them.
