### PR TITLE
Added reporter to `mocha.run()` as argument

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -70,7 +70,6 @@ window.mocha = require('mocha');
 ;(function(){
   var suite = new mocha.Suite('', new mocha.Context)
     , utils = mocha.utils
-    , Reporter = mocha.reporters.HTML
 
   $(function(){
     $('code').each(function(){
@@ -124,9 +123,10 @@ window.mocha = require('mocha');
    * Run mocha, returning the Runner.
    */
 
-  mocha.run = function(){
+  mocha.run = function(Reporter){
     suite.emit('run');
     var runner = new mocha.Runner(suite);
+    Reporter = Reporter || mocha.reporters.HTML;
     var reporter = new Reporter(runner);
     var query = parse(window.location.search || "");
     if (query.grep) runner.grep(new RegExp(query.grep));


### PR DESCRIPTION
I want that the test written for browser works in Travis CI without rewriting for Travis.
And to do that, it have to give `Reporter` to `mocha.run()` from context of Node.js.

I tried the following way using `zombie`.
For examples:
- test/driver.js

``` js
var express = require('express')
  , app = express.createServer()
  , Browser = require('zombie')
  , browser = new Browser()
  , _mocha = require('mocha')

app.use(express.static(__dirname+'/../'));
app.listen(8888);

browser.visit('http://localhost:8888/test/index.html', function() {
  // Get `mocha` from browser context.
  var mocha = browser.evaluate('mocha')
    , result = mocha.run(_mocha.reporters.Spec)
  app.close();
  if (result.failures > 0) {
    process.exit(1);
  }
});
```
- test/index.html

``` html
<!DOCTYPE html>
<html>
  <head>
    <title>My Tests</title>
    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
  </head>
  <body>
    <div id="mocha"></div>
    <script src="./jquery-1.7.1.min.js"></script>
    <script src="../node_modules/expect.js/expect.js"></script>
    <script src="../node_modules/mocha/mocha.js"></script>
    <script>mocha.setup('bdd')</script>
    <!-- load my application -->
    <script src="../public/app.js"></script>
    <!-- load test for my application -->
    <script src="../test/app.test.js"></script>
    <script>
      // Execute `mocha.run()` when accessed from browser
      if (!/Node.js/.test(navigator.appName)) {
        mocha.run();
      }
    </script>
  </body>
</html>
```

This works as my expected.

I wish that the same test works in browser and Node.js.
If you would like to my idea, please merge my patch.

Thank you:-)
