### PR TITLE
Added browser setup options

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -858,7 +858,7 @@ require.register("mocha.js", function(module, exports, require){
  * Library version.
  */
 
-exports.version = '0.14.0';
+exports.version = '0.14.1';
 
 exports.utils = require('./utils');
 exports.interfaces = require('./interfaces');
@@ -3652,6 +3652,7 @@ window.mocha = require('mocha');
 ;(function(){
   var suite = new mocha.Suite('', new mocha.Context)
     , utils = mocha.utils
+    , options = {}
 
   /**
    * Highlight the given string of `js`.
@@ -3696,12 +3697,16 @@ window.mocha = require('mocha');
   }
 
   /**
-   * Setup mocha with the give `ui` name.
+   * Setup mocha with the give setting options.
    */
 
-  mocha.setup = function(ui){
-    ui = mocha.interfaces[ui];
+  mocha.setup = function(opts){
+    if ('string' === typeof opts) options.ui = opts;
+    else options = opts;
+
+    ui = mocha.interfaces[options.ui];
     if (!ui) throw new Error('invalid mocha interface "' + ui + '"');
+    if (options.timeout) suite.timeout(options.timeout);
     ui(suite);
     suite.emit('pre-require', window);
   };
@@ -3710,13 +3715,15 @@ window.mocha = require('mocha');
    * Run mocha, returning the Runner.
    */
 
-  mocha.run = function(Reporter){
+  mocha.run = function(){
     suite.emit('run');
     var runner = new mocha.Runner(suite);
-    Reporter = Reporter || mocha.reporters.HTML;
+    var Reporter = options.reporter || mocha.reporters.HTML;
     var reporter = new Reporter(runner);
     var query = parse(window.location.search || "");
     if (query.grep) runner.grep(new RegExp(query.grep));
+    if (options.ignoreLeaks) runner.ignoreLeaks = true;
+    if (options.globals) runner.globals(options.globals);
     runner.on('end', highlightCode);
     return runner.run();
   };

--- a/support/tail.js
+++ b/support/tail.js
@@ -70,6 +70,7 @@ window.mocha = require('mocha');
 ;(function(){
   var suite = new mocha.Suite('', new mocha.Context)
     , utils = mocha.utils
+    , options = {}
 
   /**
    * Highlight the given string of `js`.
@@ -114,12 +115,16 @@ window.mocha = require('mocha');
   }
 
   /**
-   * Setup mocha with the give `ui` name.
+   * Setup mocha with the give setting options.
    */
 
-  mocha.setup = function(ui){
-    ui = mocha.interfaces[ui];
+  mocha.setup = function(opts){
+    if ('string' === typeof opts) options.ui = opts;
+    else options = opts;
+
+    ui = mocha.interfaces[options.ui];
     if (!ui) throw new Error('invalid mocha interface "' + ui + '"');
+    if (options.timeout) suite.timeout(options.timeout);
     ui(suite);
     suite.emit('pre-require', window);
   };
@@ -128,13 +133,15 @@ window.mocha = require('mocha');
    * Run mocha, returning the Runner.
    */
 
-  mocha.run = function(Reporter){
+  mocha.run = function(){
     suite.emit('run');
     var runner = new mocha.Runner(suite);
-    Reporter = Reporter || mocha.reporters.HTML;
+    var Reporter = options.reporter || mocha.reporters.HTML;
     var reporter = new Reporter(runner);
     var query = parse(window.location.search || "");
     if (query.grep) runner.grep(new RegExp(query.grep));
+    if (options.ignoreLeaks) runner.ignoreLeaks = true;
+    if (options.globals) runner.globals(options.globals);
     runner.on('end', highlightCode);
     return runner.run();
   };

--- a/test/browser/opts.html
+++ b/test/browser/opts.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <title>Mocha</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" href="style.css" />
+    <script src="../../mocha.js"></script>
+    <script>
+      mocha.setup({
+        ui: 'bdd',
+        globals: ['okGlobalA', 'okGlobalB'],
+        timeout: 1500
+      })
+    </script>
+    <script>
+      function assert(expr, msg) {
+        if (!expr) throw new Error(msg || 'failed');
+      }
+    </script>
+    <script src="opts.js"></script>
+    <script src="../acceptance/globals.js"></script>
+    <script>
+      onload = function() { mocha.run(); };
+    </script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+  </body>
+</html>

--- a/test/browser/opts.js
+++ b/test/browser/opts.js
@@ -1,0 +1,5 @@
+describe('Options', function() {
+  it('should set timeout value', function() {
+    assert(this._test._timeout === 1500);
+  });
+})


### PR DESCRIPTION
The problem is that the place of a setting is scattering.

ui setting is `setup()`, reporter setting is `run()`, globals setting is `runner.globals()`, timeout is inner testing `this.timeout()`.

This patch can be `setup()` arguments all settings.

For example.

```
mocha.setup({
  ui: 'bdd',
  globals: ['okGlobalA', 'okGlobalB'],
  timeout: 1500,
  reporter: mocha.reporters.TAP
})
```
