### PR TITLE
looks like `globals` is not a function of the `mocha` object anymore

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,31 +36,30 @@
 <li>file watcher support</li>
 <li>global variable leak detection</li>
 <li>optionally run tests that match a regexp</li>
-<li>auto-exit to prevent &ldquo;hanging&rdquo; with an active loop</li>
+<li>auto-exit to prevent "hanging" with an active loop</li>
 <li>easily meta-generate suites &amp; test-cases</li>
 <li>mocha.opts file support</li>
 <li>node debugger support</li>
 <li>detects multiple calls to <code>done()</code></li>
 <li>use any assertion library you want</li>
 <li>extensible reporting, bundled with 9+ reporters</li>
-<li>extensible test DSLs or &ldquo;interfaces&rdquo;</li>
+<li>extensible test DSLs or "interfaces"</li>
 <li>before, after, before each, after each hooks</li>
 <li>coffee-script support</li>
 <li>TextMate bundle</li>
 <li>and more!</li>
 </ul>
 
-
 <h2>Installation</h2>
 
-<p>  Install with <a href="http://npmjs.org">npm</a>:</p>
+<p>Install with <a href="http://npmjs.org">npm</a>:</p>
 
 <pre><code>$ npm install -g mocha
 </code></pre>
 
 <h2>Assertions</h2>
 
-<p>Mocha allows you to use any assertion library you want, if it throws an error, it will work! This means you can utilize libraries such as <a href="http://github.com/visionmedia/should.js">should.js</a>, node&rsquo;s regular <code>assert</code> module, or others. The following is a list of known assertion libraries for node and/or the browser:</p>
+<p>Mocha allows you to use any assertion library you want, if it throws an error, it will work! This means you can utilize libraries such as <a href="http://github.com/visionmedia/should.js">should.js</a>, node's regular <code>assert</code> module, or others. The following is a list of known assertion libraries for node and/or the browser:</p>
 
 <ul>
 <li><a href="http://github.com/visionmedia/should.js">should.js</a> BDD style shown throughout these docs</li>
@@ -68,10 +67,9 @@
 <li><a href="http://chaijs.com/">chai</a> expect(), assert() and should style assertions</li>
 </ul>
 
-
 <h2>Synchronous code</h2>
 
-<p> When testing synchronous code, omit the callback and Mocha will automatically continue on to the next test.</p>
+<p>When testing synchronous code, omit the callback and Mocha will automatically continue on to the next test.</p>
 
 <pre><code>describe('Array', function(){
   describe('#indexOf()', function(){
@@ -100,7 +98,7 @@
 })
 </code></pre>
 
-<p> To make things even easier, the <code>done()</code> callback accepts an error, so we may use this directly:</p>
+<p>To make things even easier, the <code>done()</code> callback accepts an error, so we may use this directly:</p>
 
 <pre><code>describe('User', function(){
   describe('#save()', function(){
@@ -112,7 +110,7 @@
 })
 </code></pre>
 
-<p>  All &ldquo;hooks&rdquo;, that is <code>before()</code>, <code>after()</code>, <code>beforeEach()</code>, <code>afterEach()</code> may be sync or async as well, behaving much like a regular test-case. For example you may wish to populate database with dummy content before each test:</p>
+<p>All "hooks", that is <code>before()</code>, <code>after()</code>, <code>beforeEach()</code>, <code>afterEach()</code> may be sync or async as well, behaving much like a regular test-case. For example you may wish to populate database with dummy content before each test:</p>
 
 <pre><code>describe('Connection', function(){
   var db = new Connection
@@ -141,7 +139,7 @@
 
 <h2>Pending tests</h2>
 
-<p> Pending test-cases are simply those without a callback:</p>
+<p>Pending test-cases are simply those without a callback:</p>
 
 <pre><code>describe('Array', function(){
   describe('#indexOf()', function(){
@@ -152,26 +150,26 @@
 
 <h2>Test duration</h2>
 
-<p>  Most of the reporters support some form of displaying
+<p>Most of the reporters support some form of displaying
   test duration, as well as flagging tests that are slow,
-  as shown here with the &ldquo;spec&rdquo; reporter:</p>
+  as shown here with the "spec" reporter:</p>
 
-<p>   <img src="images/reporter-spec-duration.png" alt="test duration" /></p>
+<p><img src="images/reporter-spec-duration.png" alt="test duration" title="" /></p>
 
 <h2>String diffs</h2>
 
-<p>  Mocha supports the <code>err.expected</code>, and <code>err.actual</code> properties
+<p>Mocha supports the <code>err.expected</code>, and <code>err.actual</code> properties
   when available to present expectations to the developer. Currently
   Mocha provides string diffs, however in the future object diffs and
   others may be provided.</p>
 
-<p>  <img src="http://f.cl.ly/items/3L0T1A0h2N1J3G021i0F/Screen%20Shot%202012-03-01%20at%202.31.31%20PM.png" alt="string diffs" /></p>
+<p><img src="http://f.cl.ly/items/3L0T1A0h2N1J3G021i0F/Screen%20Shot%202012-03-01%20at%202.31.31%20PM.png" alt="string diffs" title="" /></p>
 
 <h2>mocha(1)</h2>
 
-<p>  Usage: mocha [options] [files]</p>
+<p>Usage: mocha [options] [files]</p>
 
-<p>  Options:</p>
+<p>Options:</p>
 
 <pre><code>-h, --help             output usage information
 -V, --version          output the version number
@@ -193,51 +191,51 @@
 --reporters            display available reporters
 </code></pre>
 
-<h3>-w, &ndash;watch</h3>
+<h3>-w, --watch</h3>
 
-<p>  Executes tests on changes to JavaScript in the CWD.</p>
+<p>Executes tests on changes to JavaScript in the CWD.</p>
 
-<h3>-b, &ndash;bail</h3>
+<h3>-b, --bail</h3>
 
-<p>  Only interested in the first exception? use <code>--bail</code> !</p>
+<p>Only interested in the first exception? use <code>--bail</code> !</p>
 
-<h3>-d, &ndash;debug</h3>
+<h3>-d, --debug</h3>
 
-<p>  Enables node&rsquo;s debugger support, this executes your script(s) with <code>node debug &lt;file ...&gt;</code> allowing you to step through code and break with the <strong>debugger</strong> statement.</p>
+<p>Enables node's debugger support, this executes your script(s) with <code>node debug &lt;file ...&gt;</code> allowing you to step through code and break with the <strong>debugger</strong> statement.</p>
 
-<h3>&ndash;globals &lt;names&gt;</h3>
+<h3>--globals &lt;names&gt;</h3>
 
-<p>  Accepts a comma-delimited list of accepted global variable names. For example suppose your app deliberately exposes a global named <code>app</code> and <code>YUI</code>, you may want to add <code>--globals app,YUI</code>.</p>
+<p>Accepts a comma-delimited list of accepted global variable names. For example suppose your app deliberately exposes a global named <code>app</code> and <code>YUI</code>, you may want to add <code>--globals app,YUI</code>.</p>
 
-<h3>&ndash;ignore-leaks</h3>
+<h3>--ignore-leaks</h3>
 
-<p>  By default Mocha will fail when global variables are introduced, you may use <code>--globals</code> to specify a few, or use <code>--ignore-leaks</code> to disable this functionality.</p>
+<p>By default Mocha will fail when global variables are introduced, you may use <code>--globals</code> to specify a few, or use <code>--ignore-leaks</code> to disable this functionality. </p>
 
-<h3>-r, &ndash;require &lt;name&gt;</h3>
+<h3>-r, --require &lt;name&gt;</h3>
 
-<p>  The <code>--require</code> option is useful for libraries such as <a href="http://github.com/visionmedia/should.js">should.js</a>, so you may simply <code>--require should</code> instead of manually invoking <code>require('should')</code> within each test file.</p>
+<p>The <code>--require</code> option is useful for libraries such as <a href="http://github.com/visionmedia/should.js">should.js</a>, so you may simply <code>--require should</code> instead of manually invoking <code>require('should')</code> within each test file.</p>
 
-<h3>-u, &ndash;ui &lt;name&gt;</h3>
+<h3>-u, --ui &lt;name&gt;</h3>
 
-<p>  The <code>--ui</code> option lets you specify the interface to use, defaulting to &ldquo;bdd&rdquo;.</p>
+<p>The <code>--ui</code> option lets you specify the interface to use, defaulting to "bdd".</p>
 
-<h3>-R, &ndash;reporter &lt;name&gt;</h3>
+<h3>-R, --reporter &lt;name&gt;</h3>
 
-<p>  The <code>--reporter</code> option allows you to specify the reporter that will be used, defaulting to &ldquo;dot&rdquo;.</p>
+<p>The <code>--reporter</code> option allows you to specify the reporter that will be used, defaulting to "dot".</p>
 
-<h3>-t, &ndash;timeout &lt;ms&gt;</h3>
+<h3>-t, --timeout &lt;ms&gt;</h3>
 
-<p>  Specifies the test-case timeout, defaulting to 2 seconds. To override you may pass the timeout in milliseconds, or a value with the <code>s</code> suffix, ex: <code>--timeout 2s</code> or <code>--timeout 2000</code> would be equivalent.</p>
+<p>Specifies the test-case timeout, defaulting to 2 seconds. To override you may pass the timeout in milliseconds, or a value with the <code>s</code> suffix, ex: <code>--timeout 2s</code> or <code>--timeout 2000</code> would be equivalent.</p>
 
-<h3>-s, &ndash;slow &lt;ms&gt;</h3>
+<h3>-s, --slow &lt;ms&gt;</h3>
 
-<p>  Specify the &ldquo;slow&rdquo; test threshold, defaulting to 75ms. Mocha uses this to highlight test-cases that are taking too long.</p>
+<p>Specify the "slow" test threshold, defaulting to 75ms. Mocha uses this to highlight test-cases that are taking too long.</p>
 
-<h3>-g, &ndash;grep &lt;pattern&gt;</h3>
+<h3>-g, --grep &lt;pattern&gt;</h3>
 
-<p>  The <code>--grep</code> option when specified will trigger mocha to only run tests matching the given <code>pattern</code> which is internally compiled to a <code>RegExp</code>.</p>
+<p>The <code>--grep</code> option when specified will trigger mocha to only run tests matching the given <code>pattern</code> which is internally compiled to a <code>RegExp</code>. </p>
 
-<p>  Suppose for example you have &ldquo;api&rdquo; related tests, as well as &ldquo;app&rdquo; related tests, as shown in the following snippet; One could use <code>--grep api</code> or <code>--grep app</code> to run one or the other. The same goes for any other part of a suite or test-case title, <code>--grep users</code> would be valid as well, or even <code>--grep GET</code>.</p>
+<p>Suppose for example you have "api" related tests, as well as "app" related tests, as shown in the following snippet; One could use <code>--grep api</code> or <code>--grep app</code> to run one or the other. The same goes for any other part of a suite or test-case title, <code>--grep users</code> would be valid as well, or even <code>--grep GET</code>.</p>
 
 <pre><code>describe('api', function(){
   describe('GET /api/users', function(){
@@ -254,11 +252,11 @@ describe('app', function(){
 
 <h2>Interfaces</h2>
 
-<p>  Mocha &ldquo;interface&rdquo; system allows developers to choose their style of DSL. Shipping with <strong>BDD</strong>, <strong>TDD</strong>, and <strong>exports</strong> flavoured interfaces.</p>
+<p>Mocha "interface" system allows developers to choose their style of DSL. Shipping with <strong>BDD</strong>, <strong>TDD</strong>, and <strong>exports</strong> flavoured interfaces.</p>
 
 <h3>BDD</h3>
 
-<p>  The &ldquo;<strong>BDD</strong>&rdquo; interface provides <code>describe()</code>, <code>it()</code>, <code>before()</code>, <code>after()</code>, <code>beforeEach()</code>, and <code>afterEach()</code>:</p>
+<p>The "<strong>BDD</strong>" interface provides <code>describe()</code>, <code>it()</code>, <code>before()</code>, <code>after()</code>, <code>beforeEach()</code>, and <code>afterEach()</code>: </p>
 
 <pre><code>describe('Array', function(){
   before(function(){
@@ -275,7 +273,7 @@ describe('app', function(){
 
 <h3>TDD</h3>
 
-<p>  The &ldquo;<strong>TDD</strong>&rdquo; interface provides <code>suite()</code>, <code>test()</code>, <code>setup()</code>, and <code>teardown()</code>.</p>
+<p>The "<strong>TDD</strong>" interface provides <code>suite()</code>, <code>test()</code>, <code>setup()</code>, and <code>teardown()</code>.</p>
 
 <pre><code>suite('Array', function(){
   setup(function(){
@@ -292,7 +290,7 @@ describe('app', function(){
 
 <h3>Exports</h3>
 
-<p>  The &ldquo;<strong>exports</strong>&rdquo; interface is much like Mocha&rsquo;s predecessor <a href="http://github.com/visionmedia/expresso">expresso</a>. The keys <code>before</code>, <code>after</code>, <code>beforeEach</code>, and <code>afterEach</code> are special-cased, object values
+<p>The "<strong>exports</strong>" interface is much like Mocha's predecessor <a href="http://github.com/visionmedia/expresso">expresso</a>. The keys <code>before</code>, <code>after</code>, <code>beforeEach</code>, and <code>afterEach</code> are special-cased, object values
   are suites, and function values are test-cases.</p>
 
 <pre><code>module.exports = {
@@ -312,7 +310,7 @@ describe('app', function(){
 
 <h3>QUnit</h3>
 
-<p>  The qunit-inspired interface matches the &ldquo;flat&rdquo; look of QUnit where the test suite title is simply defined before the test-cases.</p>
+<p>The qunit-inspired interface matches the "flat" look of QUnit where the test suite title is simply defined before the test-cases.</p>
 
 <pre><code>function ok(expr, msg) {
   if (!expr) throw new Error(msg);
@@ -341,88 +339,88 @@ test('#length', function(){
 
 <h2>Reporters</h2>
 
-<p>  Mocha reporters adjust to the terminal window,
+<p>Mocha reporters adjust to the terminal window,
   and always disable ansi-escape colouring when
   the stdio streams are not associated with a tty.</p>
 
 <h3>Dot Matrix</h3>
 
-<p>  The &ldquo;dot&rdquo; matrix reporter is simply a series of dots
+<p>The "dot" matrix reporter is simply a series of dots
   that represent test cases, failures highlight in red,
   pending in blue, slow as yellow.</p>
 
-<p>   <img src="images/reporter-dot.png" alt="dot matrix reporter" /></p>
+<p><img src="images/reporter-dot.png" alt="dot matrix reporter" title="" /></p>
 
 <h3>Spec</h3>
 
-<p>  The &ldquo;spec&rdquo; reporter outputs a hierarchical view
+<p>The "spec" reporter outputs a hierarchical view
   nested just as the test cases are.</p>
 
-<p>   <img src="images/reporter-spec.png" alt="spec reporter" />
-   <img src="images/reporter-spec-fail.png" alt="spec reporter with failure" /></p>
+<p><img src="images/reporter-spec.png" alt="spec reporter" title="" />
+   <img src="images/reporter-spec-fail.png" alt="spec reporter with failure" title="" /></p>
 
 <h3>TAP</h3>
 
-<p>  The TAP reporter emits lines for a <a href="http://en.wikipedia.org/wiki/Test_Anything_Protocol">Test-Anything-Protocol</a> consumer.</p>
+<p>The TAP reporter emits lines for a <a href="http://en.wikipedia.org/wiki/Test_Anything_Protocol">Test-Anything-Protocol</a> consumer.</p>
 
-<p>  <img src="images/reporter-tap.png" alt="test anything protocol" /></p>
+<p><img src="images/reporter-tap.png" alt="test anything protocol" title="" /></p>
 
 <h3>Landing Strip</h3>
 
-<p>  The Landing Strip reporter is a gimmicky test reporter simulating
+<p>The Landing Strip reporter is a gimmicky test reporter simulating
   a plane landing :) unicode ftw</p>
 
-<p>  <img src="images/reporter-landing.png" alt="landing strip plane reporter" />
-  <img src="images/reporter-landing-fail.png" alt="landing strip with failure" /></p>
+<p><img src="images/reporter-landing.png" alt="landing strip plane reporter" title="" />
+  <img src="images/reporter-landing-fail.png" alt="landing strip with failure" title="" /></p>
 
 <h3>List</h3>
 
-<p>  The &ldquo;List&rdquo; reporter outputs a simple specifications list as
-  test cases pass or fail, outputting the failure details at
+<p>The "List" reporter outputs a simple specifications list as
+  test cases pass or fail, outputting the failure details at 
   the bottom of the output.</p>
 
-<p>  <img src="images/reporter-list.png" alt="list reporter" /></p>
+<p><img src="images/reporter-list.png" alt="list reporter" title="" /></p>
 
 <h3>Progress</h3>
 
-<p>  The progress reporter implements a simple progress-bar:</p>
+<p>The progress reporter implements a simple progress-bar:</p>
 
-<p>  <img src="images/reporter-progress.png" alt="progress bar" /></p>
+<p><img src="images/reporter-progress.png" alt="progress bar" title="" /></p>
 
 <h3>JSON</h3>
 
-<p>  The JSON reporter outputs a single large JSON object when
+<p>The JSON reporter outputs a single large JSON object when
   the tests have completed (failures or not).</p>
 
-<p>  <img src="images/reporter-json.png" alt="json reporter" /></p>
+<p><img src="images/reporter-json.png" alt="json reporter" title="" /></p>
 
 <h3>JSON Stream</h3>
 
-<p>  The JSON Stream reporter outputs newline-delimited JSON &ldquo;events&rdquo; as they occur, beginning with a &ldquo;start&rdquo; event, followed by test passes or failures, and then the final &ldquo;end&rdquo; event.</p>
+<p>The JSON Stream reporter outputs newline-delimited JSON "events" as they occur, beginning with a "start" event, followed by test passes or failures, and then the final "end" event.</p>
 
-<p>  <img src="images/reporter-json-stream.png" alt="json stream reporter" /></p>
+<p><img src="images/reporter-json-stream.png" alt="json stream reporter" title="" /></p>
 
 <h3>JSONCov</h3>
 
-<p>  The JSONCov reporter is similar to the JSON reporter, however when run against a library instrumented by <a href="https://github.com/visionmedia/node-jscoverage">node-jscoverage</a> it will produce coverage output.</p>
+<p>The JSONCov reporter is similar to the JSON reporter, however when run against a library instrumented by <a href="https://github.com/visionmedia/node-jscoverage">node-jscoverage</a> it will produce coverage output.</p>
 
 <h3>HTMLCov</h3>
 
-<p>  The HTMLCov reporter extends the JSONCov reporter. The library being tested should first be instrumented by <a href="https://github.com/visionmedia/node-jscoverage">node-jscoverage</a>, this allows Mocha to capture the coverage information necessary to produce a single-page HTML report.</p>
+<p>The HTMLCov reporter extends the JSONCov reporter. The library being tested should first be instrumented by <a href="https://github.com/visionmedia/node-jscoverage">node-jscoverage</a>, this allows Mocha to capture the coverage information necessary to produce a single-page HTML report.</p>
 
-<p>  Click to view the current <a href="coverage.html">Express test coverage</a> report. For an integration example view the mcoha test coverage support <a href="https://github.com/visionmedia/express/commit/b6ee5fafd0d6c79cf7df5560cb324ebee4fe3a7f">commit</a> for Express.</p>
+<p>Click to view the current <a href="coverage.html">Express test coverage</a> report. For an integration example view the mcoha test coverage support <a href="https://github.com/visionmedia/express/commit/b6ee5fafd0d6c79cf7df5560cb324ebee4fe3a7f">commit</a> for Express.</p>
 
-<p>  <img src="http://f.cl.ly/items/3T3G1h1d3Z2i3M3Y1Y0Y/Screen%20Shot%202012-02-23%20at%208.37.13%20PM.png" alt="code coverage reporting" /></p>
+<p><img src="http://f.cl.ly/items/3T3G1h1d3Z2i3M3Y1Y0Y/Screen%20Shot%202012-02-23%20at%208.37.13%20PM.png" alt="code coverage reporting" title="" /></p>
 
 <h3>Doc</h3>
 
-<p> The &ldquo;doc&rdquo; reporter outputs a hierarchical HTML body representation
+<p>The "doc" reporter outputs a hierarchical HTML body representation
  of your tests, wrap it with a header, footer, some styling and you
  have some fantastic documentation!</p>
 
-<p>  <img src="images/reporter-doc.png" alt="doc reporter" /></p>
+<p><img src="images/reporter-doc.png" alt="doc reporter" title="" /></p>
 
-<p> For example suppose you have the following JavaScript:</p>
+<p>For example suppose you have the following JavaScript:</p>
 
 <pre><code>describe('Array', function(){
   describe('#indexOf()', function(){
@@ -434,7 +432,7 @@ test('#length', function(){
 })
 </code></pre>
 
-<p> The command <code>mocha --reporter doc array</code> would yield:</p>
+<p>The command <code>mocha --reporter doc array</code> would yield:</p>
 
 <pre><code>&lt;section class="suite"&gt;
   &lt;h1&gt;Array&lt;/h1&gt;
@@ -451,7 +449,7 @@ test('#length', function(){
 &lt;/section&gt;
 </code></pre>
 
-<p>  The SuperAgent request library <a href="http://visionmedia.github.com/superagent/docs/test.html">test documentation</a> was generated with Mocha&rsquo;s doc reporter using this simple make target:</p>
+<p>The SuperAgent request library <a href="http://visionmedia.github.com/superagent/docs/test.html">test documentation</a> was generated with Mocha's doc reporter using this simple make target:</p>
 
 <pre><code>test-docs:
     make test REPORTER=doc \
@@ -459,26 +457,26 @@ test('#length', function(){
         &gt; docs/test.html
 </code></pre>
 
-<p>  View the entire <a href="https://github.com/visionmedia/superagent/blob/master/Makefile">Makefile</a> for reference.</p>
+<p>View the entire <a href="https://github.com/visionmedia/superagent/blob/master/Makefile">Makefile</a> for reference.</p>
 
 <h3>XUnit</h3>
 
-<p>   Documentation needed.</p>
+<p>Documentation needed.</p>
 
 <h3>TeamCity</h3>
 
-<p>   Documentation needed.</p>
+<p>Documentation needed.</p>
 
 <h3>HTML</h3>
 
-<p> The <strong>HTML</strong> reporter is currently the only browser reporter
+<p>The <strong>HTML</strong> reporter is currently the only browser reporter
  supported by Mocha, and it looks like this:</p>
 
-<p> <img src="images/reporter-html.png" alt="HTML test reporter" /></p>
+<p><img src="images/reporter-html.png" alt="HTML test reporter" title="" /></p>
 
 <h2>Browser support</h2>
 
-<p> Mocha runs in the browser. Every release of Mocha will have new builds of <em>./mocha.js</em> and <em>./mocha.css</em> for use in the browser. To setup Mocha for browser use all you have to do is include the script, stylesheet, tell Mocha which interface you wish to use, and then run the tests. A typical setup might look something like the following, where we call <code>mocha.setup('bdd')</code> to use the <strong>BDD</strong> interface before loading the test scripts, running them <code>onload</code> with <code>mocha.run()</code>.</p>
+<p>Mocha runs in the browser. Every release of Mocha will have new builds of <em>./mocha.js</em> and <em>./mocha.css</em> for use in the browser. To setup Mocha for browser use all you have to do is include the script, stylesheet, tell Mocha which interface you wish to use, and then run the tests. A typical setup might look something like the following, where we call <code>mocha.setup('bdd')</code> to use the <strong>BDD</strong> interface before loading the test scripts, running them <code>onload</code> with <code>mocha.run()</code>.</p>
 
 <pre><code>&lt;html&gt;
 &lt;head&gt;
@@ -488,15 +486,18 @@ test('#length', function(){
   &lt;script src="jquery.js"&gt;&lt;/script&gt;
   &lt;script src="expect.js"&gt;&lt;/script&gt;
   &lt;script src="mocha.js"&gt;&lt;/script&gt;
-  &lt;script&gt;mocha.setup('bdd')&lt;/script&gt;
+  &lt;script&gt;
+    mocha.setup({
+      ui: 'bdd'
+    , globals: ['foo', 'bar'] // acceptable globals
+    })
+  &lt;/script&gt;
   &lt;script src="test.array.js"&gt;&lt;/script&gt;
   &lt;script src="test.object.js"&gt;&lt;/script&gt;
   &lt;script src="test.xhr.js"&gt;&lt;/script&gt;
   &lt;script&gt;
     $(function(){
-      mocha
-        .globals(['foo', 'bar']) // acceptable globals
-        .run()
+      mocha.run()
     })
   &lt;/script&gt;
 &lt;/head&gt;
@@ -506,22 +507,22 @@ test('#length', function(){
 &lt;/html&gt;
 </code></pre>
 
-<p>  Feel free to hot-link the <a href="https://raw.github.com/visionmedia/mocha/master/mocha.css">mocha.css</a> and <a href="https://raw.github.com/visionmedia/mocha/master/mocha.js">mocha.js</a> from GitHub.</p>
+<p>Feel free to hot-link the <a href="https://raw.github.com/visionmedia/mocha/master/mocha.css">mocha.css</a> and <a href="https://raw.github.com/visionmedia/mocha/master/mocha.js">mocha.js</a> from GitHub.</p>
 
 <h3>grep</h3>
 
-<p>  The client-side may utilize <code>--grep</code> as well, however you use the query-string, for example <code>?grep=api</code>.</p>
+<p>The client-side may utilize <code>--grep</code> as well, however you use the query-string, for example <code>?grep=api</code>.</p>
 
 <h2>mocha.opts</h2>
 
-<p> Mocha will attempt to load <code>./test/mocha.opts</code>, these are concatenated with <code>process.argv</code>, though command-line args will take precedence. For example suppose you have the following <em>mocha.opts</em> file:</p>
+<p>Mocha will attempt to load <code>./test/mocha.opts</code>, these are concatenated with <code>process.argv</code>, though command-line args will take precedence. For example suppose you have the following <em>mocha.opts</em> file:</p>
 
 <pre><code>--require should
 --reporter dot
 --ui bdd
 </code></pre>
 
-<p>  This will default the reporter to <code>dot</code>, require the <code>should</code> library,
+<p>This will default the reporter to <code>dot</code>, require the <code>should</code> library,
   and use <code>bdd</code> as the interface. With this you may then invoke <code>mocha(1)</code>
   with additional arguments, here enabling growl support and changing
   the reporter to <code>spec</code>:</p>
@@ -531,7 +532,7 @@ test('#length', function(){
 
 <h2>Test specific timeouts</h2>
 
-<p>  To compliment the global <code>--timeout</code> option, you may also specific test-specific timeouts via <code>this.timeout()</code>, or disable the timeout all-together with <code>this.timeout(0)</code>.</p>
+<p>To compliment the global <code>--timeout</code> option, you may also specific test-specific timeouts via <code>this.timeout()</code>, or disable the timeout all-together with <code>this.timeout(0)</code>.</p>
 
 <pre><code>it('should take less than 500ms', function(done){
   this.timeout(500);
@@ -543,12 +544,12 @@ test('#length', function(){
 
 <h3>test/*</h3>
 
-<p> By default <code>mocha(1)</code> will use the pattern <code>./test/*.js</code>, so
- it&rsquo;s usually a good place to put your tests.</p>
+<p>By default <code>mocha(1)</code> will use the pattern <code>./test/*.js</code>, so
+ it's usually a good place to put your tests.</p>
 
 <h3>Makefiles</h3>
 
-<p> Be kind and don&rsquo;t make developers hunt around in your docs to figure
+<p>Be kind and don't make developers hunt around in your docs to figure
  out how to run the tests, add a <code>make test</code> target to your <em>Makefile</em>:</p>
 
 <pre><code> test:
@@ -560,11 +561,11 @@ test('#length', function(){
 
 <h2>Editors</h2>
 
-<p>  The following editor-related packages are available:</p>
+<p>The following editor-related packages are available:</p>
 
 <h3>TextMate bundle</h3>
 
-<p>  The Mocha TextMate bundle includes snippets to
+<p>The Mocha TextMate bundle includes snippets to
   make writing tests quicker and more enjoyable.
   To install the bundle run:</p>
 
@@ -573,38 +574,37 @@ test('#length', function(){
 
 <h2>Example test suites</h2>
 
-<p>  The following test suites are from real projects putting Mocha to use,
+<p>The following test suites are from real projects putting Mocha to use,
   so they serve as good examples:</p>
 
 <ul>
-<li> <a href="https://github.com/visionmedia/express/tree/master/test">Express</a></li>
-<li> <a href="https://github.com/senchalabs/connect/tree/master/test">Connect</a></li>
-<li> <a href="https://github.com/visionmedia/superagent/tree/master/test/node">SuperAgent</a></li>
-<li> <a href="https://github.com/LearnBoost/websocket.io/tree/master/test">WebSocket.io</a></li>
-<li> <a href="https://github.com/visionmedia/mocha/tree/master/test">Mocha</a></li>
+<li><a href="https://github.com/visionmedia/express/tree/master/test">Express</a></li>
+<li><a href="https://github.com/senchalabs/connect/tree/master/test">Connect</a></li>
+<li><a href="https://github.com/visionmedia/superagent/tree/master/test/node">SuperAgent</a></li>
+<li><a href="https://github.com/LearnBoost/websocket.io/tree/master/test">WebSocket.io</a></li>
+<li><a href="https://github.com/visionmedia/mocha/tree/master/test">Mocha</a></li>
 </ul>
 
+<h2>Running mocha's tests</h2>
 
-<h2>Running mocha&rsquo;s tests</h2>
-
-<p> Run the tests:</p>
+<p>Run the tests:</p>
 
 <pre><code>   $ make test
 </code></pre>
 
-<p> Run all tests, including interfaces:</p>
+<p>Run all tests, including interfaces:</p>
 
 <pre><code>   $ make test-all
 </code></pre>
 
-<p> Alter the reporter:</p>
+<p>Alter the reporter:</p>
 
 <pre><code>   $ make test REPORTER=list
 </code></pre>
 
 <h2>More information</h2>
 
-<p>  For additional information such as using spies, mocking, and shared behaviours be sure to check out the <a href="https://github.com/visionmedia/mocha/wiki">Mocha Wiki</a> on GitHub.</p>
+<p>For additional information such as using spies, mocking, and shared behaviours be sure to check out the <a href="https://github.com/visionmedia/mocha/wiki">Mocha Wiki</a> on GitHub.</p>
     </section>
     <footer>
       <span>© 2011 TJ Holowaychuk. All rights reserved.</span>

--- a/index.md
+++ b/index.md
@@ -450,15 +450,18 @@ Testing asynchronous code with Mocha could not be simpler! Simply invoke the cal
       <script src="jquery.js"></script>
       <script src="expect.js"></script>
       <script src="mocha.js"></script>
-      <script>mocha.setup('bdd')</script>
+      <script>
+        mocha.setup({
+          ui: 'bdd'
+        , globals: ['foo', 'bar'] // acceptable globals
+        })
+      </script>
       <script src="test.array.js"></script>
       <script src="test.object.js"></script>
       <script src="test.xhr.js"></script>
       <script>
         $(function(){
-          mocha
-            .globals(['foo', 'bar']) // acceptable globals
-            .run()
+          mocha.run()
         })
       </script>
     </head>


### PR DESCRIPTION
I'm sorry for the `index.html` changes, but that's the output of homebrew's markdown from the `index.md` file. I've looked at the browser and the page looks as it is today.
