### PR TITLE
Improving error message for async tests

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -142,7 +142,18 @@ Runnable.prototype.run = function(fn){
     try {
       this.fn.call(ctx, function(err){
         if (err instanceof Error) return done(err);
-        if (null != err) return done(new Error('done() invoked with non-Error: ' + err));
+        if ('function' == typeof err) {
+          var _err = err;
+          err = function() {
+            try {
+              return _err.apply(this, arguments);
+            } catch(e) {
+              done(e);
+            }
+          };
+          return err;
+        }
+        if (null != err) return done(new Error('done() invoked without Error or Function: ' + err));
         done();
       });
     } catch (err) {

--- a/mocha.js
+++ b/mocha.js
@@ -2636,7 +2636,18 @@ Runnable.prototype.run = function(fn){
     try {
       this.fn.call(ctx, function(err){
         if (err instanceof Error) return done(err);
-        if (null != err) return done(new Error('done() invoked with non-Error: ' + err));
+        if ('function' == typeof err) {
+          var _err = err;
+          err = function() {
+            try {
+              return _err.apply(this, arguments);
+            } catch(e) {
+              done(e);
+            }
+          };
+          return err;
+        }
+        if (null != err) return done(new Error('done() invoked without Error or Function: ' + err));
         done();
       });
     } catch (err) {


### PR DESCRIPTION
See here: http://jsfiddle.net/fabiomcosta/PmgEV/2/
This link illustrates what this patch does to the `done` function.

Currently, the error message for an async test, on the browser, is: "Script error." (tested on chrome and firefox).
With this patch, the message becomes what was expected.

Note that it's backwards compatible but needs a change on the current way `done` is used. You will need to pass the asynchronous function as an argument to the `done` function, instead of calling `done` inside the asynchronous function. But the current error message is useless.

Thoughts?
