### PR TITLE
[fix] html coverage template. do not escape literal html

### DIFF
--- a/lib/reporters/templates/coverage.jade
+++ b/lib/reporters/templates/coverage.jade
@@ -37,14 +37,17 @@ html
                     tr.hit 
                       td.line= number
                       td.hits= line.coverage
-                      td.source= line.source
+                      td.source
+                        | !{line.source}
                   else if 0 === line.coverage
                     tr.miss 
                       td.line= number
                       td.hits 0
-                      td.source= line.source
+                      td.source
+                        | !{line.source}
                   else
                     tr
                       td.line= number
                       td.hits
-                      td.source= line.source || ' '
+                      td.source
+                        | !{line.source || ' '}


### PR DESCRIPTION
This pull request should avoid redundant escaping of HTML in the coverage reporter

It seemed that passing in raw html in `lib/reporters/templates/coverage.jade` from each `line.source` of `file.source` was escaped, so that something like `&lt;span class="c"&gt;/*!&lt;/span&gt;` ended up in the code listings.

I am really interested in how this could have worked before, as you clearly had a working version of this reporter (to generate the [coverage reports I saw](http://visionmedia.github.com/mocha/coverage.html#middleware/session/session.js)).
