### PR TITLE
Support iced-coffee-script as alternative compiler

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -165,7 +165,11 @@ var files = program.args
 // coffee-script support
 
 try {
-  require('coffee-script');
+  try {
+    require('coffee-script');
+  } catch (err) {
+    require('iced-coffee-script');
+  }
   re = /\.(js|coffee)$/;
 } catch (err) {
   // ignore


### PR DESCRIPTION
If it can't find the `coffee-script` package, it looks for `iced-coffee-script` as an alternative.
