### PR TITLE
Adding promise support to runnables (and thus tests).

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -107,14 +107,15 @@ Runnable.prototype.run = function(fn){
     , finished
     , emitted;
 
-  // timeout
+  // timeout: set the timer even if this.async isn't true, since we don't know
+  // ahead of time for the promisey case
   if (this.async) {
-    if (ms) {
-      this.timer = setTimeout(function(){
+    this.timer = setTimeout(function(){
+      if (!finished) {
         done(new Error('timeout of ' + ms + 'ms exceeded'));
         self.timedOut = true;
-      }, ms);
-    }
+      }
+    }, ms);
   }
 
   // called multiple times
@@ -152,11 +153,25 @@ Runnable.prototype.run = function(fn){
   }
   
   // sync
+  var result;
   try {
-    if (!this.pending) this.fn.call(ctx);
-    this.duration = new Date - start;
-    fn();
+    if (!this.pending) {
+      var result = this.fn.call(ctx);
+
+      if (result && typeof result.then === "function") {
+        result.then(
+          function(){
+            done(); // don't pass through any non-error fulfillment values
+          },
+          done // pass through any errors
+        );
+      } else {
+        done();
+      }
+    } else {
+      done();
+    }
   } catch (err) {
-    fn(err);
+    done(err);
   }
 };

--- a/test/runnable.js
+++ b/test/runnable.js
@@ -176,5 +176,72 @@ describe('Runnable(title, fn)', function(){
       })
     })
 
+    describe('when fn returns a promise', function(){
+      describe('when the promise is fulfilled with no value', function(){
+        var fulfilledPromise = {
+          then: function (fulfilled, rejected) {
+            process.nextTick(fulfilled);
+          }
+        };
+
+        it('should invoke the callback', function(done){
+          var test = new Runnable('foo', function(){
+            return fulfilledPromise;
+          });
+
+          test.run(done);
+        })
+      })
+
+      describe('when the promise is fulfilled with a value', function(){
+        var fulfilledPromise = {
+          then: function (fulfilled, rejected) {
+            process.nextTick(function () {
+              fulfilled({});
+            });
+          }
+        };
+
+        it('should invoke the callback', function(done){
+          var test = new Runnable('foo', function(){
+            return fulfilledPromise;
+          });
+
+          test.run(done);
+        })
+      })
+
+      describe('when the promise is rejected', function(){
+        var expectedErr = new Error('fail');
+        var rejectedPromise = {
+          then: function (fulfilled, rejected) {
+            process.nextTick(function () {
+              rejected(expectedErr);
+            });
+          }
+        };
+
+        it('should invoke the callback', function(done){
+          var test = new Runnable('foo', function(){
+            return rejectedPromise;
+          });
+
+          test.run(function(err){
+            err.should.equal(expectedErr);
+            done();
+          });
+        })
+      })
+    })
+
+    describe('when fn returns a non-promise', function(){
+      it('should invoke the callback', function(done){
+        var test = new Runnable('foo', function(){
+          return { then: "i ran my tests" };
+        });
+
+        test.run(done);
+      })
+    })
   })
 })


### PR DESCRIPTION
- If a runnable returns a duck-typed promise, i.e. an object with a `then` method, it gets treated as an async test, with success if the promise is fulfilled and failure if it is rejected (with the rejection reason as the error).
- Includes tests both of new functionality and some to show that introducing this doesn't break any old functionality.

Would really appreciate merging this! I tried to stick as close as possible to the existing style. We <3 Mocha but also <3 promises.
