### PR TITLE
Allow scrolling for menu in html-cov report for long list of files

### DIFF
--- a/lib/reporters/templates/style.html
+++ b/lib/reporters/templates/style.html
@@ -111,6 +111,7 @@ footer span {
 
 #menu {
   position: fixed;
+  overflow: scroll;
   font-size: 12px;
   top: 0;
   right: 0;


### PR DESCRIPTION
Currently the menu for the list of files gets cut off in the html-cov report. This enables the `div` to be scrollable. 
