### PR TITLE
node.js: Maximum callstack size exceeded

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -150,7 +150,8 @@ Runner.prototype.hook = function(name, fn){
     , hooks = suite['_' + name]
     , ms = suite._timeout
     , self = this
-    , timer;
+    , timer
+    , maxAllowedCallstack = 2000;
 
   function next(i) {
     var hook = hooks[i];
@@ -168,7 +169,11 @@ Runner.prototype.hook = function(name, fn){
       hook.removeAllListeners('error');
       if (err) return self.failHook(hook, err);
       self.emit('hook end', hook);
-      next(++i);
+      if(i % maxAllowedCallstack){
+        next(++i);
+      } else {
+        setTimeout(function(){ next(++i); }, 0);
+      }
     });
   }
 


### PR DESCRIPTION
We are hitting an issue in our specs where, for some reason, we are getting 4k+ entries in the hooks array inside runnable.js. Since this array is processed using recursion, this easily blows the cap off of node's callstack.

This pull request uses the setTimeout of zero technique to reset our callstack as we reach the callstack limit. As an initial pass, I've hardcoded 2000 as the max-allowed depth before resetting the callstack - but it would probably be good for this to be configurable in some way.

On a side note, it does seem strange that we have so many entires in the hooks array. We do have about 880 specs and do tend to highly nest contexts using nested describes, many with associated beforeEach hooks. If it sounds strange that we'd have 4k+ hooks entries with that setup, please let me know.

Thanks! (and mocha friggin rocks by the way!)
