### PR TITLE
--require does not work for coffee files

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -97,6 +97,15 @@ program.on('interfaces', function(){
 
 // -r, --require
 
+// make sure coffee files are required properly
+
+try {
+  require('coffee-script');
+}
+catch (err) {
+  // no coffee
+}
+
 module.paths.push(cwd, join(cwd, 'node_modules'));
 
 program.on('require', function(mod){
@@ -135,6 +144,7 @@ var suite = new Suite('', new Context)
   , Base = require('../lib/reporters/base')
   , Reporter = require('../lib/reporters/' + program.reporter)
   , ui = interfaces[program.ui](suite);
+
 
 // --no-colors
 


### PR DESCRIPTION
require('coffee-script') should be called before the line program.parse(process.argv); in _mocha to enable requiring of coffee-script files via --require.
