### PR TITLE
Added minimal reporter (for --watch)

### DIFF
--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -6,6 +6,7 @@ exports.TAP = require('./tap');
 exports.JSON = require('./json');
 exports.HTML = require('./html');
 exports.List = require('./list');
+exports.Min = require('./min');
 exports.Spec = require('./spec');
 exports.Progress = require('./progress');
 exports.Landing = require('./landing');

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -1,0 +1,39 @@
+/**
+ * Module dependencies.
+ */
+
+var Base = require('./base')
+  , color = Base.color;
+
+/**
+ * Expose `Min`.
+ */
+
+exports = module.exports = Min;
+
+/**
+ * Initialize a new `Min` minimal test reporter (best used with --watch).
+ *
+ * @param {Runner} runner
+ * @api public
+ */
+
+function Min(runner) {
+  Base.call(this, runner);
+
+  var self = this
+    , stats = this.stats;
+  
+  runner.on('start', function(){
+    process.stdout.write('\033[2J');   // clear screen
+    process.stdout.write('\033[1;3H'); // set cursor position
+  });
+
+  runner.on('end', function(){ self.epilogue(); });
+}
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+
+Min.prototype.__proto__ = Base.prototype;


### PR DESCRIPTION
I wanted a minimal reporter to use in a window with --watch running during TDD to have a quick visual check if everything is passing.

Here's a reporter that minimizes the output if there are no errors and clears the screen between re-runs.
