### PR TITLE
Fixing the browser based tests - '__dirname' was undefined

### DIFF
--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -3,6 +3,9 @@
     <title>Mocha</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="style.css" />
+    <script>
+      var __dirname = "";
+    </script>
     <script src="../../mocha.js"></script>
     <script>mocha.setup('bdd')</script>
     <script>

--- a/test/browser/large.html
+++ b/test/browser/large.html
@@ -4,6 +4,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="style.css" />
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js" type="text/javascript"></script>
+    <script>
+      var __dirname = "";
+    </script>
     <script src="../../mocha.js"></script>
     <script>mocha.setup('bdd')</script>
     <script>

--- a/test/browser/opts.html
+++ b/test/browser/opts.html
@@ -3,6 +3,9 @@
     <title>Mocha</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="style.css" />
+    <script>
+      var __dirname = "";
+    </script>
     <script src="../../mocha.js"></script>
     <script>
       mocha.setup({


### PR DESCRIPTION
I tried running the browser based tests for mocha and received this error:

```
Uncaught ReferenceError: __dirname is not defined
```

on line 894 in mocha.js

``` javascript
var images = {
    fail: __dirname + '/../images/error.png'
```

This pull request should fix all browser based tests.
