### PR TITLE
Display exceptions thrown by before/after hooks. #270

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -78,7 +78,7 @@ function HTML(runner) {
   });
 
   runner.on('fail', function(test, err){
-    if (err.uncaught) runner.emit('test end', test);
+    if (err.uncaught || test.type==='hook') runner.emit('test end', test);
   });
 
   runner.on('test end', function(test){


### PR DESCRIPTION
Renders exceptions throws in before/after and beforeEach/afterEach hooks.

Fixed #270.
