### PR TITLE
Accept a ready function in mocha.run(), just like Mocha.prototype.run.

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -143,7 +143,6 @@ window.mocha = require('mocha');
     if (options.globals) runner.globals(options.globals);
     runner.globals(['location']);
     runner.on('end', highlightCode);
-    if (fn) runner.on('end', fn);
-    return runner.run();
+    return runner.run(fn);
   };
 })();


### PR DESCRIPTION
The JS API supports something like this:

``` js
var mocha = new Mocha();
// ...

mocha.run(function(failures){
  console.log('finished with ' + failures + ' failures');
});
```

The browser version of `mocha.run()` however didn't support this yet.
