### PR TITLE
Displaying the number of pending specs

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -193,7 +193,7 @@ exports.list = function(failures){
 
 function Base(runner) {
   var self = this
-    , stats = this.stats = { suites: 0, tests: 0, passes: 0, pendings: 0, failures: 0 }
+    , stats = this.stats = { suites: 0, tests: 0, passes: 0, pending: 0, failures: 0 }
     , failures = this.failures = [];
 
   if (!runner) return;
@@ -239,8 +239,7 @@ function Base(runner) {
   });
 
   runner.on('pending', function(){
-    stats.pendings = stats.pendings || 0;
-    stats.pendings++;
+    stats.pending++;
   });
 }
 
@@ -258,13 +257,8 @@ Base.prototype.epilogue = function(){
 
   console.log();
 
-  var pluralizeTest = function(numberOfTests) {
-    if (numberOfTests === 1) {
-      return "test";
-    }
-    else {
-      return "tests";
-    }
+  var pluralizeTest = function(n) {
+    return 1 == n ? 'test' : 'tests';
   }
 
   // failure
@@ -293,13 +287,13 @@ Base.prototype.epilogue = function(){
               stats.duration);
 
   // pending
-  if (stats.pendings > 0) {
-    fmt = color('pending', '  *')
+  if (stats.pending) {
+    fmt = color('pending', '  •')
       + color('pending', ' %d %s pending');
 
     console.log(fmt,
-                stats.pendings,
-                pluralizeTest(stats.pendings));
+                stats.pending,
+                pluralizeTest(stats.pending));
   }
 
   console.log();


### PR DESCRIPTION
I am displaying the number of pending specs at the end of the reporter output.

I also modified the way we print the summary. It now will say `1 test complete` instead of `1 tests complete`.

This is what you're getting with this pull request:
![# of pending tests](http://d3j5vwomefv46c.cloudfront.net/photos/full/557568681.png?key=28268&Expires=1334026315&Key-Pair-Id=APKAIYVGSUJFNRFZBBTA&Signature=YnqNAcSdo~87kl7tSD33oVn1wco0yNN83OKdaYNJy0Blw0si6AkRQgY76bEbYT61Rgh-9Pt12Kqf8j92nX3-8f5T6o6E98AEOji1EgfRclaUC~qCnkWnIJJ8NUUN57JR9ZzrfNFkEtR2qDB0u8Kfid2b4r~MB6RmIxfiRQ04QRE_)
