### PR TITLE
Fix for Issue #58 - Progress Reporter is off

### DIFF
--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -53,8 +53,9 @@ function Progress(runner, options) {
 
   // tests complete
   runner.on('test end', function(){
+    complete++;
     var incomplete = total - complete
-      , percent = complete++ / total
+      , percent = complete / total
       , n = width * percent | 0
       , i = width - n;
 


### PR DESCRIPTION
Updated progress reporter to properly increment `complete` before
calculating `incomplete`.  Fixes #58 so that progress always shows 100%
after all tests are successfully completed.
