### PR TITLE
Fix Makefile to work with GNU Make (3.81)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ mocha.js: $(SRC) $(SUPPORT)
 	@cat \
 	  support/head.js \
 	  _mocha.js \
-	  support/{tail,foot}.js \
+	  support/tail.js \
+	  support/foot.js \
 	  > mocha.js
 
 clean:


### PR DESCRIPTION
It would fail before with "cat: support/{tail,foot}.js: No such file or directory".
