### PR TITLE
Make order of source files well-defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 REPORTER = dot
 TM_DEST = ~/Library/Application\ Support/TextMate/Bundles
 TM_BUNDLE = JavaScript\ mocha.tmbundle
-SRC = $(shell find lib -name "*.js" -type f)
+SRC = $(shell find lib -name "*.js" -type f | sort)
 SUPPORT = $(wildcard support/*.js)
 
 all: mocha.js mocha.css


### PR DESCRIPTION
This avoids crazy git diffs when building.
