### PR TITLE
Fixes #158: removes jquery include from browser tests

### DIFF
--- a/test/browser/large.html
+++ b/test/browser/large.html
@@ -3,7 +3,6 @@
     <title>Mocha</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="style.css" />
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js" type="text/javascript"></script>
     <script src="../../mocha.js"></script>
     <script>mocha.setup('bdd')</script>
     <script>
@@ -13,7 +12,9 @@
     </script>
     <script src="large.js"></script>
     <script>
-      onload = mocha.run;
+      onload = function(){
+        var runner = mocha.run();
+      };
     </script>
   </head>
   <body>

--- a/test/browser/opts.html
+++ b/test/browser/opts.html
@@ -19,7 +19,9 @@
     <script src="opts.js"></script>
     <script src="../acceptance/globals.js"></script>
     <script>
-      onload = mocha.run;
+     onload = function(){
+        var runner = mocha.run();
+      };
     </script>
   </head>
   <body>


### PR DESCRIPTION
removes jquery include from `test/browser/large.html`

Also updated unload  in `large.html` and `opts.html` to pass a function
instead of `mocha.run` so that callback can be run on `end`
