### PR TITLE
Fixes #384 - Ability to filter test results in HTML

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -26,6 +26,16 @@ var statsTemplate = '<ul id="stats">'
   + '</ul>';
 
 /**
+ * Filters for tests results
+ */
+
+var resultFilterTemplate = '<ul id="result-filter">'
+  + '<li class="select-all filter-selected">All</li>'
+  + '<li class="select-pass">Pass</li>'
+  + '<li class="select-fail">Fail</li>'
+  + '</ul>';
+
+/**
  * Initialize a new `Doc` reporter.
  *
  * @param {Runner} runner
@@ -45,6 +55,8 @@ function HTML(runner) {
     , failures = items[2].getElementsByTagName('em')[0]
     , duration = items[3].getElementsByTagName('em')[0]
     , canvas = stat.getElementsByTagName('canvas')[0]
+    , filter = fragment(resultFilterTemplate)
+    , filterItems = filter.getElementsByTagName('li')
     , stack = [root]
     , progress
     , ctx
@@ -55,6 +67,31 @@ function HTML(runner) {
   }
 
   if (!root) return error('#mocha div missing, add it to your document');
+
+  // Results filter
+
+  root.appendChild(filter);
+
+  function filterUpdate() {
+    var selected = getElementsByClassName('filter-selected');
+    var selectedClass = selected[0].className.split(" ")[0].split('-')[1];
+    var selected = getElementsByClassName('t', filter);
+    utils.forEach(getElementsByClassName('test'), function(el) {
+      if(selectedClass === "all" || hasClass(el, selectedClass)) {
+        el.style.display = 'block';
+      } else {
+        el.style.display = 'none';
+      }
+    });
+  }
+
+  on(filter, 'click', function(e) {
+    utils.forEach(filterItems, function(el) {
+      removeClass(el, 'filter-selected');
+      addClass(e.target, 'filter-selected');
+    });
+    filterUpdate();
+  });
 
   root.appendChild(stat);
 
@@ -116,6 +153,8 @@ function HTML(runner) {
       }
 
       el.appendChild(fragment('<pre class="error">%e</pre>', str));
+    
+      filterUpdate();
     }
 
     // toggle code
@@ -209,3 +248,71 @@ function clean(str) {
 
   return str;
 }
+
+/**
+ * DOM - Returns all elements which have the class `className`
+ *
+ * @param {String} className
+ * @return {Array}
+ */
+function getElementsByClassName(className) {
+  if('getElementsByClassName' in document) {
+    return document.getElementsByClassName(className);
+  } else {
+    var result = [];
+    var root = document.getElementsByTagName("body")[0];
+    var re = new RegExp('\\b' + className + '\\b');
+    utils.forEach(root.getElementsByTagName("*"), function(el) {
+      if(re.test(el.className)) result.push(el);
+    });
+    return result;
+  }
+}
+
+/**
+ * DOM - Returns true if the provided DOM element has 
+ * `className` as a class
+ *
+ * @param {Object} el
+ * @param {String} className
+ * @return {Boolean} 
+ */
+function hasClass(el, className) {
+  var re = new RegExp('\\b' + className + '\\b');
+  return re.test(el.className);
+}
+
+/**
+ * DOM - Removes the class `className` from the provided DOM
+ * element, if it has the class
+ *
+ * @param {Object} el
+ * @param {String} className
+ * @return {Object} el
+ */
+function removeClass(el, className) {
+  if(!hasClass(el, className)) return el;
+  var previousClass = el.className;
+  var re = new RegExp('(^| )' + className + '( |$)');
+  var newClass = previousClass.replace(re, '$1');
+  newClass = newClass.replace(/ $/, '');
+  el.className = newClass;
+  return el;
+}
+
+/**
+ * DOM - Adds the class `className` from the provided DOM
+ * element, if it hasn't already the class
+ *
+ * @param {Object} el
+ * @param {String} className
+ * @return {Object} el
+ */
+function addClass(el, className) {
+  if(!hasClass(el, className)) {
+    el.className = el.className + ' ' + className;
+  }
+  return el;
+}
+
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -187,3 +187,5 @@ exports.slug = function(str){
     .replace(/ +/g, '-')
     .replace(/[^-\w]/g, '');
 };
+
+

--- a/mocha.css
+++ b/mocha.css
@@ -107,11 +107,11 @@ body {
 
 #stats {
   position: fixed;
-  top: 15px;
-  right: 10px;
   font-size: 12px;
   margin: 0;
   color: #888;
+  top: 15px;
+  right: 10px;
 }
 
 #stats .progress {
@@ -128,6 +128,43 @@ body {
   margin: 0 5px;
   list-style: none;
   padding-top: 11px;
+}
+
+#result-filter {
+  color: #888;
+  position: absolute;
+  font-size: 12px;
+  margin: 0;
+  top: 20px;
+  left: 10px;
+}
+
+#result-filter li {
+  color: white;
+  border-radius: 3px 3px 3px 3px;
+  display: inline-block;
+  font-weight: bold;
+  padding: 1px 9px 1px 8px;
+  margin: 5px;
+  text-decoration: none;
+  cursor: pointer;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
+  background-color: #ccc;
+}
+
+#result-filter li.select-all.filter-selected,
+#result-filter li.select-all:hover {
+  background-color: #5890AD;
+}
+
+#result-filter li.select-pass.filter-selected,
+#result-filter li.select-pass:hover {
+  background-color: #00C41C;
+}
+
+#result-filter li.select-fail.filter-selected,
+#result-filter li.select-fail:hover {
+  background-color: #E10C02;
 }
 
 code .comment { color: #ddd }

--- a/test/browser/style.css
+++ b/test/browser/style.css
@@ -107,11 +107,11 @@ body {
 
 #stats {
   position: fixed;
-  top: 15px;
-  right: 10px;
   font-size: 12px;
   margin: 0;
   color: #888;
+  top: 15px;
+  right: 10px;
 }
 
 #stats .progress {
@@ -128,6 +128,43 @@ body {
   margin: 0 5px;
   list-style: none;
   padding-top: 11px;
+}
+
+#result-filter {
+  color: #888;
+  position: absolute;
+  font-size: 12px;
+  margin: 0;
+  top: 20px;
+  left: 10px;
+}
+
+#result-filter li {
+  color: white;
+  border-radius: 3px 3px 3px 3px;
+  display: inline-block;
+  font-weight: bold;
+  padding: 1px 9px 1px 8px;
+  margin: 5px;
+  text-decoration: none;
+  cursor: pointer;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
+  background-color: #ccc;
+}
+
+#result-filter li.select-all.filter-selected,
+#result-filter li.select-all:hover {
+  background-color: #5890AD;
+}
+
+#result-filter li.select-pass.filter-selected,
+#result-filter li.select-pass:hover {
+  background-color: #00C41C;
+}
+
+#result-filter li.select-fail.filter-selected,
+#result-filter li.select-fail:hover {
+  background-color: #E10C02;
 }
 
 code .comment { color: #ddd }


### PR DESCRIPTION
QUnit has a very useful feature, which allows to hide passed test
results, which is very handy to identify failed results.

This adds this possibility when looking at the HTML results -
allowing to switch between all results and only failed or passed
ones, without re-running the whole test suite.
