### PR TITLE
Fixes #156 and #157 IE6-7-8 specific styles and non-canvas progress reporter for IE

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -52,6 +52,8 @@ function HTML(runner) {
   if (canvas.getContext) {
     ctx = canvas.getContext('2d');
     progress = new Progress;
+  } else {
+    root.className = 'fallback';
   }
 
   if (!root) return error('#mocha div missing, add it to your document');

--- a/mocha.css
+++ b/mocha.css
@@ -1,7 +1,11 @@
 
 body {
   font: 20px/1.5 "Helvetica Neue", Helvetica, Arial, sans-serif;
-  padding: 60px 50px;
+  padding: 0 50px;
+}
+
+#mocha {
+  position: relative;
 }
 
 #mocha h1, h2 {
@@ -9,12 +13,14 @@ body {
 }
 
 #mocha h1 {
+  padding-top: 40px;
   margin-top: 15px;
   font-size: 1em;
   font-weight: 200;
 }
 
 #mocha .suite .suite h1 {
+  padding-top: 0;
   margin-top: 0;
   font-size: .8em;
 }
@@ -49,7 +55,7 @@ body {
 }
 
 #mocha .test.pass::before {
-  content: '✓';
+  content: '\02713';
   font-size: 12px;
   display: block;
   float: left;
@@ -62,7 +68,7 @@ body {
 }
 
 #mocha .test.pending::before {
-  content: '◦';
+  content: '\02022';
   color: #0b97c4;
 }
 
@@ -75,7 +81,7 @@ body {
 }
 
 #mocha .test.fail::before {
-  content: '✖';
+  content: '\02716';
   font-size: 12px;
   display: block;
   float: left;
@@ -106,17 +112,19 @@ body {
 }
 
 #stats {
-  position: fixed;
-  top: 15px;
+  position: absolute;
+  top: 0;
   right: 10px;
   font-size: 12px;
-  margin: 0;
+  margin: 15px 0 0;
   color: #888;
+  width: 280px;
 }
 
 #stats .progress {
   float: right;
   padding-top: 0;
+  margin-top: -11px;
 }
 
 #stats em {
@@ -124,10 +132,17 @@ body {
 }
 
 #stats li {
-  display: inline-block;
+  display: inline;
   margin: 0 5px;
   list-style: none;
-  padding-top: 11px;
+}
+
+#mocha.fallback .test.pass h2 {
+  color: #00c41c;
+}
+
+#mocha.fallback .test.fail h2 {
+  color: #c00;
 }
 
 code .comment { color: #ddd }

--- a/mocha.js
+++ b/mocha.js
@@ -1591,22 +1591,12 @@ function HTML(runner) {
     , stack = [root]
     , progress
     , ctx
-    , progressBar
-    , bar
-    , innerBar
-    , innerText
 
   if (canvas.getContext) {
     ctx = canvas.getContext('2d');
     progress = new Progress;
   } else {
     root.className = 'fallback';
-    progressBar = document.createElement('div');
-    items[0].appendChild(progressBar);
-    progressBar.innerHTML = '<div class="bar"><div class="innerBar"></div></div><span></span>';
-    bar = progressBar.getElementsByTagName('div')[0];
-    innerBar = bar.getElementsByTagName('div')[0];
-    innerText = progressBar.getElementsByTagName('span')[0];
   }
 
   if (!root) return error('#mocha div missing, add it to your document');
@@ -1639,12 +1629,7 @@ function HTML(runner) {
   runner.on('test end', function(test){
     // TODO: add to stats
     var percent = stats.tests / total * 100 | 0;
-    if (progress){
-      progress.update(percent).draw(ctx);
-    } else {
-      innerBar.style.width = percent + '%';
-      innerText.innerHTML = percent + '%';
-    }
+    if (progress) progress.update(percent).draw(ctx);
 
     // update stats
     var ms = new Date - stats.start;


### PR DESCRIPTION
Updated styles to fix layout bug in IE5.5 - IE9.  Replaced unicode
characters with entities in CSS. Added a div-based progress reporter
when canvas isn't available.  Added a class to `#mocha` for fallback
and IE specific styles to show pass fail status (color coded)
