### PR TITLE
Fixes #47 Added support for showing test duration in HTML reporter

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -94,7 +94,7 @@ function HTML(runner) {
 
     // test
     if ('passed' == test.state) {
-      var el = fragment('<div class="test pass"><h2>%e</h2></div>', test.title);
+      var el = fragment('<div class="test pass %e"><h2>%e<span class="duration">%ems</span></h2></div>', test.speed, test.title, test.duration);
     } else if (test.pending) {
       var el = fragment('<div class="test pass pending"><h2>%e</h2></div>', test.title);
     } else {

--- a/mocha.css
+++ b/mocha.css
@@ -48,13 +48,35 @@ body {
   font-family: arial;
 }
 
+#mocha .test.pass.fast {
+  color: #468847;
+}
+
+#mocha .test.pass.medium {
+  color: #C09853;
+}
+
+#mocha .test.pass.slow {
+  color: #B94A48;
+}
+
 #mocha .test.pass::before {
   content: '✓';
   font-size: 12px;
   display: block;
   float: left;
   margin-right: 5px;
-  color: #00c41c;
+}
+
+#mocha .test.pass .duration {
+  color: #999999;
+  font-style: italic;
+  padding-left: 7px;
+  font-size: 10px;
+}
+
+#mocha .test.pass.fast .duration {
+  display: none;
 }
 
 #mocha .test.pending {

--- a/mocha.js
+++ b/mocha.js
@@ -1637,7 +1637,7 @@ function HTML(runner) {
 
     // test
     if ('passed' == test.state) {
-      var el = fragment('<div class="test pass"><h2>%e</h2></div>', test.title);
+      var el = fragment('<div class="test pass %e"><h2>%e<span class="duration">%ems</span></h2></div>', test.speed, test.title, test.duration);
     } else if (test.pending) {
       var el = fragment('<div class="test pass pending"><h2>%e</h2></div>', test.title);
     } else {


### PR DESCRIPTION
This is a cleaned up pull request with better formating and printf style variables in the HTML

Shows the duration color coded along with the time (if not fast) for
the HTML reporter.
fast = green
medium = yellow
slow = red
Colors from bootstrap.js form control states for success, warning, and
error.
