### PR TITLE
Only add one postMessage listener. Fixes unresponsive browser during and after tests.

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -27,15 +27,16 @@ process.nextTick = (function(){
   var timeouts = []
     , name = 'mocha-zero-timeout'
 
+  window.addEventListener('message', function(e){
+    if (e.source == window && e.data == name) {
+      if (e.stopPropagation) e.stopPropagation();
+      if (timeouts.length) timeouts.shift()();
+    }
+  }, true);
+
   return function(fn){
     timeouts.push(fn);
     window.postMessage(name, '*');
-    window.addEventListener('message', function(e){
-      if (e.source == window && e.data == name) {
-        if (e.stopPropagation) e.stopPropagation();
-        if (timeouts.length) timeouts.shift()();
-      }
-    }, true);
   }
 })();
 


### PR DESCRIPTION
Since `addEventListener` is being called with a new function reference every time, the browser considers them unique event handlers and is calling more and more each time. This change just adds the handler once.

This is the cause of a sluggish browser even long after running a decently sized test suite (millions of `postMessage` handlers are still being run minutes later).

This also makes the progress smoother while the tests are being run. :D
