### PR TITLE
Fix for issue #404 - null handling in string escape function in TeamCity reporter

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -52,5 +52,6 @@ function Teamcity(runner) {
  */
 
 function escape(str) {
+  if (str === undefined) { return ""; }
   return str.replace(/'/g, "|'");
 }


### PR DESCRIPTION
Fix for issue #404.
