### PR TITLE
Added ability to load tests with requirejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 testing
 _mocha.js
 test.js
+*.swp

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -19,7 +19,8 @@ var program = require('commander')
   , vm = require('vm')
   , fs = require('fs')
   , join = path.join
-  , cwd = process.cwd();
+  , cwd = process.cwd()
+  , moduleLoader = require('../lib/module-loader');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -70,6 +71,7 @@ program
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
   .option('-b, --bail', "bail after first test failure")
   .option('--recursive', 'include sub directories')
+  .option('--requirejs', "loads tests with RequireJs instead of Node's native require")
   .option('--debug-brk', "enable node's debugger breaking on the first line")
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--ignore-leaks', 'ignore global variable leaks')
@@ -184,6 +186,12 @@ if (program.timeout) suite.timeout(program.timeout);
 
 suite.bail(program.bail);
 
+// --requirejs
+
+if (program.requirejs) {
+  moduleLoader.UseRequireJs();
+}
+
 // custom compiler support
 
 var extensions = ['js'];
@@ -223,11 +231,27 @@ files = files.map(function(path){
 if (program.watch) {
   console.log();
   hideCursor();
-  process.on('SIGINT', function(){
-    showCursor();
-    console.log('\n');
-    process.exit();
-  });
+
+  if (process.platform === 'win32') {
+    var tty = require('tty');
+
+    process.stdin.resume();
+    tty.setRawMode(true);
+
+    process.stdin.on('keypress', function(char, key){
+      if (key && key.ctrl && key.name === 'c') {
+        showCursor();
+        console.log('\n');
+        process.exit();
+      }
+    });
+  } else {
+    process.on('SIGINT', function(){
+      showCursor();
+      console.log('\n');
+      process.exit();
+    });
+  }
 
   var frames = [
       '  \033[96m◜ \033[90mwatching\033[0m'
@@ -241,6 +265,7 @@ if (program.watch) {
   var watchFiles = utils.files(cwd);
 
   function loadAndRun() {
+    console.log('Re-Running');
     load(files, function(){
       run(suite, function(){
         play(frames);
@@ -257,6 +282,7 @@ if (program.watch) {
   loadAndRun();
 
   utils.watch(watchFiles, function(){
+    console.log('Recognized change');
     purge();
     stop()
     suite = suite.clone();
@@ -281,7 +307,7 @@ function load(files, fn) {
   files.forEach(function(file){
     delete require.cache[file];
     suite.emit('pre-require', global, file);
-    suite.emit('require', require(file), file);
+    suite.emit('require', moduleLoader(file), file);
     suite.emit('post-require', global, file);
     --pending || fn();
   });

--- a/lib/module-loader.js
+++ b/lib/module-loader.js
@@ -1,0 +1,41 @@
+
+/**
+ * Module dependencies
+ */
+
+var requirejs = require('requirejs');
+
+/**
+ * Expose `RequireJs FileLoad`
+ */
+
+module.exports = LoadModule;
+
+/**
+ * Setup requirejs configuration.
+ */
+
+requirejs.config({
+  baseUrl: process.cwd(),
+  nodeRequire: require
+});
+
+var useRequireJs = false;
+
+/**
+ * Load module using either Node's native require or the with the RequireJs AMD specification.
+ */
+
+function LoadModule(file){
+  return useRequireJs
+    ? requirejs(file)
+    : require(file);
+};
+
+/**
+ * Set the method of module loading to use RequireJs.
+ */
+
+module.exports.UseRequireJs = function(){
+  useRequireJs = true;
+};


### PR DESCRIPTION
This allows you to load client side scripts writing against an AMD module definition in node such as requirejs. You can see an example of such from my repo at: https://github.com/mtscout6/javascript-testing-example. You simply run the command `mocha --requirejs` and everything should work the same. I don't know how well this will work with the `--watch` option as it isn't working on windows, so I couldn't test it.
