### PR TITLE
Teamcity reporter escape sequences

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -52,7 +52,7 @@ function Teamcity(runner) {
  */
 
 function escape(str) {
-  return str.replace(/|/g, "||")
+  return str.replace(/\|/g, "||")
             .replace(/\n/g, "|n")
             .replace(/\r/g, "|r")
             .replace(/\[/g, "|[")


### PR DESCRIPTION
I am having issues with line breaks not being escaped and teamcity not picking up the message.

For the list of escape sequences see: http://confluence.jetbrains.net/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ServiceMessages
