### PR TITLE
Use ul/li elements instead of divs for better copy-and-pasting

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -55,7 +55,8 @@ function HTML(runner) {
     , failures = items[2].getElementsByTagName('em')[0]
     , duration = items[3].getElementsByTagName('em')[0]
     , canvas = stat.getElementsByTagName('canvas')[0]
-    , stack = [root]
+    , report = fragment('<ul id="report"></ul>')
+    , stack = [report]
     , progress
     , ctx
 
@@ -67,6 +68,7 @@ function HTML(runner) {
   if (!root) return error('#mocha div missing, add it to your document');
 
   root.appendChild(stat);
+  root.appendChild(report);
 
   if (progress) progress.size(40);
 
@@ -74,11 +76,11 @@ function HTML(runner) {
     if (suite.root) return;
 
     // suite
-    var el = fragment('<div class="suite"><h1>%s</h1></div>', suite.title);
+    var el = fragment('<li class="suite"><h1>%s</h1></li>', suite.title);
 
     // container
     stack[0].appendChild(el);
-    stack.unshift(document.createElement('div'));
+    stack.unshift(document.createElement('ul'));
     el.appendChild(stack[0]);
   });
 
@@ -104,11 +106,11 @@ function HTML(runner) {
 
     // test
     if ('passed' == test.state) {
-      var el = fragment('<div class="test pass %e"><h2>%e<span class="duration">%ems</span></h2></div>', test.speed, test.title, test.duration);
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span></h2></li>', test.speed, test.title, test.duration);
     } else if (test.pending) {
-      var el = fragment('<div class="test pass pending"><h2>%e</h2></div>', test.title);
+      var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
-      var el = fragment('<div class="test fail"><h2>%e</h2></div>', test.title);
+      var el = fragment('<li class="test fail"><h2>%e</h2></li>', test.title);
       var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message

--- a/mocha.css
+++ b/mocha.css
@@ -4,6 +4,15 @@ body {
   padding: 60px 50px;
 }
 
+#mocha ul, #mocha li {
+  margin: 0;
+  padding: 0;
+}
+
+#mocha ul {
+  list-style: none;
+}
+
 #mocha h1, #mocha h2 {
   margin: 0;
 }


### PR DESCRIPTION
Use ul/li elements instead of divs for better copy-and-pasting

This also adds a top-level #report ul to contain the .suite li elements.

I checked that visual styling remains unchanged, but copy-and-pasting
into plain-text from Firefox (though not from Chrome) on OS X is much
improved, so that the browser output can be more easily used for bug
reports.

---

When I paste from Firefox, this patch changes it from

```
Rank
value
nextLower
nextHigher

expected { value: 11 } to equal null

letter
singletons
Suit
value
letter
color
singletons
```

to

```
    Rank
        value
        nextLower
        nextHigher

        expected { value: 11 } to equal null

        letter
        singletons
    Suit
        value
        letter
        color
        singletons
```

This is useful especially with longer test suites. E.g. when I pasted failure output from chai-jquery at https://github.com/chaijs/chai-jquery/issues/10 , I found the lack of indentation quite disorienting.
