### PR TITLE
Add `context` for BDD

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -71,7 +71,7 @@ module.exports = function(suite){
      * and/or tests.
      */
   
-    context.describe = function(title, fn){
+    context.describe = context.context = function(title, fn){
       var suite = Suite.create(suites[0], title);
       suites.unshift(suite);
       fn();


### PR DESCRIPTION
Rspec has `context` it is alias of `describe`.

I think that the difference of word is important.

e.g

```
describe('Stack', function() {
  context('when stack is empty', function() {
    describe('Stack#size', function() {
      it('returns 0');
    });
    describe('Stack#push', function() {
      context('with string', function() {
        it('increments stack size');
      });
      context('with null', function() {
        it('throw error');
      });
    });
    describe('Stack#pop', function() {
      it('throw error');
    });
  });
});
```
