### PR TITLE
Fix leak of listeners for process

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -437,10 +437,14 @@ Runner.prototype.run = function(fn){
 
   debug('start');
 
+  var uncaught = function(err){
+    self.uncaught(err);
+  };
+
   // callback
   this.on('end', function(){
     debug('end');
-    process.removeListener('uncaughtException', this.uncaught);
+    process.removeListener('uncaughtException', uncaught);
     fn(self.failures);
   });
 
@@ -452,9 +456,7 @@ Runner.prototype.run = function(fn){
   });
 
   // uncaught exception
-  process.on('uncaughtException', function(err){
-    self.uncaught(err);
-  });
+  process.on('uncaughtException', uncaught);
 
   return this;
 };


### PR DESCRIPTION
When I run `mocha --watch` and after 11th running, the following message was
shown:

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners
added. Use emitter.setMaxListeners() to increase limit.
```

It seems that 'uncaughtException' listener is not released.
Because, the listener to be released is different from listened one.

To fix this issue, I gave the same listener to `process.on` and
`process.removeListener`.
