### PR TITLE
Allow directories to be passed to bin/mocha.

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -221,7 +221,7 @@ files = files.reduce(function (prev, current) {
       return prev.concat(current);
     }
   } catch (err) {
-    console.log('No "' + current + '" directory found.');
+    console.error('No "' + current + '" directory found.');
     process.exit(1);
   }
 }, []);
@@ -232,7 +232,7 @@ if (!files.length) {
   try {
     files = filesInDir("test");
   } catch (err) {
-    console.log('No test files specified and no "test" directory found.');
+    console.error('No test files specified and no "test" directory found.');
     process.exit(1);
   }
 }


### PR DESCRIPTION
When I started using Mocha today, I was confused by the fact that running `mocha spec` (my specs are in a folder called "spec") threw an exception right away. After digging into what it was doing, I discovered that the CLI assumes that all non-option arguments are files.

This patch updates the file list parsing and generation code in the CLI to allow both files and directories as arguments to `mocha`. It also reuses the same functionality to default to a "test" folder if no non-option arguments are supplied, just as it does now.

I also added some more user-friendly error messages when attempting to run Mocha against a non-existent directory.
