### PR TITLE
Fix grep url, when click title

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -76,7 +76,7 @@ function HTML(runner) {
     if (suite.root) return;
 
     // suite
-    var url = location.origin + location.pathname + '?grep=^' + utils.escapeRegexp(suite.fullTitle());
+    var url = location.protocol + '//' + location.host + location.pathname + '?grep=^' + utils.escapeRegexp(suite.fullTitle());
     var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, suite.title);
 
     // container


### PR DESCRIPTION
It is only webkit that has `location.origin`. Firefox, IE , Opera don't have it.

URL is set to `http://localhost:3000/test/undefined/test?grep=foo` when a title is clicked. 

`location.oring` is same as `location.protocol + '//' + location.host`. So it should use this.
