### PR TITLE
add support for MOCHA_OPTS environment variable as fallback

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -131,6 +131,20 @@ program.on('require', function(mod){
   require(mod);
 });
 
+// support for MOCHA_OPTS environment variable
+if (process.env.MOCHA_OPTS) {
+ var opts = process.env.MOCHA_OPTS
+    .trim()
+    .split(/\s+/);
+ try {
+    process.argv = process.argv
+    .slice(0, 2)
+    .concat(opts.concat(process.argv.slice(2)));
+ } catch (err) {
+   // ignore
+ }
+}
+
 // mocha.opts support
 
 try {


### PR DESCRIPTION
Is useful if you need different settings (e.g. timeouts) on different development machines.
