### PR TITLE
Change xdescribe and xit to add tests as pending

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,5 +1,10 @@
 
 /**
+ * Module dependencies.
+ */
+var EventEmitter = require('events').EventEmitter
+
+/**
  * Expose `Context`.
  */
 
@@ -12,6 +17,12 @@ module.exports = Context;
  */
 
 function Context(){}
+
+/**
+ * Inherit from `EventEmitter.prototype`.
+ */
+
+Context.prototype.__proto__ = EventEmitter.prototype;
 
 /**
  * Set the context `Runnable` to `runnable`.

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -28,28 +28,13 @@ module.exports = function(suite){
 
   suite.on('pre-require', function(context){
 
-    // noop variants
-
     context.xdescribe = function(title, fn){
-      var suite = Suite.create(suites[0], title)
-        , addTest = suite.addTest
-        , addSuite = suite.addSuite
-      suite.addTest = fakeAddTest;
-      suite.addSuite = fakeAddSuite;
+      suites[0].ctx.on('test', makeTestPending);
+      context.describe(title, fn);
+      suites[0].ctx.removeListener('test', makeTestPending);
 
-      suites.unshift(suite);
-      fn();
-      suites.shift();
-
-      function fakeAddTest(test) {
-        test.pending = true;
-        addTest.call(this, test);
-      };
-      // Turns the suite into a xdescribe suite
-      function fakeAddSuite(suite) {
-        suite.addTest = fakeAddTest;
-        suite.addSuite = fakeAddSuite;
-        addSuite.call(this, suite);
+      function makeTestPending(test) {
+          test.pending = true;
       };
     };
 

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -126,6 +126,7 @@ Suite.prototype.beforeAll = function(fn){
   hook.ctx = this.ctx;
   this._beforeAll.push(hook);
   this.emit('beforeAll', hook);
+  this.ctx && this.ctx.emit('beforeAll', hook);
   return this;
 };
 
@@ -144,6 +145,7 @@ Suite.prototype.afterAll = function(fn){
   hook.ctx = this.ctx;
   this._afterAll.push(hook);
   this.emit('afterAll', hook);
+  this.ctx && this.ctx.emit('afterAll', hook);
   return this;
 };
 
@@ -162,6 +164,7 @@ Suite.prototype.beforeEach = function(fn){
   hook.ctx = this.ctx;
   this._beforeEach.push(hook);
   this.emit('beforeEach', hook);
+  this.ctx && this.ctx.emit('beforeEach', hook);
   return this;
 };
 
@@ -180,6 +183,7 @@ Suite.prototype.afterEach = function(fn){
   hook.ctx = this.ctx;
   this._afterEach.push(hook);
   this.emit('afterEach', hook);
+  this.ctx && this.ctx.emit('afterEach', hook);
   return this;
 };
 
@@ -197,6 +201,7 @@ Suite.prototype.addSuite = function(suite){
   suite.bail(this.bail());
   this.suites.push(suite);
   this.emit('suite', suite);
+  this.ctx && this.ctx.emit('suite', suite);
   return this;
 };
 
@@ -214,6 +219,7 @@ Suite.prototype.addTest = function(test){
   test.ctx = this.ctx;
   this.tests.push(test);
   this.emit('test', test);
+  this.ctx && this.ctx.emit('test', test);
   return this;
 };
 

--- a/test/pending.js
+++ b/test/pending.js
@@ -11,6 +11,11 @@ describe('pending tests', function() {
     latestTestIsPending = false;
     oldAddTest = mocha.Suite.prototype.addTest;
     mocha.Suite.prototype.addTest = function(test) {
+      // We need to call the original addTest for the events to be fired correctly
+      oldAddTest.call(this, test);
+      // but we don't want to actually add any tests within these tests.
+      this.tests = [];
+
       allTests.push(test);
       latestTestIsPending = !!test.pending;
     };

--- a/test/runner.js
+++ b/test/runner.js
@@ -8,7 +8,7 @@ describe('Runner', function(){
   var suite, runner;
 
   beforeEach(function(){
-    suite = new Suite(null, 'root');
+    suite = new Suite('root', null);
     runner = new Runner(suite);
   })
 


### PR DESCRIPTION
It annoyed me that when disabling tests by adding `xit` or `xdescribe`, the tests were not marked as pending. This made it non-visible that code were disabled.

For `it()`, another way is to add a null-object before the function:

```
it('some test', null, function() {
  Some test-code..
});
```

But for `describe()`, there were no such convenience.

Now, `xit('title', function or null)` will be the same as `it('title')` and `xdescribe('title', function-with-its)` will be the same as `describe('title', function-where-all-its-are-xits)`.
