### PR TITLE
Allows a wildcard (%) to be specified when defining allowed globals.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -115,7 +115,7 @@ Runner.prototype.checkGlobals = function(test){
   if (this.ignoreLeaks) return;
   var leaks = utils.filter(utils.keys(global), function(key){
     var matched = utils.filter(this._globals, function(allowed){
-      return allowed == key || key.lastIndexOf(allowed.split('%')[0], 0) == 0;
+      return allowed == key || key.lastIndexOf(allowed.split('*')[0], 0) == 0;
     });
     return matched.length == 0 && (!global.navigator || 'onerror' !== key);
   }, this);

--- a/mocha.js
+++ b/mocha.js
@@ -3197,7 +3197,7 @@ Runner.prototype.checkGlobals = function(test){
   if (this.ignoreLeaks) return;
   var leaks = utils.filter(utils.keys(global), function(key){
     var matched = utils.filter(this._globals, function(allowed){
-      return allowed == key || key.lastIndexOf(allowed.split('%')[0], 0) == 0;
+      return allowed == key || key.lastIndexOf(allowed.split('*')[0], 0) == 0;
     });
     return matched.length == 0 && (!global.navigator || 'onerror' !== key);
   }, this);

--- a/test/runner.js
+++ b/test/runner.js
@@ -47,7 +47,7 @@ describe('Runner', function(){
 
   describe('.checkGlobals(test)', function(){
     it('should allow variables that match a wildcard', function(done) {
-      runner.globals(['foo%', 'giz%']);
+      runner.globals(['foo*', 'giz*']);
       foo = 'baz';
       gizmo = 'quux'
       runner.checkGlobals();


### PR DESCRIPTION
As discussed on irc, some libraries pollute the global window object when events are attached to window.  jQuery does this and creates a bunch of jQuery390203903, etc. objects.  This allows a wildcard to be added on a global flag, to ignore everything that follows.

https://github.com/visionmedia/mocha/issues/455
