### PR TITLE
Fix image paths for growl when running through JavaScript API

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -309,10 +309,11 @@ function growl(runner, reporter) {
     var stats = reporter.stats;
     if (stats.failures) {
       var msg = stats.failures + ' of ' + runner.total + ' tests failed';
-      notify(msg, { title: 'Failed', image: images.fail });
+      notify(msg, { name: 'mocha', title: 'Failed', image: images.fail });
     } else {
       notify(stats.passes + ' tests passed in ' + stats.duration + 'ms', {
-          title: 'Passed'
+          name: 'mocha'
+        , title: 'Passed'
         , image: images.pass
       });
     }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -145,10 +145,11 @@ Mocha.prototype.growl = function(runner, reporter) {
     var stats = reporter.stats;
     if (stats.failures) {
       var msg = stats.failures + ' of ' + runner.total + ' tests failed';
-      notify(msg, { title: 'Failed', image: image('error') });
+      notify(msg, { name: 'mocha', title: 'Failed', image: image('error') });
     } else {
       notify(stats.passes + ' tests passed in ' + stats.duration + 'ms', {
-          title: 'Passed'
+          name: 'mocha'
+        , title: 'Passed'
         , image: image('ok')
       });
     }


### PR DESCRIPTION
Mistakes like this could be prevented if the binaries used the same JavaScript API.
