### PR TITLE
Add "specify" synonym for "it".

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -84,7 +84,7 @@ module.exports = function(suite){
      * acting as a thunk.
      */
 
-    context.it = function(title, fn){
+    context.it = context.specify = function(title, fn){
       suites[0].addTest(new Test(title, fn));
     };
   });

--- a/test/acceptance/interfaces/bdd.js
+++ b/test/acceptance/interfaces/bdd.js
@@ -23,3 +23,13 @@ describe('Array', function(){
     })
   })
 })
+
+context('Array', function(){
+  beforeEach(function(){
+    this.arr = [1,2,3];
+  })
+
+  specify('has a length property', function(){
+    this.arr.length.should.equal(3);
+  })
+})


### PR DESCRIPTION
Ran into another use for this in my projects the other day, and thought I'd just do a PR, especially since "context" as a synonym for "describe" made it in recently.

Closes #396.

Adds tests for `context` and `specify`, as they work great together.
