### PR TITLE
mocha doesn't fire test end for 'before' test failures

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -36,7 +36,11 @@ function XUnit(runner) {
     , tests = []
     , self = this;
 
-  runner.on('test end', function(test){
+  runner.on('pass', function(test){
+    tests.push(test);
+  });
+  
+  runner.on('fail', function(test){
     tests.push(test);
   });
 


### PR DESCRIPTION
When a mocha tests bails out in the before block, it does't emit a test end event.
This causes the xunit format to not include any testcases, which breaks some (jenkins) junit xml parsing.

I'm not sure what the desired behaviour is, but I've applied this patch to our local install and find the xml now includes failure messages for the before tests.

Use case provided:

$ mocha test.js

```


  ✔ 0 tests complete (1ms)

```

$ mocha test.js --reporter xunit

``` xml
<testsuite name="Mocha Tests" tests="0" failures="0" errors="0" skip="0" timestamp="Wed, 20 Jun 2012 21:45:23 GMT" time="0">
</testsuite>
```

$ cat test.js 

``` javascript
describe("before-fails", function() {
    before(function(done) {
        // undefined function
        die("script dies");
    }); 
});
```
