### PR TITLE
fixed `js` code block format error.

### DIFF
--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -80,7 +79,7 @@ function Markdown(runner) {
   runner.on('pass', function(test){
     var code = utils.clean(test.fn.toString());
     buf += test.title + '.\n';
-    buf += '\n```js';
+    buf += '\n```js\n';
     buf += code + '\n';
     buf += '```\n\n';
   });


### PR DESCRIPTION
``````
```jsvar router = ut ...
``````

=>

``````
```js
var router = ut ...
``````
