### PR TITLE
Allow test selections to be inverted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ test-grep:
 	  --grep fast \
 	  test/acceptance/misc/grep
 
+test-invert:
+	@./bin/mocha \
+	  --reporter $(REPORTER) \
+	  --grep slow \
+	  --invert \
+	  test/acceptance/misc/grep
+
 test-bail:
 	@./bin/mocha \
 		--reporter $(REPORTER) \

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -61,6 +61,7 @@ program
   .option('-R, --reporter <name>', 'specify the reporter to use', 'dot')
   .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-i, --invert', 'inverts test selection')
   .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
   .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]', parseInt)
   .option('-w, --watch', 'watch files for changes')
@@ -310,7 +311,7 @@ function run(suite, fn) {
   var runner = new Runner(suite);
   runner.globals(globals);
   if (program.ignoreLeaks) runner.ignoreLeaks = true;
-  if (program.grep) runner.grep(new RegExp(program.grep));
+  if (program.grep) runner.grep(new RegExp(program.grep), program.invert);
   var reporter = new Reporter(runner);
   if (program.growl) growl(runner, reporter);
   runner.run(fn);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -59,13 +59,15 @@ Runner.prototype.__proto__ = EventEmitter.prototype;
  * with number of tests matched.
  *
  * @param {RegExp} re
+ * @param {Boolean} invert
  * @return {Runner} for chaining
  * @api public
  */
 
-Runner.prototype.grep = function(re){
+Runner.prototype.grep = function(re, invert){
   debug('grep %s', re);
   this._grep = re;
+  this._invert = invert;
   this.total = this.grepTotal(this.suite);
   return this;
 };
@@ -84,7 +86,9 @@ Runner.prototype.grepTotal = function(suite) {
   var total = 0;
 
   suite.eachTest(function(test){
-    if (self._grep.test(test.fullTitle())) total++;
+    var match = self._grep.test(test.fullTitle());
+    if (self._invert) match = !match;
+    if (match) total++;
   });
 
   return total;
@@ -324,7 +328,9 @@ Runner.prototype.runTests = function(suite, fn){
     if (!test) return fn();
 
     // grep
-    if (!self._grep.test(test.fullTitle())) return next();
+    var match = self._grep.test(test.fullTitle());
+    if (self._invert) match = !match;
+    if (!match) return next();
 
     // pending
     if (test.pending) {

--- a/test/grep.js
+++ b/test/grep.js
@@ -32,4 +32,11 @@ describe('Mocha', function(){
       mocha.grep().should.equal(mocha);
     })
   })
+
+  describe('"invert" option', function(){
+    it('should add a Boolean to the mocha.options object', function(){
+      var mocha = new Mocha({ invert: true });
+      mocha.options.invert.should.be.ok;
+    })
+  })
 })

--- a/test/runner.js
+++ b/test/runner.js
@@ -21,6 +21,15 @@ describe('Runner', function(){
       newRunner.grep(/lions/);
       newRunner.total.should.equal(2);
     })
+
+    it('should update the runner.total with number of matched tests when inverted', function(){
+      suite.addTest(new Test('im a test about lions'));
+      suite.addTest(new Test('im another test about lions'));
+      suite.addTest(new Test('im a test about bears'));
+      var newRunner = new Runner(suite);
+      newRunner.grep(/lions/, true);
+      newRunner.total.should.equal(1);
+    })
   })
 
   describe('.grepTotal()', function(){
@@ -30,6 +39,14 @@ describe('Runner', function(){
       suite.addTest(new Test('im a test about bears'));
       runner.grep(/lions/);
       runner.grepTotal(suite).should.equal(2);
+    })
+
+    it('should return the total number of matched tests when inverted', function(){
+      suite.addTest(new Test('im a test about lions'));
+      suite.addTest(new Test('im another test about lions'));
+      suite.addTest(new Test('im a test about bears'));
+      runner.grep(/lions/, true);
+      runner.grepTotal(suite).should.equal(1);
     })
   })
 


### PR DESCRIPTION
This allows an easy way to ignore a subset of tests, such as:

`mocha --grep slow --invert  # Ignore all tests tagged with "slow"`
