### PR TITLE
LCOV reporter

### DIFF
--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -15,3 +15,4 @@ exports.HTMLCov = require('./html-cov');
 exports.JSONStream = require('./json-stream');
 exports.XUnit = require('./xunit')
 exports.Teamcity = require('./teamcity')
+exports.LCov = require('./lcov');

--- a/lib/reporters/lcov.js
+++ b/lib/reporters/lcov.js
@@ -46,4 +46,6 @@ function reportFile(filename, data) {
       process.stdout.write('DA:' + num + ',' + data[num] + '\n');
     }
   });
+
+  process.stdout.write('end_of_record\n');
 }


### PR DESCRIPTION
I have written a LCOV reporter. I am currently using this in conjunction with SonarSource [http://www.sonarsource.org/] and the Sonar Javascript plugin [http://docs.codehaus.org/display/SONAR/JavaScript+Plugin].

The LCOV file format can be found here at [http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php]. The LCOV reporter only uses a partial part of the LCOV format. This is due to the fact that the Sonar Javascript plugin does not use any other parts of the LCOV file format.

Please comment on this, and if found ok, possibly integrate.
