### PR TITLE
Spurious 'undefined' output with log4js-node

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -265,7 +265,7 @@ Base.prototype.epilogue = function(){
     , fmt
     , tests;
 
-  console.log();
+  console.log('');
 
   function pluralize(n) {
     return 1 == n ? 'test' : 'tests';
@@ -305,7 +305,7 @@ Base.prototype.epilogue = function(){
     console.log(fmt, stats.pending, pluralize(stats.pending));
   }
 
-  console.log();
+  console.log('');
 };
 
 /**

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -50,7 +50,7 @@ function Dot(runner) {
   });
 
   runner.on('end', function(){
-    console.log();
+    console.log('');
     self.epilogue();
   });
 }

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -85,7 +85,7 @@ function Landing(runner) {
 
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    console.log('');
     self.epilogue();
   });
 }

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -28,7 +28,7 @@ function List(runner) {
     , n = 0;
 
   runner.on('start', function(){
-    console.log();
+    console.log('');
   });
 
   runner.on('test', function(test){

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -47,7 +47,7 @@ function Progress(runner, options) {
 
   // tests started
   runner.on('start', function(){
-    console.log();
+    console.log('');
     cursor.hide();
   });
 
@@ -74,7 +74,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    console.log('');
     self.epilogue();
   });
 }

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -33,7 +33,7 @@ function Spec(runner) {
   }
 
   runner.on('start', function(){
-    console.log();
+    console.log('');
   });
 
   runner.on('suite', function(suite){
@@ -43,7 +43,7 @@ function Spec(runner) {
 
   runner.on('suite end', function(suite){
     --indents;
-    if (1 == indents) console.log();
+    if (1 == indents) console.log('');
   });
 
   runner.on('test', function(test){

--- a/mocha.js
+++ b/mocha.js
@@ -1311,7 +1311,7 @@ Base.prototype.epilogue = function(){
     , fmt
     , tests;
 
-  console.log();
+  console.log('');
 
   function pluralize(n) {
     return 1 == n ? 'test' : 'tests';
@@ -1351,7 +1351,7 @@ Base.prototype.epilogue = function(){
     console.log(fmt, stats.pending, pluralize(stats.pending));
   }
 
-  console.log();
+  console.log('');
 };
 
 /**
@@ -1515,7 +1515,7 @@ function Dot(runner) {
   });
 
   runner.on('end', function(){
-    console.log();
+    console.log('');
     self.epilogue();
   });
 }
@@ -2189,7 +2189,7 @@ function Landing(runner) {
 
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    console.log('');
     self.epilogue();
   });
 }
@@ -2234,7 +2234,7 @@ function List(runner) {
     , n = 0;
 
   runner.on('start', function(){
-    console.log();
+    console.log('');
   });
 
   runner.on('test', function(test){
@@ -2726,7 +2726,7 @@ function Progress(runner, options) {
 
   // tests started
   runner.on('start', function(){
-    console.log();
+    console.log('');
     cursor.hide();
   });
 
@@ -2753,7 +2753,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    console.log('');
     self.epilogue();
   });
 }
@@ -2804,7 +2804,7 @@ function Spec(runner) {
   }
 
   runner.on('start', function(){
-    console.log();
+    console.log('');
   });
 
   runner.on('suite', function(suite){
@@ -2814,7 +2814,7 @@ function Spec(runner) {
 
   runner.on('suite end', function(suite){
     --indents;
-    if (1 == indents) console.log();
+    if (1 == indents) console.log('');
   });
 
   runner.on('test', function(test){


### PR DESCRIPTION
When used with git://github.com/nomiddlename/log4js-node.git, mocha's use of console.log() to generate a blank line causes 'undefined' to be output instead.

So have replaced console.log() with console.log(''), as the easiest option.
