### PR TITLE
Empty mocha.opts no longer searches for a .js file

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -152,9 +152,8 @@ program.on('require', function(mod){
 // mocha.opts support
 
 try {
-  var opts = fs.readFileSync('test/mocha.opts', 'utf8')
-    .trim()
-    .split(/\s+/);
+  var opts = fs.readFileSync('test/mocha.opts', 'utf8').trim();
+  opts = (opts.length === 0) ? [] : opts.split(/\s+/);
 
   process.argv = process.argv
     .slice(0, 2)


### PR DESCRIPTION
`"".split(/\s+/)` returns `[ '' ]`. By default, mocha searches in the `test/`
directory if the array is empty, but since the previous sentence was
happening, the array was not empty and it searched for a file called
`'.js'`. Fixes #477
