### PR TITLE
Add Mocha backwards compatibility with 0.4.12

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -56,7 +56,7 @@ var images = {
 // options
 
 program
-  .version(require('../package').version)
+  .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage('[debug] [options] [files]')
   .option('-r, --require <name>', 'require the given module')
   .option('-R, --reporter <name>', 'specify the reporter to use', 'dot')


### PR DESCRIPTION
Address issue visionmedia/mocha#489 by using JSON parsing and a file read instead of the `require` method to acquire the current version of the Mocha module.
