### PR TITLE
Fixes error when clicking pending test in html report

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -134,17 +134,16 @@ function HTML(runner) {
     }
 
     // toggle code
-    var h2 = el.getElementsByTagName('h2')[0];
-
-    on(h2, 'click', function(){
-      pre.style.display = 'none' == pre.style.display
-        ? 'inline-block'
-        : 'none';
-    });
-
-    // code
     // TODO: defer
     if (!test.pending) {
+      var h2 = el.getElementsByTagName('h2')[0];
+
+      on(h2, 'click', function(){
+        pre.style.display = 'none' == pre.style.display
+          ? 'inline-block'
+          : 'none';
+      });
+
       var pre = fragment('<pre><code>%e</code></pre>', utils.clean(test.fn.toString()));
       el.appendChild(pre);
       pre.style.display = 'none';


### PR DESCRIPTION
'Cause `pre` doesn't exist for pending tests
