### PR TITLE
Output difference between two objects by their stringified versions

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -146,8 +146,8 @@ exports.list = function(failures){
       , stack = err.stack || message
       , index = stack.indexOf(message) + message.length
       , msg = stack.slice(0, index)
-      , actual = err.actual
-      , expected = err.expected;
+      , actual = stringify(err.actual)
+      , expected = stringify(err.expected);
 
     // actual / expected diff
     if ('string' == typeof actual && 'string' == typeof expected) {
@@ -188,6 +188,28 @@ exports.list = function(failures){
     console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
   });
 };
+
+function stringify(object) {
+  if (typeof object != 'object')
+    return JSON.stringify(object);
+
+  if (Array.isArray(object))
+    return '[' +
+           object.map(function(item) {
+             return stringify(item);
+           }).join(', ') +
+           ']';
+
+  if (!object)
+    return JSON.stringify(object);
+
+  var sorted = {};
+  Object.keys(object).sort().forEach(function(key) {
+    if (object.hasOwnProperty(key))
+      sorted[key] = object[key];
+  });
+  return JSON.stringify(sorted);
+}
 
 /**
  * Initialize a new `Base` reporter.
@@ -331,7 +353,9 @@ function pad(str, len) {
  */
 
 function errorDiff(err, type) {
-  return diff['diff' + type](err.actual, err.expected).map(function(str){
+  var actual = stringify(err.actual);
+  var expected = stringify(err.expected);
+  return diff['diff' + type](actual, expected).map(function(str){
     if (/^(\n+)$/.test(str.value)) str.value = Array(++RegExp.$1.length).join('<newline>');
     if (str.added) return colorLines('diff added', str.value);
     if (str.removed) return colorLines('diff removed', str.value);


### PR DESCRIPTION
When I compare two objects (hashes) for the expected and the actual, then no diff is shown. It is hard to debug if expected and actual values are very large hashes.

For example, with "chai",

```
assert.deepEqual({ key1: 'value1',
                   key2: 'value2',
                   key3: 'value2', // different from below
                   key4: 'value4',
                   key5: 'value5' },
                 { key1: 'value1',
                   key2: 'value2',
                   key3: 'value3',
                   key4: 'value4',
                   key5: 'value5' });
```

Mocha reports an report for the assertion failure like:

<pre>
  1) test:
     expected { key1: 'value1',
  key2: 'value2',
  key3: 'value2',
  key4: 'value4',
  key5: 'value5' } to deeply equal { key1: 'value1',
  key2: 'value2',
  key3: 'value3',
  key4: 'value4',
  key5: 'value5' }
</pre>


With these patches, Mocha reports the assertion failure like:

![screenshot of colored diff](https://raw.github.com/gist/1357549/9ce0090637871de5fdde0e8d463332c56f4eabfd/deep-equal-with-diff.png)

It is very helpful for debugging.
