### PR TITLE
Add -o --opts options support

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -55,7 +55,7 @@ var images = {
 // options
 
 program
-  .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
+  .version(require(__dirname + '/../package.json').version)
   .usage('[debug] [options] [files]')
   .option('-r, --require <name>', 'require the given module')
   .option('-R, --reporter <name>', 'specify the reporter to use', 'dot')
@@ -70,13 +70,14 @@ program
   .option('-G, --growl', 'enable growl notification support')
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
   .option('-b, --bail', "bail after first test failure")
+  .option('-o, --opts <mocha.opts>', "specify mocha options file")
   .option('--recursive', 'include sub directories')
   .option('--debug-brk', "enable node's debugger breaking on the first line")
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--ignore-leaks', 'ignore global variable leaks')
   .option('--interfaces', 'display available interfaces')
   .option('--reporters', 'display available reporters')
-  .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
+  .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, []);
 
 program.name = 'mocha';
 
@@ -150,9 +151,10 @@ program.on('require', function(mod){
 });
 
 // mocha.opts support
-
+program.parse(process.argv);
 try {
-  var opts = fs.readFileSync('test/mocha.opts', 'utf8')
+  var optsPath = program.opts || 'test/mocha.opts';
+  var opts = fs.readFileSync(optsPath, 'utf8')
     .trim()
     .split(/\s+/);
 


### PR DESCRIPTION
Sometimes we put testcases at `test` folder, but sometimes we put testcases at `unittest` folder. The mocha default support `test/mocha.opts` file, Add this patch, we can execute it like `mocha -o unittest/mocha.opts`.
