### PR TITLE
Make Mocha runnable in an iframe

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -42,13 +42,12 @@ var statsTemplate = '<ul id="stats">'
  * @api public
  */
 
-function HTML(runner) {
+function HTML(runner, root) {
   Base.call(this, runner);
 
   var self = this
     , stats = this.stats
     , total = runner.total
-    , root = document.getElementById('mocha')
     , stat = fragment(statsTemplate)
     , items = stat.getElementsByTagName('li')
     , passes = items[1].getElementsByTagName('em')[0]
@@ -61,6 +60,8 @@ function HTML(runner) {
     , stack = [report]
     , progress
     , ctx
+
+  root = root || document.getElementById('mocha');
 
   if (canvas.getContext) {
     var ratio = window.devicePixelRatio || 1;
@@ -97,7 +98,7 @@ function HTML(runner) {
 
     // suite
     var grep = '^' + encodeURIComponent(utils.escapeRegexp(suite.fullTitle()));
-    var url = location.protocol + '//' + location.host + location.pathname + '?grep=' + grep;
+    var url = '?grep=' + grep;
     var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, escape(suite.title));
 
     // container


### PR DESCRIPTION
For Konacha, we'd love to be able to run Mocha inside an iframe, and
have the report rendered in the top-level frame. Here is an
illustration:

http://i.imgur.com/qD8em.png

I actually have this working in my Konacha working copy, and it's really
cool and useful, but it needs just a little help from Mocha's side to
work. This commit makes two small changes:
- Make the root element for the HTML reporter parameterizable. (The
  default is still #mocha.)
- Do not repeat the current path in the ?grep URLs. It's redundant, and
  it messes up the path with an iframe setup like we're trying to do.

There are no functional changes on Mocha's end.

---

Please merge this? It'd be super-awesome!
