### PR TITLE
Handle require Failures otherwise crashing mocha

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -128,17 +128,17 @@ Mocha.prototype.loadFiles = function(fn){
     // here we divert such crashes into an imaginary test that fails
     // mocha presents this as any other failure
     var module = {}
-    var exception
     try {
       module = require(file)
     } catch (e) {
-      exception = e
       // create a failing test
-      it('LoadFailed', loadFailed)
+      it('LoadFailed', getFunc(e))
 
-      function loadFailed() {
-        // it's a cruel world
-        throw exception
+      function getFunc(exception) {
+        return function loadFailed() {
+          // it's a cruel world
+          throw exception
+        }
       }
     }
 


### PR DESCRIPTION
On launch, when mocha loads the test files, the whole process crashes if there is a syntax error in any of the files

Here we prevent that by wrapping require in a try-catch. If the require throws an exception, a fake test called LoadFail is created that throws the exception at a later time when mocha can handle it.

Such failure are then presented as any other test failures

AWESOMENESS!

This is the fix for #547
