### PR TITLE
`mocha.reporter()` should accept a constructor

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -82,16 +82,20 @@ Mocha.prototype.addFile = function(file){
 };
 
 /**
- * Set reporter to `name`, defaults to "dot".
+ * Set reporter to `reporter`, defaults to "dot".
  *
- * @param {String} name
+ * @param {String|Function} reporter name of a reporter or a reporter constructor
  * @api public
  */
 
-Mocha.prototype.reporter = function(name){
-  name = name || 'dot';
-  this._reporter = require('./reporters/' + name);
-  if (!this._reporter) throw new Error('invalid reporter "' + name + '"');
+Mocha.prototype.reporter = function(reporter){
+  if ('function' == typeof reporter) {
+    this._reporter = reporter;
+  } else {
+    reporter = reporter || 'dot';
+    this._reporter = require('./reporters/' + reporter);
+    if (!this._reporter) throw new Error('invalid reporter "' + reporter + '"');
+  }
   return this;
 };
 


### PR DESCRIPTION
In addition to the name of a reporter, `mocha.reporter()` should alternatively accept a reporter constructor directly, so that I can [do this](https://github.com/jfirebaugh/konacha/blob/remove_konacha_config_support/lib/assets/javascripts/konacha/runner.js#L9).
