### PR TITLE
Fixes #541: Load third-party reporters

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -94,7 +94,11 @@ Mocha.prototype.reporter = function(reporter){
     this._reporter = reporter;
   } else {
     reporter = reporter || 'dot';
-    this._reporter = require('./reporters/' + reporter);
+    try {
+      this._reporter = require('./reporters/' + reporter);
+    } catch (err) {
+      this._reporter = require(reporter);
+    }
     if (!this._reporter) throw new Error('invalid reporter "' + reporter + '"');
   }
   return this;


### PR DESCRIPTION
Mocha was only attempting to load bundled reporters. This change attempts to load any third-party module as a reporter if a bundled reporter of the given name was not found.
