### PR TITLE
Do not collapse on empty test or suite titles

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -102,7 +102,8 @@ function HTML(runner, root) {
 
     // suite
     var url = '?grep=' + encodeURIComponent(suite.fullTitle());
-    var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, escape(suite.title));
+    var title = suite.title.trim() || '\xA0'; // &nbsp;
+    var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, escape(title));
 
     // container
     stack[0].appendChild(el);
@@ -133,12 +134,13 @@ function HTML(runner, root) {
     text(duration, (ms / 1000).toFixed(2));
 
     // test
+    var title = test.title.trim() || '\xA0'; // &nbsp;
     if ('passed' == test.state) {
-      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, title, test.duration, encodeURIComponent(test.fullTitle()));
     } else if (test.pending) {
-      var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
+      var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', title);
     } else {
-      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', title, encodeURIComponent(test.fullTitle()));
       var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -56,7 +56,7 @@ function Suite(title, ctx) {
   this._beforeAll = [];
   this._afterEach = [];
   this._afterAll = [];
-  this.root = !title;
+  this.root = (title == null);
   this._timeout = 2000;
   this._slow = 75;
   this._bail = false;


### PR DESCRIPTION
Empty suite titles used to not be indented at all, because they were
treated like the root suite. This patch also causes suite.root to be
only true if the title is null or undefined, not if the title is ''.
