### PR TITLE
relay signals from the "_mocha" process to the main "mocha" bin

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -34,4 +34,12 @@ process.argv.slice(2).forEach(function (arg) {
 });
 
 var proc = spawn(process.argv[0], args, { customFds: [0,1,2] });
-proc.on('exit', process.exit);
+proc.on('exit', function (code, signal) {
+  process.on('exit', function () {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code);
+    }
+  });
+});


### PR DESCRIPTION
This makes is so that if your test case cases node to crash with a SIGSEGV
or SIGBUS for example, than "mocha" will have a proper exit code (instead of 0).
