### PR TITLE
Helpful exception for missing ext:module

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -244,7 +244,11 @@ program.compilers.forEach(function(c) {
     , ext = compiler[0]
     , mod = compiler[1];
 
-  if (mod[0] == '.') mod = join(process.cwd(), mod);
+  try {
+    if (mod[0] == '.') mod = join(process.cwd(), mod);
+  } catch (err) {
+    throw new Error('"--compilers <ext>:<module>,..." argument missing');
+  }
   require(mod);
   extensions.push(ext);
 });


### PR DESCRIPTION
It'd be nice to go away with the below message to something that was more explicit:

[tw-mbp13-jsmith mocha (master)]$ ./bin/mocha --compilers epicwin

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
TypeError: Cannot read property '0' of undefined
    at /Users/jsmith/Documents/mocha/bin/_mocha:247:10
    at Array.forEach (native)
    at Object.<anonymous> (/Users/jsmith/Documents/mocha/bin/_mocha:242:19)
    at Module._compile (module.js:441:26)
    at Object..js (module.js:459:10)
    at Module.load (module.js:348:31)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:479:10)
    at EventEmitter._tickCallback (node.js:192:40)
