### PR TITLE
Some more node options passing - --gc-global

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -22,6 +22,9 @@ process.argv.slice(2).forEach(function (arg) {
     case '--expose-gc':
       args.unshift('--expose-gc');
       break;
+    case '--gc-global':
+      args.unshift('--gc-global');
+      break;
     case '--harmony-proxies':
     case '--harmony-collections':
       args.unshift(arg);


### PR DESCRIPTION
I'm making some tests for memory leaks against my project. gc-global is needed for a more predictable gc.
