### PR TITLE
package: keep the patch version of deps loose

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   , "dependencies":{
       "commander": "0.6.x"
     , "growl": "1.5.x"
-    , "jade": "0.26.x"
+    , "jade": "0.27.x"
     , "diff": "1.0.x"
     , "debug": "*"
     , "mkdirp": "0.3.x"


### PR DESCRIPTION
This will prevent duplicate copies of `mkdirp`
(and possibly others) from being installed at the same time:

```
├─┬ mocha@1.4.2
│ ├── commander@0.6.1
│ ├── debug@0.7.0
│ ├── diff@1.0.2
│ ├── growl@1.5.1
│ ├─┬ jade@0.26.3
│ │ └── mkdirp@0.3.0
│ └── mkdirp@0.3.3
```

turns to:

```
├─┬ mocha@1.5.0
│ ├── commander@0.6.1
│ ├── debug@0.7.0
│ ├── diff@1.0.3
│ ├── growl@1.5.1
│ ├── jade@0.27.5
│ ├── mkdirp@0.3.4
│ └── ms@0.3.0
```
