### PR TITLE
Support 'border-radius'

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ h1 {
   opacity: 0;
   -webkit-border-radius: 100px;
   -moz-border-radius: 100px;
+  border-radius: 100px;
   -webkit-transition: opacity 1s, background-color 200ms;
   -moz-transition: opacity 1s, background-color 200ms;
 }


### PR DESCRIPTION
Currently `-moz-border-radius` is **unsupported** by Firefox(>= 12.0).

> In Gecko 2.0 `-moz-border-radius` was renamed to `border-radius; -moz-border-radius` was supported as an alias until Gecko 12.0.

ref: https://developer.mozilla.org/en-US/docs/CSS/border-radius#Gecko_notes
