### PR TITLE
Runner no longer mutates Suite tests Array

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -321,7 +321,7 @@ Runner.prototype.runTest = function(fn){
 
 Runner.prototype.runTests = function(suite, fn){
   var self = this
-    , tests = suite.tests
+    , tests = suite.tests.slice()
     , test;
 
   function next(err) {


### PR DESCRIPTION
Previously, any given Runner/Suite pair could only be run once; afterwards, the suite was empty.

Now, Runner/Suite pairs can be reused indefinitely.
