### PR TITLE
Properly Escape Suite and Test Titles for Doc

### DIFF
--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -36,7 +36,7 @@ function Doc(runner) {
     ++indents;
     console.log('%s<section class="suite">', indent());
     ++indents;
-    console.log('%s<h1>%s</h1>', indent(), suite.title);
+    console.log('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
     console.log('%s<dl>', indent());
   });
 
@@ -49,7 +49,7 @@ function Doc(runner) {
   });
 
   runner.on('pass', function(test){
-    console.log('%s  <dt>%s</dt>', indent(), test.title);
+    console.log('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
     var code = utils.escape(utils.clean(test.fn.toString()));
     console.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });


### PR DESCRIPTION
The attached fixes the following bug:
## Repro
1. Name a suite something with HTML tags `describe('Something like <b>', function () { ... });`
2. Add a test with HTML in the title `it('has a <b> element');`
3. Run doc reporter
## Expected

Output is escaped and `<b>` tags turn into `&lt;b&gt;`
## Actual

Output is not escaped and tag affects the output HTML.
