### PR TITLE
Add max-height to error boxes

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -135,6 +135,7 @@ body {
 #mocha .test pre.error {
   color: #c00;
   max-height: 300px;
+  overflow: auto;
 }
 
 #mocha .test pre {


### PR DESCRIPTION
Error boxes when comparing the value of objects can be very long, this change adds a max-height of 300px and overflow: auto; to allow them to scroll.
