### PR TITLE
Update growl dependency to 1.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   }
   , "dependencies":{
       "commander": "0.6.1"
-    , "growl": "1.5.x"
+    , "growl": "1.6.x"
     , "jade": "0.26.3"
     , "diff": "1.0.2"
     , "debug": "*"


### PR DESCRIPTION
Update the growl dependency to 1.6.x - without this change mocha would not update.

I am using growl 2.0
