### PR TITLE
Remove output from tested code

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -106,36 +106,36 @@ program.on('globals', function(val){
 // --reporters
 
 program.on('reporters', function(){
-  console.log();
-  console.log('    dot - dot matrix');
-  console.log('    doc - html documentation');
-  console.log('    spec - hierarchical spec list');
-  console.log('    json - single json object');
-  console.log('    progress - progress bar');
-  console.log('    list - spec-style listing');
-  console.log('    tap - test-anything-protocol');
-  console.log('    landing - unicode landing strip');
-  console.log('    xunit - xunit reportert');
-  console.log('    teamcity - teamcity ci support');
-  console.log('    html-cov - HTML test coverage');
-  console.log('    json-cov - JSON test coverage');
-  console.log('    min - minimal reporter (great with --watch)');
-  console.log('    json-stream - newline delimited json events');
-  console.log('    markdown - markdown documentation (github flavour)');
-  console.log('    nyan - nyan cat!');
-  console.log();
+  mconsole.log();
+  mconsole.log('    dot - dot matrix');
+  mconsole.log('    doc - html documentation');
+  mconsole.log('    spec - hierarchical spec list');
+  mconsole.log('    json - single json object');
+  mconsole.log('    progress - progress bar');
+  mconsole.log('    list - spec-style listing');
+  mconsole.log('    tap - test-anything-protocol');
+  mconsole.log('    landing - unicode landing strip');
+  mconsole.log('    xunit - xunit reportert');
+  mconsole.log('    teamcity - teamcity ci support');
+  mconsole.log('    html-cov - HTML test coverage');
+  mconsole.log('    json-cov - JSON test coverage');
+  mconsole.log('    min - minimal reporter (great with --watch)');
+  mconsole.log('    json-stream - newline delimited json events');
+  mconsole.log('    markdown - markdown documentation (github flavour)');
+  mconsole.log('    nyan - nyan cat!');
+  mconsole.log();
   process.exit();
 });
 
 // --interfaces
 
 program.on('interfaces', function(){
-  console.log('');
-  console.log('    bdd');
-  console.log('    tdd');
-  console.log('    qunit');
-  console.log('    exports');
-  console.log('');
+  mconsole.log('');
+  mconsole.log('    bdd');
+  mconsole.log('    tdd');
+  mconsole.log('    qunit');
+  mconsole.log('    exports');
+  mconsole.log('');
   process.exit();
 });
 
@@ -273,11 +273,11 @@ files = files.map(function(path){
 // --watch
 
 if (program.watch) {
-  console.log();
+  mconsole.log();
   hideCursor();
   process.on('SIGINT', function(){
     showCursor();
-    console.log('\n');
+    mconsole.log('\n');
     process.exit();
   });
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+mconsole = {};
+mconsole.log = console.log;
+mconsole.warn = console.warn;
+mconsole.error = console.error;
+mconsole.trace = console.trace;
+global.mconsole = mconsole;
+if (process.env.NOLOG) {
+    console.log = console.warn = console.error = console.trace = function() {};
+}
 
 module.exports = process.env.COV
   ? require('./lib-cov/mocha')

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -127,7 +127,7 @@ exports.cursor = {
  */
 
 exports.list = function(failures){
-  console.error();
+  mconsole.error();
   failures.forEach(function(test, i){
     // format
     var fmt = color('error title', '  %s) %s:\n')
@@ -187,7 +187,7 @@ exports.list = function(failures){
     stack = stack.slice(index ? index + 1 : index)
       .replace(/^/gm, '  ');
 
-    console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
+    mconsole.error(fmt, (i + 1), test.fullTitle(), msg, stack);
   });
 };
 
@@ -269,7 +269,7 @@ Base.prototype.epilogue = function(){
     , fmt
     , tests;
 
-  console.log();
+  mconsole.log();
 
   function pluralize(n) {
     return 1 == n ? 'test' : 'tests';
@@ -281,13 +281,13 @@ Base.prototype.epilogue = function(){
       + color('fail', ' %d of %d %s failed')
       + color('light', ':')
 
-    console.error(fmt,
+    mconsole.error(fmt,
       stats.failures,
       this.runner.total,
       pluralize(this.runner.total));
 
     Base.list(this.failures);
-    console.error();
+    mconsole.error();
     return;
   }
 
@@ -296,7 +296,7 @@ Base.prototype.epilogue = function(){
     + color('green', ' %d %s complete')
     + color('light', ' (%s)');
 
-  console.log(fmt,
+  mconsole.log(fmt,
     stats.tests || 0,
     pluralize(stats.tests),
     ms(stats.duration));
@@ -306,10 +306,10 @@ Base.prototype.epilogue = function(){
     fmt = color('pending', '  •')
       + color('pending', ' %d %s pending');
 
-    console.log(fmt, stats.pending, pluralize(stats.pending));
+    mconsole.log(fmt, stats.pending, pluralize(stats.pending));
   }
 
-  console.log();
+  mconsole.log();
 };
 
 /**

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -34,23 +34,23 @@ function Doc(runner) {
   runner.on('suite', function(suite){
     if (suite.root) return;
     ++indents;
-    console.log('%s<section class="suite">', indent());
+    mconsole.log('%s<section class="suite">', indent());
     ++indents;
-    console.log('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
-    console.log('%s<dl>', indent());
+    mconsole.log('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
+    mconsole.log('%s<dl>', indent());
   });
 
   runner.on('suite end', function(suite){
     if (suite.root) return;
-    console.log('%s</dl>', indent());
+    mconsole.log('%s</dl>', indent());
     --indents;
-    console.log('%s</section>', indent());
+    mconsole.log('%s</section>', indent());
     --indents;
   });
 
   runner.on('pass', function(test){
-    console.log('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
+    mconsole.log('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
     var code = utils.escape(utils.clean(test.fn.toString()));
-    console.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
+    mconsole.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 }

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -51,7 +51,7 @@ function Dot(runner) {
   });
 
   runner.on('end', function(){
-    console.log();
+    mconsole.log();
     self.epilogue();
   });
 }

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -27,15 +27,15 @@ function List(runner) {
     , total = runner.total;
 
   runner.on('start', function(){
-    console.log(JSON.stringify(['start', { total: total }]));
+    mconsole.log(JSON.stringify(['start', { total: total }]));
   });
 
   runner.on('pass', function(test){
-    console.log(JSON.stringify(['pass', clean(test)]));
+    mconsole.log(JSON.stringify(['pass', clean(test)]));
   });
 
   runner.on('fail', function(test, err){
-    console.log(JSON.stringify(['fail', clean(test)]));
+    mconsole.log(JSON.stringify(['fail', clean(test)]));
   });
 
   runner.on('end', function(){

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -85,7 +85,7 @@ function Landing(runner) {
 
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    mconsole.log();
     self.epilogue();
   });
 }

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -28,7 +28,7 @@ function List(runner) {
     , n = 0;
 
   runner.on('start', function(){
-    console.log();
+    mconsole.log();
   });
 
   runner.on('test', function(test){
@@ -38,7 +38,7 @@ function List(runner) {
   runner.on('pending', function(test){
     var fmt = color('checkmark', '  -')
       + color('pending', ' %s');
-    console.log(fmt, test.fullTitle());
+    mconsole.log(fmt, test.fullTitle());
   });
 
   runner.on('pass', function(test){
@@ -46,12 +46,12 @@ function List(runner) {
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
     cursor.CR();
-    console.log(fmt, test.fullTitle(), test.duration);
+    mconsole.log(fmt, test.fullTitle(), test.duration);
   });
 
   runner.on('fail', function(test, err){
     cursor.CR();
-    console.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    mconsole.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.on('end', self.epilogue.bind(self));

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -47,7 +47,7 @@ function Progress(runner, options) {
 
   // tests started
   runner.on('start', function(){
-    console.log();
+    mconsole.log();
     cursor.hide();
   });
 
@@ -74,7 +74,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    mconsole.log();
     self.epilogue();
   });
 }

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -33,17 +33,17 @@ function Spec(runner) {
   }
 
   runner.on('start', function(){
-    console.log();
+    mconsole.log();
   });
 
   runner.on('suite', function(suite){
     ++indents;
-    console.log(color('suite', '%s%s'), indent(), suite.title);
+    mconsole.log(color('suite', '%s%s'), indent(), suite.title);
   });
 
   runner.on('suite end', function(suite){
     --indents;
-    if (1 == indents) console.log();
+    if (1 == indents) mconsole.log();
   });
 
   runner.on('test', function(test){
@@ -52,7 +52,7 @@ function Spec(runner) {
 
   runner.on('pending', function(test){
     var fmt = indent() + color('pending', '  - %s');
-    console.log(fmt, test.title);
+    mconsole.log(fmt, test.title);
   });
 
   runner.on('pass', function(test){
@@ -61,20 +61,20 @@ function Spec(runner) {
         + color('checkmark', '  ✓')
         + color('pass', ' %s ');
       cursor.CR();
-      console.log(fmt, test.title);
+      mconsole.log(fmt, test.title);
     } else {
       var fmt = indent()
         + color('checkmark', '  ✓')
         + color('pass', ' %s ')
         + color(test.speed, '(%dms)');
       cursor.CR();
-      console.log(fmt, test.title, test.duration);
+      mconsole.log(fmt, test.title, test.duration);
     }
   });
 
   runner.on('fail', function(test, err){
     cursor.CR();
-    console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    mconsole.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.on('end', self.epilogue.bind(self));

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -29,7 +29,7 @@ function TAP(runner) {
 
   runner.on('start', function(){
     var total = runner.grepTotal(runner.suite);
-    console.log('%d..%d', 1, total);
+    mconsole.log('%d..%d', 1, total);
   });
 
   runner.on('test end', function(){
@@ -37,16 +37,16 @@ function TAP(runner) {
   });
 
   runner.on('pending', function(test){
-    console.log('ok %d %s # SKIP -', n, title(test));
+    mconsole.log('ok %d %s # SKIP -', n, title(test));
   });
 
   runner.on('pass', function(test){
-    console.log('ok %d %s', n, title(test));
+    mconsole.log('ok %d %s', n, title(test));
   });
 
   runner.on('fail', function(test, err){
-    console.log('not ok %d %s', n, title(test));
-    console.log(err.stack.replace(/^/gm, '  '));
+    mconsole.log('not ok %d %s', n, title(test));
+    mconsole.log(err.stack.replace(/^/gm, '  '));
   });
 }
 

--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -23,27 +23,27 @@ function Teamcity(runner) {
   var stats = this.stats;
 
   runner.on('start', function() {
-    console.log("##teamcity[testSuiteStarted name='mocha.suite']");
+    mconsole.log("##teamcity[testSuiteStarted name='mocha.suite']");
   });
 
   runner.on('test', function(test) {
-    console.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "']");
+    mconsole.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "']");
   });
 
   runner.on('fail', function(test, err) {
-    console.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "' message='" + escape(err.message) + "']");
+    mconsole.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "' message='" + escape(err.message) + "']");
   });
 
   runner.on('pending', function(test) {
-    console.log("##teamcity[testIgnored name='" + escape(test.fullTitle()) + "' message='pending']");
+    mconsole.log("##teamcity[testIgnored name='" + escape(test.fullTitle()) + "' message='pending']");
   });
 
   runner.on('test end', function(test) {
-    console.log("##teamcity[testFinished name='" + escape(test.fullTitle()) + "' duration='" + test.duration + "']");
+    mconsole.log("##teamcity[testFinished name='" + escape(test.fullTitle()) + "' duration='" + test.duration + "']");
   });
 
   runner.on('end', function() {
-    console.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
+    mconsole.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
   });
 }
 

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -45,7 +45,7 @@ function XUnit(runner) {
   });
 
   runner.on('end', function(){
-    console.log(tag('testsuite', {
+    mconsole.log(tag('testsuite', {
         name: 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
@@ -56,7 +56,7 @@ function XUnit(runner) {
     }, false));
 
     tests.forEach(test);
-    console.log('</testsuite>');    
+    mconsole.log('</testsuite>');
   });
 }
 
@@ -80,11 +80,11 @@ function test(test) {
   if ('failed' == test.state) {
     var err = test.err;
     attrs.message = escape(err.message);
-    console.log(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
+    mconsole.log(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
   } else if (test.pending) {
-    console.log(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    mconsole.log(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    console.log(tag('testcase', attrs, true) );
+    mconsole.log(tag('testcase', attrs, true) );
   }
 }
 

--- a/mocha.js
+++ b/mocha.js
@@ -1448,7 +1448,7 @@ exports.cursor = {
  */
 
 exports.list = function(failures){
-  console.error();
+  mconsole.error();
   failures.forEach(function(test, i){
     // format
     var fmt = color('error title', '  %s) %s:\n')
@@ -1508,7 +1508,7 @@ exports.list = function(failures){
     stack = stack.slice(index ? index + 1 : index)
       .replace(/^/gm, '  ');
 
-    console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
+    mconsole.error(fmt, (i + 1), test.fullTitle(), msg, stack);
   });
 };
 
@@ -1590,7 +1590,7 @@ Base.prototype.epilogue = function(){
     , fmt
     , tests;
 
-  console.log();
+  mconsole.log();
 
   function pluralize(n) {
     return 1 == n ? 'test' : 'tests';
@@ -1602,13 +1602,13 @@ Base.prototype.epilogue = function(){
       + color('fail', ' %d of %d %s failed')
       + color('light', ':')
 
-    console.error(fmt,
+    mconsole.error(fmt,
       stats.failures,
       this.runner.total,
       pluralize(this.runner.total));
 
     Base.list(this.failures);
-    console.error();
+    mconsole.error();
     return;
   }
 
@@ -1617,7 +1617,7 @@ Base.prototype.epilogue = function(){
     + color('green', ' %d %s complete')
     + color('light', ' (%s)');
 
-  console.log(fmt,
+  mconsole.log(fmt,
     stats.tests || 0,
     pluralize(stats.tests),
     ms(stats.duration));
@@ -1627,10 +1627,10 @@ Base.prototype.epilogue = function(){
     fmt = color('pending', '  •')
       + color('pending', ' %d %s pending');
 
-    console.log(fmt, stats.pending, pluralize(stats.pending));
+    mconsole.log(fmt, stats.pending, pluralize(stats.pending));
   }
 
-  console.log();
+  mconsole.log();
 };
 
 /**
@@ -1723,24 +1723,24 @@ function Doc(runner) {
   runner.on('suite', function(suite){
     if (suite.root) return;
     ++indents;
-    console.log('%s<section class="suite">', indent());
+    mconsole.log('%s<section class="suite">', indent());
     ++indents;
-    console.log('%s<h1>%s</h1>', indent(), suite.title);
-    console.log('%s<dl>', indent());
+    mconsole.log('%s<h1>%s</h1>', indent(), suite.title);
+    mconsole.log('%s<dl>', indent());
   });
 
   runner.on('suite end', function(suite){
     if (suite.root) return;
-    console.log('%s</dl>', indent());
+    mconsole.log('%s</dl>', indent());
     --indents;
-    console.log('%s</section>', indent());
+    mconsole.log('%s</section>', indent());
     --indents;
   });
 
   runner.on('pass', function(test){
-    console.log('%s  <dt>%s</dt>', indent(), test.title);
+    mconsole.log('%s  <dt>%s</dt>', indent(), test.title);
     var code = utils.escape(utils.clean(test.fn.toString()));
-    console.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
+    mconsole.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 }
 
@@ -1800,7 +1800,7 @@ function Dot(runner) {
   });
 
   runner.on('end', function(){
-    console.log();
+    mconsole.log();
     self.epilogue();
   });
 }
@@ -2332,15 +2332,15 @@ function List(runner) {
     , total = runner.total;
 
   runner.on('start', function(){
-    console.log(JSON.stringify(['start', { total: total }]));
+    mconsole.log(JSON.stringify(['start', { total: total }]));
   });
 
   runner.on('pass', function(test){
-    console.log(JSON.stringify(['pass', clean(test)]));
+    mconsole.log(JSON.stringify(['pass', clean(test)]));
   });
 
   runner.on('fail', function(test, err){
-    console.log(JSON.stringify(['fail', clean(test)]));
+    mconsole.log(JSON.stringify(['fail', clean(test)]));
   });
 
   runner.on('end', function(){
@@ -2527,7 +2527,7 @@ function Landing(runner) {
 
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    mconsole.log();
     self.epilogue();
   });
 }
@@ -2572,7 +2572,7 @@ function List(runner) {
     , n = 0;
 
   runner.on('start', function(){
-    console.log();
+    mconsole.log();
   });
 
   runner.on('test', function(test){
@@ -2582,7 +2582,7 @@ function List(runner) {
   runner.on('pending', function(test){
     var fmt = color('checkmark', '  -')
       + color('pending', ' %s');
-    console.log(fmt, test.fullTitle());
+    mconsole.log(fmt, test.fullTitle());
   });
 
   runner.on('pass', function(test){
@@ -2590,12 +2590,12 @@ function List(runner) {
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
     cursor.CR();
-    console.log(fmt, test.fullTitle(), test.duration);
+    mconsole.log(fmt, test.fullTitle(), test.duration);
   });
 
   runner.on('fail', function(test, err){
     cursor.CR();
-    console.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    mconsole.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.on('end', self.epilogue.bind(self));
@@ -3064,7 +3064,7 @@ function Progress(runner, options) {
 
   // tests started
   runner.on('start', function(){
-    console.log();
+    mconsole.log();
     cursor.hide();
   });
 
@@ -3091,7 +3091,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.on('end', function(){
     cursor.show();
-    console.log();
+    mconsole.log();
     self.epilogue();
   });
 }
@@ -3142,17 +3142,17 @@ function Spec(runner) {
   }
 
   runner.on('start', function(){
-    console.log();
+    mconsole.log();
   });
 
   runner.on('suite', function(suite){
     ++indents;
-    console.log(color('suite', '%s%s'), indent(), suite.title);
+    mconsole.log(color('suite', '%s%s'), indent(), suite.title);
   });
 
   runner.on('suite end', function(suite){
     --indents;
-    if (1 == indents) console.log();
+    if (1 == indents) mconsole.log();
   });
 
   runner.on('test', function(test){
@@ -3161,7 +3161,7 @@ function Spec(runner) {
 
   runner.on('pending', function(test){
     var fmt = indent() + color('pending', '  - %s');
-    console.log(fmt, test.title);
+    mconsole.log(fmt, test.title);
   });
 
   runner.on('pass', function(test){
@@ -3170,20 +3170,20 @@ function Spec(runner) {
         + color('checkmark', '  ✓')
         + color('pass', ' %s ');
       cursor.CR();
-      console.log(fmt, test.title);
+      mconsole.log(fmt, test.title);
     } else {
       var fmt = indent()
         + color('checkmark', '  ✓')
         + color('pass', ' %s ')
         + color(test.speed, '(%dms)');
       cursor.CR();
-      console.log(fmt, test.title, test.duration);
+      mconsole.log(fmt, test.title, test.duration);
     }
   });
 
   runner.on('fail', function(test, err){
     cursor.CR();
-    console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    mconsole.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.on('end', self.epilogue.bind(self));
@@ -3231,7 +3231,7 @@ function TAP(runner) {
 
   runner.on('start', function(){
     var total = runner.grepTotal(runner.suite);
-    console.log('%d..%d', 1, total);
+    mconsole.log('%d..%d', 1, total);
   });
 
   runner.on('test end', function(){
@@ -3239,16 +3239,16 @@ function TAP(runner) {
   });
 
   runner.on('pending', function(test){
-    console.log('ok %d %s # SKIP -', n, title(test));
+    mconsole.log('ok %d %s # SKIP -', n, title(test));
   });
 
   runner.on('pass', function(test){
-    console.log('ok %d %s', n, title(test));
+    mconsole.log('ok %d %s', n, title(test));
   });
 
   runner.on('fail', function(test, err){
-    console.log('not ok %d %s', n, title(test));
-    console.log(err.stack.replace(/^/gm, '  '));
+    mconsole.log('not ok %d %s', n, title(test));
+    mconsole.log(err.stack.replace(/^/gm, '  '));
   });
 }
 
@@ -3292,27 +3292,27 @@ function Teamcity(runner) {
   var stats = this.stats;
 
   runner.on('start', function() {
-    console.log("##teamcity[testSuiteStarted name='mocha.suite']");
+    mconsole.log("##teamcity[testSuiteStarted name='mocha.suite']");
   });
 
   runner.on('test', function(test) {
-    console.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "']");
+    mconsole.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "']");
   });
 
   runner.on('fail', function(test, err) {
-    console.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "' message='" + escape(err.message) + "']");
+    mconsole.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "' message='" + escape(err.message) + "']");
   });
 
   runner.on('pending', function(test) {
-    console.log("##teamcity[testIgnored name='" + escape(test.fullTitle()) + "' message='pending']");
+    mconsole.log("##teamcity[testIgnored name='" + escape(test.fullTitle()) + "' message='pending']");
   });
 
   runner.on('test end', function(test) {
-    console.log("##teamcity[testFinished name='" + escape(test.fullTitle()) + "' duration='" + test.duration + "']");
+    mconsole.log("##teamcity[testFinished name='" + escape(test.fullTitle()) + "' duration='" + test.duration + "']");
   });
 
   runner.on('end', function() {
-    console.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
+    mconsole.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
   });
 }
 
@@ -3383,7 +3383,7 @@ function XUnit(runner) {
   });
 
   runner.on('end', function(){
-    console.log(tag('testsuite', {
+    mconsole.log(tag('testsuite', {
         name: 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
@@ -3394,7 +3394,7 @@ function XUnit(runner) {
     }, false));
 
     tests.forEach(test);
-    console.log('</testsuite>');    
+    mconsole.log('</testsuite>');
   });
 }
 
@@ -3420,11 +3420,11 @@ function test(test) {
   if ('failed' == test.state) {
     var err = test.err;
     attrs.message = escape(err.message);
-    console.log(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
+    mconsole.log(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
   } else if (test.pending) {
-    console.log(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    mconsole.log(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    console.log(tag('testcase', attrs, true) );
+    mconsole.log(tag('testcase', attrs, true) );
   }
 }
 

--- a/support/compile.js
+++ b/support/compile.js
@@ -13,7 +13,7 @@ var args = process.argv.slice(2)
   , pending = args.length
   , files = {};
 
-console.log('');
+mconsole.log('');
 
 // parse arguments
 
@@ -21,7 +21,7 @@ args.forEach(function(file){
   var mod = file.replace('lib/', '');
   fs.readFile(file, 'utf8', function(err, js){
     if (err) throw err;
-    console.log('  \u001b[90mcompile : \u001b[0m\u001b[36m%s\u001b[0m', file);
+    mconsole.log('  \u001b[90mcompile : \u001b[0m\u001b[36m%s\u001b[0m', file);
     files[file] = ~js.indexOf('require: off')
       ? js
       : parse(js);
@@ -84,8 +84,8 @@ function compile() {
   });
   fs.writeFile('_mocha.js', buf, function(err){
     if (err) throw err;
-    console.log('  \u001b[90m create : \u001b[0m\u001b[36m%s\u001b[0m', 'mocha.js');
-    console.log();
+    mconsole.log('  \u001b[90m create : \u001b[0m\u001b[36m%s\u001b[0m', 'mocha.js');
+    mconsole.log();
   });
 }
 

--- a/test/acceptance/misc/cascade.js
+++ b/test/acceptance/misc/cascade.js
@@ -1,57 +1,57 @@
 
 describe('one', function(){
   before(function(){
-    console.log('before one');
+    mconsole.log('before one');
   })
   
   after(function(){
-    console.log('after one');
+    mconsole.log('after one');
   })
   
   beforeEach(function(){
-    console.log('  before each one');
+    mconsole.log('  before each one');
   })
 
   afterEach(function(){
-    console.log('  after each one');
+    mconsole.log('  after each one');
   })
 
   describe('two', function(){
     before(function(){
-      console.log('  before two');
+      mconsole.log('  before two');
     })
     
     after(function(){
-      console.log('  after two');
+      mconsole.log('  after two');
     })
     
     beforeEach(function(){
-      console.log('    before each two');
+      mconsole.log('    before each two');
     })
     
     afterEach(function(){
-      console.log('    after each two');
+      mconsole.log('    after each two');
     })
     
     describe('three', function(){
       before(function(){
-        console.log('    before three');
+        mconsole.log('    before three');
       })
       
       after(function(){
-        console.log('    after three');
+        mconsole.log('    after three');
       })
 
       beforeEach(function(){
-        console.log('    before each three');
+        mconsole.log('    before each three');
       })
       
       afterEach(function(){
-        console.log('    after each three');
+        mconsole.log('    after each three');
       })
 
       it('should three', function(){
-        console.log('      TEST three');
+        mconsole.log('      TEST three');
       })
     })
   })

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -19,7 +19,7 @@
         runner.globals(['foo', 'bar', 'baz']);
 
         // runner.on('test end', function(test){
-        //   console.log(test.fullTitle());
+        //   mconsole.log(test.fullTitle());
         // });
       };
     </script>

--- a/test/jsapi/index.js
+++ b/test/jsapi/index.js
@@ -25,7 +25,7 @@ mocha.addFile('test/acceptance/pending.js');
 mocha.addFile('test/acceptance/timeout.js');
 
 mocha.run(function(){
-  console.log('done');
+  mconsole.log('done');
 }).on('pass', function(test){
-  // console.log('... %s', test.title);
+  // mconsole.log('... %s', test.title);
 });


### PR DESCRIPTION
This fix resolves issue #290 by setting up an internal console.log reference and then overriding the console.log for everything else. Also applies to console.log, console.warn, and console.error.
