### PR TITLE
Whitelist common globals

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -45,7 +45,7 @@ function Runner(suite) {
   this.on('test end', function(test){ self.checkGlobals(test); });
   this.on('hook end', function(hook){ self.checkGlobals(hook); });
   this.grep(/.*/);
-  this.globals(utils.keys(global).concat(['errno']));
+  this.globals(this.globalProps().concat(['errno']));
 }
 
 /**
@@ -143,7 +143,7 @@ Runner.prototype.globals = function(arr){
 Runner.prototype.checkGlobals = function(test){
   if (this.ignoreLeaks) return;
   var ok = this._globals;
-  var globals = keys(global);
+  var globals = this.globalProps();
   var isNode = process.kill;
   var leaks;
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -97,6 +97,28 @@ describe('Runner', function(){
       runner.checkGlobals('im a test');
     })
 
+    it ('should not fail when a new common global is introduced', function(){
+      // verify that the prop isn't enumerable
+      delete global.XMLHttpRequest;
+      global.propertyIsEnumerable('XMLHttpRequest').should.not.be.ok;
+
+      // create a new runner and keep a reference to the test.
+      var test = new Test('im a test about bears');
+      suite.addTest(test);
+      var newRunner = new Runner(suite);
+
+      // make the prop enumerable again.
+      global.XMLHttpRequest = function() {};
+      global.propertyIsEnumerable('XMLHttpRequest').should.be.ok;
+
+      // verify the test hasn't failed.
+      newRunner.checkGlobals(test);
+      test.should.not.have.key('state');
+
+      // clean up our global space.
+      delete global.XMLHttpRequest;
+    });
+
     it('should pluralize the error message when several are introduced', function(done){
       runner.checkGlobals();
       global.foo = 'bar';


### PR DESCRIPTION
This is a fix for #467. These are all the globals that sinon defines so this fix should make sinon and mocha fully inter-operable.
