### PR TITLE
Added Doctype To Template

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Mocha</title>


### PR DESCRIPTION
I added a Doctype to the browser template that is used with `mocha init`. The reason for this is that the recommended assertion library ChaiJS, doesn't work in quirks mode in internet explorer. In other words, using mocha init with ChaiJS out of the box doesn't work in internet explorer. This resolves that problem.

Thanks!
