### PR TITLE
Revert grep to original functionality with strings converted to regex's....

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lib-cov:
 
 test: test-unit
 
-test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers
+test-all: test-bdd test-tdd test-qunit test-exports test-unit test-only test-jsapi test-compilers
 
 test-jsapi:
 	@node test/jsapi
@@ -72,16 +72,16 @@ test-exports:
 		--ui exports \
 		test/acceptance/interfaces/exports
 
-test-grep:
+test-only:
 	@./bin/mocha \
 	  --reporter $(REPORTER) \
-	  --grep fast \
+	  --only fast \
 	  test/acceptance/misc/grep
 
 test-invert:
 	@./bin/mocha \
 	  --reporter $(REPORTER) \
-	  --grep slow \
+	  --only slow \
 	  --invert \
 	  test/acceptance/misc/grep
 
@@ -123,4 +123,4 @@ tm:
 	mkdir -p $(TM_DEST)
 	cp -fr editors/$(TM_BUNDLE) $(TM_DEST)
 
-.PHONY: test-cov test-jsapi test-compilers watch test test-all test-bdd test-tdd test-qunit test-exports test-unit non-tty test-grep tm clean
+.PHONY: test-cov test-jsapi test-compilers watch test test-all test-bdd test-tdd test-qunit test-exports test-unit non-tty test-only tm clean

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -60,9 +60,8 @@ program
   .option('-r, --require <name>', 'require the given module')
   .option('-R, --reporter <name>', 'specify the reporter to use', 'dot')
   .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
-  .option('-g, --grep <regex>', 'only run tests matching <regex>')
-  .option('-f, --find <string>', 'only run tests containing <string>')
-  .option('-i, --invert', 'inverts --grep matches')
+  .option('-o, --only <string>', 'only run tests containing <string>')
+  .option('-i, --invert', 'inverts --only and --only-regexp matches')
   .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
   .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
   .option('-w, --watch', 'watch files for changes')
@@ -79,6 +78,7 @@ program
   .option('--interfaces', 'display available interfaces')
   .option('--reporters', 'display available reporters')
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
+  .option('--only-regexp <pattern>', 'only run tests matching <pattern>')
 
 program.name = 'mocha';
 
@@ -218,13 +218,13 @@ if (program.timeout) mocha.suite.timeout(program.timeout);
 
 mocha.suite.bail(program.bail);
 
-// --grep
+// --only
 
-if (program.grep) mocha.grep(program.grep);
+if (program.only) mocha.only(program.only);
 
-// --find
+// --only-regexp
 
-if (program.find) mocha.find(program.find);
+if (program.onlyRegexp) mocha.only(new RegExp(program.onlyRegexp));
 
 // --invert
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -60,7 +60,8 @@ program
   .option('-r, --require <name>', 'require the given module')
   .option('-R, --reporter <name>', 'specify the reporter to use', 'dot')
   .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
-  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-g, --grep <regex>', 'only run tests matching <regex>')
+  .option('-f, --find <string>', 'only run tests containing <string>')
   .option('-i, --invert', 'inverts --grep matches')
   .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
   .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
@@ -219,7 +220,11 @@ mocha.suite.bail(program.bail);
 
 // --grep
 
-if (program.grep) mocha.grep(new RegExp(program.grep));
+if (program.grep) mocha.grep(program.grep);
+
+// --find
+
+if (program.find) mocha.find(program.find);
 
 // --invert
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -64,7 +64,8 @@ function Mocha(options) {
   options = options || {};
   this.files = [];
   this.options = options;
-  this.grep(options.grep);
+  if (options.grep) this.grep(options.grep);
+  if (options.find) this.find(options.find);
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
   this.reporter(options.reporter);

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -165,7 +165,7 @@ Mocha.prototype._growl = function(runner, reporter) {
 };
 
 /**
- * Add regexp to grep, if `re` is a string it is escaped.
+ * Add regexp to grep
  *
  * @param {RegExp|String} re
  * @return {Mocha}
@@ -173,6 +173,21 @@ Mocha.prototype._growl = function(runner, reporter) {
  */
 
 Mocha.prototype.grep = function(re){
+  this.options.grep = 'string' == typeof re
+    ? new RegExp(re)
+    : re;
+  return this;
+};
+
+/**
+ * Add regexp to grep, if `re` is a string it is escaped.
+ *
+ * @param {RegExp|String} re
+ * @return {Mocha}
+ * @api public
+ */
+
+Mocha.prototype.find = function(re){
   this.options.grep = 'string' == typeof re
     ? new RegExp(utils.escapeRegexp(re))
     : re;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -64,8 +64,8 @@ function Mocha(options) {
   options = options || {};
   this.files = [];
   this.options = options;
-  if (options.grep) this.grep(options.grep);
-  if (options.find) this.find(options.find);
+  if (options.only) this.only(options.only);
+  if (options['only-regexp']) this.only(new RegExp(options['only-regexp']));
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
   this.reporter(options.reporter);
@@ -166,32 +166,17 @@ Mocha.prototype._growl = function(runner, reporter) {
 };
 
 /**
- * Add regexp to grep
+ * Add a pattern to grep, if `pattern` is a string, it is escaped.
  *
- * @param {RegExp|String} re
+ * @param {RegExp|String} pattern
  * @return {Mocha}
  * @api public
  */
 
-Mocha.prototype.grep = function(re){
-  this.options.grep = 'string' == typeof re
-    ? new RegExp(re)
-    : re;
-  return this;
-};
-
-/**
- * Add regexp to grep, if `re` is a string it is escaped.
- *
- * @param {RegExp|String} re
- * @return {Mocha}
- * @api public
- */
-
-Mocha.prototype.find = function(re){
-  this.options.grep = 'string' == typeof re
-    ? new RegExp(utils.escapeRegexp(re))
-    : re;
+Mocha.prototype.only = function(pattern){
+  this.options.grep = 'string' == typeof pattern
+    ? new RegExp(utils.escapeRegexp(pattern))
+    : pattern;
   return this;
 };
 

--- a/support/tail.js
+++ b/support/tail.js
@@ -100,8 +100,8 @@ process.on = function(e, fn){
     mocha.globals('location');
 
     var query = Mocha.utils.parseQuery(window.location.search || '');
-    if (query.grep) mocha.grep(query.grep);
-    if (query.find) mocha.find(query.find);
+    if (query.only) mocha.only(query.only);
+    if (query['only-regexp']) mocha.only(new RegExp(query['only-regexp']));
     if (query.invert) mocha.invert();
 
     return Mocha.prototype.run.call(mocha, function(){

--- a/support/tail.js
+++ b/support/tail.js
@@ -101,6 +101,7 @@ process.on = function(e, fn){
 
     var query = Mocha.utils.parseQuery(window.location.search || '');
     if (query.grep) mocha.grep(query.grep);
+    if (query.find) mocha.find(query.find);
     if (query.invert) mocha.invert();
 
     return Mocha.prototype.run.call(mocha, function(){

--- a/test/grep.js
+++ b/test/grep.js
@@ -2,65 +2,46 @@
 var Mocha = require('../');
 
 describe('Mocha', function(){
-  describe('"grep" option', function(){
+  describe('"only-regexp" option', function(){
     it('should add a RegExp to the mocha.options object', function(){
-      var mocha = new Mocha({ grep: /foo()/ });
+      var mocha = new Mocha({ 'only-regexp': /foo()/ });
       mocha.options.grep.toString().should.equal('/foo()/');
     })
 
-    it('should convert grep string to a RegExp', function(){
-      var mocha = new Mocha({ grep: 'foo()' });
+    it('should convert string to a RegExp', function(){
+      var mocha = new Mocha({ 'only-regexp': 'foo()' });
       mocha.options.grep.toString().should.equal('/foo()/');
     })
   })
 
-  describe('.grep()', function(){
+  describe('.only()', function(){
     it('should add a RegExp to the mocha.options object', function(){
       var mocha = new Mocha;
-      mocha.grep(/foo()/);
+      mocha.only(/foo()/);
       mocha.options.grep.toString().should.equal('/foo()/');
     })
 
-    it('should convert grep string to a RegExp', function(){
+    it('should convert string to an escaped RegExp', function(){
       var mocha = new Mocha;
-      mocha.grep('foo()');
-      mocha.options.grep.toString().should.equal('/foo()/');
-    })
-
-    it('should return it\'s parent Mocha object for chainability', function(){
-      var mocha = new Mocha;
-      mocha.grep().should.equal(mocha);
-    })
-  })
-
-  describe('"find" option', function(){
-    it('should add a RegExp to the mocha.options object', function(){
-      var mocha = new Mocha({ find: /foo()/ });
-      mocha.options.grep.toString().should.equal('/foo()/');
-    })
-
-    it('should convert find string to an escaped RegExp', function(){
-      var mocha = new Mocha({ find: 'foo()' });
-      mocha.options.grep.toString().should.equal('/foo\\(\\)/');
-    })
-  })
-
-  describe('.find()', function(){
-    it('should add a RegExp to the mocha.options object', function(){
-      var mocha = new Mocha;
-      mocha.find(/foo()/);
-      mocha.options.grep.toString().should.equal('/foo()/');
-    })
-
-    it('should convert find string to an escaped RegExp', function(){
-      var mocha = new Mocha;
-      mocha.find('foo()');
+      mocha.only('foo()');
       mocha.options.grep.toString().should.equal('/foo\\(\\)/');
     })
 
     it('should return it\'s parent Mocha object for chainability', function(){
       var mocha = new Mocha;
-      mocha.find().should.equal(mocha);
+      mocha.only().should.equal(mocha);
+    })
+  })
+
+  describe('"only" option', function(){
+    it('should add a RegExp to the mocha.options object', function(){
+      var mocha = new Mocha({ 'only': /foo()/ });
+      mocha.options.grep.toString().should.equal('/foo()/');
+    })
+
+    it('should convert string to an escaped RegExp', function(){
+      var mocha = new Mocha({ 'only': 'foo()' });
+      mocha.options.grep.toString().should.equal('/foo\\(\\)/');
     })
   })
 

--- a/test/grep.js
+++ b/test/grep.js
@@ -4,32 +4,63 @@ var Mocha = require('../');
 describe('Mocha', function(){
   describe('"grep" option', function(){
     it('should add a RegExp to the mocha.options object', function(){
-      var mocha = new Mocha({ grep: /foo/ });
-      mocha.options.grep.toString().should.equal('/foo/');
+      var mocha = new Mocha({ grep: /foo()/ });
+      mocha.options.grep.toString().should.equal('/foo()/');
     })
 
     it('should convert grep string to a RegExp', function(){
-      var mocha = new Mocha({ grep: 'foo' });
-      mocha.options.grep.toString().should.equal('/foo/');
+      var mocha = new Mocha({ grep: 'foo()' });
+      mocha.options.grep.toString().should.equal('/foo()/');
     })
   })
 
   describe('.grep()', function(){
     it('should add a RegExp to the mocha.options object', function(){
       var mocha = new Mocha;
-      mocha.grep(/foo/);
-      mocha.options.grep.toString().should.equal('/foo/');
+      mocha.grep(/foo()/);
+      mocha.options.grep.toString().should.equal('/foo()/');
     })
 
     it('should convert grep string to a RegExp', function(){
       var mocha = new Mocha;
-      mocha.grep('foo');
-      mocha.options.grep.toString().should.equal('/foo/');
+      mocha.grep('foo()');
+      mocha.options.grep.toString().should.equal('/foo()/');
     })
 
     it('should return it\'s parent Mocha object for chainability', function(){
       var mocha = new Mocha;
       mocha.grep().should.equal(mocha);
+    })
+  })
+
+  describe('"find" option', function(){
+    it('should add a RegExp to the mocha.options object', function(){
+      var mocha = new Mocha({ find: /foo()/ });
+      mocha.options.grep.toString().should.equal('/foo()/');
+    })
+
+    it('should convert find string to an escaped RegExp', function(){
+      var mocha = new Mocha({ find: 'foo()' });
+      mocha.options.grep.toString().should.equal('/foo\\(\\)/');
+    })
+  })
+
+  describe('.find()', function(){
+    it('should add a RegExp to the mocha.options object', function(){
+      var mocha = new Mocha;
+      mocha.find(/foo()/);
+      mocha.options.grep.toString().should.equal('/foo()/');
+    })
+
+    it('should convert find string to an escaped RegExp', function(){
+      var mocha = new Mocha;
+      mocha.find('foo()');
+      mocha.options.grep.toString().should.equal('/foo\\(\\)/');
+    })
+
+    it('should return it\'s parent Mocha object for chainability', function(){
+      var mocha = new Mocha;
+      mocha.find().should.equal(mocha);
     })
   })
 


### PR DESCRIPTION
...  Add Mocha#find() which escapes the string.

We have a bunch of grep-strings which we pass via URL using a script.  With commit b00b6f54, the Mocha#grep() behavior changed so that the grep strings, which were previously treated as regular expressions, are now escaped.  This broke our grep-patterns.

To me, the word "grep" implies regular expressions, and it is occasionally useful to use regular expressions when selecting tests/suites.  I've reverted Mocha#grep() to the original functionality and implemented the new functionality in Mocha#find(), adding support for a new URL variable "find" which uses the new function.

You may not want this behavior in the main tree, but I thought I'd pass it along.  Feel free to reject.