### PR TITLE
HTMLReporter: Fix "Property 'appendChild' of undefined".

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -132,14 +132,14 @@ function HTML(runner, root) {
     text(failures, stats.failures);
     text(duration, (ms / 1000).toFixed(2));
 
-      // test
-      if ('passed' == test.state) {
-        var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, test.fullTitle());
-      } else if (test.pending) {
-        var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
-      } else {
-        var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, test.fullTitle());
-        var str = test.err.stack || test.err.toString();
+    // test
+    if ('passed' == test.state) {
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, test.fullTitle());
+    } else if (test.pending) {
+      var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
+    } else {
+      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, test.fullTitle());
+      var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message
       if (!~str.indexOf(test.err.message)) {
@@ -174,7 +174,10 @@ function HTML(runner, root) {
       pre.style.display = 'none';
     }
 
-    stack[0].appendChild(el);
+    // Don't call .appendChild if #mocha-report was already .shift()'ed off the stack.
+    if (stack[0]) {
+      stack[0].appendChild(el);
+    }
   });
 }
 

--- a/mocha.js
+++ b/mocha.js
@@ -2003,14 +2003,14 @@ function HTML(runner, root) {
     text(failures, stats.failures);
     text(duration, (ms / 1000).toFixed(2));
 
-      // test
-      if ('passed' == test.state) {
-        var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, test.fullTitle());
-      } else if (test.pending) {
-        var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
-      } else {
-        var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, test.fullTitle());
-        var str = test.err.stack || test.err.toString();
+    // test
+    if ('passed' == test.state) {
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, test.fullTitle());
+    } else if (test.pending) {
+      var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
+    } else {
+      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, test.fullTitle());
+      var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message
       if (!~str.indexOf(test.err.message)) {
@@ -2045,7 +2045,10 @@ function HTML(runner, root) {
       pre.style.display = 'none';
     }
 
-    stack[0].appendChild(el);
+    // Don't call .appendChild if #mocha-report was already .shift()'ed off the stack.
+    if (stack[0]) {
+      stack[0].appendChild(el);
+    }
   });
 }
 


### PR DESCRIPTION
IE9 throws the following error on the large.js test:

> (mocha.js:2072) Unable to get value of the property 'appendChild': object is null or undefined.

Which is caused by the stack.shift() call earlier.
