### PR TITLE
With node.js on Windows: use symbols available in terminal default fonts

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -62,6 +62,22 @@ exports.colors = {
 };
 
 /**
+ * Default symbol map.
+ */
+exports.symbols = {
+    ok: '✓',
+    err: '✖',
+    dot: '․'
+};
+
+// With node.js on Windows: use symbols available in terminal default fonts
+if(process && process.platform === 'win32') {
+  exports.symbols.ok = '\u221A';
+  exports.symbols.err = '\u00D7';
+  exports.symbols.dot = '.';
+}
+
+/**
  * Color `str` with the given `type`,
  * allowing colors to be disabled,
  * as well as user-defined color
@@ -277,7 +293,7 @@ Base.prototype.epilogue = function(){
 
   // failure
   if (stats.failures) {
-    fmt = color('bright fail', '  ✖')
+    fmt = color('bright fail', '  '+exports.symbols.err)
       + color('fail', ' %d of %d %s failed')
       + color('light', ':')
 
@@ -292,7 +308,7 @@ Base.prototype.epilogue = function(){
   }
 
   // pass
-  fmt = color('bright pass', '  ✔')
+  fmt = color('bright pass', '  '+exports.symbols.ok)
     + color('green', ' %d %s complete')
     + color('light', ' (%s)');
 

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -25,7 +25,6 @@ function Dot(runner) {
   var self = this
     , stats = this.stats
     , width = Base.window.width * .75 | 0
-    , c = '․'
     , n = 0;
 
   runner.on('start', function(){
@@ -33,21 +32,21 @@ function Dot(runner) {
   });
 
   runner.on('pending', function(test){
-    process.stdout.write(color('pending', c));
+    process.stdout.write(color('pending', Base.symbols.dot));
   });
 
   runner.on('pass', function(test){
     if (++n % width == 0) process.stdout.write('\n  ');
     if ('slow' == test.speed) {
-      process.stdout.write(color('bright yellow', c));
+      process.stdout.write(color('bright yellow', Base.symbols.dot));
     } else {
-      process.stdout.write(color(test.speed, c));
+      process.stdout.write(color(test.speed, Base.symbols.dot));
     }
   });
 
   runner.on('fail', function(test, err){
     if (++n % width == 0) process.stdout.write('\n  ');
-    process.stdout.write(color('fail', c));
+    process.stdout.write(color('fail', Base.symbols.err));
   });
 
   runner.on('end', function(){

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -25,6 +25,7 @@ function List(runner) {
 
   var self = this
     , stats = this.stats
+    , c = (process && process.platform === 'win32' && '.') || '․'
     , n = 0;
 
   runner.on('start', function(){
@@ -42,7 +43,7 @@ function List(runner) {
   });
 
   runner.on('pass', function(test){
-    var fmt = color('checkmark', '  ✓')
+    var fmt = color('checkmark', '  '+c)
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
     cursor.CR();

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -5,7 +5,8 @@
 
 var Base = require('./base')
   , cursor = Base.cursor
-  , color = Base.color;
+  , color = Base.color
+  , c = (process && process.platform === 'win32' && '\u221A') || '✓';
 
 /**
  * Expose `Spec`.
@@ -58,13 +59,13 @@ function Spec(runner) {
   runner.on('pass', function(test){
     if ('fast' == test.speed) {
       var fmt = indent()
-        + color('checkmark', '  ✓')
+        + color('checkmark', '  '+c)
         + color('pass', ' %s ');
       cursor.CR();
       console.log(fmt, test.title);
     } else {
       var fmt = indent()
-        + color('checkmark', '  ✓')
+        + color('checkmark', '  '+c)
         + color('pass', ' %s ')
         + color(test.speed, '(%dms)');
       cursor.CR();


### PR DESCRIPTION
This pull request fixes - imho - a major annoyance with Mocha when running with node.js on Windows.

Several reporters (`dot`, `list` and `spec`) use special unicode symbols for visualising check marks (`✓`), error marks (`✖`) and small dots (`․`).

Sadly, default terminal fonts for Windows don't support these symbols. While mocha itself works just fine, it is somewhat annoying that your console gets filled with odd placeholder characters. This problem can be worked around by installing a custom font, such as DeJavu Sans Mono (http://stackoverflow.com/questions/9817926/how-can-i-get-mochas-unicode-output-to-display-properly-in-a-windows-console). Given this requires extra work, I'm pretty sure many developers just live with the broken symbols.

This pull request introduces the fix for this annoying problem as follows:
- A new, common symbol map containing symbols for check mark, error mark and small dots has been added to `reporters/base.js`
- In case Node.js/Windows are detected, the default symbol map is modified to fall back to use symbols that are readily available on default console fonts
- Reporters (`dot`, `list`, `spec`) have been modified to use special symbols from the symbol map
