### PR TITLE
--no-animations for --watch

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -78,6 +78,7 @@ program
   .option('--interfaces', 'display available interfaces')
   .option('--reporters', 'display available reporters')
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
+  .option('--no-animations', 'disable animations (saves power)')
 
 program.name = 'mocha';
 
@@ -285,15 +286,23 @@ if (program.watch) {
     console.log('\n');
     process.exit();
   });
-
-  var frames = [
-      '  \u001b[96m◜ \u001b[90mwatching\u001b[0m'
-    , '  \u001b[96m◠ \u001b[90mwatching\u001b[0m'
-    , '  \u001b[96m◝ \u001b[90mwatching\u001b[0m'
-    , '  \u001b[96m◞ \u001b[90mwatching\u001b[0m'
-    , '  \u001b[96m◡ \u001b[90mwatching\u001b[0m'
-    , '  \u001b[96m◟ \u001b[90mwatching\u001b[0m'
-  ];
+  
+  var frames;
+  
+  if (program.animations) {
+    frames = [
+        '  \u001b[96m◜ \u001b[90mwatching\u001b[0m'
+      , '  \u001b[96m◠ \u001b[90mwatching\u001b[0m'
+      , '  \u001b[96m◝ \u001b[90mwatching\u001b[0m'
+      , '  \u001b[96m◞ \u001b[90mwatching\u001b[0m'
+      , '  \u001b[96m◡ \u001b[90mwatching\u001b[0m'
+      , '  \u001b[96m◟ \u001b[90mwatching\u001b[0m'
+    ];
+  } else {
+    frames = [
+        '  \u001b[96m⟳ \u001b[90mwatching\u001b[0m'
+    ];
+  }
 
   var watchFiles = utils.files(cwd);
 
@@ -414,9 +423,14 @@ function play(arr, interval) {
   var len = arr.length
     , interval = interval || 100
     , i = 0;
-
-  play.timer = setInterval(function(){
+  
+  if (len > 1) {
+    play.timer = setInterval(function(){
+      var str = arr[i++ % len];
+      process.stdout.write('\r' + str);
+    }, interval);
+  } else {
     var str = arr[i++ % len];
     process.stdout.write('\r' + str);
-  }, interval);
+  }
 }


### PR DESCRIPTION
This is more of a heads-up / proposal rather than a legit patch I expect you to land.

Basically, whilst rather aesthetically pleasing, the cyclic animation on `--watch` constantly burns ~10% CPU on this reasonably powerful notebook (sporting a 2.66 GHz i7).

![:(](http://i.imgur.com/G5z96.png)

Personally, I'd prefer the extended battery life. Especially when I'm out and about without mains power.

I did not investigate making the animation itself more efficient. I have simply provided the option to disable it.

Ideally this would use some kind of battery/power API to engage/disengage itself but I have a feeling you'd find that overkill.

I don't mind changing the patch if you indeed want to land this in some alternate way, shape or form.
