### PR TITLE
Remove instanceof occurrence

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -188,7 +188,7 @@ Runnable.prototype.run = function(fn){
   if (this.async) {
     try {
       this.fn.call(ctx, function(err){
-        if (err instanceof Error) return done(err);
+        if (Object.prototype.toString.call(err) === "[object Error]") return done(err);
         if (null != err) return done(new Error('done() invoked with non-Error: ' + err));
         done();
       });


### PR DESCRIPTION
instanceof is not reliable in a cross-iframe environment, whereas 
Object.prototype.toString comparison is.

See https://github.com/jfirebaugh/konacha/issues/74

Fixes #646.
