### PR TITLE
Add console reporter with tree layout

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -1,0 +1,105 @@
+
+  /**
+   * Module dependencies.
+   */
+
+  var Base = require('./base')
+    , utils = require('../utils')
+    , escape = utils.escape;
+
+  /**
+   * Save timer references to avoid Sinon interfering (see GH-237).
+   */
+
+  var Date = global.Date
+    , setTimeout = global.setTimeout
+    , setInterval = global.setInterval
+    , clearTimeout = global.clearTimeout
+    , clearInterval = global.clearInterval;
+
+  /**
+   * Expose `XUnit`.
+   */
+
+  exports = module.exports = Console;
+
+  /**
+   * Initialize a new `Console` reporter.
+   *
+   * @param {Runner} runner
+   * @api public
+   */
+
+  function Console(runner, options) {
+    //TODO needs to be removed to options somehow
+    var defaultParameters = '&reporter=console'
+    var parameterForRunningAllTests = '?test=true'
+
+    Base.call(this, runner);
+    var stats = this.stats
+      , tests = []
+      , self = this
+      , total = runner.total
+      , title = document.title
+      , calls = [];
+
+    runner.on('pass', function(test){
+    });
+
+    runner.on('fail', function(test){
+      calls.push(['info', null, test.title])
+      calls.push(['error', null, test.err.stack])
+      flagFailures(test.parent)
+    });
+
+    function flagFailures(node) {
+      node.hasFailures = true
+      if(node.parent) flagFailures(node.parent)
+    }
+
+    runner.on('suite', function(suite) {
+      var parameter = '?grep=' + encodeURIComponent(suite.fullTitle()) + defaultParameters
+      var location = document.location
+      var url = location.origin + location.pathname + parameter
+      calls.push(['group', suite, suite.title])
+      calls.push(['groupCollapsed', suite , 'url'])
+      calls.push(['log', suite, url])
+      calls.push(['groupEnd', suite])
+    })
+    runner.on('suite end', function(suite) {
+      calls.push(['groupEnd', suite])
+    })
+
+    runner.on('test end', function() {
+      var percent = stats.tests / total * 100 | 0;
+      document.title = percent + '% '+(stats.failures ? stats.failures + ' failures ' : '' ) + title
+    })
+
+    runner.on('end', function(){
+      if(stats.errors || stats.failures) {
+        utils.forEach(calls, function(call) {
+          var command = call.shift()
+          var suite = call.shift()
+          var failures = !suite || suite.hasFailures
+          if (failures || command == 'info' || command == 'error') {
+            console[command].apply(console, call)
+          }
+        })
+      }
+      if(stats.errors) console.warn(stats.errors,' errors')
+      if(stats.failures) console.warn(stats.failures,' failures')
+      var skipped = stats.tests - stats.failures - stats.passes
+      if(skipped) console.warn(skipped, ' skipped')
+      console.log(stats.passes, ' tests passed')
+      console.log(stats.duration / 1000, ' seconds')
+      console.log((new Date).toUTCString())
+      console.log('Run all tests ' + location.origin + location.pathname + parameterForRunningAllTests + defaultParameters)
+    });
+  }
+  /**
+   * Inherit from `Base.prototype`.
+   */
+
+  Console.prototype = new Base;
+  Console.prototype.constructor = Console;
+

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -17,3 +17,4 @@ exports.JSONCov = require('./json-cov');
 exports.HTMLCov = require('./html-cov');
 exports.JSONStream = require('./json-stream');
 exports.Teamcity = require('./teamcity');
+exports.Console = require('./console');

--- a/mocha.js
+++ b/mocha.js
@@ -1724,6 +1724,115 @@ function colorLines(name, str) {
 
 }); // module: reporters/base.js
 
+require.register("reporters/console.js", function(module, exports, require){
+
+  /**
+   * Module dependencies.
+   */
+
+  var Base = require('./base')
+    , utils = require('../utils')
+    , escape = utils.escape;
+
+  /**
+   * Save timer references to avoid Sinon interfering (see GH-237).
+   */
+
+  var Date = global.Date
+    , setTimeout = global.setTimeout
+    , setInterval = global.setInterval
+    , clearTimeout = global.clearTimeout
+    , clearInterval = global.clearInterval;
+
+  /**
+   * Expose `XUnit`.
+   */
+
+  exports = module.exports = Console;
+
+  /**
+   * Initialize a new `Console` reporter.
+   *
+   * @param {Runner} runner
+   * @api public
+   */
+
+  function Console(runner, options) {
+    //TODO needs to be removed to options somehow
+    var defaultParameters = '&reporter=console'
+    var parameterForRunningAllTests = '?test=true'
+
+    Base.call(this, runner);
+    var stats = this.stats
+      , tests = []
+      , self = this
+      , total = runner.total
+      , title = document.title
+      , calls = [];
+
+    runner.on('pass', function(test){
+    });
+
+    runner.on('fail', function(test){
+      calls.push(['info', null, test.title])
+      calls.push(['error', null, test.err.stack])
+      flagFailures(test.parent)
+    });
+
+    function flagFailures(node) {
+      node.hasFailures = true
+      if(node.parent) flagFailures(node.parent)
+    }
+
+    runner.on('suite', function(suite) {
+      var parameter = '?grep=' + encodeURIComponent(suite.fullTitle()) + defaultParameters
+      var location = document.location
+      var url = location.origin + location.pathname + parameter
+      calls.push(['group', suite, suite.title])
+      calls.push(['groupCollapsed', suite , 'url'])
+      calls.push(['log', suite, url])
+      calls.push(['groupEnd', suite])
+    })
+    runner.on('suite end', function(suite) {
+      calls.push(['groupEnd', suite])
+    })
+
+    runner.on('test end', function() {
+      var percent = stats.tests / total * 100 | 0;
+      document.title = percent + '% '+(stats.failures ? stats.failures + ' failures ' : '' ) + title
+    })
+
+    runner.on('end', function(){
+      if(stats.errors || stats.failures) {
+        utils.forEach(calls, function(call) {
+          var command = call.shift()
+          var suite = call.shift()
+          var failures = !suite || suite.hasFailures
+          if (failures || command == 'info' || command == 'error') {
+            console[command].apply(console, call)
+          }
+        })
+      }
+      if(stats.errors) console.warn(stats.errors,' errors')
+      if(stats.failures) console.warn(stats.failures,' failures')
+      var skipped = stats.tests - stats.failures - stats.passes
+      if(skipped) console.warn(skipped, ' skipped')
+      console.log(stats.passes, ' tests passed')
+      console.log(stats.duration / 1000, ' seconds')
+      console.log((new Date).toUTCString())
+      console.log('Run all tests ' + location.origin + location.pathname + parameterForRunningAllTests + defaultParameters)
+    });
+  }
+  /**
+   * Inherit from `Base.prototype`.
+   */
+
+  Console.prototype = new Base;
+  Console.prototype.constructor = Console;
+
+
+}); // module: reporters/console.js
+
 require.register("reporters/doc.js", function(module, exports, require){
 
 /**
@@ -2184,6 +2293,7 @@ exports.JSONCov = require('./json-cov');
 exports.HTMLCov = require('./html-cov');
 exports.JSONStream = require('./json-stream');
 exports.Teamcity = require('./teamcity');
+exports.Console = require('./console');
 
 }); // module: reporters/index.js
 


### PR DESCRIPTION
- Console reporter which works at least with Chrome and Firefox
- Uses group, groupCollapsed and groupEnd for nesting results
- Shows only failed contexts (chrome limits console output when it is closed)
- Generates clickable links for running separate contexts
- Generates clickable stack trace for errors
- Performs much faster than html reporter
- Reports passes, failures, skipped and run time
- Updates progress % in title
