### PR TITLE
Improve multi-line diff output

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -171,17 +171,19 @@ exports.list = function(failures){
     // actual / expected diff
     if ('string' == typeof actual && 'string' == typeof expected) {
       var len = Math.max(actual.length, expected.length);
+      var lines = (actual.length > expected.length ? actual : expected).match(/\n/g).length;
 
-      if (len < 20) msg = errorDiff(err, 'Chars', escape);
-      else msg = errorDiff(err, 'Words', escape);
+      if (len < 20) {
+        msg = errorDiff(err, 'Chars', escape);
+      } else if (lines > 4) {
+        var width = String(lines).length;
 
-      // linenos
-      var lines = msg.split('\n');
-      if (lines.length > 4) {
-        var width = String(lines.length).length;
-        msg = lines.map(function(str, i){
+        // linenos
+        msg = errorDiff(err, 'Lines', escape).split('\n').map(function(str, i) {
           return pad(++i, width) + ' |' + ' ' + str;
         }).join('\n');
+      } else {
+        msg = errorDiff(err, 'Words', escape);
       }
 
       // legend


### PR DESCRIPTION
This patch improves multi-line diff output by utilizing `diff.diffLines` instead of  `diff.diffWords` which ignores whitespace.

Here's an image showing the differences before and after the patch:

![Patch result animation](http://i.imgur.com/0PX5S.png)
