### PR TITLE
Add table of contents to webpage

### DIFF
--- a/head.html
+++ b/head.html
@@ -6,6 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <script src="jquery.js"></script>
     <script src="highlight.js"></script>
+    <script src="nav.js"></script>
     <script>
       setTimeout(function(){
         $('body').addClass('onload');
@@ -13,6 +14,36 @@
     </script>
   </head>
   <body>
+    <div id="nav-table">
+      <div id="nav-cell">
+        <div id="nav">
+          <a href="#content"><span style="font-size: 200%">•</span></a><br>
+          <a href="#features">features</a><br>
+          <a href="#installation">installation</a><br>
+          <a href="#getting-started">getting started</a><br>
+          <a href="#assertions">assertions</a><br>
+          <a href="#synchronous-code">synchronous code</a><br>
+          <a href="#asynchronous-code">asynchronous code</a><br>
+          <a href="#pending-tests">pending tests</a><br>
+          <a href="#exclusive-tests">exclusive tests</a><br>
+          <a href="#inclusive-tests">inclusive tests</a><br>
+          <a href="#test-duration">test duration</a><br>
+          <a href="#string-diffs">string diffs</a><br>
+          <a href="#usage">usage</a><br>
+          <a href="#interfaces">interfaces</a><br>
+          <a href="#reporters">reporters</a><br>
+          <a href="#browser-support">browser support</a><br>
+          <a href="#mocha.opts">mocha.opts</a><br>
+          <a href="#suite-specific-timeouts">suite specific timeouts</a><br>
+          <a href="#test-specific-timeouts">test specific timeouts</a><br>
+          <a href="#best-practices">best practices</a><br>
+          <a href="#editors">editors</a><br>
+          <a href="#example-test-suites">example test suites</a><br>
+          <a href="#running-mochas-tests">running mocha's tests</a><br>
+          <a href="#more-information">more information</a><br>
+        </div>
+      </div>
+    </div>
     <section id="content">
       <h1><a href="http://github.com/visionmedia/mocha">Mocha</a></h1>
       <p id="tag"><em>simple</em>, <em>flexible</em>, <em>fun</em></p>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <script src="jquery.js"></script>
     <script src="highlight.js"></script>
+    <script src="nav.js"></script>
     <script>
       setTimeout(function(){
         $('body').addClass('onload');
@@ -13,6 +14,36 @@
     </script>
   </head>
   <body>
+    <div id="nav-table">
+      <div id="nav-cell">
+        <div id="nav">
+          <a href="#content"><span style="font-size: 200%">•</span></a><br>
+          <a href="#features">features</a><br>
+          <a href="#installation">installation</a><br>
+          <a href="#getting-started">getting started</a><br>
+          <a href="#assertions">assertions</a><br>
+          <a href="#synchronous-code">synchronous code</a><br>
+          <a href="#asynchronous-code">asynchronous code</a><br>
+          <a href="#pending-tests">pending tests</a><br>
+          <a href="#exclusive-tests">exclusive tests</a><br>
+          <a href="#inclusive-tests">inclusive tests</a><br>
+          <a href="#test-duration">test duration</a><br>
+          <a href="#string-diffs">string diffs</a><br>
+          <a href="#usage">usage</a><br>
+          <a href="#interfaces">interfaces</a><br>
+          <a href="#reporters">reporters</a><br>
+          <a href="#browser-support">browser support</a><br>
+          <a href="#mocha.opts">mocha.opts</a><br>
+          <a href="#suite-specific-timeouts">suite specific timeouts</a><br>
+          <a href="#test-specific-timeouts">test specific timeouts</a><br>
+          <a href="#best-practices">best practices</a><br>
+          <a href="#editors">editors</a><br>
+          <a href="#example-test-suites">example test suites</a><br>
+          <a href="#running-mochas-tests">running mocha's tests</a><br>
+          <a href="#more-information">more information</a><br>
+        </div>
+      </div>
+    </div>
     <section id="content">
       <h1><a href="http://github.com/visionmedia/mocha">Mocha</a></h1>
       <p id="tag"><em>simple</em>, <em>flexible</em>, <em>fun</em></p>
@@ -50,33 +81,6 @@
 <li>arbitrary transpiler support (coffee-script etc)</li>
 <li>TextMate bundle</li>
 <li>and more!</li>
-</ul>
-
-<h2 id="table-of-contents">Table of contents</h2>
-
-<ul>
-<li><a href="#installation">Installation</a></li>
-<li><a href="#getting-started">1. 2. 3. Mocha!</a></li>
-<li><a href="#assertions">Assertions</a></li>
-<li><a href="#synchronous-code">Synchronous code</a></li>
-<li><a href="#asynchronous-code">Asynchronous code</a></li>
-<li><a href="#pending-tests">Pending tests</a></li>
-<li><a href="#exclusive-tests">Exclusive tests</a></li>
-<li><a href="#inclusive-tests">Inclusive tests</a></li>
-<li><a href="#test-duration">Test duration</a></li>
-<li><a href="#string-diffs">String diffs</a></li>
-<li><a href="#usage">mocha(1)</a></li>
-<li><a href="#interfaces">Interfaces</a></li>
-<li><a href="#reporters">Reporters</a></li>
-<li><a href="#browser-support">Browser support</a></li>
-<li><a href="#mocha.opts">mocha.opts</a></li>
-<li><a href="#suite-specific-timeouts">Suite specific timeouts</a></li>
-<li><a href="#test-specific-timeouts">Test specific timeouts</a></li>
-<li><a href="#best-practices">Best practices</a></li>
-<li><a href="#editors">Editors</a></li>
-<li><a href="#example-test-suites">Example test suites</a></li>
-<li><a href="#running-mochas-tests">Running mocha's tests</a></li>
-<li><a href="#more-information">More information</a></li>
 </ul>
 
 <h2 id="installation">Installation</h2>

--- a/index.md
+++ b/index.md
@@ -33,31 +33,6 @@ Mocha is a feature-rich JavaScript test framework running on [node](http://nodej
   - TextMate bundle
   - and more!
 
-<h2 id="table-of-contents">Table of contents</h2>
-
-  - [Installation](#installation)
-  - [1\. 2\. 3\. Mocha!](#getting-started)
-  - [Assertions](#assertions)
-  - [Synchronous code](#synchronous-code)
-  - [Asynchronous code](#asynchronous-code)
-  - [Pending tests](#pending-tests)
-  - [Exclusive tests](#exclusive-tests)
-  - [Inclusive tests](#inclusive-tests)
-  - [Test duration](#test-duration)
-  - [String diffs](#string-diffs)
-  - [mocha(1)](#usage)
-  - [Interfaces](#interfaces)
-  - [Reporters](#reporters)
-  - [Browser support](#browser-support)
-  - [mocha.opts](#mocha.opts)
-  - [Suite specific timeouts](#suite-specific-timeouts)
-  - [Test specific timeouts](#test-specific-timeouts)
-  - [Best practices](#best-practices)
-  - [Editors](#editors)
-  - [Example test suites](#example-test-suites)
-  - [Running mocha's tests](#running-mochas-tests)
-  - [More information](#more-information)
-
 <h2 id="installation">Installation</h2>
 
   Install with [npm](http://npmjs.org):

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,37 @@
+$(function () {
+  setTimeout(function () {
+    var prev;
+    var headings = $('h2').map(function (i, el) {
+      return {
+        top: $(el).offset().top,
+        id: el.id
+      };
+    }).get();
+
+    headings.unshift({top: 0, id: 'content'});
+
+    function closest() {
+      var mid = $(window).scrollTop() + ($(window).height() / 2);
+      var i = headings.length;
+      while (i--) {
+        if (mid >= headings[i].top) {
+          return headings[i];
+        }
+      }
+    }
+
+    $(document).scroll(function () {
+      var heading = closest();
+      if (heading) {
+        if (prev) {
+          prev.removeClass('active');
+        }
+
+        prev = $('a[href="#' + heading.id + '"]').addClass('active');
+      }
+    });
+    
+    $('a[href="#content"]').addClass('active');
+  }, 1000);
+});
+

--- a/style.css
+++ b/style.css
@@ -6,8 +6,36 @@ body {
   border-top: 2px solid #ddd;
 }
 
+#nav-table {
+  display: table;
+  position: fixed;
+  top: 0;
+  right: 1.5em;
+  height: 100%;
+  text-align: right;
+  font-size: 80%;
+}
+
+#nav-cell {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+#nav a {
+  transition: 0.5s;
+  transition-property: color;
+  -moz-transition: 0.5s;
+  -moz-transition-property: color;
+  -webkit-transition: 0.5s;
+  -webkit-transition-property: color;
+}
+
+#nav a.active {
+  color: #2C2C2C;
+}
+
 #content {
-  padding: 140px 110px 60px 110px;
+  padding: 140px 210px 60px 110px;
 }
 
 h1 {
@@ -94,12 +122,11 @@ ul {
   margin-top: 20px;
   padding: 0 15px;
   width: 100%;
-  column-count: 2;
-  -moz-column-count: 2;
-  -webkit-column-count: 2;
 }
 
 ul li {
+  float: left;
+  width: 40%;
   margin-top: 5px;
   margin-right: 60px;
   list-style: none;
@@ -180,3 +207,4 @@ code .init { color: #2F6FAD }
 code .string { color: #5890AD }
 code .keyword { color: #8A6343 }
 code .number { color: #2F6FAD }
+


### PR DESCRIPTION
This may be a rather opinionated pull request, but it's bothered me more than once that the webpage for mocha doesn't have a table of contents. It makes it hard to go back to it and find one specific section again, or to browse the whole thing with a nice, nonlinear _section click_ -- _back_ -- _other section click_ flow.

As a part of this change, I corrected the duplicated `exclusive-tests` anchor to `inclusive-tests` and the `string diffs` anchor to `string-diffs`.

There are a few considerations to be made:
- In order to have the list ordering make sense for a table of contents (descend vertically rather than horizontally), but retain the two-column styling, I removed `float: left` and `width: 40%` from the `ul li` style and added `column-count: 2` to the `ul` style. This currently affects all other `ul`s as well. In addition, `column-count` is not supported in versions of IE below 10.
- I put the TOC below the feature list to keep the latter above the fold and more front-and-center.
- I was unsure whether or not to capitalize the section headers. The feature list, which is right above it, is uncapitalized and undecorated, so there's a slight discordance. In the end, I decided to keep them exactly the same as the actual section headers they link to.
- Similarly, I was unsure whether or not to make "Getting started" the link to "1. 2. 3. Mocha!", and "Usage" the link to "mocha(1)". They look slightly out of place among the other textual headers, and it may not be very clear what they are out of context, despite being fairly important and looked-for sections. Again, though, I decided to keep them the same pending consideration.
