### PR TITLE
Try/catch guard on require()-ing test files. [fixes #655]

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -137,7 +137,7 @@ Mocha.prototype.loadFiles = function(fn){
     try {
       suite.emit('require', require(file), file, self);
     } catch(e) {
-      console.error('\u001b[31mError: ' + e.message + '\r\n');
+      console.error('\u001b[31mError: ' + e.message + '\u001b[0m\r\n');
     }
     suite.emit('post-require', global, file, self);
     --pending || (fn && fn());


### PR DESCRIPTION
Syntax errors in test files will cause mocha to crash since it is using
simple require() to load the test files.

This also breaks out of the file `--watch` loop which makes it very
annoying when you just misplaced one simple character and have to switch
to your other tdd window to restart the tests.

So I've added a try/catch guard against the require() call.

---

Since error handling (and console colors configuration) is embedded in
`lib/runnable.js` and `lib/runner.js` which isn't available when we are
just loading the tests, I have made it prints out the error message and
error stack to `process.stderr` for the time being.

Also I've skipped the `suite.emit('require'...` call on error. I'm not sure
if that will breaks anything as `pre-require` and `post-require` will still
run even if the file has errors.

But tests still pass so I'm submitting this as I really want this to be fixed. :(
