### PR TITLE
window.onerror and Asynchronous Errors

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -116,7 +116,7 @@ function HTML(runner, root) {
   });
 
   runner.on('fail', function(test, err){
-    if ('hook' == test.type || err.uncaught) runner.emit('test end', test);
+    if ('hook' == test.type) runner.emit('test end', test);
   });
 
   runner.on('test end', function(test){

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -181,9 +181,10 @@ Runner.prototype.checkGlobals = function(test){
 Runner.prototype.fail = function(test, err){
   ++this.failures;
   test.state = 'failed';
-  if ('string' == typeof err) {
+  if ('string' == typeof err &&  ! err.uncaught) {
     err = new Error('the string "' + err + '" was thrown, throw an Error :)');
   }
+  
   this.emit('fail', test, err);
 };
 
@@ -486,8 +487,8 @@ Runner.prototype.run = function(fn){
   debug('start');
 
   // uncaught callback
-  function uncaught(err) {
-    self.uncaught(err);
+  function uncaught(err, url, line) {
+    self.uncaught(new Error(err + '(' + url + ':' + line + ')'));
   }
 
   // callback


### PR DESCRIPTION
## The problem:

Currently asyncronous errors in the browser are horrific, we don't get access to an Error object but just a string. This means that every error thrown in a callback within a Mocha test like this:

``` javascript

describe('sad day', function() {
  it('should have a nice trace', function(done) {
     setTimeout(function() {
        throw new Error('A little bit better.');
          done();
     }, 500);
  });
});

```

The problem is Mocha wraps this and warns you not to throw strings, but the end user isn't throwing a string, `window.onerror` just blows! Unfortunately we lose access to the stack trace as well with no handle of getting it back. To help make this suck a little less I've taken the url and line parameters thrown with `window.onerror` and added them to the message to make it a bit more useful, so now instead of the top error being from Mocha.js some crazy line number, the top line shows where your actual error is from.
## Before the pull request:

![Before Pull Request](http://f.cl.ly/items/2B1a0v2O13061n0m440q/useless.png)
## After the pull request:

![After Pull Request](http://f.cl.ly/items/20332E410Z1r3D1V2B35/useful.png)

Notice how after the pull request we get the file url and the line number. Albeit no stack trace cause thats currently the name of the game with browsers as far as I know.
