### PR TITLE
Use `path.resolve` when resolving requires.

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -148,7 +148,7 @@ program.on('require', function(mod){
   var abs = exists(mod)
     || exists(mod + '.js');
 
-  if (abs) mod = join(cwd, mod);
+  if (abs) mod = resolve(cwd, mod);
   require(mod);
 });
 


### PR DESCRIPTION
This allows absolute paths to be given using `--require` as well as relative paths.
