### PR TITLE
Improve Growl message for failed tests

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -153,7 +153,25 @@ Mocha.prototype._growl = function(runner, reporter) {
     var stats = reporter.stats;
     if (stats.failures) {
       var msg = stats.failures + ' of ' + runner.total + ' tests failed';
-      notify(msg, { name: 'mocha', title: 'Failed', image: image('error') });
+      var title = 'Failed';
+      if (reporter.failures.length > 0) {
+        var test = reporter.failures[0];
+        title = msg;
+        msg = test.fullTitle();
+
+        var err = test.err
+          , message = err.message || (err.stack && err.stack.split("\n")[0].trim()) || ''
+          , stack = err.stack || message
+          , index = stack.indexOf(message) + message.length
+          , friendlyMessage = stack.slice(0, index)
+          , stackitem = stack.slice(index ? index + 1 : index).trim().split("\n")[0]
+          , m = stackitem.match(/\((.*):(\d+):\d+\)/);
+        if (m) {
+          msg += "\n\n" + path.basename(m[1]) + ":" + m[2];
+        }
+        msg += "\n\n" + friendlyMessage;
+      }
+      notify(msg, { name: 'mocha', title: title, image: image('error') });
     } else {
       notify(stats.passes + ' tests passed in ' + stats.duration + 'ms', {
           name: 'mocha'


### PR DESCRIPTION
Growl enough information to allow debugging of simple failures based solely on the information provided by Growl.

Specifically, instead of the traditional notification like

```
Title: Failed

1 of 40 tests failed
```

display a more detailed notification like

```
Title: 1 of 40 tests failed

Session should monitor the added projects and issue reload requests

session.js:40

ReferenceError: foo is not defined
```

This is a very simple patch; didn't try to make it an option or something. I welcome your suggestions.
