### PR TITLE
Add total number of passes and failures to TAP

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -25,7 +25,9 @@ function TAP(runner) {
 
   var self = this
     , stats = this.stats
-    , n = 1;
+    , n = 1
+    , passes = 0
+    , failures = 1;
 
   runner.on('start', function(){
     var total = runner.grepTotal(runner.suite);
@@ -41,12 +43,20 @@ function TAP(runner) {
   });
 
   runner.on('pass', function(test){
+    passes++;
     console.log('ok %d %s', n, title(test));
   });
 
   runner.on('fail', function(test, err){
+    failures++;
     console.log('not ok %d %s', n, title(test));
     console.log(err.stack.replace(/^/gm, '  '));
+  });
+
+  runner.on('end', function () {
+    console.log('# tests ' + (passes + failures));
+    console.log('# pass ' + passes);
+    console.log('# fail ' + failures);
   });
 }
 


### PR DESCRIPTION
This logs the total number of passes and failures at the end of the TAP report.  It prefixes them with a '#' so there shouldn't be any problem, and it makes the TAP reporter compatible with http://ci.testling.com, which unfortunately relies on these messages at the moment.
