### PR TITLE
Avoid 'undefined' err.stack use on checkGlobals reported leak test failures.

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -3290,7 +3290,7 @@ function TAP(runner) {
 
   runner.on('fail', function(test, err){
     console.log('not ok %d %s', n, title(test));
-    console.log(err.stack.replace(/^/gm, '  '));
+    if (err.stack) console.log(err.stack.replace(/^/gm, '  '));
   });
 }
 


### PR DESCRIPTION
The Runner.checkGlobals uses new Error() which doesn't provide stack (observed in Chrome 23).
