### PR TITLE
The Runner.checkGlobals new Error doesn't provide err.stack.

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -50,7 +50,7 @@ function TAP(runner) {
   runner.on('fail', function(test, err){
     failures++;
     console.log('not ok %d %s', n, title(test));
-    console.log(err.stack.replace(/^/gm, '  '));
+    if (err.stack) console.log(err.stack.replace(/^/gm, '  '));
   });
 
   runner.on('end', function(){

--- a/mocha.js
+++ b/mocha.js
@@ -3294,7 +3294,7 @@ function TAP(runner) {
   runner.on('fail', function(test, err){
     failures++;
     console.log('not ok %d %s', n, title(test));
-    console.log(err.stack.replace(/^/gm, '  '));
+    if (err.stack) console.log(err.stack.replace(/^/gm, '  '));
   });
 
   runner.on('end', function(){


### PR DESCRIPTION
This fixed the original #679 - "Avoid 'undefined' err.stack use on checkGlobals reported leak test failures." hopefully in the right place. Sorry for that.
