### PR TITLE
Handle non-string non-errors

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -182,8 +181,8 @@ Runner.prototype.fail = function(test, err){
   ++this.failures;
   test.state = 'failed';
 
-  if ('string' == typeof err) {
-    err = new Error('the string "' + err + '" was thrown, throw an Error :)');
+  if (!(err instanceof Error)) {
+    err = new Error('the ' + (typeof err) + ' ' + JSON.stringify(err) + ' was thrown, throw an Error :)');
   }
   
   this.emit('fail', test, err);


### PR DESCRIPTION
Errors that don't pass the `instanceof` test will almost never have proper stack trace info, and some crazy people throw numbers etc.
