### PR TITLE
Use proper Object.create-style inheritance in browsers.

### DIFF
--- a/support/compile.js
+++ b/support/compile.js
@@ -58,7 +58,9 @@ function parseRequires(js) {
 function parseInheritance(js) {
   return js
     .replace(/^ *(\w+)\.prototype\.__proto__ * = *(\w+)\.prototype *;?/gm, function(_, child, parent){
-      return child + '.prototype = new ' + parent + ';\n'
+      return 'function F(){};\n'
+        + 'F.prototype = ' + parent + '.prototype;\n'
+        + child + '.prototype = new F;\n'
         + child + '.prototype.constructor = '+ child + ';\n';
     });
 }


### PR DESCRIPTION
Before this pull request, inheritance in browsers was done via

``` js
Test.prototype = new Runnable;
```

after this pull request it is done via

``` js
function F(){}
F.prototype = Runnable.prototype;
Test.prototype = new F;
```

which is equivalent to the less-cross-browser

``` js
Test.prototype = Object.create(Runnable.prototype);
```

(See [all the usual stuff about `Object.create` shims](http://stackoverflow.com/questions/10141086/understanding-crockfords-object-create-shim).)
## 

The big difference is that, with this change, changes to `Runnable.prototype` propagate to `Test` instances; without it, changes do not propagate, since it just uses the version of `Runnable.prototype` that existed at the time of the `new`ing.

This helps fix domenic/mocha-as-promised#6, wherein I am plugging in to `Runnable.prototype` and expecting the changes to propagate to `Test`, etc.
