### PR TITLE
Minor update to HTML reporter's CSS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _mocha.js
 test.js
 my-reporter.js
 *.sw*
+.idea
+*.iml

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -165,7 +165,7 @@ function HTML(runner, root) {
 
       on(h2, 'click', function(){
         pre.style.display = 'none' == pre.style.display
-          ? 'inline-block'
+          ? 'block'
           : 'none';
       });
 

--- a/mocha.css
+++ b/mocha.css
@@ -53,6 +53,7 @@ body {
 
 #mocha .test {
   margin-left: 15px;
+  overflow: hidden;
 }
 
 #mocha .test.pending:hover h2::after {
@@ -129,7 +130,9 @@ body {
 }
 
 #mocha .test pre {
-  display: inline-block;
+  display: block;
+  float: left;
+  clear: left;
   font: 12px/1.5 monaco, monospace;
   margin: 5px;
   padding: 15px;

--- a/mocha.js
+++ b/mocha.js
@@ -1005,6 +1005,7 @@ function image(name) {
  *   - `reporter` reporter instance, defaults to `mocha.reporters.Dot`
  *   - `globals` array of accepted globals
  *   - `timeout` timeout in milliseconds
+ *   - `bail` bail on the first test failure
  *   - `slow` milliseconds to wait before considering a test slow
  *   - `ignoreLeaks` ignore global leaks
  *   - `grep` string or regexp to filter tests with
@@ -1020,10 +1021,24 @@ function Mocha(options) {
   this.grep(options.grep);
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
+  this.bail(options.bail);
   this.reporter(options.reporter);
   if (options.timeout) this.timeout(options.timeout);
   if (options.slow) this.slow(options.slow);
 }
+
+/**
+ * Enable or disable bailing on the first failure.
+ *
+ * @param {Boolean} [bail]
+ * @api public
+ */
+
+Mocha.prototype.bail = function(bail){
+  if (null == bail) bail = true;
+  this.suite.bail(bail);
+  return this;
+};
 
 /**
  * Add test `file`.
@@ -1040,7 +1055,7 @@ Mocha.prototype.addFile = function(file){
 /**
  * Set reporter to `reporter`, defaults to "dot".
  *
- * @param {String|Function} reporter name of a reporter or a reporter constructor
+ * @param {String|Function} reporter name or constructor
  * @api public
  */
 
@@ -2073,7 +2088,7 @@ function HTML(runner, root) {
 
       on(h2, 'click', function(){
         pre.style.display = 'none' == pre.style.display
-          ? 'inline-block'
+          ? 'block'
           : 'none';
       });
 


### PR DESCRIPTION
Previously the HTML reporter displayed 'pre' blocks with display set to 'inline-block', however given a wide enough screen, when a test fails and you click the h2, the code snippet will display beside the error output (with whitespace being introduced directly below the test heading), as opposed to below it which would look more consistent. This commit fixes this styling.

Here's a screenshot illustrating the issue before the fix:
![Screen Shot 2013-01-08 at 13 25 09](https://f.cloud.github.com/assets/974125/50183/f83cd97c-5996-11e2-845a-265e40f9bd69.png)

After applying this fix, the code preview is shown directly below the error output as expect.
