### PR TITLE
improve diff behavior, specially on white spaces and line breaks.

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -172,8 +172,9 @@ exports.list = function(failures){
     if ('string' == typeof actual && 'string' == typeof expected) {
       var len = Math.max(actual.length, expected.length);
 
-      if (len < 20) msg = errorDiff(err, 'Chars', escape);
-      else msg = errorDiff(err, 'Words', escape);
+      // always use Chars diff otherwise it won't show white space differences
+      // properly
+      msg = errorDiff(err, 'Chars', escape);
 
       // linenos
       var lines = msg.split('\n');
@@ -352,17 +353,33 @@ function pad(str, len) {
  */
 
 function errorDiff(err, type, escape) {
+  // we replace invisible chars before calling diff to avoid issues with
+  // leading line breaks just before end of strings
+  if (escape) {
+    err.actual = replaceInvisibleChars(err.actual);
+    err.expected = replaceInvisibleChars(err.expected);
+  }
   return diff['diff' + type](err.actual, err.expected).map(function(str){
-    if (escape) {
-      str.value = str.value
-        .replace(/\t/g, '<tab>')
-        .replace(/\r/g, '<CR>')
-        .replace(/\n/g, '<LF>\n');
-    }
     if (str.added) return colorLines('diff added', str.value);
     if (str.removed) return colorLines('diff removed', str.value);
     return str.value;
   }).join('');
+}
+
+
+/**
+ * Replace Invisible chars for better diffs.
+ *
+ * @param {String} str
+ * @return {String}
+ * @api private
+ */
+
+function replaceInvisibleChars(str) {
+  return str
+    .replace(/\t/g, '<tab>')
+    .replace(/\r/g, '<CR>')
+    .replace(/\n/g, '<LF>\n');
 }
 
 /**

--- a/test/acceptance/diffs.js
+++ b/test/acceptance/diffs.js
@@ -11,14 +11,23 @@ describe('diffs', function(){
     // a.should.equal(b);
   })
 
-  it('should display a word diff for medium strings', function(){
+  it('should display a char diff for medium strings', function(){
     var a = 'foo bar baz\nfoo bar baz\nfoo bar baz'
       , b = 'foo bar baz\nfoo rar baz\nfoo bar raz';
 
     // a.should.equal(b);
   })
 
-  it('should display a word diff for large strings', function(){
+  it('should display a char diff for large strings', function(){
     // cssin.should.equal(cssout);
   })
+
+  it('should display line breaks and white space diffs', function(){
+    // special notice to the 4 spaces indent before bar() and the leading line
+    // breaks before end of string
+    var a = 'function foo(){\n    bar(); }\n// foo\n';
+    var b = 'function foo () {\n  bar();\n}\n// foo\n\n\n';
+    // a.should.equal(b);
+  })
+
 })


### PR DESCRIPTION
Change the diff to always use "Chars" diff since it will work better with white spaces.

Also make sure we replace invisible chars before doing the diff to avoid issues with leading line breaks just before end of the string.

---

My changes doesn't affect the line numbers (so it's a better solution than #657)

See test that I added to `acceptance/diff`, try running it before/after my changes to see how it was improved. Here is a screenshot:

![mocha-diff](https://f.cloud.github.com/assets/155633/53608/ff9dda1c-5a6e-11e2-9717-c60a5df4a5d0.png)
