### PR TITLE
improve `error.showDiff` behavior for multiline strings

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -161,8 +161,10 @@ exports.list = function(failures){
       , expected = err.expected
       , escape = true;
 
-    // explicitly show diff
-    if (err.showDiff) {
+    // explicitly show diff for non-string values
+    // no need to call JSON.stringify on strings and escape should be true if
+    // value is a string, otherwise multi-line diffs won't work properly
+    if (err.showDiff && ('string' != typeof actual || 'string' != typeof expected)) {
       escape = false;
       err.actual = actual = JSON.stringify(actual, null, 2);
       err.expected = expected = JSON.stringify(expected, null, 2);

--- a/test/acceptance/diffs.js
+++ b/test/acceptance/diffs.js
@@ -19,6 +19,12 @@ describe('diffs', function(){
   })
 
   it('should display a word diff for large strings', function(){
-    // cssin.should.equal(cssout);
+    var err = new Error();
+    err.message = 'strings are not the same';
+    err.expected = cssout;
+    err.actual = cssin;
+    // showDiff = true to check conflicts with multi-line string diffs
+    err.showDiff = true;
+    // throw err;
   })
 })


### PR DESCRIPTION
previously `error.showDiff` was conflicting with strings, so diff wasn't escaping invisible chars and also wasn't displaying line numbers.

now we make sure `JSON.stringify()` is only called if `error.actual` and/or `error.expected` aren't strings.

Before:

![before](https://f.cloud.github.com/assets/155633/56983/3a992bc6-5b37-11e2-910e-b49922def0a9.png)

After:

![after](https://f.cloud.github.com/assets/155633/56985/4697fce0-5b37-11e2-9811-56d2dfc79697.png)
