### PR TITLE
Restricted tmbundles to js scope. Renamed bdd-describe

### DIFF
--- a/editors/JavaScript mocha.tmbundle/Snippets/bdd - after each.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/bdd - after each.tmSnippet
@@ -8,6 +8,8 @@
 })</string>
 	<key>name</key>
 	<string>bdd - after each</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>ae</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/bdd - after.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/bdd - after.tmSnippet
@@ -8,6 +8,8 @@
 })</string>
 	<key>name</key>
 	<string>bdd - after</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>a</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/bdd - before each.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/bdd - before each.tmSnippet
@@ -8,6 +8,8 @@
 })</string>
 	<key>name</key>
 	<string>bdd - before each</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>be</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/bdd - before.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/bdd - before.tmSnippet
@@ -8,6 +8,8 @@
 })</string>
 	<key>name</key>
 	<string>bdd - before</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>b</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/bdd - describe.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/bdd - describe.tmSnippet
@@ -8,6 +8,8 @@
 })</string>
 	<key>name</key>
 	<string>bdd - describe</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>des</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/bdd - it.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/bdd - it.tmSnippet
@@ -8,6 +8,8 @@
 })</string>
 	<key>name</key>
 	<string>bdd - it</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>it</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert.tmSnippet
@@ -6,6 +6,8 @@
 	<string>assert($0);</string>
 	<key>name</key>
 	<string>tdd - assert</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>as</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_deepEqual.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_deepEqual.tmSnippet
@@ -6,6 +6,8 @@
 	<string>assert.deepEqual($1, $2);</string>
 	<key>name</key>
 	<string>tdd - assert.deepEqual</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>deq</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_equal.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_equal.tmSnippet
@@ -6,6 +6,8 @@
 	<string>assert.equal($1, $2);</string>
 	<key>name</key>
 	<string>tdd - assert.equal</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>eq</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_fail.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_fail.tmSnippet
@@ -6,6 +6,8 @@
 	<string>assert.fail($0);</string>
 	<key>name</key>
 	<string>tdd - assert.fail</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>fail</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_isFunction.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - assert_isFunction.tmSnippet
@@ -6,6 +6,8 @@
 	<string>assert.isFunction($0);</string>
 	<key>name</key>
 	<string>tdd - assert.isFunction</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>isf</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - setup.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - setup.tmSnippet
@@ -8,6 +8,8 @@
 });</string>
 	<key>name</key>
 	<string>tdd - setup</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>setup</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - suite.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - suite.tmSnippet
@@ -8,6 +8,8 @@
 });</string>
 	<key>name</key>
 	<string>tdd - suite</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>suite</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - teardown.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - teardown.tmSnippet
@@ -8,6 +8,8 @@
 });</string>
 	<key>name</key>
 	<string>tdd - teardown</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>teardown</string>
 	<key>uuid</key>

--- a/editors/JavaScript mocha.tmbundle/Snippets/tdd - test.tmSnippet
+++ b/editors/JavaScript mocha.tmbundle/Snippets/tdd - test.tmSnippet
@@ -8,6 +8,8 @@
 });</string>
 	<key>name</key>
 	<string>tdd - test</string>
+	<key>scope</key>
+	<string>source.js</string>
 	<key>tabTrigger</key>
 	<string>test</string>
 	<key>uuid</key>


### PR DESCRIPTION
Mocha autocompletes annoys me while doing C development. They shouldn't really appear outside javascript syntax.
