### PR TITLE
Added deferred execution support

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -145,14 +145,31 @@ Mocha.prototype.ui = function(name){
 Mocha.prototype.loadFiles = function(fn){
   var self = this;
   var suite = this.suite;
-  var pending = this.files.length;
-  this.files.forEach(function(file){
-    file = path.resolve(file);
-    suite.emit('pre-require', global, file, self);
-    suite.emit('require', require(file), file, self);
-    suite.emit('post-require', global, file, self);
-    --pending || (fn && fn());
-  });
+  var pending = this.files.slice();
+  function nextFile() {
+    var file = pending.shift();
+    var processNextFile = true;
+    var semaphore = {
+      resume: function(){
+        process.nextTick(nextFile); 
+      }
+    };
+    if (file) {
+      file = path.resolve(file);
+      global.wait = function(){
+        processNextFile = false;
+        return semaphore;
+      };
+      suite.emit('pre-require', global, file, self);
+      suite.emit('require', require(file), file, self);
+      suite.emit('post-require', global, file, self);
+      if (processNextFile) process.nextTick(nextFile);
+    } else {
+      delete global.wait;
+      fn && fn();
+    }
+  }
+  nextFile();
 };
 
 /**
@@ -302,15 +319,21 @@ Mocha.prototype.asyncOnly = function(){
  */
 
 Mocha.prototype.run = function(fn){
-  if (this.files.length) this.loadFiles();
+  var _this = this;
   var suite = this.suite;
   var options = this.options;
   var runner = new exports.Runner(suite);
   var reporter = new this._reporter(runner);
-  runner.ignoreLeaks = options.ignoreLeaks;
-  runner.asyncOnly = options.asyncOnly;
-  if (options.grep) runner.grep(options.grep, options.invert);
-  if (options.globals) runner.globals(options.globals);
-  if (options.growl) this._growl(runner, reporter);
-  return runner.run(fn);
+  function run() {
+    runner.initDefaultGlobals();
+    runner.ignoreLeaks = options.ignoreLeaks;
+    runner.asyncOnly = options.asyncOnly;
+    if (options.grep) runner.grep(options.grep, options.invert);
+    if (options.globals) runner.globals(options.globals);
+    if (options.growl) _this._growl(runner, reporter);
+    runner.run(fn);
+  }
+  if (this.files.length) this.loadFiles(run);
+  else run();
+  return runner;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -58,7 +58,6 @@ function Runner(suite) {
   this.on('test end', function(test){ self.checkGlobals(test); });
   this.on('hook end', function(hook){ self.checkGlobals(hook); });
   this.grep(/.*/);
-  this.globals(this.globalProps().concat(['errno']));
 }
 
 /**
@@ -141,6 +140,17 @@ Runner.prototype.globals = function(arr){
     this._globals.push(arr);
   }, this);
   return this;
+};
+
+
+/**
+ * Initialize default globals list.
+ *
+ * @api private
+ */
+
+Runner.prototype.initDefaultGlobals = function(){
+  this.globals(this.globalProps().concat(['errno']));
 };
 
 /**

--- a/test/runner.js
+++ b/test/runner.js
@@ -10,6 +10,7 @@ describe('Runner', function(){
   beforeEach(function(){
     suite = new Suite(null, 'root');
     runner = new Runner(suite);
+    runner.initDefaultGlobals();
   })
 
   describe('.grep()', function(){
@@ -18,6 +19,7 @@ describe('Runner', function(){
       suite.addTest(new Test('im another test about lions'));
       suite.addTest(new Test('im a test about bears'));
       var newRunner = new Runner(suite);
+      newRunner.initDefaultGlobals();
       newRunner.grep(/lions/);
       newRunner.total.should.equal(2);
     })
@@ -27,6 +29,7 @@ describe('Runner', function(){
       suite.addTest(new Test('im another test about lions'));
       suite.addTest(new Test('im a test about bears'));
       var newRunner = new Runner(suite);
+      newRunner.initDefaultGlobals();
       newRunner.grep(/lions/, true);
       newRunner.total.should.equal(1);
     })

--- a/test/semaphore.js
+++ b/test/semaphore.js
@@ -1,0 +1,15 @@
+var semaphore = wait();
+
+process.nextTick(function() {
+
+  describe('test', function() {
+
+    it('can be generated asynchronously', function(done) {
+      done();
+    });
+
+  });
+
+  semaphore.resume();
+
+});


### PR DESCRIPTION
This should solve issue #362.

A global 'wait' function is added so the test files can pause mocha processing and generate
tests asynchronously. The function returns a semaphore with a single method 'resume' to continue processing test files.
