### PR TITLE
Fix RangeError when indents is negative

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -29,6 +29,9 @@ function Spec(runner) {
     , n = 0;
 
   function indent() {
+    if(indents < 0) {
+      indents = 0;
+    }
     return Array(indents).join('  ')
   }
 


### PR DESCRIPTION
I was getting this error:

```
/usr/local/Cellar/node/0.8.12/lib/node_modules/mocha/lib/reporters/spec.js:33
    return Array(indents).join('  ')
           ^
RangeError: Invalid array length
    at indent (/usr/local/Cellar/node/0.8.12/lib/node_modules/mocha/lib/reporters/spec.js:33:12)
```

It turns out that the `indents` var was getting set to a negative number and causes this error. The fix was just to set it to 0 if it is below 0.
