### PR TITLE
tab based indentation used to show up funny in the browser code samples

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -193,11 +192,11 @@ exports.slug = function(str){
 
 exports.clean = function(str) {
   str = str
-    .replace(/^function *\(.*\) *{/, '')
+    .replace(/^function *\(.*\) *\{/, '')
     .replace(/\s+\}$/, '');
 
-  var spaces = str.match(/^\n?( *)/)[1].length
-    , re = new RegExp('^ {' + spaces + '}', 'gm');
+  var spaces = str.match(/^\n?(\s*)/)[1].length
+    , re = new RegExp('^\\s{' + spaces + '}', 'gm');
 
   str = str.replace(re, '');
 


### PR DESCRIPTION
I just switched to using the white-space character \s. I haven't tested it thoroughly or anything btw.
