### PR TITLE
Updated TeamCity reporter to handle suites

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -22,28 +22,30 @@ function Teamcity(runner) {
   Base.call(this, runner);
   var stats = this.stats;
 
-  runner.on('start', function() {
-    console.log("##teamcity[testSuiteStarted name='mocha.suite']");
+  runner.on('suite', function(suite) {
+    if(suite.title && suite.title !== '')
+      console.log("##teamcity[testSuiteStarted name='" + escape(suite.title) + "']");
   });
 
   runner.on('test', function(test) {
-    console.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "']");
+    console.log("##teamcity[testStarted name='" + escape(test.title) + "']");
   });
 
   runner.on('fail', function(test, err) {
-    console.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "' message='" + escape(err.message) + "']");
+    console.log("##teamcity[testFailed name='" + escape(test.title) + "' message='" + escape(err.message) + "']");
   });
 
   runner.on('pending', function(test) {
-    console.log("##teamcity[testIgnored name='" + escape(test.fullTitle()) + "' message='pending']");
+    console.log("##teamcity[testIgnored name='" + escape(test.title) + "' message='pending']");
   });
 
   runner.on('test end', function(test) {
-    console.log("##teamcity[testFinished name='" + escape(test.fullTitle()) + "' duration='" + test.duration + "']");
+    console.log("##teamcity[testFinished name='" + escape(test.title) + "' duration='" + test.duration + "']");
   });
 
-  runner.on('end', function() {
-    console.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
+  runner.on('suite end', function(suite) {
+    if(suite.title && suite.title !== '')
+      console.log("##teamcity[testSuiteFinished name='" + escape(suite.title) + "']");
   });
 }
 


### PR DESCRIPTION
The TeamCity reporter currently throws away all suite information. This update brings it back.

The top-level suite (with no title) is ignored, as it would be a nuisance for the TeamCity test reporter (having to drill-down into it before seeing the actual suites).
