### PR TITLE
use setImmediate when available instead of process.nextTick

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -10,11 +10,7 @@ var EventEmitter = require('events').EventEmitter
   , filter = utils.filter
   , keys = utils.keys
   , noop = function(){}
-  , immediately = process.nextTick;
-
-if( global.setImmediate != undefined ) {
-  immediately = global.setImmediate;
-}
+  , immediately = global.setImmediate || process.nextTick;
 
 /**
  * Non-enumerable globals.

--- a/mocha.js
+++ b/mocha.js
@@ -4066,7 +4066,8 @@ var EventEmitter = require('browser/events').EventEmitter
   , utils = require('./utils')
   , filter = utils.filter
   , keys = utils.keys
-  , noop = function(){};
+  , noop = function(){}
+  , immediately = global.setImmediate || process.nextTick;
 
 /**
  * Non-enumerable globals.
@@ -4246,7 +4247,7 @@ Runner.prototype.fail = function(test, err){
   if ('string' == typeof err) {
     err = new Error('the string "' + err + '" was thrown, throw an Error :)');
   }
-  
+
   this.emit('fail', test, err);
 };
 
@@ -4303,7 +4304,7 @@ Runner.prototype.hook = function(name, fn){
     });
   }
 
-  process.nextTick(function(){
+  immediately(function(){
     next(0);
   });
 };
@@ -4544,10 +4545,11 @@ Runner.prototype.uncaught = function(err){
 
 Runner.prototype.run = function(fn){
   var self = this
-    , fn = fn || function(){}
-    , uncaught = function(err){
-      self.uncaught(err);
-    };
+    , fn = fn || function(){};
+
+  function uncaught(err){
+    self.uncaught(err);
+  }
 
   debug('start');
 


### PR DESCRIPTION
In node 0.9+, recursive use of process.nextTick emits a warning (and will soon break).

The warning says to use setImmediate for recursive deferral.  This pull request makes this change.

Tested against 0.8.9 (which lacks setImmediate) and 0.9.9 (which has it).
