### PR TITLE
The Object.keys of Firefox has bug

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,7 +107,7 @@ exports.filter = function(arr, fn){
  * @api private
  */
 
-exports.keys = Object.keys || function(obj) {
+exports.keys = function(obj) {
   var keys = []
     , has = Object.prototype.hasOwnProperty // for `window` on <=IE8
 


### PR DESCRIPTION
The Object.keys of Firefox has bug, you can try like this in Firefox:

```
<script>
    console.log(Object.keys(window));
    if(top == window){}
    console.log(Object.keys(window));
</script>
```

Results here:

```
["window", "document", "InstallTrigger", "console", "process", "global", "Mocha", "mocha", "sinon", "expect", "location", "mouseEvents", "msPointerEvents", "keyEvents", "uiEvents", "bubbleEvents", "touchEvents", "gestureEvents", "before", "after", "beforeEach", "afterEach", "context", "describe", "xcontext", "xdescribe", "specify", "it", "xspecify", "xit", "getInterface"]
["window", "document", "InstallTrigger", "console", "process", "global", "Mocha", "mocha", "sinon", "expect", "location", "mouseEvents", "msPointerEvents", "keyEvents", "uiEvents", "bubbleEvents", "touchEvents", "gestureEvents", "before", "after", "beforeEach", "afterEach", "context", "describe", "xcontext", "xdescribe", "specify", "it", "xspecify", "xit", "getInterface", "top"]
```

Some variables can't be read by Object.keys, until the variable been used in code.
