### PR TITLE
Fix indentation in clean utility

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,11 +193,13 @@ exports.slug = function(str){
 
 exports.clean = function(str) {
   str = str
+    .replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, '')
     .replace(/^function *\(.*\) *{/, '')
     .replace(/\s+\}$/, '');
 
   var spaces = str.match(/^\n?( *)/)[1].length
-    , re = new RegExp('^ {' + spaces + '}', 'gm');
+    , tabs = str.match(/^\n?(\t*)/)[1].length
+    , re = new RegExp('^\n?' + (tabs ? '\t' : ' ') + '{' + (tabs ? tabs : spaces) + '}', 'gm');
 
   str = str.replace(re, '');
 

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -1,0 +1,59 @@
+var utils = require('../../lib/utils');
+
+describe('lib/utils', function () {
+  describe('clean', function () {
+    it("should format a single line test function", function () {
+      var fn = [
+        "function () {"
+        , "  var a = 1;"
+        , "}"
+      ].join("\n");
+      utils.clean(fn).should.equal("var a = 1;");
+    });
+
+    it("should format a multi line test indented with spaces", function () {
+      // and no new lines after curly braces, shouldn't matter
+      var fn = [
+        "function(){  var a = 1;"
+        , "    var b = 2;" // this one has more spaces
+        , "  var c = 3;  }"
+      ].join("\n");
+      utils.clean(fn).should.equal("var a = 1;\n  var b = 2;\nvar c = 3;");
+    });
+
+    it("should format a multi line test indented with tabs", function () {
+      var fn = [
+        "function (arg1, arg2)   {"
+        , "\tif (true) {"
+        , "\t\tvar a = 1;"
+        , "\t}"
+        , "}"
+      ].join("\n");
+      utils.clean(fn).should.equal("if (true) {\n\tvar a = 1;\n}");
+    });
+
+    it("should format functions saved in windows style - spaces", function () {
+      var fn = [
+        "function (one) {"
+        , "   do {",
+        , '    "nothing";',
+        , "   } while (false);"
+        , ' }'
+      ].join("\r\n");
+      utils.clean(fn).should.equal('do {\n "nothing";\n} while (false);');
+    });
+
+    it("should format functions saved in windows style - tabs", function () {
+      var fn = [
+        "function ( )   {"
+        , "\tif (false) {"
+        , "\t\tvar json = {"
+        , '\t\t\tone : 1'
+        , '\t\t};'
+        , "\t}"
+        , "}"
+      ].join("\r\n");
+      utils.clean(fn).should.equal("if (false) {\n\tvar json = {\n\t\tone : 1\n\t};\n}");
+    });
+  });
+});


### PR DESCRIPTION
`utils.clean` extracts a test method content re-indenting the function for whitespaces.
This commit fixes to issues with indentation
- windows line feed `\r\n`
- tab indentation `\t`

I've added a test inside `test/acceptance`, it should run with `make test-unit`, and I've tried to follow your coding style (changes are very small)
Hope you'd like it :smile: 
