### PR TITLE
Add when() to BDD

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -68,8 +68,23 @@ module.exports = function(suite){
   
     context.describe = context.context = function(title, fn){
       var suite = Suite.create(suites[0], title);
+      suite.pending = !!suites[0].makeNextPending;
       suites.unshift(suite);
       fn.call(suite);
+      suites.shift();
+      return suite;
+    };
+
+    /**
+    * Make nested "suites" pending if the test
+    * is not truthy.
+    */
+    context.when = function (test, fn) {
+      var suite = suites[0];
+      suite.makeNextPending = !test;
+      suites.unshift(suite);
+      fn.call(suite);
+      suite.makeNextPending = false;
       suites.shift();
       return suite;
     };

--- a/test/when.js
+++ b/test/when.js
@@ -1,0 +1,32 @@
+describe("Suite", function () {
+	describe(".when()", function () {
+		var containedSuite;
+		describe("when when() is called with true", function () {
+			it("should not make inner-suites pending", function () {
+				when(true, function () {
+					containedSuite = describe("this block should run", function () {
+						it("should run this test", function () {
+							true.should.equal(true);
+						});
+					});
+				});
+
+				containedSuite.pending.should.equal(false);
+			});
+		});
+
+		describe("when when() is called with false", function () {
+			it("should make inner-suites pending", function () {
+				when(false, function () {
+					containedSuite = describe("this block should not run", function () {
+						it("should not run this test", function () {
+							true.should.equal(false);
+						});
+					});
+				});
+
+				containedSuite.pending.should.equal(true);
+			});
+		});
+	});
+});


### PR DESCRIPTION
This is useful if you want to maintain a group of tests, only some of which
need to run in certain circumstances. For example, testing your shimmed
Array.forEach, but only on browsers that don't support it natively.

Rather than including/excluding specific test files depending on which
platform you are testing, simply wrap the questionable test suite in a
when() block.
