### PR TITLE
process directories' files in a deterministic order

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -390,7 +390,7 @@ function lookupFiles(path, recursive) {
   var stat = fs.statSync(path);
   if (stat.isFile()) return path;
 
-  fs.readdirSync(path).forEach(function(file){
+  fs.readdirSync(path).sort().forEach(function(file){
     file = join(path, file);
     var stat = fs.statSync(file);
     if (stat.isDirectory()) {


### PR DESCRIPTION
This allows me to use a `_setup.coffee` file that will be executed before all the test files and expose things like egal helpers or a scoped filesystem interface. If there's a better way to do this, I'd love to know, but I think this change has merit either way.
