### PR TITLE
Modify gh-pages css for firefox

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,8 +127,10 @@ pre {
   border-bottom-color: #ddd;
   -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
+  border-radius: 2px;
   -webkit-box-shadow: inset 0 0 10px #eee;
   -moz-box-shadow: inset 0 0 10px #eee;
+  box-shadow: inset 0 0 10px #eee;
   overflow-x: auto;
 }
 
@@ -137,8 +139,10 @@ img {
   padding: 1px;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
+  border-radius: 3px;
   -webkit-box-shadow: 0 3px 10px #dedede, 0 1px 5px #888;
   -moz-box-shadow: 0 3px 10px #dedede, 0 1px 5px #888;
+  box-shadow: 0 3px 10px #dedede, 0 1px 5px #888;
   max-width: 100%;
 }
 


### PR DESCRIPTION
Currently, Firefox supports `border-radius` and `box-shadow`.
And the another one with vender-prefix is not supported.

Before:
![ 2013-03-15 2 41 46](https://f.cloud.github.com/assets/290782/260105/785f3950-8cce-11e2-951f-11d608df7c6e.png)

After:
![ 2013-03-15 2 42 27](https://f.cloud.github.com/assets/290782/260112/9111d1b0-8cce-11e2-818b-5e37ef057370.png)
