### PR TITLE
Actual value of ignoreLeaks from configuration

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -209,12 +209,13 @@ Mocha.prototype.invert = function(){
 /**
  * Ignore global leaks.
  *
+ * @param {Boolean} ignore
  * @return {Mocha}
  * @api public
  */
 
-Mocha.prototype.ignoreLeaks = function(){
-  this.options.ignoreLeaks = true;
+Mocha.prototype.ignoreLeaks = function(ignore){
+  this.options.ignoreLeaks = !!ignore;
   return this;
 };
 


### PR DESCRIPTION
`ignoreLeaks` value is ignored by the setup function.

By doing this

``` js
mocha.setup({
   ui : "bdd",
   ignoreLeaks : false
});
```

`ignoreLeaks` happens to be `true`.

It happens because the [boot code](https://github.com/visionmedia/mocha/blob/master/support/tail.js#L90)

``` js
mocha.setup = function(opts){
    if ('string' == typeof opts) opts = { ui: opts };
    for (var opt in opts) this[opt](opts[opt]);   // calls this.ignoreLeaks(false);
    return this;
};
```

passes the configured value to [this function](https://github.com/visionmedia/mocha/blob/master/lib/mocha.js#L216)

``` js
Mocha.prototype.ignoreLeaks = function(){
  this.options.ignoreLeaks = true;
  return this;
};
```

which simply sets the value to `true` no matter what was passed.

I'm not sure how to test this with your suite, probably by appending a 

``` js
--ignoreLeaks false
```

in [mocha.opts](https://github.com/visionmedia/mocha/blob/master/test/mocha.opts)
