### PR TITLE
global leaks improvements

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -52,15 +52,14 @@ module.exports = Runner;
 
 function Runner(suite) {
   var self = this;
-  this._globals = this.globalProps();
+  this._globals = [];
   this.suite = suite;
   this.total = suite.total();
   this.failures = 0;
   this.on('test end', function(test){ self.checkGlobals(test); });
   this.on('hook end', function(hook){ self.checkGlobals(hook); });
   this.grep(/.*/);
-  this.specifiedGlobalsLen = 0;
-  this.globals(['errno']);
+  this.globals(this.globalProps().concat(['errno']));
 }
 
 /**
@@ -142,7 +141,6 @@ Runner.prototype.globals = function(arr){
   utils.forEach(arr, function(arr){
     this._globals.push(arr);
   }, this);
-  this.specifiedGlobalsLen = this.specifiedGlobalsLen + arr.length;
   return this;
 };
 
@@ -160,11 +158,15 @@ Runner.prototype.checkGlobals = function(test){
   var leaks;
 
   // check length - 2 ('errno' and 'location' globals)
-  if (isNode && this.specifiedGlobalsLen == ok.length - globals.length) return
-  else if (this.specifiedGlobalsLen == ok.length - globals.length) return;
-  console.time('filterLeaksTime');
+  if (isNode && 1 == ok.length - globals.length) return;
+  else if (2 == ok.length - globals.length) return;
+  
+  if(this.prevGlobalsLength == globals.length) return;
+  this.prevGlobalsLength = globals.length;
+  
+  //console.time('filterLeaksTime');
   leaks = filterLeaks(ok, globals);
-  console.timeEnd('filterLeaksTime');
+  //console.timeEnd('filterLeaksTime');
   this._globals = this._globals.concat(leaks);
 
   if (leaks.length > 1) {


### PR DESCRIPTION
3 improvements
### 1. in ie6,7,8 and opera, insert iframe will cause global leaks

**analysis**

An iframe could be approached by window[iframeIndex].
In ie6,7,8 and opera, iframeIndex is enumerable, this could cause leaks.

**solution**

see: lib/runner.js 540
### 2. in firefox, window.getInterface may cause global leaks

**analysis**

If runner runs in an iframe, this iframe's window.getInterface method not init at first.
It is assigned in some seconds.

**solution**

see: lib/runner.js line536
### 3. in some browsers, mocha.globals([...]) make tests run very slow

**analysis**
- if user specified globals argument, every time a test finished, filterLeaks() will run.
- nested loop is not efficient

**solution**
- see: lib/runner.js line164 ~ 165. I use this.prevGlobalsLength to remember how many global variables are when last test finished. When this test finished, this.prevGlobalsLength  will be compared with globals.length, if they are equals, I think this test dose not has global leaks, so filterLeaks() could be jumped.（it is not very strict, if someone delete a global variable, and then create a new one in this test, this won't be found. but if it happened, just let it go). this promotion is huge.
- see: lib/runner.js line531 ~ 547. I moved some code to outer loop from inner loop. this cuts down run time by 50%.
