### PR TITLE
Support programmatic specification of requirements

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -144,11 +144,7 @@ program.on('interfaces', function(){
 module.paths.push(cwd, join(cwd, 'node_modules'));
 
 program.on('require', function(mod){
-  var abs = exists(mod)
-    || exists(mod + '.js');
-
-  if (abs) mod = join(cwd, mod);
-  require(mod);
+  mocha.addRequirements(mod);
 });
 
 // mocha.opts support

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -9,6 +9,7 @@
  */
 
 var path = require('path')
+  , exists = require('fs').existsSync || path.existsSync
   , utils = require('./utils');
 
 /**
@@ -63,8 +64,10 @@ function image(name) {
 
 function Mocha(options) {
   options = options || {};
+  this.requirements = [];
   this.files = [];
   this.options = options;
+  this.addRequirements(options.require);
   this.grep(options.grep);
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
@@ -96,6 +99,19 @@ Mocha.prototype.bail = function(bail){
 
 Mocha.prototype.addFile = function(file){
   this.files.push(file);
+  return this;
+};
+
+/**
+ * Add required file
+ * @param {String|Array} file or list of files
+ * @api public
+ */
+
+Mocha.prototype.addRequirements = function(files){
+  if (files) {
+    this.requirements = this.requirements.concat(files);
+  }
   return this;
 };
 
@@ -133,6 +149,23 @@ Mocha.prototype.ui = function(name){
   this._ui = exports.interfaces[name];
   if (!this._ui) throw new Error('invalid interface "' + name + '"');
   this._ui = this._ui(this.suite);
+  return this;
+};
+
+/**
+ * Load required files.
+ *
+ * @api private
+ */
+
+Mocha.prototype.loadRequirements = function(){
+  this.requirements.forEach(function(file) {
+    var abs = exists(file)
+      || exists(file + '.js');
+
+    if (abs) file = path.resolve(file);
+    require(file);
+  });
   return this;
 };
 
@@ -302,6 +335,7 @@ Mocha.prototype.asyncOnly = function(){
  */
 
 Mocha.prototype.run = function(fn){
+  if (this.requirements.length) this.loadRequirements();
   if (this.files.length) this.loadFiles();
   var suite = this.suite;
   var options = this.options;

--- a/test/jsapi/index.js
+++ b/test/jsapi/index.js
@@ -5,12 +5,12 @@ var Mocha = require('../../')
 var mocha = new Mocha({
   ui: 'bdd',
   globals: ['okGlobalA', 'okGlobalB', 'okGlobalC', 'callback*'],
+  require: ['should'],
   // ignoreLeaks: true,
   growl: true
 });
 
 // mocha.reporter('spec');
-require('should');
 
 mocha.addFile('test/suite.js');
 mocha.addFile('test/runner.js');


### PR DESCRIPTION
Move support for "requirements" into the Mocha library itself (instead
of a CLI abstraction) so that requirements can be used programmatically
through the Mocha API.

I think it's generally a good idea to have this functionality available programmatically. My use case is with [the "Simple Mocha" plugin for Grunt](https://github.com/yaymukund/grunt-simple-mocha), where I'd like to specify Mocha test requirements from my Gruntfile.
