### PR TITLE
Fix typo.

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,7 +564,7 @@ test('#length', function(){
 
 <p>  The HTMLCov reporter extends the JSONCov reporter. The library being tested should first be instrumented by <a href="https://github.com/visionmedia/node-jscoverage">node-jscoverage</a>, this allows Mocha to capture the coverage information necessary to produce a single-page HTML report.</p>
 
-<p>  Click to view the current <a href="coverage.html">Express test coverage</a> report. For an integration example view the mcoha test coverage support <a href="https://github.com/visionmedia/express/commit/b6ee5fafd0d6c79cf7df5560cb324ebee4fe3a7f">commit</a> for Express.</p>
+<p>  Click to view the current <a href="coverage.html">Express test coverage</a> report. For an integration example view the mocha test coverage support <a href="https://github.com/visionmedia/express/commit/b6ee5fafd0d6c79cf7df5560cb324ebee4fe3a7f">commit</a> for Express.</p>
 
 <p>  <img src="http://f.cl.ly/items/3T3G1h1d3Z2i3M3Y1Y0Y/Screen%20Shot%202012-02-23%20at%208.37.13%20PM.png" alt="code coverage reporting" /></p>
 


### PR DESCRIPTION
Changed `mcoha` to `mocha`. GitHub apparently added a newline to the end of the file automatically too.
