### PR TITLE
Fix off-by-one in dot reporter

### DIFF
--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -36,7 +36,8 @@ function Dot(runner) {
   });
 
   runner.on('pass', function(test){
-    if (++n % width == 0) process.stdout.write('\n  ');
+    if (n % width == 0) process.stdout.write('\n  ');
+    ++n;
     if ('slow' == test.speed) {
       process.stdout.write(color('bright yellow', Base.symbols.dot));
     } else {


### PR DESCRIPTION
Instead of:

```
  .........   <- missing last dot
  ..........
  ..........
  ..........
```

Let's do:

```
  ..........
  ..........
  ..........
  ..........
```
