### PR TITLE
Node shims should save timer reference to avoid sinon interferring.

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -47,6 +47,16 @@ process.on = function(e, fn){
   var immediateQueue = []
     , immediateTimeout;
 
+  /**
+   * Save timer references to avoid Sinon interfering (see GH-237).
+   */
+  
+  var Date = global.Date
+    , setTimeout = global.setTimeout
+    , setInterval = global.setInterval
+    , clearTimeout = global.clearTimeout
+    , clearInterval = global.clearInterval;
+
   function timeslice() {
     var immediateStart = new Date().getTime();
     while (immediateQueue.length && (new Date().getTime() - immediateStart) < 100) {


### PR DESCRIPTION
Related issue: https://github.com/visionmedia/mocha/issues/237
