### PR TITLE
CLI spits a clean error when path/js input does not exist

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -264,9 +264,16 @@ var files = []
 
 if (!args.length) args.push('test');
 
-args.forEach(function(arg){
-  files = files.concat(lookupFiles(arg, program.recursive));
-});
+try{
+  args.forEach(function(arg){
+    files = files.concat(lookupFiles(arg, program.recursive));
+  });
+}
+catch(err){
+  console.error("\t" + err);
+  process.exit(0);
+}
+
 
 // resolve
 
@@ -387,6 +394,7 @@ function lookupFiles(path, recursive) {
   var files = [];
 
   if (!exists(path)) path += '.js';
+  if (!exists(path)) throw new Error("Couldn't resolve path or js from: " + path.slice(0,path.length-3));
   var stat = fs.statSync(path);
   if (stat.isFile()) return path;
 


### PR DESCRIPTION
<p>
Basically, a simple error message is presented to the CLI user instead of fs thrown exception if the file or path to be tested does not exist. For example: <em>mocha dajlksdj</em> spits an error :).
</p>

<p>
I believe more cleanup work should be made in the CLI area. We should consider adding some tests.
