### PR TITLE
Add option to disable spinner in `--watch`.

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -77,6 +77,7 @@ program
   .option('--interfaces', 'display available interfaces')
   .option('--reporters', 'display available reporters')
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
+  .option('--no-spinner', 'disable animated spinner in --watch mode')
 
 program.name = 'mocha';
 
@@ -298,7 +299,11 @@ if (program.watch) {
   function loadAndRun() {
     mocha.files = files;
     mocha.run(function(){
-      play(frames);
+      if (program.spinner) {
+        play(frames);
+      } else {
+        process.stdout.write('  \u001b[90mwatching...\u001b[0m');
+      }
     });
   }
 


### PR DESCRIPTION
I'm unable to use [node-foreman](/NodeFly/node-foreman) with `--watch` because of the spinner animation -

Screenshot with spinner:
![Screen Shot 2013-04-11 at 8 51 15 PM](https://f.cloud.github.com/assets/217126/368300/7b74a716-a2bc-11e2-97aa-13ec54b2040e.png)

and without:
![Screen Shot 2013-04-11 at 8 53 59 PM](https://f.cloud.github.com/assets/217126/368304/81dc84ac-a2bc-11e2-88b1-1e23fcf60215.png)

Let me know if something needs to be changed.
