### PR TITLE
Sort tests files using argument flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ test-async-only:
 	  --async-only \
 	  test/acceptance/misc/asyncOnly
 
+test-sort:
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		--sort \
+		test/acceptance/sort
+
 non-tty:
 	@./bin/mocha \
 		--reporter dot \

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -70,6 +70,7 @@ program
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
   .option('-b, --bail', "bail after first test failure")
   .option('-A, --async-only', "force all tests to take a callback (async)")
+  .option('-S, --sort', "sort test files")
   .option('--recursive', 'include sub directories')
   .option('--debug-brk', "enable node's debugger breaking on the first line")
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
@@ -274,6 +275,10 @@ args.forEach(function(arg){
 files = files.map(function(path){
   return resolve(path);
 });
+
+if (program.sort) {
+  files.sort();
+}
 
 // --watch
 

--- a/test/acceptance/sort/alpha.js
+++ b/test/acceptance/sort/alpha.js
@@ -1,0 +1,7 @@
+describe('alpha', function(){
+  it('should be executed first', function(){
+  	if (global.beta) {
+      throw new Error('alpha was not executed first');
+  	}
+  });
+});

--- a/test/acceptance/sort/beta.js
+++ b/test/acceptance/sort/beta.js
@@ -1,0 +1,5 @@
+describe('beta', function(){
+  it('should be executed second', function(){
+    global.beta = 1;
+  });
+});


### PR DESCRIPTION
Sort tests files using argument flag: `-S` or `--sort`

Useful if used in conjunction with `--bail` and require that tests follow a certain high level order.
