### PR TITLE
Preserve window.location.hash when running a single suite/test using the (‣) buttons

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -101,7 +101,7 @@ function HTML(runner, root) {
     if (suite.root) return;
 
     // suite
-    var url = '?grep=' + encodeURIComponent(suite.fullTitle());
+    var url = '?grep=' + encodeURIComponent(suite.fullTitle()) + window.location.hash;
     var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, escape(suite.title));
 
     // container
@@ -132,11 +132,11 @@ function HTML(runner, root) {
 
     // test
     if ('passed' == test.state) {
-      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, encodeURIComponent(test.fullTitle()) + window.location.hash);
     } else if (test.pending) {
       var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
-      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, encodeURIComponent(test.fullTitle()) + window.location.hash);
       var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message

--- a/mocha.js
+++ b/mocha.js
@@ -2314,7 +2314,7 @@ function HTML(runner, root) {
     if (suite.root) return;
 
     // suite
-    var url = '?grep=' + encodeURIComponent(suite.fullTitle());
+    var url = '?grep=' + encodeURIComponent(suite.fullTitle()) + window.location.hash;
     var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, escape(suite.title));
 
     // container
@@ -2345,11 +2345,11 @@ function HTML(runner, root) {
 
     // test
     if ('passed' == test.state) {
-      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="?grep=%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, encodeURIComponent(test.fullTitle()) + window.location.hash);
     } else if (test.pending) {
       var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
-      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, encodeURIComponent(test.fullTitle()) + window.location.hash);
       var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message


### PR DESCRIPTION
If you're using `window.location.hash` to modify the behavior of your test runner, clicking the (‣) buttons to run a single suite/test will not pass the current hash along.

In my case, I set the value `window.location.hash` to the variation of the source code I wanted to test, then loaded the source files dynamically. This worked fine, but clicking (‣) would not pass `window.location.hash`, which resulted in my loader code not loading any source files.

**Note:** If a test expects `window.location.hash` to be unset when it runs, this could produce unexpected behavior. However, this is already a problem if a test that precedes it sets `window.location.hash`, so I'm very concerned.
