### PR TITLE
Fix #369 - Support non-js langs with --require

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lib-cov:
 
 test: test-unit
 
-test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers test-glob
+test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers test-glob test-requires
 
 test-jsapi:
 	@node test/jsapi
@@ -50,6 +50,16 @@ test-compilers:
 		--compilers coffee:coffee-script,foo:./test/compiler/foo \
 		test/acceptance/test.coffee \
 		test/acceptance/test.foo
+
+test-requires:
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		--compilers coffee:coffee-script \
+		--require test/acceptance/require/a.js \
+		--require test/acceptance/require/b.coffee \
+		--require test/acceptance/require/c.js \
+		--require test/acceptance/require/d.coffee \
+		test/acceptance/require/require.js
 
 test-bdd:
 	@./bin/mocha \

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -44,6 +44,12 @@ var files = [];
 var globals = [];
 
 /**
+ * Requires.
+ */
+
+var requires = [];
+
+/**
  * Images.
  */
 
@@ -148,7 +154,7 @@ module.paths.push(cwd, join(cwd, 'node_modules'));
 program.on('require', function(mod){
   var abs = exists(mod) || exists(mod + '.js');
   if (abs) mod = resolve(mod);
-  require(mod);
+  requires.push(mod);
 });
 
 // mocha.opts support
@@ -254,6 +260,12 @@ program.compilers.forEach(function(c) {
 });
 
 var re = new RegExp('\\.(' + extensions.join('|') + ')$');
+
+// requires
+
+requires.forEach(function(mod) {
+  require(mod);
+});
 
 // files
 

--- a/test/acceptance/require/a.js
+++ b/test/acceptance/require/a.js
@@ -1,0 +1,2 @@
+global.required = (global.required || [])
+global.required.push('a.js')

--- a/test/acceptance/require/b.coffee
+++ b/test/acceptance/require/b.coffee
@@ -1,0 +1,2 @@
+global.required ?= []
+global.required.push 'b.coffee'

--- a/test/acceptance/require/c.js
+++ b/test/acceptance/require/c.js
@@ -1,0 +1,2 @@
+global.required = (global.required || [])
+global.required.push('c.js')

--- a/test/acceptance/require/d.coffee
+++ b/test/acceptance/require/d.coffee
@@ -1,0 +1,2 @@
+global.required ?= []
+global.required.push 'd.coffee'

--- a/test/acceptance/require/require.js
+++ b/test/acceptance/require/require.js
@@ -1,0 +1,10 @@
+
+describe('require test', function(){
+  it('should require args in order', function(){
+    var req = global.required;
+    req.indexOf('a.js').should.equal(0);
+    req.indexOf('b.coffee').should.equal(1);
+    req.indexOf('c.js').should.equal(2);
+    req.indexOf('d.coffee').should.equal(3);
+  })
+});


### PR DESCRIPTION
Allows `--require` to make use of `--compilers`. Such that any files can be required, when using the appropriate compiler.

Comes with a test to ensure that `--require` functions as expected, and retains order of execution for included scripts.

Fixes #369.
