### PR TITLE
Tweaked Makefile for better Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ lib/browser/diff.js: node_modules/diff/diff.js
 mocha.js: $(SRC) $(SUPPORT) lib/browser/diff.js
 	@node support/compile $(SRC)
 	@cat \
-	  support/head.js \
-	  _mocha.js \
-	  support/tail.js \
-	  support/foot.js \
-	  > mocha.js
+		support/head.js \
+		_mocha.js \
+		support/tail.js \
+		support/foot.js \
+		> mocha.js
 
 clean:
 	rm -f mocha.js
@@ -39,83 +39,83 @@ test-jsapi:
 	@node test/jsapi
 
 test-unit:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		test/acceptance/*.js \
 		test/*.js
 
 test-compilers:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		--compilers coffee:coffee-script,foo:./test/compiler/foo \
 		test/acceptance/test.coffee \
 		test/acceptance/test.foo
 
 test-bdd:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		--ui bdd \
 		test/acceptance/interfaces/bdd
 
 test-tdd:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		--ui tdd \
 		test/acceptance/interfaces/tdd
 
 test-qunit:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		--ui qunit \
 		test/acceptance/interfaces/qunit
 
 test-exports:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		--ui exports \
 		test/acceptance/interfaces/exports
 
 test-grep:
-	@./bin/mocha \
-	  --reporter $(REPORTER) \
-	  --grep fast \
-	  test/acceptance/misc/grep
+	mocha \
+		--reporter $(REPORTER) \
+		--grep fast \
+		test/acceptance/misc/grep
 
 test-invert:
-	@./bin/mocha \
-	  --reporter $(REPORTER) \
-	  --grep slow \
-	  --invert \
-	  test/acceptance/misc/grep
+	mocha \
+		--reporter $(REPORTER) \
+		--grep slow \
+		--invert \
+		test/acceptance/misc/grep
 
 test-bail:
-	@./bin/mocha \
+	mocha \
 		--reporter $(REPORTER) \
 		--bail \
 		test/acceptance/misc/bail
 
 test-async-only:
-	@./bin/mocha \
-	  --reporter $(REPORTER) \
-	  --async-only \
-	  test/acceptance/misc/asyncOnly
+	mocha \
+		--reporter $(REPORTER) \
+		--async-only \
+		test/acceptance/misc/asyncOnly
 
 non-tty:
-	@./bin/mocha \
+	mocha \
 		--reporter dot \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/dot.out
 
 	@echo dot:
 	@cat /tmp/dot.out
 
-	@./bin/mocha \
+	mocha \
 		--reporter list \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/list.out
 
 	@echo list:
 	@cat /tmp/list.out
 
-	@./bin/mocha \
+	mocha \
 		--reporter spec \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/spec.out
 


### PR DESCRIPTION
Windows has trouble with dot slash notation, so `npm test` had trouble running in Command Prompt and Cygwin. I was able to get the make tasks to run by shortening the paths to just `mocha`, which NPM is able to resolve fairly well.

There's still a minor failing test in Windows, but at least `npm test` is able to run now.

```
$ npm test

> mocha@1.9.0 test c:\Documents and Settings\apenneba\Desktop\src\mocha
> make test-all

mocha \
                --reporter dot \
                --ui bdd \
                test/acceptance/interfaces/bdd
mocha \
                --reporter dot \
                --ui tdd \
                test/acceptance/interfaces/tdd
mocha \
                --reporter dot \
                --ui qunit \
                test/acceptance/interfaces/qunit
mocha \
                --reporter dot \
                --ui exports \
                test/acceptance/interfaces/exports
mocha \
                --reporter dot \
                test/acceptance/*.js \
                test/*.js

  ..................................................................
  .......................................

  × 1 of 105 tests failed:

  1) fs.readFile() when the file exists should succeed:
     Error: ENOENT, open 'c:\tmp\mocha'



make: *** [test-unit] Error 1
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
