### PR TITLE
Save timer references to avoid Sinon interfering in the browser build

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -38,6 +38,16 @@ process.on = function(e, fn){
 ;(function(){
 
   /**
+   * Save timer references to avoid Sinon interfering (see GH-237).
+   */
+
+  var Date = global.Date,
+    setTimeout = global.setTimeout,
+    setInterval = global.setInterval,
+    clearTimeout = global.clearTimeout,
+    clearInterval = global.clearInterval;
+
+  /**
    * Expose mocha.
    */
 


### PR DESCRIPTION
I discovered that the issues discussed in #237 still affect the browser build of Mocha because references to the global Date/timer objects were not being saved in the closure that defines the `timeslice` function. I added the same code that is being used in other modules to `tail.js` which fixes this problem. This keeps the test runner from hanging for me.
