### PR TITLE
Fixing call chaining for before*, after*, it.only, and describe.only

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -30,34 +30,46 @@ module.exports = function(suite){
 
     /**
      * Execute before running tests.
+     *
+     * @return {Hook} the beforeAll hook for chaining
      */
 
     context.before = function(fn){
       suites[0].beforeAll(fn);
+      return suites[0]._beforeAll.slice(-1)[0];
     };
 
     /**
      * Execute after running tests.
+     *
+     * @return {Hook} the afterAll hook for chaining
      */
 
     context.after = function(fn){
       suites[0].afterAll(fn);
+      return suites[0]._afterAll.slice(-1)[0];
     };
 
     /**
      * Execute before each test case.
+     *
+     * @return {Hook} the beforeEach hook for chaining
      */
 
     context.beforeEach = function(fn){
       suites[0].beforeEach(fn);
+      return suites[0]._beforeEach.slice(-1)[0];
     };
 
     /**
      * Execute after each test case.
+     *
+     * @return {Hook} the afterEach hook for chaining
      */
 
     context.afterEach = function(fn){
       suites[0].afterEach(fn);
+      return suites[0]._afterEach.slice(-1)[0];
     };
 
     /**
@@ -95,6 +107,7 @@ module.exports = function(suite){
     context.describe.only = function(title, fn){
       var suite = context.describe(title, fn);
       mocha.grep(suite.fullTitle());
+      return suite
     };
 
     /**
@@ -118,6 +131,7 @@ module.exports = function(suite){
     context.it.only = function(title, fn){
       var test = context.it(title, fn);
       mocha.grep(test.fullTitle());
+      return test
     };
 
     /**


### PR DESCRIPTION
For BDD style test suites you could not do .timeout() or anything else after any of these functions. This fixes that, especially important for it.only().
