### PR TITLE
JSON stringifying non error objects passed to done

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -195,7 +195,14 @@ Runnable.prototype.run = function(fn){
     try {
       this.fn.call(ctx, function(err){
         if (err instanceof Error || toString.call(err) === "[object Error]") return done(err);
-        if (null != err) return done(new Error('done() invoked with non-Error: ' + err));
+
+        if (null != err) {
+          if (toString.call(err) === '[object Object]') {
+            err = JSON.stringify(err);
+          }
+          return done(new Error('done() invoked with non-Error: ' + err));
+        }
+
         done();
       });
     } catch (err) {


### PR DESCRIPTION
When passing an object to done() within a test a rather unhelpful error is printed. This makes an attempt to give the printed error more information rather than just `Error: done() invoked with non-Error: [object Object]`.
