### PR TITLE
Uses util.inspect in base reporter to support showing diff of circular object

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -165,8 +165,8 @@ exports.list = function(failures){
     // explicitly show diff
     if (err.showDiff) {
       escape = false;
-      err.actual = actual = inspect(actual);
-      err.expected = expected = inspect(expected);
+      err.actual = actual = inspect(actual, {depth: null});
+      err.expected = expected = inspect(expected, {depth: null});
     }
 
     // actual / expected diff


### PR DESCRIPTION
showing diff of objects which contain circular object, instead of silently fail.

```
actual expected

   1 | { id: null,
   2 |   name: 'Root',
   3 |   meta: null,
   4 |   categories:
   5 |    { aab:
   6 |       { id: 'aab',
   7 |         name: 'A',
   8 |         meta: null,
   9 |         categories: [Object],
  10 |         sources: [Object],
  11 |         parent: [Circular] },
  12 |      c:
  13 |       { id: 'c',
  14 |         name: 'C',
  15 |         meta: null,
  16 |         categories: {},
  17 |         sources: {},
  18 |         parent: [Circular] } },
  19 |   sources: {},
  20 |   parent: null }

expected { id: null,
name: 'Root',
meta: null,
categories:
 { ab:
    { id: 'ab',
      name: 'A',
      meta: null,
      categories: [Object],
      sources: [Object],
      parent: [Circular] },
   c:
    { id: 'c',
      name: 'C',
      meta: null,
      categories: {},
      sources: {},
      parent: [Circular] } },
sources: {},
parent: null } to equal { id: null,
name: 'Root',
meta: null,
categories:
 { a:
    { id: 'a',
      name: 'A',
      meta: null,
      categories: [Object],
      sources: [Object],
      parent: [Circular] },
   c:
    { id: 'c',
      name: 'C',
      meta: null,
      categories: {},
      sources: {},
      parent: [Circular] } },
sources: {},
parent: null }
```
