### PR TITLE
Some rules in mocha.css seem too broad.

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -1,8 +1,10 @@
 @charset "utf-8";
-
 body {
+  margin:0;
+}
+#mocha {
   font: 20px/1.5 "Helvetica Neue", Helvetica, Arial, sans-serif;
-  padding: 60px 50px;
+  margin: 60px 50px;
 }
 
 #mocha ul, #mocha li {
@@ -38,7 +40,7 @@ body {
   font-size: .8em;
 }
 
-.hidden {
+#mocha .hidden {
   display: none;
 }
 
@@ -229,18 +231,18 @@ body {
   height: 40px;
 }
 
-code .comment { color: #ddd }
-code .init { color: #2F6FAD }
-code .string { color: #5890AD }
-code .keyword { color: #8A6343 }
-code .number { color: #2F6FAD }
+#mocha code .comment { color: #ddd }
+#mocha code .init { color: #2F6FAD }
+#mocha code .string { color: #5890AD }
+#mocha code .keyword { color: #8A6343 }
+#mocha code .number { color: #2F6FAD }
 
 @media screen and (max-device-width: 480px) {
-  body {
-    padding: 60px 0px;
+  #mocha  {
+    margin: 60px 0px;
   }
 
-  #stats {
+  #mocha #stats {
     position: absolute;
   }
 }


### PR DESCRIPTION
Restricting css rules to the mocha container as necessary. Should minimize interference with external styles
