### PR TITLE
Runnable.timeout(0) no longer allows silent exits

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -132,15 +132,13 @@ Runnable.prototype.inspect = function(){
 
 Runnable.prototype.resetTimeout = function(){
   var self = this
-    , ms = this.timeout();
+    , ms = this.timeout() || 1e9; // If the timeout is disabled, leave Node running.
 
   this.clearTimeout();
-  if (ms) {
-    this.timer = setTimeout(function(){
-      self.callback(new Error('timeout of ' + ms + 'ms exceeded'));
-      self.timedOut = true;
-    }, ms);
-  }
+  this.timer = setTimeout(function(){
+    self.callback(new Error('timeout of ' + ms + 'ms exceeded'));
+    self.timedOut = true;
+  }, ms);
 };
 
 /**

--- a/test/runnable.js
+++ b/test/runnable.js
@@ -211,6 +211,18 @@ describe('Runnable(title, fn)', function(){
           });
         })
       })
+
+      it('should allow updating the timeout', function(done){
+        var test = new Runnable('foo', function(done){
+          this.timeout(10);
+        });
+        test.run(function(err){
+          err.message.should.include('timeout');
+          done();
+        });
+      })
+
+      it('should allow a timeout of 0')
     })
 
   })


### PR DESCRIPTION
Otherwise, it's possible to create an async test with a timeout of 0 and have Node exit silently. This way, it should be obvious the async test is malformed.
