### PR TITLE
Adds ability to load external interfaces

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -131,6 +131,10 @@ Mocha.prototype.reporter = function(reporter){
 Mocha.prototype.ui = function(name){
   name = name || 'bdd';
   this._ui = exports.interfaces[name];
+  if(!this._ui){
+    exports.interfaces[name] = require(name);
+    this._ui = exports.interfaces[name];
+  }
   if (!this._ui) throw new Error('invalid interface "' + name + '"');
   this._ui = this._ui(this.suite);
   return this;


### PR DESCRIPTION
This adds support for loading additional interfaces with the `--ui` option, similar to how the `--reporter` option works.

After this commit, you should be able use an alternate interface like this:
`npm install someMochaUI`
`mocha --ui someMochaUI path/to/a/mochatest.js`
