### PR TITLE
Support node's --debug-brk=1234 syntax to have debugger listen on specif...

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -71,7 +71,7 @@ program
   .option('-b, --bail', "bail after first test failure")
   .option('-A, --async-only', "force all tests to take a callback (async)")
   .option('--recursive', 'include sub directories')
-  .option('--debug-brk', "enable node's debugger breaking on the first line")
+  .option('--debug-brk', "enable node's debugger breaking on the first line. --debug-brk=<port> to debug on alternate port.")
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--check-leaks', 'check for global variable leaks')
   .option('--interfaces', 'display available interfaces')

--- a/bin/mocha
+++ b/bin/mocha
@@ -33,6 +33,10 @@ process.argv.slice(2).forEach(function (arg) {
       else args.push(arg);
       break;
   }
+  //support --debug-brk=1234
+  if (/^--debug-brk(=\d+)?$/.test(arg)) {
+    args.unshift(arg);
+  }
 });
 
 var proc = spawn(process.argv[0], args, { customFds: [0,1,2] });


### PR DESCRIPTION
...ic port

I like to use a range of ports for each project so I can switch between projects at will without worrying about port conflicts. This is supported by node but was not supported by the mocha wrapper.
