### PR TITLE
Add globbing to support windows-style globs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lib-cov:
 
 test: test-unit
 
-test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers
+test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers test-glob
 
 test-jsapi:
 	@node test/jsapi
@@ -100,6 +100,9 @@ test-async-only:
 	  --reporter $(REPORTER) \
 	  --async-only \
 	  test/acceptance/misc/asyncOnly
+
+test-glob:
+	@./test/acceptance/glob/glob.sh
 
 non-tty:
 	@./bin/mocha \

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -8,6 +8,7 @@ var program = require('commander')
   , sprintf = require('util').format
   , path = require('path')
   , fs = require('fs')
+  , glob = require('glob')
   , resolve = path.resolve
   , exists = fs.existsSync || path.existsSync
   , Mocha = require('../')
@@ -387,7 +388,15 @@ function stop() {
 function lookupFiles(path, recursive) {
   var files = [];
 
-  if (!exists(path)) path += '.js';
+  if (!exists(path)) {
+    if (exists(path + '.js')) {
+      path += '.js'
+    } else {
+      // Try glob expansion of path. This will return empty if not glob or no matches found.
+      return glob.sync(path);
+    }
+  }
+
   var stat = fs.statSync(path);
   if (stat.isFile()) return path;
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "diff": "1.0.2",
     "debug": "*",
     "mkdirp": "0.3.3",
-    "ms": "0.3.0"
+    "ms": "0.3.0",
+    "glob": "3.2.1"
   },
   "devDependencies": {
     "should": "*",

--- a/test/acceptance/glob/glob.js
+++ b/test/acceptance/glob/glob.js
@@ -1,0 +1,6 @@
+
+describe('globbing test', function(){
+  it('should find this test', function(){
+    // see glob.sh for details
+  })
+});

--- a/test/acceptance/glob/glob.sh
+++ b/test/acceptance/glob/glob.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+REL_SCRIPT_DIR="`dirname \"$0\"`"
+SCRIPT_DIR="`( cd \"$REL_SCRIPT_DIR\" && pwd )`"
+
+cd $SCRIPT_DIR || {
+    echo Could not cd to $SCRIPT_DIR from `pwd`
+    exit 1
+}
+
+../../../bin/mocha -R json-stream  ./*.js > /tmp/mocha-glob.txt || {
+    echo Globbing ./*.js in `pwd` failed.
+    exit 1
+}
+
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"pending":0,"failures":0,' || {
+    echo Globbing ./*.js in `pwd` should match glob.js with one test inside.
+    exit 1
+}
+
+../../../bin/mocha -R json-stream  ./*-none.js > /tmp/mocha-glob.txt || {
+    echo Globbing './*-none.js' in `pwd` failed.
+    exit 1
+}
+
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":0,"tests":0,"passes":0,"pending":0,"failures":0,' || {
+    echo Globbing './*-none.js' in `pwd` should match no files and run no tests.
+    exit 1
+}
+
+# Globbing in windows command-shell differs completely from unix-style globbing.
+# In bash, the shell expands globs and passes the result to executables.
+# In windows, the shell passes globs unexpanded, executables do expansion if they support it.
+# Adding single-quotes around the glob below makes bash pass glob unexpanded,
+#     allowing us to test windows-style globbing in bash.
+../../../bin/mocha -R json-stream  './*.js' > /tmp/mocha-glob.txt || {
+    echo Globbing './*.js' in `pwd` failed.
+    exit 1
+}
+
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"pending":0,"failures":0,' || {
+    echo Globbing './*.js' in `pwd` should match glob.js with one test inside.
+    exit 1
+}
+
+../../../bin/mocha -R json-stream  './*-none.js' > /tmp/mocha-glob.txt || {
+    echo Globbing './*-none.js' in `pwd` failed.
+    exit 1
+}
+
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":0,"tests":0,"passes":0,"pending":0,"failures":0,' || {
+    echo Globbing './*-none.js' in `pwd` should match no files and run no tests.
+    exit 1
+}
+
+echo Glob-test passed.


### PR DESCRIPTION
In unix shell, globs are expanded by the shell, whereas in windows
globs are passed to the application for expansion.

If the specified filepath doesn't exist and filepath.js doesn't exist,
then try globbing that string.  This has no runtime cost in most
scenarios, and if filepath is not a glob the result is unchanged.

Closes #844
