### PR TITLE
New --unified-diff flag makes expected/actual easier to read without colors

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -78,7 +78,7 @@ program
   .option('--interfaces', 'display available interfaces')
   .option('--reporters', 'display available reporters')
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
-  .option('--unified-diff', 'display actual/expected errors as a patch')
+  .option('--inline-diffs', 'display actual/expected differences inline within each string')
 
 program.name = 'mocha';
 
@@ -205,9 +205,9 @@ if (~process.argv.indexOf('--colors') ||
   Base.useColors = true;
 }
 
-// --unified-diff
+// --inline-diffs
 
-if (~process.argv.indexOf('--unified-diff')) Base.unifiedDiff = true;
+if (program.inlineDiffs) Base.inlineDiffs = true;
 
 // --slow <ms>
 

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -36,10 +36,10 @@ exports = module.exports = Base;
 exports.useColors = isatty;
 
 /**
- * Enable unified diff by default.
+ * Inline diffs instead of +/-
  */
 
-exports.unifiedDiff = false;
+exports.inlineDiffs = false;
 
 /**
  * Default color map.
@@ -177,10 +177,10 @@ exports.list = function(failures){
     // actual / expected diff
     if ('string' == typeof actual && 'string' == typeof expected) {      
       fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
-      if (exports.unifiedDiff) {
-        msg = unifiedDiff(err);
+      if (exports.inlineDiffs) {
+        msg = inlineDiff(err, escape);
       } else {
-        msg = inlineDiff(err);
+        msg = unifiedDiff(err, escape);
       }
     }
 
@@ -336,7 +336,7 @@ function pad(str, len) {
  * @api private
  */
 
-function inlineDiff(err) {
+function inlineDiff(err, escape) {
   var msg = errorDiff(err, 'Words', escape);
 
   // linenos
@@ -370,22 +370,28 @@ function inlineDiff(err) {
  * @api private
  */
 
-function unifiedDiff(err) {
+function unifiedDiff(err, escape) {
+  var indent = '      ';
   function cleanUp(line) {
-    if (line[0] === '+') return colorLines('diff added', line);
-    if (line[0] === '-') return colorLines('diff removed', line);
+    if (escape) {
+      line = escapeInvisibles(line);
+    }
+    if (line[0] === '+') return indent + colorLines('diff added', line);
+    if (line[0] === '-') return indent + colorLines('diff removed', line);
     if (line.match(/\@\@/)) return null;
     if (line.match(/\\ No newline/)) return null;
-    else return line;
+    else return indent + line;
   }
   function notBlank(line) {
     return line != null;
   }
   msg = diff.createPatch('string', err.actual, err.expected);
   var lines = msg.split('\n').splice(4);
-  return '\n' + colorLines('diff added',   '+ expected') + 
-         '\n' + colorLines('diff removed', '- actual') + 
-         '\n\n' + lines.map(cleanUp).filter(notBlank).join('\n');
+  return '\n      '
+         + colorLines('diff added',   '+ expected') + ' '
+         + colorLines('diff removed', '- actual')
+         + '\n\n'
+         + lines.map(cleanUp).filter(notBlank).join('\n');
 }
 
 /**
@@ -397,17 +403,26 @@ function unifiedDiff(err) {
  */
 
 function errorDiff(err, type, escape) {
-  return diff['diff' + type](err.actual, err.expected).map(function(str){
-    if (escape) {
-      str.value = str.value
-        .replace(/\t/g, '<tab>')
-        .replace(/\r/g, '<CR>')
-        .replace(/\n/g, '<LF>\n');
-    }
+  var actual   = escape ? escapeInvisibles(err.actual)   : err.actual;
+  var expected = escape ? escapeInvisibles(err.expected) : err.expected;
+  return diff['diff' + type](actual, expected).map(function(str){
     if (str.added) return colorLines('diff added', str.value);
     if (str.removed) return colorLines('diff removed', str.value);
     return str.value;
   }).join('');
+}
+
+/**
+ * Returns a string with all invisible characters in plain text
+ *
+ * @param {String} line
+ * @return {String}
+ * @api private
+ */
+function escapeInvisibles(line) {
+    return line.replace(/\t/g, '<tab>')
+               .replace(/\r/g, '<CR>')
+               .replace(/\n/g, '<LF>\n');
 }
 
 /**

--- a/test/acceptance/diffs.js
+++ b/test/acceptance/diffs.js
@@ -26,6 +26,12 @@ describe('diffs', function(){
     //actual.should.eql(expected);
   });
 
+  it('should display a full-comparison with escaped special characters', function(){
+    var expected = 'one\ttab\ntwo\t\ttabs';
+    var actual   = 'one\ttab\ntwo\t\t\ttabs';
+    //actual.should.equal(expected);
+  });
+
   it('should display a word diff for large strings', function(){
     // cssin.should.equal(cssout);
   });


### PR DESCRIPTION
As suggested in this issue: #702

For example, take this test:

```
var a = { name: 'joe',  age: 30, address: {city: 'new york', country: 'us' }};
var b = { name: 'joel', age: 30, address: {city: 'new york', country: 'usa'}};
a.should.eql(b);
```

`mocha`

![inline](http://dl.dropboxusercontent.com/u/11407680/mocha/diff-inline-color.png)

`mocha -C`  (or looking at text-only logs)

![inline no color](http://dl.dropboxusercontent.com/u/11407680/mocha/diff-inline-nocolor.png)

`mocha --unified-diff`

![unified diff](http://dl.dropboxusercontent.com/u/11407680/mocha/diff-unified-color.png)

`mocha --unified-diff -C`  (or looking at text-only logs)

![unified diff no color](http://dl.dropboxusercontent.com/u/11407680/mocha/diff-unified-nocolor.png)

It's my first contrib to Mocha, so another pair of eyes would be helpful.
But hopefully this will make troubleshooting tests easier!
