### PR TITLE
Fix exceptions when running mocha in Web Workers.

### DIFF
--- a/lib/browser/tty.js
+++ b/lib/browser/tty.js
@@ -4,5 +4,10 @@ exports.isatty = function(){
 };
 
 exports.getWindowSize = function(){
-  return [window.innerHeight, window.innerWidth];
+  if ('innerHeight' in global) {
+    return [global.innerHeight, global.innerWidth];
+  } else {
+    // In a Web Worker, the DOM Window is not available.
+    return [640, 480];
+  }
 };


### PR DESCRIPTION
This is a minimal change that makes mocha not crash when running a test suite in a Web Worker environment, per the discussion in https://github.com/visionmedia/mocha/pull/780

Given the constraints in the discussion above, the Web Worker environment is not covered by tests, so mocha might break in Web workers again in the future.
