### PR TITLE
Return true from window.onerror handler

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -41,6 +41,7 @@ process.on = function(e, fn){
   if ('uncaughtException' == e) {
     window.onerror = function(err, url, line){
       fn(new Error(err + ' (' + url + ':' + line + ')'));
+      return true;
     };
   }
 };


### PR DESCRIPTION
Mocha's own error reporter will report the error; it shouldn't be printed to
the console, trigger an error badge on the Firebug toolbar button, etc.
