### PR TITLE
Log passed tests, not completed tests

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -311,8 +311,8 @@ Base.prototype.epilogue = function(){
     + color('light', ' (%s)');
 
   console.log(fmt,
-    stats.tests || 0,
-    pluralize(stats.tests),
+    stats.passes || 0,
+    pluralize(stats.passes),
     ms(stats.duration));
 
   // pending


### PR DESCRIPTION
In an effort to separate tests the pass from tests that are pending, or failed; log the count of passed tests instead of the count of tests that completed. (completed !== passed)

NOTE: should probably have also changed ' %d %s complete' to reflect this change
