### PR TITLE
log pass/pending test count even when tests fail

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -289,22 +289,6 @@ Base.prototype.epilogue = function(){
     return 1 == n ? 'test' : 'tests';
   }
 
-  // failure
-  if (stats.failures) {
-    fmt = color('bright fail', '  ' + exports.symbols.err)
-      + color('fail', ' %d of %d %s failed')
-      + color('light', ':')
-
-    console.error(fmt,
-      stats.failures,
-      this.runner.total,
-      pluralize(this.runner.total));
-
-    Base.list(this.failures);
-    console.error();
-    return;
-  }
-
   // pass
   fmt = color('bright pass', ' ')
     + color('green', ' %d %s complete')
@@ -321,6 +305,21 @@ Base.prototype.epilogue = function(){
       + color('pending', ' %d %s pending');
 
     console.log(fmt, stats.pending, pluralize(stats.pending));
+  }
+
+  // failure
+  if (stats.failures) {
+    fmt = color('bright fail', '  ' + exports.symbols.err)
+      + color('fail', ' %d of %d %s failed')
+      + color('light', ':')
+
+    console.error(fmt,
+      stats.failures,
+      this.runner.total,
+      pluralize(this.runner.total));
+
+    Base.list(this.failures);
+    console.error();
   }
 
   console.log();


### PR DESCRIPTION
Maybe this just a problem with using the Spec reporter, but just because there was a failure, it is good to know how many tests have passed or skipped.
