### PR TITLE
emit the failed event onto the suite so the tests (before/after) can listen for it

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -255,6 +255,10 @@ function Base(runner) {
   });
 
   runner.on('fail', function(test, err){
+    //emit the failed event onto the suite so the tests can listen for it
+    testSuite = test.parent;
+    testSuite.emit('failed', test, err);
+
     stats.failures = stats.failures || 0;
     stats.failures++;
     test.err = err;


### PR DESCRIPTION
implemented this in order to hook into the failed event for a test so that the afterEach can execute failed functionality 
