### PR TITLE
runner.js: 'pending' event is not mentioned in docs

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -44,6 +43,7 @@ module.exports = Runner;
  *   - `hook end`  (hook) hook complete
  *   - `pass`  (test) test passed
  *   - `fail`  (test, err) test failed
+ *   - `pending`  (test) test pending
  *
  * @api public
  */


### PR DESCRIPTION
'pending' event is emitted, but there is no mention of it in the documentation. I assume it's not supposed to be private; we are relying on it in our test reports.
