### PR TITLE
TM bundle installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
 REPORTER ?= dot
-TM_DEST = ~/Library/Application\ Support/TextMate/Bundles
 TM_BUNDLE = JavaScript\ mocha.tmbundle
 SRC = $(shell find lib -name "*.js" -type f | sort)
 SUPPORT = $(wildcard support/*.js)
@@ -127,7 +126,6 @@ non-tty:
 	@cat /tmp/spec.out
 
 tm:
-	mkdir -p $(TM_DEST)
-	cp -fr editors/$(TM_BUNDLE) $(TM_DEST)
+	@open editors/$(TM_BUNDLE)
 
 .PHONY: test-cov test-jsapi test-compilers watch test test-all test-bdd test-tdd test-qunit test-exports test-unit non-tty test-grep tm clean


### PR DESCRIPTION
Copying the .tmbundle to ~/Library/Application Support doesn't work with TextMate latest version. I fixed it by running open on the bundle, which let TM installs it.
