### PR TITLE
Strip tab indentation in `clean` utility method

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,8 +196,8 @@ exports.clean = function(str) {
     .replace(/^function *\(.*\) *{/, '')
     .replace(/\s+\}$/, '');
 
-  var spaces = str.match(/^\n?( *)/)[1].length
-    , re = new RegExp('^ {' + spaces + '}', 'gm');
+  var whitespace = str.match(/^\n?(\s*)/)[1]
+    , re = new RegExp('^' + whitespace, 'gm');
 
   str = str.replace(re, '');
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,22 @@
+
+var mocha = require('../')
+  , utils = mocha.utils;
+
+describe("Utils", function (){
+
+  describe('.clean()', function() {
+    var clean = utils.clean;
+
+    it('should remove the wrapping function declaration', function(){
+      clean('function  (one, two, three)  {\n//code\n}').should.equal('//code');
+    })
+
+    it('should remove space character indentation from the function body', function(){
+      clean('  //line1\n    //line2').should.equal('//line1\n  //line2');
+    })
+
+    it('should remove tab character indentation from the function body', function(){
+      clean('\t//line1\n\t\t//line2').should.equal('//line1\n\t//line2');
+    })
+  })
+})


### PR DESCRIPTION
The `clean` method is intended to normalize function body indentation to
be relative to the first line. Update the implementation to support
tab-indented function bodies (in addition to space-indented bodies).
