### PR TITLE
Implement `suite.skip()`

### DIFF
--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -83,6 +83,17 @@ module.exports = function(suite){
     };
 
     /**
+     * Pending suite.
+     */
+    context.suite.skip = function(title, fn) {
+      var suite = Suite.create(suites[0], title);
+      suite.pending = true;
+      suites.unshift(suite);
+      fn.call(suite);
+      suites.shift();
+    };
+
+    /**
      * Exclusive test-case.
      */
 
@@ -98,8 +109,10 @@ module.exports = function(suite){
      */
 
     context.test = function(title, fn){
+      var suite = suites[0];
+      if (suite.pending) var fn = null;
       var test = new Test(title, fn);
-      suites[0].addTest(test);
+      suite.addTest(test);
       return test;
     };
 

--- a/test/acceptance/interfaces/tdd.js
+++ b/test/acceptance/interfaces/tdd.js
@@ -27,6 +27,13 @@ suite('Array', function(){
       zero.should.equal(1, 'this test should have been skipped');
     });
 
+    suite.skip('should skip this suite', function(){
+      test('should skip this test', function(){
+        var zero = 0;
+        zero.should.equal(1, 'this test should have been skipped');
+      });
+    });
+
     suiteTeardown(function(done){
       initialValue.should.eql(42);
       done();


### PR DESCRIPTION
Increase parity between the "TDD" and "BDD" interfaces by implementing
`suite.skip()`. (The implementation was originally authored by
@jaredwinick in GitHub pull request #762 but applied to the wrong file
and lacking a unit test.)
