### PR TITLE
Add resume() for async tests that trap exceptions

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -188,14 +188,31 @@ Runnable.prototype.run = function(fn){
   // for .resetTimeout()
   this.callback = done;
 
+  // concludes an async test
+  // can be used as a callback with first-param-error style
+  function asyncCallback(err) {
+    if (err instanceof Error || toString.call(err) === "[object Error]") return done(err);
+    if (null != err) return done(new Error('done() invoked with non-Error: ' + err));
+    done();
+  }
+
+  // concludes an async test after calling a function
+  asyncCallback.resume = function(fn) {
+    // use try...catch to check for errors when calling the function
+    // this allows for the propagation of assertion results when in an async
+    // callback that catches errors
+    try {
+      fn();
+      asyncCallback();
+    } catch (err) {
+      asyncCallback(err);
+    }
+  };
+
   // async
   if (this.async) {
     try {
-      this.fn.call(ctx, function(err){
-        if (err instanceof Error || toString.call(err) === "[object Error]") return done(err);
-        if (null != err) return done(new Error('done() invoked with non-Error: ' + err));
-        done();
-      });
+      this.fn.call(ctx, asyncCallback);
     } catch (err) {
       done(err);
     }

--- a/test/hook.async.js
+++ b/test/hook.async.js
@@ -26,6 +26,11 @@ describe('async', function(){
       , 'three'
       , 'after'
       , 'parent after'
+      , 'parent before'
+      , 'before'
+      , 'four'
+      , 'after'
+      , 'parent after'
       , 'after all'
       , 'root after all']);
   })
@@ -95,6 +100,14 @@ describe('async', function(){
         , 'parent before'
         , 'before']);
       calls.push('three');
+    })
+
+    it('four', function(done){
+      process.nextTick(function () {
+        done.resume(function () {
+          calls.push('four');
+        })
+      })
     })
 
     afterEach(function(done){


### PR DESCRIPTION
Hi!

Mocha's async support is awesome, but it as a small deficiency for testing code that catches exceptions, most notably promise-based code or code using [task.js](http://taskjs.org/). For example:

``` javascript
it('should show the correct assertion failure', function (done) {
  somePromise.then(function (value) {
    // since then() catches exceptions here
    // when the test passes everything is ok
    // but when the assertion fails
    // the test doesn't report the assertion failure
    expect(value).to.be(5);
    done();
  })
})
```

This pull request introduces a helper function hidden as a property of the `done` callback that catches its own exceptions and concludes the test the same way as `done`. This would let us use the following pattern:

``` javascript
it('should show the correct assertion failure', function (then) {
  somePromise.then(function (value) {
    then.resume(function () {
      expect(value).to.be(5);
    });
  })
})
```

I would be very much OK with other names for `resume` like `next`, or a second callback if you think it would be a better choice.
