### PR TITLE
Change in xunit reporter in test case time when the test fails

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -75,7 +75,7 @@ function test(test) {
       classname: test.parent.fullTitle()
     , name: test.title
     // , time: test.duration / 1000  //old
-    time: test.duration ? test.duration / 1000 : 0  //new
+    ,time: test.duration ? test.duration / 1000 : 0  //new
   };
 
   if ('failed' == test.state) {


### PR DESCRIPTION
If we use xunit format as the mocha reporter, when the test case fails, the time attribute in test case will be NaN. So when sonar wants to parse this xunit report, it raises parse exception which means it can not parse NaN value of time.  So we replaced part related to create time value of test case 

FROM :    time: test.duration / 1000
TO :         time: test.duration ? test.duration / 1000 : 0
