### PR TITLE
fix xunit NaN on failure. #894

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -74,7 +74,7 @@ function test(test) {
   var attrs = {
       classname: test.parent.fullTitle()
     , name: test.title
-    , time: test.duration / 1000 || 0
+    , time: (test.duration / 1000) || 0
   };
 
   if ('failed' == test.state) {


### PR DESCRIPTION
The fix for issue xunit reporter problem when the test fails does not solve the problem. The time=NaN is on testcase not in testsuite. So I also made the same change in test function :

FROM : time: (test.duration / 1000)  
TO:       time: (test.duration / 1000) || 0
