### PR TITLE
Moved watch onto dynamic file extensions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,13 +156,18 @@ function ignored(path){
 exports.files = function(dir, ret){
   ret = ret || [];
 
+  var exts = Object.getOwnPropertyNames(require.extensions),
+      escapedExts = exts.map(function (ext) {
+        return ext.replace(/\./g, '\\.');
+      }),
+      extRegexp = new RegExp('(' + escapedExts.join('|') + ')$');
   fs.readdirSync(dir)
   .filter(ignored)
   .forEach(function(path){
     path = join(dir, path);
     if (fs.statSync(path).isDirectory()) {
       exports.files(path, ret);
-    } else if (path.match(/\.(js|coffee|litcoffee|coffee.md)$/)) {
+    } else if (path.match(extRegexp)) {
       ret.push(path);
     }
   });


### PR DESCRIPTION
I am developing a test framework on top of `mocha` which uses `.json` and `.yaml` files as part of its usage. To make `--watch` work with the relevant files, I have expanded `utils.files` to watch all file extensions we have registered.

Additionally, this patches #804.

If you are interested in the framework, it is called [doubleshot](https://github.com/twolfson/doubleshot).
