### PR TITLE
Programmatically change title of test case

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -67,3 +67,18 @@ Context.prototype.inspect = function(){
     return val;
   }, 2);
 };
+
+/**
+ * Programmatically obtain or set the title of test case.
+ *
+ * @return String
+ * @api public
+ */
+
+Context.prototype.title = function(text){
+  if (!text) {
+    return this._runnable.title;
+  };
+
+  this._runnable.title = text;
+};


### PR DESCRIPTION
Right now it has to be done by using [this hack](https://coderwall.com/p/riklkg)

Provide a `this.title()` method inside a test case such that it returns the present test case's title if called without any argument. If called with an argument set it as the title of that test case. 
### Use Case

So that we can do something like this. Displaying the input along with the title in report.

``` javascript
var assert = require('assert');

describe("My Test", function(){
    it("should pass with input ", function(){
        var input = "This will be appended at the end of the title ";
        this.title( this.title() + input );
        assert(typeof input === 'string');
    });
});
```
