### PR TITLE
Allow timeout: 0 to be passed via the jsapi

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -70,7 +70,7 @@ function Mocha(options) {
   this.ui(options.ui);
   this.bail(options.bail);
   this.reporter(options.reporter);
-  if (options.timeout) this.timeout(options.timeout);
+  if (typeof options.timeout === 'number') this.timeout(options.timeout);
   if (options.slow) this.slow(options.slow);
 }
 


### PR DESCRIPTION
Previously, the conditional check caused the timeout not be set if it was 0.  Example:

``` javascript
new Mocha({timeout: 0});
```

It would default the timeout back to 2000ms.  This PR relaxes the condition a little.
