### PR TITLE
fix for undefined string escaping

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -52,6 +52,7 @@ function Teamcity(runner) {
  */
 
 function escape(str) {
+  if(!str) return '';
   return str
     .replace(/\|/g, "||")
     .replace(/\n/g, "|n")


### PR DESCRIPTION
It seems like sometimes (I saw it on the fail event), the err argument is undefined causing you to try to escape an undefined string in the teamcity runner. I know this is a rather naive fix, but might be a valid safety check..
