### PR TITLE
Add Literate CoffeScript support for --watch mode

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -163,7 +162,7 @@ exports.files = function(dir, ret){
     path = join(dir, path);
     if (fs.statSync(path).isDirectory()) {
       exports.files(path, ret);
-    } else if (path.match(/\.(js|coffee)$/)) {
+    } else if (path.match(/\.(js|coffee|litcoffee|coffee.md)$/)) {
       ret.push(path);
     }
   });


### PR DESCRIPTION
I love using the --watch mode for developing in coffee, but once my file extensions change to `.coffee.md` or `.litcoffee` the watch doesn't refresh upon saving.

This fixes it for me :)
