### PR TITLE
Bump glob dependency to v3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "debug": "*",
     "mkdirp": "0.3.5",
     "ms": "0.3.0",
-    "glob": "3.2.1"
+    "glob": "3.2.3"
   },
   "devDependencies": {
     "should": "*",


### PR DESCRIPTION
It picks up a couple `glob` dependency updates, and all tests still pass.
