### PR TITLE
Support for multiple reporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,21 +39,21 @@ test-jsapi:
 
 test-unit:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		test/acceptance/*.js \
 		--growl \
 		test/*.js
 
 test-compilers:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--compilers coffee:coffee-script,foo:./test/compiler/foo \
 		test/acceptance/test.coffee \
 		test/acceptance/test.foo
 
 test-requires:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--compilers coffee:coffee-script \
 		--require test/acceptance/require/a.js \
 		--require test/acceptance/require/b.coffee \
@@ -63,50 +63,50 @@ test-requires:
 
 test-bdd:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--ui bdd \
 		test/acceptance/interfaces/bdd
 
 test-tdd:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--ui tdd \
 		test/acceptance/interfaces/tdd
 
 test-qunit:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--ui qunit \
 		test/acceptance/interfaces/qunit
 
 test-exports:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--ui exports \
 		test/acceptance/interfaces/exports
 
 test-grep:
 	@./bin/mocha \
-	  --reporters $(REPORTER) \
+	  --reporter $(REPORTER) \
 	  --grep fast \
 	  test/acceptance/misc/grep
 
 test-invert:
 	@./bin/mocha \
-	  --reporters $(REPORTER) \
+	  --reporter $(REPORTER) \
 	  --grep slow \
 	  --invert \
 	  test/acceptance/misc/grep
 
 test-bail:
 	@./bin/mocha \
-		--reporters $(REPORTER) \
+		--reporter $(REPORTER) \
 		--bail \
 		test/acceptance/misc/bail
 
 test-async-only:
 	@./bin/mocha \
-	  --reporters $(REPORTER) \
+	  --reporter $(REPORTER) \
 	  --async-only \
 	  test/acceptance/misc/asyncOnly
 
@@ -115,7 +115,7 @@ test-glob:
 
 non-tty:
 	@./bin/mocha \
-		--reporters dot \
+		--reporter dot \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/dot.out
 
 	@echo dot:
@@ -129,7 +129,7 @@ non-tty:
 	@cat /tmp/list.out
 
 	@./bin/mocha \
-		--reporters spec \
+		--reporter spec \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/spec.out
 
 	@echo spec:

--- a/Makefile
+++ b/Makefile
@@ -39,21 +39,21 @@ test-jsapi:
 
 test-unit:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		test/acceptance/*.js \
 		--growl \
 		test/*.js
 
 test-compilers:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--compilers coffee:coffee-script,foo:./test/compiler/foo \
 		test/acceptance/test.coffee \
 		test/acceptance/test.foo
 
 test-requires:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--compilers coffee:coffee-script \
 		--require test/acceptance/require/a.js \
 		--require test/acceptance/require/b.coffee \
@@ -63,59 +63,59 @@ test-requires:
 
 test-bdd:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--ui bdd \
 		test/acceptance/interfaces/bdd
 
 test-tdd:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--ui tdd \
 		test/acceptance/interfaces/tdd
 
 test-qunit:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--ui qunit \
 		test/acceptance/interfaces/qunit
 
 test-exports:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--ui exports \
 		test/acceptance/interfaces/exports
 
 test-grep:
 	@./bin/mocha \
-	  --reporter $(REPORTER) \
+	  --reporters $(REPORTER) \
 	  --grep fast \
 	  test/acceptance/misc/grep
 
 test-invert:
 	@./bin/mocha \
-	  --reporter $(REPORTER) \
+	  --reporters $(REPORTER) \
 	  --grep slow \
 	  --invert \
 	  test/acceptance/misc/grep
 
 test-bail:
 	@./bin/mocha \
-		--reporter $(REPORTER) \
+		--reporters $(REPORTER) \
 		--bail \
 		test/acceptance/misc/bail
 
 test-async-only:
 	@./bin/mocha \
-	  --reporter $(REPORTER) \
+	  --reporters $(REPORTER) \
 	  --async-only \
 	  test/acceptance/misc/asyncOnly
 
 test-glob:
-	@./test/acceptance/glob/glob.sh
+	./test/acceptance/glob/glob.sh
 
 non-tty:
 	@./bin/mocha \
-		--reporter dot \
+		--reporters dot \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/dot.out
 
 	@echo dot:
@@ -129,7 +129,7 @@ non-tty:
 	@cat /tmp/list.out
 
 	@./bin/mocha \
-		--reporter spec \
+		--reporters spec \
 		test/acceptance/interfaces/bdd 2>&1 > /tmp/spec.out
 
 	@echo spec:

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -64,7 +64,7 @@ program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage('[debug] [options] [files]')
   .option('-r, --require <name>', 'require the given module')
-  .option('-R, --reporters <name>,...', 'specify the reporters to use', ['dot'])
+  .option('-R, --reporter <name>,...', 'specify the reporters to use', list, ['dot'])
   .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
   .option('-i, --invert', 'inverts --grep matches')
@@ -82,7 +82,7 @@ program
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--check-leaks', 'check for global variable leaks')
   .option('--interfaces', 'display available interfaces')
-  .option('--list-reporters', 'display available reporters')
+  .option('--reporters', 'display available reporters')
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
 
 program.name = 'mocha';
@@ -113,7 +113,7 @@ program.on('globals', function(val){
 
 // --reporters
 
-program.on('list-reporters', function(){
+program.on('reporters', function(){
   console.log();
   console.log('    dot - dot matrix');
   console.log('    doc - html documentation');
@@ -181,7 +181,7 @@ Error.stackTraceLimit = Infinity; // TODO: config
 
 // reporter
 
-mocha.reporters(program.reporters);
+mocha.reporters(program.reporter);
 
 // interface
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -64,7 +64,7 @@ program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage('[debug] [options] [files]')
   .option('-r, --require <name>', 'require the given module')
-  .option('-R, --reporter <name>', 'specify the reporter to use', 'dot')
+  .option('-R, --reporters <name>,...', 'specify the reporters to use', ['dot'])
   .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
   .option('-i, --invert', 'inverts --grep matches')
@@ -82,7 +82,7 @@ program
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--check-leaks', 'check for global variable leaks')
   .option('--interfaces', 'display available interfaces')
-  .option('--reporters', 'display available reporters')
+  .option('--list-reporters', 'display available reporters')
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
 
 program.name = 'mocha';
@@ -113,7 +113,7 @@ program.on('globals', function(val){
 
 // --reporters
 
-program.on('reporters', function(){
+program.on('list-reporters', function(){
   console.log();
   console.log('    dot - dot matrix');
   console.log('    doc - html documentation');
@@ -181,23 +181,11 @@ Error.stackTraceLimit = Infinity; // TODO: config
 
 // reporter
 
-mocha.reporter(program.reporter);
+mocha.reporters(program.reporters);
 
 // interface
 
 mocha.ui(program.ui);
-
-// load reporter
-
-try {
-  Reporter = require('../lib/reporters/' + program.reporter);
-} catch (err) {
-  try {
-    Reporter = require(program.reporter);
-  } catch (err) {
-    throw new Error('reporter "' + program.reporter + '" does not exist');
-  }
-}
 
 // --no-colors
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -103,9 +103,8 @@ Mocha.prototype.addFile = function(file){
 /**
  * Set reporters to `reporters`, defaults to "dot".
  *
- * @param {String|Function|Array of string|Array of functions} comma separated list
- * of reporter names as string, array of constructors, reporter name as string or
- * reporter constructor
+ * @param {String|Function|Array of strings|Array of functions} reporter name as string,
+ * reporter constructor, or array of constructors or reporter names as strings.
  * @api public
  */
 
@@ -116,13 +115,12 @@ Mocha.prototype.reporters = function(reporters) {
   // if no reporter is given as input, default to dot reporter
   reporters = reporters || 'dot';
 
-  // turn reporters into a list of reporter names
-  // that we'll iterate on right after to initialize them
+  // If reporters argument is not a list, turn it into a list of reporter names
+  // or constructors that we'll iterate on right after to initialize them
   reportersList = reporters;
   if (!Array.isArray(reporters)) {
-    if ('string' == typeof reporters) {
-      reportersList = reporters.split(',');
-    } else if ('function' == typeof reporters) {
+    if (('string' == typeof reporters) ||
+        ('function' == typeof reporters)) {
       reportersList = [reporters];
     }
   }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -9,7 +9,8 @@
  */
 
 var path = require('path')
-  , utils = require('./utils');
+  , utils = require('./utils')
+  , debug = require('debug')('mocha:mocha')
 
 /**
  * Expose `Mocha`.
@@ -69,7 +70,7 @@ function Mocha(options) {
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
   this.bail(options.bail);
-  this.reporter(options.reporter);
+  this.reporters(options.reporters);
   if (options.timeout) this.timeout(options.timeout);
   if (options.slow) this.slow(options.slow);
 }
@@ -100,24 +101,54 @@ Mocha.prototype.addFile = function(file){
 };
 
 /**
- * Set reporter to `reporter`, defaults to "dot".
+ * Set reporters to `reporters`, defaults to "dot".
  *
- * @param {String|Function} reporter name or constructor
+ * @param {String|Function|Array of string|Array of functions} comma separated list
+ * of reporter names as string, array of constructors, reporter name as string or
+ * reporter constructor
  * @api public
  */
 
-Mocha.prototype.reporter = function(reporter){
-  if ('function' == typeof reporter) {
-    this._reporter = reporter;
-  } else {
-    reporter = reporter || 'dot';
-    try {
-      this._reporter = require('./reporters/' + reporter);
-    } catch (err) {
-      this._reporter = require(reporter);
+Mocha.prototype.reporters = function(reporters) {
+
+  this._reportersConstructors = [];
+
+  // if no reporter is given as input, default to dot reporter
+  reporters = reporters || 'dot';
+
+  // turn reporters into a list of reporter names
+  // that we'll iterate on right after to initialize them
+  reportersList = reporters;
+  if (!Array.isArray(reporters)) {
+    if ('string' == typeof reporters) {
+      reportersList = reporters.split(',');
+    } else if ('function' == typeof reporters) {
+      reportersList = [reporters];
     }
-    if (!this._reporter) throw new Error('invalid reporter "' + reporter + '"');
   }
+
+  // Load each reporter
+  self  = this;
+  reportersList.forEach(function (reporter) {
+    if ('function' == typeof reporter) {
+      this._reportersConstructors.push(reportersArg);
+    } else {
+      var reporterInstance = null;
+      debug('loading reporter: %s', reporter);
+      try {
+        reporterInstance = require('./reporters/' + reporter);
+      } catch (err) {
+        reporterInstance = require(reporter);
+      }
+
+      if (!reporterInstance) {
+        throw new Error('invalid reporter "' + reporter + '"');
+      } else {
+        self._reportersConstructors.push(reporterInstance);
+      }
+    }
+  });
+
   return this;
 };
 
@@ -307,11 +338,21 @@ Mocha.prototype.run = function(fn){
   var suite = this.suite;
   var options = this.options;
   var runner = new exports.Runner(suite);
-  var reporter = new this._reporter(runner);
+
+  // For each loaded reporter constructor, create
+  // an instance and initialize it with the runner
+  this._reportersInstances = [];
+  self = this;
+  this._reportersConstructors.forEach(function (reporterConstructor) {
+    self._reportersInstances.push(new reporterConstructor(runner));
+  });
+
   runner.ignoreLeaks = false !== options.ignoreLeaks;
   runner.asyncOnly = options.asyncOnly;
   if (options.grep) runner.grep(options.grep, options.invert);
   if (options.globals) runner.globals(options.globals);
-  if (options.growl) this._growl(runner, reporter);
+  // Use only the first reporter for growl, since we don't want to
+  // send several notifications for the same tests suite
+  if (options.growl) this._growl(runner, this._reportersInstances[0]);
   return runner.run(fn);
 };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --require should
---reporter dot
+--reporters dot
 --ui bdd
 --globals okGlobalA,okGlobalB
 --globals okGlobalC

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --require should
---reporters dot
+--reporter dot
 --ui bdd
 --globals okGlobalA,okGlobalB
 --globals okGlobalC


### PR DESCRIPTION
Hi! 

This pull request adds support for multiple reporters. 

One of my use cases for multiple reporters is described in my recent post on [mocha's google group](https://groups.google.com/forum/#!topic/mochajs/l7QrifO2bdE). To sum it up, I'm using mocha to run tests on a Bamboo instance, and I use the xunit-file reporter to create a file that can be parsed by Bamboo to display tests results. However, I also need to send tests reports to a CouchDB instance that doesn't accept xml files, but JSON documents. Right now, I'm running the tests twice: first with the xunit-file reporter, and then with the mocha-json-file-reporter to generate the xunit file and the json document. This has a number of cons like slowing down the whole process, and even sometimes not generating the exact same results, which can lead to a lot of confusion.

These changes allow me to run both reporters at the same time, and I think being able to run more than one reporter at a time can be useful to others. All the tests seem to run fine.