### PR TITLE
Explicitly define what files to include in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-test
-examples
-*.sock
-lib-cov
-editors
-support

--- a/package.json
+++ b/package.json
@@ -38,5 +38,13 @@
   "devDependencies": {
     "should": "*",
     "coffee-script": "1.2"
-  }
+  },
+  "files": [
+    "bin",
+    "images",
+    "lib",
+    "index.js",
+    "mocha.css",
+    "mocha.js"
+  ]
 }


### PR DESCRIPTION
Even with .npmignore Mocha still includes some moot files.
