### PR TITLE
Added a bower.json file for bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "mocha",
+  "version": "1.12.0",
+  "main": "mocha.js",
+  "ignore": [
+    "bin",
+    "editors",
+    "images",
+    "lib",
+    "support",
+    "test",
+    ".gitignore",
+    ".npmignore",
+    ".travis.yml",
+    "component.json",
+    "index.js",
+    "Makefile",
+    "package.json"
+  ]
+}


### PR DESCRIPTION
It would be nice if we can have [Bower](http://bower.io/) support for Mocha.

Assuming you agree to register bower as a module, users should be able to run `bower install mocha`, and they should then be able to access mocha via `./bower_components/mocha/mocha.js`.

And as an added bonus: it doesn't conflict with `component.json`.

This pull request tackles #584.
