### PR TITLE
Makes Suite.create check for same-titled suites in the parent suite

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -29,6 +29,11 @@ exports = module.exports = Suite;
  */
 
 exports.create = function(parent, title){
+  for (var i = 0, l = parent.suites.length, i < l, i++) {
+    if (title === parent.suites[i].title) {
+      return parent.suites[i];
+    }
+  }
   var suite = new Suite(title, parent.ctx);
   suite.parent = parent;
   if (parent.pending) suite.pending = true;


### PR DESCRIPTION
If a suite by the same title is found, it is returned instead of making a new
one. This makes reporters like spec produce prettier results, and is also what
the comment for this function already claimed it did.
