### PR TITLE
modify --watch option: continue when SyntaxError

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -314,7 +314,7 @@ if (program.watch) {
         play(frames);
       });
     } catch(e) {
-      process.stdout.write(e.stack);
+      console.log(e.stack);
     }
   }
 


### PR DESCRIPTION
i want 'mocha --watch' continue when SytaxError.
becase rerun is a little difficultiy. (running happy!)
but was stopped 'mocha --watch' when SytaxError.

this modify ...
- when command start and SytaxError then stopped.
- when 'mocha --watch' runninng and modify js SytaxError then running.
