### PR TITLE
Fix bugged example source

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,7 +651,8 @@ test('#length', function(){
   &lt;script src="test.xhr.js"&gt;&lt;/script&gt;
   &lt;script&gt;
     mocha.checkLeaks();
-    mocha.globals(['jQuery']);
+    // Set accepted leaks in your test
+    mocha.globals(['leak1', 'leak2']);
     mocha.run();
   &lt;/script&gt;
 &lt;/body&gt;


### PR DESCRIPTION
When I created a HTML file according the example, it ignored one global leak.

Because "jQuery" was defined already, checkGlobals failed checking in this part:

```
else if (2 == ok.length - globals.length) return;
```
