### PR TITLE
Fix bug in millisecond-to-string logic

### DIFF
--- a/lib/ms.js
+++ b/lib/ms.js
@@ -3,10 +3,11 @@
  * Helpers.
  */
 
-var s = 1000;
-var m = s * 60;
-var h = m * 60;
-var d = h * 24;
+var units = {};
+units.second = 1000;
+units.minute = units.second * 60;
+units.hour = units.minute * 60;
+units.day = units.hour * 24;
 
 /**
  * Parse or format the given `val`.
@@ -69,13 +70,21 @@ function parse(str) {
  */
 
 function format(ms) {
-  if (ms == d) return Math.round(ms / d) + ' day';
-  if (ms > d) return Math.round(ms / d) + ' days';
-  if (ms == h) return Math.round(ms / h) + ' hour';
-  if (ms > h) return Math.round(ms / h) + ' hours';
-  if (ms == m) return Math.round(ms / m) + ' minute';
-  if (ms > m) return Math.round(ms / m) + ' minutes';
-  if (ms == s) return Math.round(ms / s) + ' second';
-  if (ms > s) return Math.round(ms / s) + ' seconds';
-  return ms + ' ms';
+  var unit;
+
+  if (ms >= units.day) unit = 'day';
+  else if (ms >= units.hour) unit = 'hour';
+  else if (ms >= units.minute) unit = 'minute';
+  else if (ms >= units.second)  unit = 'second';
+
+  if (unit) {
+    ms = Math.round(ms / units[unit]);
+    if (ms !== 1) {
+      unit += 's';
+    }
+  } else {
+    unit = 'ms';
+  }
+
+  return ms + ' ' + unit;
 }

--- a/test/ms.js
+++ b/test/ms.js
@@ -1,0 +1,72 @@
+var ms = require('../lib/ms');
+
+describe('ms', function(){
+
+  describe('millisecond to string', function(){
+    it('does not pluralize durations that equate to single units of time', function(){
+      ms(1).should.equal('1 ms');
+      ms(1000).should.equal('1 second');
+      ms(1000 * 60).should.equal('1 minute');
+      ms(1000 * 60 * 60).should.equal('1 hour');
+      ms(1000 * 60 * 60 * 24).should.equal('1 day');
+    });
+
+    it('does not pluralize durations that round to single units of time', function(){
+      ms(1 + 1000).should.equal('1 second');
+      ms(1 + 1000 * 60).should.equal('1 minute');
+      ms(1 + 1000 * 60 * 60).should.equal('1 hour');
+      ms(1 + 1000 * 60 * 60 * 24).should.equal('1 day');
+    });
+
+    it('pluralizes durations when necessary', function(){
+      ms(2 * 1000).should.equal('2 seconds');
+      ms(2 * 1000 * 60).should.equal('2 minutes');
+      ms(2 * 1000 * 60 * 60).should.equal('2 hours');
+      ms(2 * 1000 * 60 * 60 * 24).should.equal('2 days');
+    });
+  });
+
+  describe('string to millisecond', function(){
+    it('returns the correct milliseconds for years', function(){
+      ms('1.5 years').should.equal(1.5 * 31557600000);
+      ms('1.5 Years').should.equal(1.5 * 31557600000);
+      ms('1.5 year').should.equal(1.5 * 31557600000);
+      ms('1.5 y').should.equal(1.5 * 31557600000);
+    });
+
+    it('returns the correct milliseconds for days', function(){
+      ms('1.5 days').should.equal(1.5 * 86400000);
+      ms('1.5 Days').should.equal(1.5 * 86400000);
+      ms('1.5 day').should.equal(1.5 * 86400000);
+      ms('1.5 d').should.equal(1.5 * 86400000);
+    });
+
+    it('returns the correct milliseconds for hours', function(){
+      ms('1.5 hours').should.equal(1.5 * 3600000);
+      ms('1.5 Hours').should.equal(1.5 * 3600000);
+      ms('1.5 hour').should.equal(1.5 * 3600000);
+      ms('1.5 h').should.equal(1.5 * 3600000);
+    });
+
+    it('returns the correct milliseconds for minutes', function(){
+      ms('1.5 minutes').should.equal(1.5 * 60000);
+      ms('1.5 Minutes').should.equal(1.5 * 60000);
+      ms('1.5 minute').should.equal(1.5 * 60000);
+      ms('1.5 m').should.equal(1.5 * 60000);
+    });
+
+    it('returns the correct milliseconds for seconds', function(){
+      ms('1.5 seconds').should.equal(1.5 * 1000);
+      ms('1.5 Seconds').should.equal(1.5 * 1000);
+      ms('1.5 second').should.equal(1.5 * 1000);
+      ms('1.5 s').should.equal(1.5 * 1000);
+    });
+
+    it('returns the correct milliseconds for milliseconds', function(){
+      ms('1.5 ms').should.equal(1.5);
+      ms('1.5 MS').should.equal(1.5);
+      ms('1.5').should.equal(1.5);
+    });
+  });
+
+});


### PR DESCRIPTION
Since I needed to create a new test file for the `ms` module, I rounded it off by testing the entire module. I can imagine that these tests might be too low-level, so if you'd prefer, I can try writing integration-style tests instead.

Commit message:

> When generating a string representation of a millisecond duration, use
> the rounded value to determine if the unit should be pluralized.
> 
> This commit also introduces unit tests for previously-untested string
> parsing logic belonging to the same module.
