### PR TITLE
Preserve custom messages in diff output

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -159,6 +159,7 @@ exports.list = function(failures){
       , msg = stack.slice(0, index)
       , actual = err.actual
       , expected = err.expected
+      , legend
       , escape = true;
 
     // uncaught
@@ -187,11 +188,19 @@ exports.list = function(failures){
       }
 
       // legend
-      msg = '\n'
+      legend = '\n';
+      if (err.extraMessage) {
+        legend += err.extraMessage + ': ';
+      }
+
+      legend = legend
         + color('diff removed', 'actual')
         + ' '
         + color('diff added', 'expected')
-        + '\n\n'
+        + '\n';
+
+      msg = '\n'
+        + legend
         + msg
         + '\n';
 


### PR DESCRIPTION
When the developer adds extra information to assertion, e.g.

   expect('actual', 'description').to.equal('expected'); // Chai style

this extra message ('description') is preserved in the output
even in case when Mocha overwrites the original assertion message with
a string diff.

See also chaijs/chai#189.
