### PR TITLE
Allow a failed test to skip subsequent irrelevant tests

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -99,6 +99,15 @@ module.exports = function(suite){
     };
 
     /**
+     * Abortive suite.
+     */
+
+    context.describe.skipsOnFailure = function(title, fn){
+      var suite = context.describe(title, fn);
+      suite._skip = true;
+    };
+
+    /**
      * Describe a specification or test-case
      * with the given `title` and callback `fn`
      * acting as a thunk.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -441,6 +441,11 @@ Runner.prototype.runSuite = function(suite, fn){
   this.emit('suite', this.suite = suite);
 
   function next() {
+    if (suite._skip) {
+      var failed = 0;
+      suite.eachTest(function(test) { failed += test.state == 'failed'; });
+      if (failed) return done();
+    }
     var curr = suite.suites[i++];
     if (!curr) return done();
     self.runSuite(curr, next);

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -60,6 +60,7 @@ function Suite(title, ctx) {
   this._timeout = 2000;
   this._slow = 75;
   this._bail = false;
+  this._skip = false;
 }
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -22,6 +22,7 @@ module.exports = Test;
 function Test(title, fn) {
   Runnable.call(this, title, fn);
   this.pending = !fn;
+  this._skip = false;
   this.type = 'test';
 }
 

--- a/mocha.js
+++ b/mocha.js
@@ -914,6 +914,15 @@ module.exports = function(suite){
     };
 
     /**
+     * Abortive suite.
+     */
+
+    context.describe.skipsOnFailure = function(title, fn){
+      var suite = context.describe(title, fn);
+      suite._skip = true;
+    };
+
+    /**
      * Describe a specification or test-case
      * with the given `title` and callback `fn`
      * acting as a thunk.
@@ -4583,6 +4592,11 @@ Runner.prototype.runSuite = function(suite, fn){
   this.emit('suite', this.suite = suite);
 
   function next() {
+    if (suite._skip) {
+      var failed = 0;
+      suite.eachTest(function(test) { failed += test.state == 'failed'; });
+      if (failed) return done();
+    }
     var curr = suite.suites[i++];
     if (!curr) return done();
     self.runSuite(curr, next);
@@ -4754,6 +4768,7 @@ function Suite(title, ctx) {
   this._timeout = 2000;
   this._slow = 75;
   this._bail = false;
+  this._skip = false;
 }
 
 /**
@@ -5020,6 +5035,7 @@ module.exports = Test;
 function Test(title, fn) {
   Runnable.call(this, title, fn);
   this.pending = !fn;
+  this._skip = false;
   this.type = 'test';
 }
 


### PR DESCRIPTION
Example use case:
- perform an HTTP request
- assert that it returned status code 200
- only if it did, perform a zillion tests on the response

Method:
- a new `it.skipsOnFailure` function that makes subsequent `it`:s not run if that one failed
- a new `describe.skipsOnFailure` that makes descendant `describe`s not run if any encountered in it failed

I am apparently [not the first](https://groups.google.com/forum/#!searchin/mochajs/fail$20skip/mochajs/3pY5FVfigk0/zGqnUu0SFuQJ) to want this feature. Is the function name good? (It's a little long, but reads like English. As `it.only` doesn't, though, maybe `.skipOnFail` or even `.skip` is better?)
