### PR TITLE
Un-ignore test.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 *.sock
 testing
 _mocha.js
-test.js
 my-reporter.js
 *.sw*
 lib/browser/diff.js


### PR DESCRIPTION
This seems to target lib/test.js, which is definitely necessary.
Not having it causes a require error in lib/interfaces/bdd.js
