### PR TITLE
force color use when MOCHA_COLORS is set to 'always'

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -33,7 +33,7 @@ exports = module.exports = Base;
  * Enable coloring by default.
  */
 
-exports.useColors = isatty;
+exports.useColors = isatty || (process && process.env.MOCHA_COLORS === 'always');
 
 /**
  * Default color map.


### PR DESCRIPTION
useful for an env that doesn't want to `forkpty` but still wants colored output.
