### PR TITLE
Add a new option "loadInNewContext" that require's test files in a new V8 context.

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -149,7 +149,20 @@ Mocha.prototype.loadFiles = function(fn){
   this.files.forEach(function(file){
     file = path.resolve(file);
     suite.emit('pre-require', global, file, self);
-    suite.emit('require', require(file), file, self);
+
+    var fileExports;
+    if (!self.options.loadInNewContext) {
+      fileExports = require(file);
+    } else {
+      var filePathAsJsString = file.replace(/\\/g, "\\\\");
+      var newContextScript = 'var module = new Module("' + filePathAsJsString + '"); module.load("' + filePathAsJsString + '"); module.exports';
+      fileExports = require('vm').runInNewContext(newContextScript, {
+        Module: module.constructor,
+        process: process
+      });
+    }
+    suite.emit('require', fileExports, file, self);
+
     suite.emit('post-require', global, file, self);
     --pending || (fn && fn());
   });


### PR DESCRIPTION
This option allows tests to be run multiple times in the same node process, such as in a build process that watches source files and runs the tests on every change.

This adds a dependency on vm module if the option is used, but not otherwise.

npm test reported no test failures.
