### PR TITLE
Expose only the specified UI in the browser

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -53,6 +53,11 @@ process.on = function(e, fn){
 var Mocha = global.Mocha = require('mocha'),
     mocha = global.mocha = new Mocha({ reporter: 'html' });
 
+// The BDD UI is registered by default, but no UI will be functional in the
+// browser without an explicit call to the overridden `mocha.ui` (see below).
+// Ensure that this default UI does not expose its methods to the global scope.
+mocha.suite.removeAllListeners('pre-require');
+
 var immediateQueue = []
   , immediateTimeout;
 


### PR DESCRIPTION
I'm happy to add tests for this, but it doesn't look like there are any tests for the browser build--is this the case?

Commit message:

> When instantiated in the browser, Mocha registers the "BDD-style"
> interface. Since an explicit call to the browser-specific `mocha.ui` is
> required, the original registration is invalid. Prevent that UI from
> reacting to the `pre-require` event (and exposing its API).
