### PR TITLE
Introducing mocha.throwError for better async error handling

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -5510,13 +5510,18 @@ var process = {};
 process.exit = function(status){};
 process.stdout = {};
 
+var uncaughtExceptionHandlers = [];
+
 /**
  * Remove uncaughtException listener.
  */
 
-process.removeListener = function(e){
+process.removeListener = function(e, fn){
   if ('uncaughtException' == e) {
     global.onerror = function() {};
+
+    var indexOfFn = uncaughtExceptionHandlers.indexOf(fn);
+    if (indexOfFn != -1) { uncaughtExceptionHandlers.splice(indexOfFn, 1); }
   }
 };
 
@@ -5529,6 +5534,7 @@ process.on = function(e, fn){
     global.onerror = function(err, url, line){
       fn(new Error(err + ' (' + url + ':' + line + ')'));
     };
+    uncaughtExceptionHandlers.push(fn);
   }
 };
 
@@ -5563,6 +5569,18 @@ Mocha.Runner.immediately = function(callback) {
   if (!immediateTimeout) {
     immediateTimeout = setTimeout(timeslice, 0);
   }
+};
+
+/**
+ * Function to allow assertion libraries to throw errors directly into mocha.
+ * This is useful when running tests in a browser because window.onerror will
+ * only receive the 'message' attribute of the Error.
+ */
+mocha.throwError = function(err) {
+  uncaughtExceptionHandlers.forEach(function (fn) {
+    fn(err);
+  });
+  throw err;
 };
 
 /**

--- a/support/tail.js
+++ b/support/tail.js
@@ -24,13 +24,18 @@ var process = {};
 process.exit = function(status){};
 process.stdout = {};
 
+var uncaughtExceptionHandlers = [];
+
 /**
  * Remove uncaughtException listener.
  */
 
-process.removeListener = function(e){
+process.removeListener = function(e, fn){
   if ('uncaughtException' == e) {
     global.onerror = function() {};
+
+    var indexOfFn = uncaughtExceptionHandlers.indexOf(fn);
+    if (indexOfFn != -1) { uncaughtExceptionHandlers.splice(indexOfFn, 1); }
   }
 };
 
@@ -43,6 +48,7 @@ process.on = function(e, fn){
     global.onerror = function(err, url, line){
       fn(new Error(err + ' (' + url + ':' + line + ')'));
     };
+    uncaughtExceptionHandlers.push(fn);
   }
 };
 
@@ -77,6 +83,18 @@ Mocha.Runner.immediately = function(callback) {
   if (!immediateTimeout) {
     immediateTimeout = setTimeout(timeslice, 0);
   }
+};
+
+/**
+ * Function to allow assertion libraries to throw errors directly into mocha.
+ * This is useful when running tests in a browser because window.onerror will
+ * only receive the 'message' attribute of the Error.
+ */
+mocha.throwError = function(err) {
+  uncaughtExceptionHandlers.forEach(function (fn) {
+    fn(err) ;
+  });
+  throw err;
 };
 
 /**

--- a/test/browser/large.js
+++ b/test/browser/large.js
@@ -29,4 +29,21 @@ describe('something', function(){
       done();
     }, 1);
   })
+
+  it('should provide an even better error on phantomjs', function(done){
+    setTimeout(function(){
+      var AssertionError = function(message, actual, expected) {
+        this.message = message;
+        this.actual = actual;
+        this.expected = expected;
+        this.showDiff = true;
+      };
+      AssertionError.prototype = Object.create(Error.prototype);
+      AssertionError.prototype.name = 'AssertionError';
+      AssertionError.prototype.constructor = AssertionError;
+
+      mocha.throwError(new AssertionError('kabooom', 'text with a typo', 'text without a typo'));
+      done();
+    }, 1);
+  })
 })


### PR DESCRIPTION
This `mocha.throwError` is supposed to be called by assertion libraries.

It will allows awesome diffs (like [this](http://visionmedia.github.io/mocha/#string-diffs)) to be shown even when running async tests is a browser like phantomjs.

It's an alternative to https://github.com/visionmedia/mocha/pull/278 and https://github.com/visionmedia/mocha/pull/942

I plan to send a PR to chai, with a mirroring change.
