### PR TITLE
Include assertion message as context

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -182,10 +182,19 @@ exports.list = function(failures){
     // actual / expected diff
     if ('string' == typeof actual && 'string' == typeof expected) {
       fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
+      msg = '';
+      
+      // expect("foo", "the foo").to.equal("bar"); ->      
+      //  the foo: expected 'foo' to equal 'bar'
+      var expectMessageMatch = message.match(/^([^:]+): expected/);
+      if (expectMessageMatch) {
+        msg = '\n      ' + color('error message', expectMessageMatch[1]);
+      }
+      
       if (exports.inlineDiffs) {
-        msg = inlineDiff(err, escape);
+        msg += inlineDiff(err, escape);
       } else {
-        msg = unifiedDiff(err, escape);
+        msg += unifiedDiff(err, escape);
       }
     }
 


### PR DESCRIPTION
Resolves #991

This expect statement

```
expect("foo", "the foo").to.equal("bar");
```

now includes "the foo" as context for the failed match.

```
1) reporter shows reason for failed assertion:

    the foo
   + expected - actual

    +"bar"
   -"foo"
```
