### PR TITLE
Removed duplicate test output for multi-line specs in spec reporter

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -46,10 +46,6 @@ function Spec(runner) {
     if (1 == indents) console.log();
   });
 
-  runner.on('test', function(test){
-    process.stdout.write(indent() + color('pass', '  ◦ ' + test.title + ': '));
-  });
-
   runner.on('pending', function(test){
     var fmt = indent() + color('pending', '  - %s');
     console.log(fmt, test.title);


### PR DESCRIPTION
As metioned in #899, the spec reporter duplicates output when the terminal window can't contain a spec on a single line. I noticed that by removing the below line of code, the spec reporter never duplicates lines and still prints failures and passes correctly.

Here is the before and after:

**Before**
![screen shot 2013-10-14 at 21 46 57](https://f.cloud.github.com/assets/2061937/1331431/009773c4-3557-11e3-8b5d-84cb1da3a470.png)

**After**
![screen shot 2013-10-14 at 22 06 00](https://f.cloud.github.com/assets/2061937/1331442/903ab4dc-3557-11e3-956f-16716d969e21.png)
