### PR TITLE
Updated commander to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "make test-all"
   },
   "dependencies": {
-    "commander": "0.6.1",
+    "commander": "2.0.0",
     "growl": "1.7.x",
     "jade": "0.26.3",
     "diff": "1.0.7",


### PR DESCRIPTION
I've updated the commander dependency to 2.0.0 as we were having trouble with commander 0.6.1 on windows 7 (https://github.com/andrew/node-sass/pull/148)
