### PR TITLE
Prevent indents being negative in the spec reporter.

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -29,7 +29,10 @@ function Spec(runner) {
     , n = 0;
 
   function indent() {
-    return Array(indents).join('  ')
+    if (indents > 0) {
+      return Array(indents).join('  ');
+    }
+    return '';
   }
 
   runner.on('start', function(){
@@ -42,7 +45,7 @@ function Spec(runner) {
   });
 
   runner.on('suite end', function(suite){
-    --indents;
+    if (indents > 0) --indents;
     if (1 == indents) console.log();
   });
 


### PR DESCRIPTION
There was an issue where the spec reporter will attempt to create an Array with a negative size, and crashes. This will safeguard against illegal Array creation.
