### PR TITLE
Mocha.ui() now tries to import ui module if name is not found in mocha.interfaces

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -135,6 +135,7 @@ Mocha.prototype.reporter = function(reporter){
 Mocha.prototype.ui = function(name){
   name = name || 'bdd';
   this._ui = exports.interfaces[name];
+  if (!this._ui) try { this._ui = require(name); } catch (err) {};
   if (!this._ui) throw new Error('invalid interface "' + name + '"');
   this._ui = this._ui(this.suite);
   return this;


### PR DESCRIPTION
Hi, `--require <ui-module> --ui <name of the ui exported by ui-module>` doesn't work cause requires processed after settings an UI. I also think that having a `--ui` option to require a module is also consistent with how `--reporter` works and more straightforward than using `--require mod --ui name` even if it would work.

I believe this is better a version of #851.
