### PR TITLE
Added support for showing stack traces from JsUnit assertions

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -191,6 +191,10 @@ Runner.prototype.fail = function(test, err){
   ++this.failures;
   test.state = 'failed';
 
+  if (err.stackTrace) {
+    err.stack = err.stackTrace;
+  }
+
   if ('string' == typeof err) {
     err = new Error('the string "' + err + '" was thrown, throw an Error :)');
   }


### PR DESCRIPTION
I'm not sure if this is a good way to do this, or if it should even be done, but this makes JsUnit assertions work correctly in Mocha.
