### PR TITLE
Makes mocha.js YUI-compressible

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -1730,9 +1730,7 @@ var y = d * 365.25;
 module.exports = function(val, options){
   options = options || {};
   if ('string' == typeof val) return parse(val);
-  return options.long
-    ? long(val)
-    : short(val);
+  return options['long'] ? formatLong(val) : formatShort(val);
 };
 
 /**
@@ -1782,7 +1780,7 @@ function parse(str) {
  * @api private
  */
 
-function short(ms) {
+function formatShort(ms) {
   if (ms >= d) return Math.round(ms / d) + 'd';
   if (ms >= h) return Math.round(ms / h) + 'h';
   if (ms >= m) return Math.round(ms / m) + 'm';
@@ -1798,7 +1796,7 @@ function short(ms) {
  * @api private
  */
 
-function long(ms) {
+function formatLong(ms) {
   return plural(ms, d, 'day')
     || plural(ms, h, 'hour')
     || plural(ms, m, 'minute')


### PR DESCRIPTION
Before this diff, trying to compress mocha.js with YUI compressor would result in the following output

```
=> java -jar yuicompressor-2.4.8.jar mocha.js
[ERROR] in mocha.js
  1733:19:missing name after . operator
[ERROR] in mocha.js
  1734:16:identifier is a reserved word
[ERROR] in mocha.js
  1735:9:missing ; before statement
[ERROR] in mocha.js
  1736:17:identifier is a reserved word
[ERROR] in mocha.js
  1738:2:missing ) after argument list
[ERROR] in mocha.js
  1787:15:missing ( before function parameters.
[ERROR] in mocha.js
  1787:15:missing } after function body
[ERROR] in mocha.js
  1788:22:missing ; before statement
[ERROR] in mocha.js
  1789:22:invalid return
[ERROR] in mocha.js
  1790:22:invalid return
[ERROR] in mocha.js
  1791:22:invalid return
[ERROR] in mocha.js
  1792:9:invalid return
[ERROR] in mocha.js
  1793:1:syntax error
[ERROR] in mocha.js
  1803:14:identifier is a reserved word
[ERROR] in mocha.js
  1809:1:syntax error
[ERROR] in mocha.js
  1815:30:missing ; before statement
[ERROR] in mocha.js
  1816:21:missing ; before statement
[ERROR] in mocha.js
  1817:27:invalid return
[ERROR] in mocha.js
  1818:9:invalid return
[ERROR] in mocha.js
  1819:1:syntax error
[ERROR] in mocha.js
  1821:2:syntax error
[ERROR] in mocha.js
  5600:1:syntax error
[ERROR] in mocha.js
  1:0:Compilation produced 22 syntax errors.
org.mozilla.javascript.EvaluatorException: Compilation produced 22 syntax errors.
    at com.yahoo.platform.yui.compressor.YUICompressor$1.runtimeError(YUICompressor.java:172)
    at org.mozilla.javascript.Parser.parse(Parser.java:396)
    at org.mozilla.javascript.Parser.parse(Parser.java:340)
    at com.yahoo.platform.yui.compressor.JavaScriptCompressor.parse(JavaScriptCompressor.java:315)
    at com.yahoo.platform.yui.compressor.JavaScriptCompressor.<init>(JavaScriptCompressor.java:536)
    at com.yahoo.platform.yui.compressor.YUICompressor.main(YUICompressor.java:147)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at com.yahoo.platform.yui.compressor.Bootstrap.main(Bootstrap.java:21)
```

After this change, mocha.js compresses as you would expect, without errors.

The reason why YUI failed to compress `mocha.js`: it uses of `long` and `short` as identifiers. They are reserved word in ECMAScript since [ECMAScript v2](http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%202nd%20edition,%20August%201998.pdf):
![reserved_words](https://f.cloud.github.com/assets/208469/1518024/00f25afe-4b2e-11e3-834e-64920fd54289.png)

Cheers,
Arnaud.
