### PR TITLE
Fix for NaN coming in time attribute when test fails.

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -74,7 +74,7 @@ function test(test) {
   var attrs = {
       classname: test.parent.fullTitle()
     , name: test.title
-    , time: test.duration / 1000
+    , time: (test.duration / 1000) || 0
   };
 
   if ('failed' == test.state) {


### PR DESCRIPTION
When a test fails, division of duration property computes to NaN. An attempt to submit a report containing time="NaN" to Sonar throws an error and report gets rejected. To make Mocha XUnit compatible with Sonar, I propose this amazing change! This will return 0 when tests fail.
