### PR TITLE
Correct erroneous test

### DIFF
--- a/test/runnable.js
+++ b/test/runnable.js
@@ -213,11 +213,18 @@ describe('Runnable(title, fn)', function(){
       })
 
       it('should allow updating the timeout', function(done){
+        var callCount = 0;
+        var increment = function() {
+          callCount++;
+        };
         var test = new Runnable('foo', function(done){
-          this.timeout(10);
+          setTimeout(increment, 4);
+          setTimeout(increment, 6);
         });
+        test.timeout(5);
         test.run(function(err){
-          err.message.should.include('timeout');
+          err.should.be.ok;
+          callCount.should.equal(1);
           done();
         });
       })


### PR DESCRIPTION
Because the Runnable under test is not part of a Suite, its context is
undefined. Prior to this commit, the error returned was a
runtime-generated `ReferenceError`, not a Mocha-generated `Error`.

Set the timeout via the `Runnable#timeout` method, and update the test
to assert the correct behavior (not implementation details such as the
message body of the generated error).
