### PR TITLE
Unbreak mocha --inline-diffs

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -211,8 +211,7 @@ if (~process.argv.indexOf('--colors') ||
 }
 
 // --inline-diffs
-
-if (program.inlineDiffs) Base.inlineDiffs = true;
+if (program.inlineDiffs) require('../lib/reporters/base').inlineDiffs = true;
 
 // --slow <ms>
 


### PR DESCRIPTION
Previously `mocha --inline-diffs` threw a ReferenceError:

```
/path/to/mocha/bin/_mocha:215
if (program.inlineDiffs) Base.inlineDiffs = true;
                         ^
ReferenceError: Base is not defined
    at Object.<anonymous> (/path/to/mocha/bin/_mocha:215:26)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```

Seems like it broke in this refactoring: https://github.com/visionmedia/mocha/commit/805c95d2e6ecd2775b1093fc24bf45d8a1e95ab6

This fix doesn't seem like it's the entirely correct way to get the `inlineDiffs` option set on the base reporter, but it's a start.
