### PR TITLE
add Runnable.globals(arr) method for per test global whitelist

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -142,6 +142,16 @@ Runnable.prototype.resetTimeout = function(){
 };
 
 /**
+ * Whitelist these globals for this test run
+ *
+ * @api private
+ */
+Runnable.prototype.globals = function(arr){
+  var self = this;
+  this._allowedGlobals = arr;
+};
+
+/**
  * Run the test and invoke `fn(err)`.
  *
  * @param {Function} fn

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -158,9 +158,14 @@ Runner.prototype.globals = function(arr){
 Runner.prototype.checkGlobals = function(test){
   if (this.ignoreLeaks) return;
   var ok = this._globals;
+
   var globals = this.globalProps();
   var isNode = process.kill;
   var leaks;
+
+  if (test) {
+    ok = ok.concat(test._allowedGlobals || []);
+  }
 
   // check length - 2 ('errno' and 'location' globals)
   if (isNode && 1 == ok.length - globals.length) return;

--- a/test/runnable.js
+++ b/test/runnable.js
@@ -71,6 +71,16 @@ describe('Runnable(title, fn)', function(){
     })
   })
 
+  describe('#globals', function(){
+    it('should allow for whitelisting globals', function(done){
+      var test = new Runnable('foo', function(){});
+      test.async.should.be.equal(0);
+      test.sync.should.be.true;
+      test.globals(['foobar']);
+      test.run(done);
+    })
+  })
+
   describe('.run(fn)', function(){
     describe('when .pending', function(){
       it('should not invoke the callback', function(done){

--- a/test/runner.js
+++ b/test/runner.js
@@ -132,6 +132,39 @@ describe('Runner', function(){
       });
       runner.checkGlobals('im a test');
     })
+
+    it('should respect per test whitelisted globals', function() {
+      var test = new Test('im a test about lions');
+      test.globals(['foo']);
+
+      suite.addTest(test);
+      var runner = new Runner(suite);
+
+      global.foo = 'bar';
+
+      // verify the test hasn't failed.
+      runner.checkGlobals(test);
+      test.should.not.have.key('state');
+
+      delete global.foo;
+    })
+
+    it('should respect per test whitelisted globals but still detect other leaks', function(done) {
+      var test = new Test('im a test about lions');
+      test.globals(['foo']);
+
+      suite.addTest(test);
+
+      global.foo = 'bar';
+      global.bar = 'baz';
+      runner.on('fail', function(test, err){
+        test.title.should.equal('im a test about lions');
+        err.message.should.equal('global leak detected: bar');
+        delete global.foo;
+        done();
+      });
+      runner.checkGlobals(test);
+    })
   })
 
   describe('.fail(test, err)', function(){


### PR DESCRIPTION
Instead of suite wide whitelisting of global leaks, this allows for
individual tests to whitelist globals. This allows for keeping global
detection for tests which are not expected to set globals while allowing
for certain globals if the author expects a test to set globals
