### PR TITLE
Add <testcase></skipped><testcase> for pending tests to xunit reporter

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -36,6 +36,10 @@ function XUnit(runner) {
     , tests = []
     , self = this;
 
+  runner.on('pending', function(test){
+    tests.push(test);
+  });
+
   runner.on('pass', function(test){
     tests.push(test);
   });


### PR DESCRIPTION
Resolves #1050

Adds test result for pending tests to results array. Pending tests will be then reported individually as `<testcase name="test1"></skipped></testcase>`. These entries are currently not shown in detail, only the total number of skipped test is shown (as the `<testsuite skipped="1">` attribute).
