### PR TITLE
Fix verbose failures in xunit output

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -45,6 +44,7 @@ function XUnit(runner) {
   });
 
   runner.on('fail', function(test){
+    test.state = 'failed';
     tests.push(test);
   });
 


### PR DESCRIPTION
This looks like the wrong place to fix my issue, but without it, I only get the number of failures in the resulting xunit, and not a `<failure classsname name time message><![CDATA[stacktrace]]></failure>` inside the failed testcase, which is needed for a useful Bamboo CI output.
