### PR TITLE
Ensure process exit code is preserved when using --no-exit

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -348,7 +348,11 @@ if (program.watch) {
 // load
 
 mocha.files = files;
-mocha.run(program.exit ? process.exit : function() {});
+mocha.run(program.exit ? process.exit : exitLater);
+
+function exitLater(code) {
+  process.on('exit', function() { process.exit(code) })
+}
 
 // enable growl notifications
 


### PR DESCRIPTION
When using --no-exit to wait for the event loop to finish, the exit code gets lost.

This patch ensures that if tests fail, the exit code makes it back to the shell
