### PR TITLE
only write to stdout in reporters

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -154,7 +154,7 @@ exports.cursor = {
  */
 
 exports.list = function(failures){
-  console.error();
+  console.log();
   failures.forEach(function(test, i){
     // format
     var fmt = color('error title', '  %s) %s:\n')
@@ -200,7 +200,7 @@ exports.list = function(failures){
     stack = stack.slice(index ? index + 1 : index)
       .replace(/^/gm, '  ');
 
-    console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
+    console.log(fmt, (i + 1), test.fullTitle(), msg, stack);
   });
 };
 
@@ -305,11 +305,10 @@ Base.prototype.epilogue = function(){
   if (stats.failures) {
     fmt = color('fail', '  %d failing');
 
-    console.error(fmt,
-      stats.failures);
+    console.log(fmt, stats.failures);
 
     Base.list(this.failures);
-    console.error();
+    console.log();
   }
 
   console.log();


### PR DESCRIPTION
The base reporter outputs some of its failure information to stderr via console.error - this makes it a bit fiddly to redirect output from any reporter using Base.list

This patch switches them over to stdout via console.log, it also means that debug output on stderr won't get mixed in with test results.
