### PR TITLE
Expose the globals as modules in mocha.

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -32,23 +32,6 @@ exports.Hook = require('./hook');
 exports.Test = require('./test');
 
 /**
- * Expose interfaces
- */
-
-exports.afterEach = global.afterEach || global.teardown;
-exports.after = global.after || global.suiteTeardown;
-exports.beforeEach = global.beforeEach || global.setup;
-exports.before = global.before || global.suiteSetup;
-exports.describe = global.describe || global.suite;
-exports.it = global.it || global.test;
-exports.setup = global.setup || global.beforeEach;
-exports.suiteSetup = global.suiteSetup || global.before;
-exports.suiteTeardown = global.suiteTeardown || global.after;
-exports.suite = global.suite || global.describe;
-exports.teardown = global.teardown || global.afterEach;
-exports.test = global.test || global.it;
-
-/**
  * Return image `name` path.
  *
  * @param {String} name
@@ -90,6 +73,21 @@ function Mocha(options) {
   if (null != options.timeout) this.timeout(options.timeout);
   this.useColors(options.useColors)
   if (options.slow) this.slow(options.slow);
+
+  this.suite.on('pre-require', function (context) {
+    exports.afterEach = context.afterEach || context.teardown;
+    exports.after = context.after || context.suiteTeardown;
+    exports.beforeEach = context.beforeEach || context.setup;
+    exports.before = context.before || context.suiteSetup;
+    exports.describe = context.describe || context.suite;
+    exports.it = context.it || context.test;
+    exports.setup = context.setup || context.beforeEach;
+    exports.suiteSetup = context.suiteSetup || context.before;
+    exports.suiteTeardown = context.suiteTeardown || context.after;
+    exports.suite = context.suite || context.describe;
+    exports.teardown = context.teardown || context.afterEach;
+    exports.test = context.test || context.it;
+  });
 }
 
 /**

--- a/test/acceptance/required-tokens.js
+++ b/test/acceptance/required-tokens.js
@@ -1,0 +1,10 @@
+var assert = require('assert');
+var describe = require('../..').describe;
+var it = require('../..').it;
+
+describe('using imported describe', function () {
+  it('using imported it', function (done) {
+    assert.ok(true);
+    done();
+  })
+})


### PR DESCRIPTION
This change allows you to write mocha tests without referencing globals in your test files.

This is useful when you want to lint your tests and your linter complains about globals.

For example

``` js
var assert = require("assert")
var describe = require("mocha/describe")
var it = require("mocha/it")
describe('Array', function(){
  describe('#indexOf()', function(){
    it('should return -1 when the value is not present', function(){
      assert.equal(-1, [1,2,3].indexOf(5));
      assert.equal(-1, [1,2,3].indexOf(0));
    })
  })
})
```

This also has a benefit of being able to write mocha tests in either the BDD or the TDD style by just requiring either `test` or `it` and the command line setting of the interface is irrelevant.
