### PR TITLE
Canonicalize objects before stringifying and diffing them

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -5,7 +5,8 @@
 
 var tty = require('tty')
   , diff = require('diff')
-  , ms = require('../ms');
+  , ms = require('../ms')
+  , utils = require('../utils');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -179,8 +180,8 @@ exports.list = function(failures){
     // explicitly show diff
     if (err.showDiff && sameType(actual, expected)) {
       escape = false;
-      err.actual = actual = stringify(actual);
-      err.expected = expected = stringify(expected);
+      err.actual = actual = stringify(canonicalizeObject(actual));
+      err.expected = expected = stringify(canonicalizeObject(expected));
     }
 
     // actual / expected diff
@@ -453,6 +454,39 @@ function colorLines(name, str) {
 function stringify(obj) {
   if (obj instanceof RegExp) return obj.toString();
   return JSON.stringify(obj, null, 2);
+}
+
+/**
+ * Return a new object that has the in sorted order.
+ * @param {Mixed} obj
+ * @return {Mixed}
+ */
+function canonicalizeObject(obj, stack) {
+  if (!stack) {
+    stack = [];
+  } else if (utils.indexOf(stack, obj) !== -1) {
+    // There's a cycle, bail out
+    return obj;
+  }
+  stack = stack || [];
+  if ('[object Array]' == {}.toString.call(obj)) {
+    stack.push(obj);
+    var returnValue = utils.map(obj, function (item) {
+        return canonicalizeObject(item, stack);
+    });
+    stack.pop();
+    return returnValue;
+  } else if (typeof obj === 'object' && obj !== null) {
+    stack.push(obj);
+    var sortedObj = {};
+    utils.forEach(utils.keys(obj).sort(), function (key) {
+      sortedObj[key] = canonicalizeObject(obj[key], stack);
+    });
+    stack.pop();
+    return sortedObj;
+  } else {
+    return obj;
+  }
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,6 +44,22 @@ exports.forEach = function(arr, fn, scope){
 };
 
 /**
+ * Array#map (<=IE8)
+ *
+ * @param {Array} array
+ * @param {Function} fn
+ * @param {Object} scope
+ * @api private
+ */
+
+exports.map = function(arr, fn, scope){
+  var result = [];
+  for (var i = 0, l = arr.length; i < l; i++)
+    result.push(fn.call(scope, arr[i], i));
+  return result;
+};
+
+/**
  * Array#indexOf (<=IE8)
  *
  * @parma {Array} arr


### PR DESCRIPTION
Assertion libraries can set the `showDiff` of the thrown Error instances to true, which makes mocha serialize the `actual` and `expected` properties, then do a string diff -- effectively a poor man's object diff. However, it produces an unnecessarily big diff when the key definition order in objects are different:

``` javascript
var expect = require('unexpected');

describe('the thing', function () {
    it('should DTRT', function () {
        expect({foo: 123, bar: 456, quux: 789}, 'to equal', {quux: 78, foo: 123, bar: 456});
    });
});
```

```
  0 passing (5ms)
  1 failing

  1) the thing should DTRT:

      + expected - actual

       {
      +  "quux": 78,
         "foo": 123,
      +  "bar": 456
      -  "bar": 456,
      -  "quux": 789
       }
```

This patch canonicalizes objects before comparing them so the above example produces:

```
  0 passing (5ms)
  1 failing

  1) the thing should DTRT:

      + expected - actual

       {
         "bar": 456,
         "foo": 123,
      +  "quux": 78
      -  "quux": 789
       }
```

... which I've found to be a great help when diffing large objects.
