### PR TITLE
Add link to Node.js assert module in Assertions section

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@ $  mocha
 
 <h2 id="assertions">Assertions</h2>
 
-<p>Mocha allows you to use any assertion library you want, if it throws an error, it will work! This means you can utilize libraries such as <a href="https://github.com/visionmedia/should.js">should.js</a>, node's regular <code>assert</code> module, or others. The following is a list of known assertion libraries for node and/or the browser:</p>
+<p>Mocha allows you to use any assertion library you want, if it throws an error, it will work! This means you can utilize libraries such as <a href="https://github.com/visionmedia/should.js">should.js</a>, node's <a href="http://nodejs.org/api/assert.html">regular <code>assert</code> module</a>, or others. The following is a list of known assertion libraries for node and/or the browser:</p>
 
 <ul>
 <li><a href="https://github.com/visionmedia/should.js">should.js</a> BDD style shown throughout these docs</li>


### PR DESCRIPTION
I was looking for a list of available assertions with the built in list, and didn't find it. I thought adding the link to Node's assert module would be a good idea since you're already linking to the others.
