### PR TITLE
Fixed Broken Nyan Reporter

### DIFF
--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -3,7 +3,8 @@
  */
 
 var Base = require('./base')
-  , color = Base.color;
+  , color = Base.color
+  , rainbowColors = generateColors();
 
 /**
  * Expose `Dot`.
@@ -23,7 +24,6 @@ function NyanCat(runner) {
   var self = this
     , stats = this.stats
     , width = Base.window.width * .75 | 0
-    , rainbowColors = this.rainbowColors = self.generateColors()
     , colorIndex = this.colorIndex = 0
     , numerOfLines = this.numberOfLines = 4
     , trajectories = this.trajectories = [[], [], [], []]
@@ -32,6 +32,57 @@ function NyanCat(runner) {
     , scoreboardWidth = this.scoreboardWidth = 5
     , tick = this.tick = 0
     , n = 0;
+
+  // Bind the drawing functions to this
+  this.appendRainbow = appendRainbow.bind(this);
+  this.drawScoreboard = drawScoreboard.bind(this);
+  this.drawRainbow = drawRainbow.bind(this);
+  this.drawNyanCat = drawNyanCat.bind(this);
+
+
+  /**
+   * Draw nyan cat face.
+   *
+   * @return {String}
+   * @api private
+   */
+  this.face = function() {
+    if (this.stats.failures) {
+      return '( x .x)';
+    } else if (this.stats.pending) {
+      return '( o .o)';
+    } else if(this.stats.passes) {
+      return '( ^ .^)';
+    } else {
+      return '( - .-)';
+    }
+  }
+
+  /**
+   * Apply rainbow to the given `str`.
+   *
+   * @param {String} str
+   * @return {String}
+   * @api private
+   */
+  this.rainbowify = function(str) {
+    var color = rainbowColors[this.colorIndex % rainbowColors.length];
+    this.colorIndex += 1;
+    return '\u001b[38;5;' + color + 'm' + str + '\u001b[0m';
+  };
+
+  /**
+   * Draw the nyan cat
+   *
+   * @api private
+   */
+  self.draw = function(){
+    self.appendRainbow();
+    self.drawScoreboard();
+    self.drawRainbow();
+    self.drawNyanCat();
+    self.tick = !self.tick;
+  };
 
   runner.on('start', function(){
     Base.cursor.hide();
@@ -57,19 +108,6 @@ function NyanCat(runner) {
   });
 }
 
-/**
- * Draw the nyan cat
- *
- * @api private
- */
-
-NyanCat.prototype.draw = function(){
-  this.appendRainbow();
-  this.drawScoreboard();
-  this.drawRainbow();
-  this.drawNyanCat();
-  this.tick = !this.tick;
-};
 
 /**
  * Draw the "scoreboard" showing the number
@@ -78,7 +116,7 @@ NyanCat.prototype.draw = function(){
  * @api private
  */
 
-NyanCat.prototype.drawScoreboard = function(){
+function drawScoreboard() {
   var stats = this.stats;
   var colors = Base.colors;
 
@@ -93,7 +131,7 @@ NyanCat.prototype.drawScoreboard = function(){
   draw(colors.pending, stats.pending);
   write('\n');
 
-  this.cursorUp(this.numberOfLines);
+  cursorUp(this.numberOfLines);
 };
 
 /**
@@ -102,7 +140,7 @@ NyanCat.prototype.drawScoreboard = function(){
  * @api private
  */
 
-NyanCat.prototype.appendRainbow = function(){
+function appendRainbow() {
   var segment = this.tick ? '_' : '-';
   var rainbowified = this.rainbowify(segment);
 
@@ -118,8 +156,7 @@ NyanCat.prototype.appendRainbow = function(){
  *
  * @api private
  */
-
-NyanCat.prototype.drawRainbow = function(){
+function drawRainbow() {
   var self = this;
 
   this.trajectories.forEach(function(line, index) {
@@ -128,7 +165,7 @@ NyanCat.prototype.drawRainbow = function(){
     write('\n');
   });
 
-  this.cursorUp(this.numberOfLines);
+  cursorUp(this.numberOfLines);
 };
 
 /**
@@ -136,8 +173,7 @@ NyanCat.prototype.drawRainbow = function(){
  *
  * @api private
  */
-
-NyanCat.prototype.drawNyanCat = function() {
+function drawNyanCat() {
   var self = this;
   var startWidth = this.scoreboardWidth + this.trajectories[0].length;
   var color = '\u001b[' + startWidth + 'C';
@@ -164,28 +200,8 @@ NyanCat.prototype.drawNyanCat = function() {
   write(padding + '""  "" ');
   write('\n');
 
-  this.cursorUp(this.numberOfLines);
+  cursorUp(this.numberOfLines);
 };
-
-/**
- * Draw nyan cat face.
- *
- * @return {String}
- * @api private
- */
-
-NyanCat.prototype.face = function() {
-  var stats = this.stats;
-  if (stats.failures) {
-    return '( x .x)';
-  } else if (stats.pending) {
-    return '( o .o)';
-  } else if(stats.passes) {
-    return '( ^ .^)';
-  } else {
-    return '( - .-)';
-  }
-}
 
 /**
  * Move cursor up `n`.
@@ -193,8 +209,7 @@ NyanCat.prototype.face = function() {
  * @param {Number} n
  * @api private
  */
-
-NyanCat.prototype.cursorUp = function(n) {
+function cursorUp(n) {
   write('\u001b[' + n + 'A');
 };
 
@@ -204,8 +219,7 @@ NyanCat.prototype.cursorUp = function(n) {
  * @param {Number} n
  * @api private
  */
-
-NyanCat.prototype.cursorDown = function(n) {
+function cursorDown(n) {
   write('\u001b[' + n + 'B');
 };
 
@@ -215,8 +229,7 @@ NyanCat.prototype.cursorDown = function(n) {
  * @return {Array}
  * @api private
  */
-
-NyanCat.prototype.generateColors = function(){
+function generateColors() {
   var colors = [];
 
   for (var i = 0; i < (6 * 7); i++) {
@@ -231,24 +244,10 @@ NyanCat.prototype.generateColors = function(){
   return colors;
 };
 
-/**
- * Apply rainbow to the given `str`.
- *
- * @param {String} str
- * @return {String}
- * @api private
- */
-
-NyanCat.prototype.rainbowify = function(str){
-  var color = this.rainbowColors[this.colorIndex % this.rainbowColors.length];
-  this.colorIndex += 1;
-  return '\u001b[38;5;' + color + 'm' + str + '\u001b[0m';
-};
 
 /**
  * Stdout helper.
  */
-
 function write(string) {
   process.stdout.write(string);
 }
@@ -256,5 +255,4 @@ function write(string) {
 /**
  * Inherit from `Base.prototype`.
  */
-
 NyanCat.prototype.__proto__ = Base.prototype;

--- a/mocha.js
+++ b/mocha.js
@@ -1977,7 +1977,7 @@ exports.cursor = {
       exports.cursor.deleteLine();
       exports.cursor.beginningOfLine();
     } else {
-      process.stdout.write('\n');
+      process.stdout.write('\r');
     }
   }
 };
@@ -3442,7 +3442,8 @@ require.register("reporters/nyan.js", function(module, exports, require){
  */
 
 var Base = require('./base')
-  , color = Base.color;
+  , color = Base.color
+  , rainbowColors = generateColors();
 
 /**
  * Expose `Dot`.
@@ -3462,7 +3463,6 @@ function NyanCat(runner) {
   var self = this
     , stats = this.stats
     , width = Base.window.width * .75 | 0
-    , rainbowColors = this.rainbowColors = self.generateColors()
     , colorIndex = this.colorIndex = 0
     , numerOfLines = this.numberOfLines = 4
     , trajectories = this.trajectories = [[], [], [], []]
@@ -3471,6 +3471,57 @@ function NyanCat(runner) {
     , scoreboardWidth = this.scoreboardWidth = 5
     , tick = this.tick = 0
     , n = 0;
+
+  // Bind the drawing functions to this
+  this.appendRainbow = appendRainbow.bind(this);
+  this.drawScoreboard = drawScoreboard.bind(this);
+  this.drawRainbow = drawRainbow.bind(this);
+  this.drawNyanCat = drawNyanCat.bind(this);
+
+
+  /**
+   * Draw nyan cat face.
+   *
+   * @return {String}
+   * @api private
+   */
+  this.face = function() {
+    if (this.stats.failures) {
+      return '( x .x)';
+    } else if (this.stats.pending) {
+      return '( o .o)';
+    } else if(this.stats.passes) {
+      return '( ^ .^)';
+    } else {
+      return '( - .-)';
+    }
+  }
+
+  /**
+   * Apply rainbow to the given `str`.
+   *
+   * @param {String} str
+   * @return {String}
+   * @api private
+   */
+  this.rainbowify = function(str) {
+    var color = rainbowColors[this.colorIndex % rainbowColors.length];
+    this.colorIndex += 1;
+    return '\u001b[38;5;' + color + 'm' + str + '\u001b[0m';
+  };
+
+  /**
+   * Draw the nyan cat
+   *
+   * @api private
+   */
+  self.draw = function(){
+    self.appendRainbow();
+    self.drawScoreboard();
+    self.drawRainbow();
+    self.drawNyanCat();
+    self.tick = !self.tick;
+  };
 
   runner.on('start', function(){
     Base.cursor.hide();
@@ -3496,19 +3547,6 @@ function NyanCat(runner) {
   });
 }
 
-/**
- * Draw the nyan cat
- *
- * @api private
- */
-
-NyanCat.prototype.draw = function(){
-  this.appendRainbow();
-  this.drawScoreboard();
-  this.drawRainbow();
-  this.drawNyanCat();
-  this.tick = !this.tick;
-};
 
 /**
  * Draw the "scoreboard" showing the number
@@ -3517,7 +3555,7 @@ NyanCat.prototype.draw = function(){
  * @api private
  */
 
-NyanCat.prototype.drawScoreboard = function(){
+function drawScoreboard() {
   var stats = this.stats;
   var colors = Base.colors;
 
@@ -3532,7 +3570,7 @@ NyanCat.prototype.drawScoreboard = function(){
   draw(colors.pending, stats.pending);
   write('\n');
 
-  this.cursorUp(this.numberOfLines);
+  cursorUp(this.numberOfLines);
 };
 
 /**
@@ -3541,7 +3579,7 @@ NyanCat.prototype.drawScoreboard = function(){
  * @api private
  */
 
-NyanCat.prototype.appendRainbow = function(){
+function appendRainbow() {
   var segment = this.tick ? '_' : '-';
   var rainbowified = this.rainbowify(segment);
 
@@ -3557,8 +3595,7 @@ NyanCat.prototype.appendRainbow = function(){
  *
  * @api private
  */
-
-NyanCat.prototype.drawRainbow = function(){
+function drawRainbow() {
   var self = this;
 
   this.trajectories.forEach(function(line, index) {
@@ -3567,7 +3604,7 @@ NyanCat.prototype.drawRainbow = function(){
     write('\n');
   });
 
-  this.cursorUp(this.numberOfLines);
+  cursorUp(this.numberOfLines);
 };
 
 /**
@@ -3575,8 +3612,7 @@ NyanCat.prototype.drawRainbow = function(){
  *
  * @api private
  */
-
-NyanCat.prototype.drawNyanCat = function() {
+function drawNyanCat() {
   var self = this;
   var startWidth = this.scoreboardWidth + this.trajectories[0].length;
   var color = '\u001b[' + startWidth + 'C';
@@ -3603,28 +3639,8 @@ NyanCat.prototype.drawNyanCat = function() {
   write(padding + '""  "" ');
   write('\n');
 
-  this.cursorUp(this.numberOfLines);
+  cursorUp(this.numberOfLines);
 };
-
-/**
- * Draw nyan cat face.
- *
- * @return {String}
- * @api private
- */
-
-NyanCat.prototype.face = function() {
-  var stats = this.stats;
-  if (stats.failures) {
-    return '( x .x)';
-  } else if (stats.pending) {
-    return '( o .o)';
-  } else if(stats.passes) {
-    return '( ^ .^)';
-  } else {
-    return '( - .-)';
-  }
-}
 
 /**
  * Move cursor up `n`.
@@ -3632,8 +3648,7 @@ NyanCat.prototype.face = function() {
  * @param {Number} n
  * @api private
  */
-
-NyanCat.prototype.cursorUp = function(n) {
+function cursorUp(n) {
   write('\u001b[' + n + 'A');
 };
 
@@ -3643,8 +3658,7 @@ NyanCat.prototype.cursorUp = function(n) {
  * @param {Number} n
  * @api private
  */
-
-NyanCat.prototype.cursorDown = function(n) {
+function cursorDown(n) {
   write('\u001b[' + n + 'B');
 };
 
@@ -3654,8 +3668,7 @@ NyanCat.prototype.cursorDown = function(n) {
  * @return {Array}
  * @api private
  */
-
-NyanCat.prototype.generateColors = function(){
+function generateColors() {
   var colors = [];
 
   for (var i = 0; i < (6 * 7); i++) {
@@ -3670,24 +3683,10 @@ NyanCat.prototype.generateColors = function(){
   return colors;
 };
 
-/**
- * Apply rainbow to the given `str`.
- *
- * @param {String} str
- * @return {String}
- * @api private
- */
-
-NyanCat.prototype.rainbowify = function(str){
-  var color = this.rainbowColors[this.colorIndex % this.rainbowColors.length];
-  this.colorIndex += 1;
-  return '\u001b[38;5;' + color + 'm' + str + '\u001b[0m';
-};
 
 /**
  * Stdout helper.
  */
-
 function write(string) {
   process.stdout.write(string);
 }
@@ -3695,7 +3694,6 @@ function write(string) {
 /**
  * Inherit from `Base.prototype`.
  */
-
 function F(){};
 F.prototype = Base.prototype;
 NyanCat.prototype = new F;


### PR DESCRIPTION
The Nyan reporter is the only reporter that modified the reporter
prototype. This prototype is overwritten in the mocha.js compilation,
causing the reporter to fail when used in mocha.js. Normally mocha.js
is only used in browsers, where this reporter wouldn't work anyway. But
there are many CLIs that use mocha & phantomJS to run front-end tests
on the command line. Because they rely on mocha.js, Nyan wasn't working.

This commit removes the prototype modifications and moves those functions off
of the NyanCat instance, instead binding them to be run with the correct
this context. This way the prototype can be properly overwritten in mocha.js
while still allowing the reporter to work as expencted.

See: 
https://github.com/jdcataldo/grunt-mocha-phantomjs/issues/14
https://github.com/metaskills/mocha-phantomjs/issues/71#issuecomment-28753156
