### PR TITLE
Add support for suppressing stack traces

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -85,6 +85,7 @@ program
   .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
   .option('--inline-diffs', 'display actual/expected differences inline within each string')
   .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
+  .option('--suppress-stack', 'suppress stack trace on error')
 
 program.name = 'mocha';
 
@@ -249,6 +250,10 @@ if (program.asyncOnly) mocha.asyncOnly();
 // --globals
 
 mocha.globals(globals);
+
+// --suppress-stack
+
+if (program.suppressStack) mocha.suppressStack();
 
 // custom compiler support
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -292,6 +292,18 @@ Mocha.prototype.useInlineDiffs = function(inlineDiffs) {
 };
 
 /**
+ * Suppress stack traces
+ *
+ * @return {Mocha}
+ * @api public
+ */
+
+Mocha.prototype.suppressStack = function() {
+  this.options.suppressStack = true;
+  return this;
+};
+
+/**
  * Set the timeout in milliseconds.
  *
  * @param {Number} timeout
@@ -350,5 +362,6 @@ Mocha.prototype.run = function(fn){
   if (options.growl) this._growl(runner, reporter);
   exports.reporters.Base.useColors = options.useColors;
   exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
+  exports.reporters.Base.suppressStack = options.suppressStack;
   return runner.run(fn);
 };

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -43,6 +43,12 @@ exports.useColors = isatty || (process.env.MOCHA_COLORS !== undefined);
 exports.inlineDiffs = false;
 
 /**
+ * Suppress stack traces
+ */
+
+exports.suppressStack = false;
+
+/**
  * Default color map.
  */
 
@@ -160,7 +166,8 @@ exports.list = function(failures){
     // format
     var fmt = color('error title', '  %s) %s:\n')
       + color('error message', '     %s')
-      + color('error stack', '\n%s\n');
+    
+    if (!exports.suppressStack) fmt += color('error stack', '\n%s\n');
 
     // msg
     var err = test.err
@@ -170,7 +177,8 @@ exports.list = function(failures){
       , msg = stack.slice(0, index)
       , actual = err.actual
       , expected = err.expected
-      , escape = true;
+      , escape = true
+      , errorArgs = [];
 
     // uncaught
     if (err.uncaught) {
@@ -201,7 +209,10 @@ exports.list = function(failures){
     stack = stack.slice(index ? index + 1 : index)
       .replace(/^/gm, '  ');
 
-    console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
+    errorArgs = [fmt, (i + 1), test.fullTitle(), msg];
+    if (!exports.suppressStack) errorArgs.push(stack);
+
+    console.error.apply(console, errorArgs);
   });
 };
 


### PR DESCRIPTION
I run mocha tests with `--watch` in a small tmux pane, but even using `--reporter min`, the stack trace makes it impossible to see the actual error messages. For instant feedback, it's nice to get ONLY the error message. If you're running mocha with `--watch`, you're likely to know, already, where the error in the code is.
