### PR TITLE
Abort previous run on --watch change.

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -307,11 +307,18 @@ if (program.watch) {
   });
 
   var watchFiles = utils.files(cwd);
+  var runAgain = false;
 
   function loadAndRun() {
     try {
       mocha.files = files;
-      runner = mocha.run(function(){});
+      runAgain = false;
+      runner = mocha.run(function(){
+        runner = null;
+        if (runAgain) {
+          rerun();
+        }
+      });
     } catch(e) {
       console.log(e.stack);
     }
@@ -325,15 +332,21 @@ if (program.watch) {
 
   loadAndRun();
 
-  utils.watch(watchFiles, function(){
+  function rerun() {
     purge();
     stop()
-    if (runner) {
-      runner.abort();
-    }
     mocha.suite = mocha.suite.clone();
     mocha.ui(program.ui);
     loadAndRun();
+  }
+
+  utils.watch(watchFiles, function(){
+    runAgain = true;
+    if (runner) {
+      runner.abort();
+    } else {
+      rerun();
+    }
   });
 
   return;


### PR DESCRIPTION
Currently when a file change is detected the previous test suite continues running and a new one starts in parallel. This can cause issues with the context sharing issue fixed in #1099; but I also suspect it's not the desired behaviour.

This change aborts the current test suite before starting the fresh one.

(An alternative option would be to queue a new test suite run after the current one completes - I am not sure which is the more desirable option; I think running the fresh tests sooner probably wins from the point of view of giving the programmer up to date feedback?)
