### PR TITLE
Prefer `process.stdout.write` in xUnit reporter.

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -49,7 +49,7 @@ function XUnit(runner) {
   });
 
   runner.on('end', function(){
-    console.log(tag('testsuite', {
+    writeLine(tag('testsuite', {
         name: 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
@@ -60,7 +60,7 @@ function XUnit(runner) {
     }, false));
 
     tests.forEach(test);
-    console.log('</testsuite>');
+    writeLine('</testsuite>');
   });
 }
 
@@ -84,11 +84,11 @@ function test(test) {
   if ('failed' == test.state) {
     var err = test.err;
     attrs.message = escape(err.message);
-    console.log(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
+    writeLine(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
   } else if (test.pending) {
-    console.log(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    writeLine(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    console.log(tag('testcase', attrs, true) );
+    writeLine(tag('testcase', attrs, true) );
   }
 }
 
@@ -116,4 +116,29 @@ function tag(name, attrs, close, content) {
 
 function cdata(str) {
   return '<![CDATA[' + escape(str) + ']]>';
+}
+
+/**
+ * Write to standard output if available (through Node.js), or otherwise
+ * to `console.log`.
+ *
+ * NOTE: Beware of the differences between `console.log` and
+ * `process.stdout.write`--most importantly that `console.log`
+ * on some browsers may format its arguments a la `printf`,
+ * whereas `process.stdout.write` expects a string to print
+ * verbatim as its first argument. Fortunately most browsers
+ * (at least Firefox and Chrome) print the first argument
+ * verbatim as long as there are no others, so this is unlikely
+ * to be a problem in practice.
+ */
+
+var writeLine;
+if ((typeof process != 'undefined') && (typeof process.stdout != 'undefined')) {
+  writeLine = function(str) {
+    process.stdout.write(str + '\n');
+  };
+} else {
+  writeLine = function(str) {
+    console.log(str);
+  };
 }

--- a/mocha.js
+++ b/mocha.js
@@ -1977,7 +1977,7 @@ exports.cursor = {
       exports.cursor.deleteLine();
       exports.cursor.beginningOfLine();
     } else {
-      process.stdout.write('\n');
+      process.stdout.write('\r');
     }
   }
 };
@@ -4018,7 +4018,7 @@ function XUnit(runner) {
   });
 
   runner.on('end', function(){
-    console.log(tag('testsuite', {
+    writeLine(tag('testsuite', {
         name: 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
@@ -4029,7 +4029,7 @@ function XUnit(runner) {
     }, false));
 
     tests.forEach(test);
-    console.log('</testsuite>');
+    writeLine('</testsuite>');
   });
 }
 
@@ -4057,11 +4057,11 @@ function test(test) {
   if ('failed' == test.state) {
     var err = test.err;
     attrs.message = escape(err.message);
-    console.log(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
+    writeLine(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
   } else if (test.pending) {
-    console.log(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    writeLine(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    console.log(tag('testcase', attrs, true) );
+    writeLine(tag('testcase', attrs, true) );
   }
 }
 
@@ -4091,6 +4091,30 @@ function cdata(str) {
   return '<![CDATA[' + escape(str) + ']]>';
 }
 
+/**
+ * Write to standard output if available (through Node.js), or otherwise
+ * to `console.log`.
+ *
+ * NOTE: Beware of the differences between `console.log` and
+ * `process.stdout.write`--most importantly that `console.log`
+ * on some browsers may format its arguments a la `printf`,
+ * whereas `process.stdout.write` expects a string to print
+ * verbatim as its first argument. Fortunately most browsers
+ * (at least Firefox and Chrome) print the first argument
+ * verbatim as long as there are no others, so this is unlikely
+ * to be a problem in practice.
+ */
+
+var writeLine;
+if ((typeof process != 'undefined') && (typeof process.stdout != 'undefined')) {
+  writeLine = function(str) {
+    process.stdout.write(str + '\n');
+  };
+} else {
+  writeLine = function(str) {
+    console.log(str);
+  };
+}
 }); // module: reporters/xunit.js
 
 require.register("runnable.js", function(module, exports, require){


### PR DESCRIPTION
Falls back to `console.log` if `process.stdout` is unavailable.

This is another stab at fixing #1068 without breaking existing use cases. It works for me on my own ~1500 test suite in both Chrome and through mocha-phantomjs, and the Mocha self-tests pass.

I was having an issue with mocha-phantomjs not picking up the reporter output when used with the `--file` options because of the use of `console.log`. Switching to `process.stdout.write` (when it is available) fixes the problem for me.

This also seems to have picked up a completely unrelated change to another file that hadn't yet made it into the mocha.js snapshot. (See diff.) Is this sort of thing a regular occurrence?
