### PR TITLE
Pass the --use_strict flag through to mocha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,16 +140,10 @@ test-sort:
 		--sort \
 		test/acceptance/sort
 
-# The test/mocha.opts requires should.js which is not use_strict compliant,
-# so it is necessary to move it before testing harmony. The harmony file uses
-# extension js6 so that it is not included in the unit tests.
 test-harmony:
-	@mv test/mocha.opts test/mocha.opts.backup && \
-	./bin/mocha \
+	@./bin/mocha \
 		--harmony \
-		--use_strict \
-		test/acceptance/harmony.js6; \
-	mv test/mocha.opts.backup test/mocha.opts
+		test/acceptance/harmony.js6
 
 non-tty:
 	@./bin/mocha \

--- a/bin/mocha
+++ b/bin/mocha
@@ -30,7 +30,6 @@ process.argv.slice(2).forEach(function(arg){
     case '--harmony-collections':
     case '--harmony-generators':
     case '--prof':
-    case '--use_strict':
       args.unshift(arg);
       break;
     default:

--- a/test/acceptance/harmony.js6
+++ b/test/acceptance/harmony.js6
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('harmony', function(){
   it('should allow let in for statements', function(){
     for (let i = 0; i < 1; i++) {


### PR DESCRIPTION
Passes the --use_strict flag through to support harmony/ES6.

Adds a test to ensure that it works (only verifies a usage of 'let' but that should be enough).
The test is goofy because should.js isn't --use_strict compatible so the rule needs to remove test/mocha.opts for its run and return it after completion.

Requires mocha be clean with respect to --use_strict; added two vars to do this. The test will ensure it stays this way.
