### PR TITLE
Remove invalid optimization in checkGlobals().

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -168,10 +168,6 @@ Runner.prototype.checkGlobals = function(test){
     ok = ok.concat(test._allowedGlobals || []);
   }
 
-  // check length - 2 ('errno' and 'location' globals)
-  if (isNode && 1 == ok.length - globals.length) return;
-  else if (2 == ok.length - globals.length) return;
-
   if(this.prevGlobalsLength == globals.length) return;
   this.prevGlobalsLength = globals.length;
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -97,6 +97,21 @@ describe('Runner', function(){
       runner.checkGlobals('im a test');
     })
 
+    it('should emit "fail" when a single new disallowed global is introduced after a single extra global is allowed', function(done) {
+      var doneCalled = false;
+      runner.globals('good');
+      global.bad = 1;
+      runner.on('fail', function(test, err) {
+        delete global.bad;
+        done();
+        doneCalled = true;
+      });
+      runner.checkGlobals('test');
+      if (!doneCalled) {
+        done(Error("Expected test failure did not occur."));
+      }
+    });
+
     it ('should not fail when a new common global is introduced', function(){
       // verify that the prop isn't enumerable
       delete global.XMLHttpRequest;


### PR DESCRIPTION
fixes #1015

There was an attempt at an optimization in checkGlobals that would short circuit globals checking if the number of tolerated globals was equal (correcting for a couple of expected differences) to the number of actual globals.  This is completely invalid since you could tolerate a new global in your mocha config and the system under test could add a different global but not the new global you are tolerating.  (Or you could tolerate two new ones, and two new unexpected ones could be added by the system under test, etc.)  In these cases, the unexpected globals will not be reported by mocha and tests will pass when they should not.  So basically the code was assuming that the system under test would DEFINITELY add any globals that were added to the list of tolerated globals through mocha config.

I added a test for the simplest failure case, saw it fail, and then removed the offending code.
