### PR TITLE
lib: errno is not a global in node >= v0.9.11

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -58,7 +58,19 @@ function Runner(suite) {
   this.on('test end', function(test){ self.checkGlobals(test); });
   this.on('hook end', function(hook){ self.checkGlobals(hook); });
   this.grep(/.*/);
-  this.globals(this.globalProps().concat(['errno']));
+  var extraGlobals = [];
+  if (typeof(process) === 'object' &&
+      typeof(process.versions) === 'object' &&
+      typeof(process.versions.node) === 'string') {
+    var nodeVersion = process.versions.node.split('.').reduce(function(a, v) {
+      return a << 8 | v;
+    });
+    // 'errno' was renamed to process._errno in v0.9.11.
+    if (nodeVersion < 0x00090B) {
+      extraGlobals.push('errno');
+    }
+  }
+  this.globals(this.globalProps().concat(extraGlobals));
 }
 
 /**

--- a/mocha.js
+++ b/mocha.js
@@ -4404,7 +4404,19 @@ function Runner(suite) {
   this.on('test end', function(test){ self.checkGlobals(test); });
   this.on('hook end', function(hook){ self.checkGlobals(hook); });
   this.grep(/.*/);
-  this.globals(this.globalProps().concat(['errno']));
+  var extraGlobals = [];
+  if (typeof(process) === 'object' &&
+      typeof(process.versions) === 'object' &&
+      typeof(process.versions.node) === 'string') {
+    var nodeVersion = process.versions.node.split('.').reduce(function(a, v) {
+      return a << 8 | v;
+    });
+    // 'errno' was renamed to process._errno in v0.9.11.
+    if (nodeVersion < 0x00090B) {
+      extraGlobals.push('errno');
+    }
+  }
+  this.globals(this.globalProps().concat(extraGlobals));
 }
 
 /**


### PR DESCRIPTION
Update the global leak checker to add errno to the list of expected
globals only when the node version is < v0.9.11.

I'd like to add a regression test but I'm not sure how to go about it.  I've seen test/acceptance/globals.js but there doesn't seem to be a way to make it work with conditional failures.
