### PR TITLE
Support special case 'timeout' for interface 'exports'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test-exports:
 	@./bin/mocha \
 		--reporter $(REPORTER) \
 		--ui exports \
-		test/acceptance/interfaces/exports
+		test/acceptance/interfaces/exports*
 
 test-grep:
 	@./bin/mocha \

--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -2,7 +2,6 @@
 /**
  * Module dependencies.
  */
-
 var Suite = require('../suite')
   , Test = require('../test');
 
@@ -31,29 +30,43 @@ module.exports = function(suite){
   function visit(obj) {
     var suite;
     for (var key in obj) {
-      if ('function' == typeof obj[key]) {
-        var fn = obj[key];
-        switch (key) {
-          case 'before':
-            suites[0].beforeAll(fn);
-            break;
-          case 'after':
-            suites[0].afterAll(fn);
-            break;
-          case 'beforeEach':
-            suites[0].beforeEach(fn);
-            break;
-          case 'afterEach':
-            suites[0].afterEach(fn);
-            break;
-          default:
-            suites[0].addTest(new Test(key, fn));
-        }
-      } else {
-        var suite = Suite.create(suites[0], key);
-        suites.unshift(suite);
-        visit(obj[key]);
-        suites.shift();
+      var fn = obj[key];
+      switch(typeof fn) {
+        case 'function': 
+          switch (key) {
+            case 'before':
+              suites[0].beforeAll(fn);
+              break;
+            case 'after':
+              suites[0].afterAll(fn);
+              break;
+            case 'beforeEach':
+              suites[0].beforeEach(fn);
+              break;
+            case 'afterEach':
+              suites[0].afterEach(fn);
+              break;
+            default:
+              suites[0].addTest(new Test(key, fn));
+          };
+          break;
+        case 'boolean':
+        case 'number':
+        case 'string':
+          switch(key) {
+            case 'timeout': 
+              suites[0].timeout(fn);
+              if (isNaN(suites[0]._timeout)) 
+                  throw new Error("wrong format in timeout specification: " + fn );
+              continue;
+            //TRICKY: no case default on purpose - results in 
+            //        case sliding of outer switch
+          }
+        default:
+          var suite = Suite.create(suites[0], key);
+          suites.unshift(suite);
+          visit(obj[key]);
+          suites.shift();
       }
     }
   }

--- a/test/acceptance/interfaces/exports.js
+++ b/test/acceptance/interfaces/exports.js
@@ -1,4 +1,3 @@
-
 var calls = [];
 
 exports.Array = {
@@ -27,6 +26,8 @@ exports.Array = {
     afterEach: function(){
       calls.push('after each');
     },
+    
+    timeout: 100, 
 
     'should return -1 when the value is not present': function(){
       calls.push('one');

--- a/test/acceptance/interfaces/exports.timeouts.js
+++ b/test/acceptance/interfaces/exports.timeouts.js
@@ -1,0 +1,37 @@
+var ui = require('../../../lib/interfaces/exports'),
+    Suite = require('../../../lib/suite'),
+    should = require('should');
+
+function testTimeoutValueFactory(value, expected) {
+    return function() {
+        var time = 0
+          , suite = new Suite("no-such-suite", {})
+          ;
+        ui(suite);
+        suite.emit('require', {
+          'some test with timeout' : {
+            timeout: value
+          }
+        }, 'no-such-file.js', {});
+        
+        suite.suites.length.should.equal(1);
+        suite.suites[0]._timeout.should.equal(expected);
+    }
+}
+
+module.exports.testTimeouts = {
+  'suite with key \'timeout\'': {
+    'with numeric value' : {
+      'should call this.timeout(..) on the suite with the numeric value' : testTimeoutValueFactory(42,42)
+    },
+      'with string value usign postfix' : {
+      "'ms' should call this.timeout(..) on the suite with the numeric part of the value" : testTimeoutValueFactory("43ms", 43),
+      "'s' should parsed as second" : testTimeoutValueFactory("0.42s", 420),
+      "'m' should parse as minutes" : testTimeoutValueFactory("0.1m", 6000),
+      "'h' should parse as hours"   : testTimeoutValueFactory("1h", 1000 * 60 * 60 ),
+      "that is not supported should throw" : function(){
+          should( testTimeoutValueFactory("0x", 6000) ).throw( /wrong format in timeout specification/ );
+      }
+    }
+  }
+};


### PR DESCRIPTION
Like **before**, **beforeEach**, **afterEach** and **after** - let the user support **timeout** as well.

If this goes well - I might try add support for **skip : true** and **only : true** for full compatibility between the interfaces :)

Thanks
    Osher