### PR TITLE
Show also failed test for doc reporter

### DIFF
--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -53,4 +53,11 @@ function Doc(runner) {
     var code = utils.escape(utils.clean(test.fn.toString()));
     console.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
+
+  runner.on('fail', function(test, err){
+    console.log('%s  <dt class="error">%s</dt>', indent(), utils.escape(test.title));
+    var code = utils.escape(utils.clean(test.fn.toString()));
+    console.log('%s  <dd class="error"><pre><code>%s</code></pre></dd>', indent(), code);
+    console.log('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
+  });
 }


### PR DESCRIPTION
With this pull request the doc reporter can also display the tests that actually failed.
This is very useful documentation and the previously behavior can be meet defining an error class as display none.
