### PR TITLE
Throw hard error when test function is undefined

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -40,6 +39,9 @@ module.exports = Runnable;
 function Runnable(title, fn) {
   this.title = title;
   this.fn = fn;
+  if(! (fn instanceof Function) ){
+    throw fn;
+  }
   this.async = fn && fn.length;
   this.sync = ! this.async;
   this._timeout = 2000;


### PR DESCRIPTION
Right now mocha will accept an undefined for the test function and effectively will skip over this test silently.

For example:
describe('blah', function(){
    it('should blah blah', performSomeActionAndValidateResult);
});

var performSomeActionAndValidateResult = function(){
     assert(false);
};

The var performSomeActionAndValidateResult gets hoisted to the top of the file, so referencing "performSomeActionAndValidateResult" will not throw a  referenceError, however it will be undefined at the time that the tests are registered using Context.it().  

So the assert false never gets called and mocha does not report an error here but instead lists that test as "pending" i.e. https://cloudup.com/ceY4AhG3f4r .  

Yes, this is a developer error and could have been fixed by defining the test function before the it() block, or using syntax
function performSomeActionAndValidateResult(){
     assert(false);
};

but it would be nice if mocha helped prevent this type of developer oversight and presented a harsher alert when tests were not running/effectively failing silently.

As for why to even pass in a lambda test function at all rather than a function literal, I find it convenient to reuse the same test function at different points of the test suite execution, i.e.

var checkForSomeCondition = function(){
assert(someCondition);
};
it('should pass some condition check', checkForSomeCondition);
it('should allow me to mutate the state', function(done){
mutateState(done);
});
it('should pass the same condition check', checkForSomeCondition);
