### PR TITLE
Deferred execution (2014)

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -165,14 +165,31 @@ Mocha.prototype.ui = function(name){
 Mocha.prototype.loadFiles = function(fn){
   var self = this;
   var suite = this.suite;
-  var pending = this.files.length;
-  this.files.forEach(function(file){
-    file = path.resolve(file);
-    suite.emit('pre-require', global, file, self);
-    suite.emit('require', require(file), file, self);
-    suite.emit('post-require', global, file, self);
-    --pending || (fn && fn());
-  });
+  var pending = this.files.slice();
+  function nextFile() {
+    var file = pending.shift();
+    var processNextFile = true;
+    var semaphore = {
+      resume: function(){
+        process.nextTick(nextFile); 
+      }
+    };
+    if (file) {
+      file = path.resolve(file);
+      global.wait = function(){
+        processNextFile = false;
+        return semaphore;
+      };
+      suite.emit('pre-require', global, file, self);
+      suite.emit('require', require(file), file, self);
+      suite.emit('post-require', global, file, self);
+      if (processNextFile) process.nextTick(nextFile);
+    } else {
+      delete global.wait;
+      fn && fn();
+    }
+  }
+  nextFile();
 };
 
 /**
@@ -353,17 +370,23 @@ Mocha.prototype.asyncOnly = function(){
  */
 
 Mocha.prototype.run = function(fn){
-  if (this.files.length) this.loadFiles();
+  var _this = this;
   var suite = this.suite;
   var options = this.options;
   var runner = new exports.Runner(suite);
   var reporter = new this._reporter(runner);
-  runner.ignoreLeaks = false !== options.ignoreLeaks;
-  runner.asyncOnly = options.asyncOnly;
-  if (options.grep) runner.grep(options.grep, options.invert);
-  if (options.globals) runner.globals(options.globals);
-  if (options.growl) this._growl(runner, reporter);
-  exports.reporters.Base.useColors = options.useColors;
-  exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
-  return runner.run(fn);
+  function run() {
+    runner.initDefaultGlobals();
+    runner.ignoreLeaks = false !== options.ignoreLeaks;
+    runner.asyncOnly = options.asyncOnly;
+    if (options.grep) runner.grep(options.grep, options.invert);
+    if (options.globals) runner.globals(options.globals);
+    if (options.growl) _this._growl(runner, reporter);
+    exports.reporters.Base.useColors = options.useColors;
+    exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
+    runner.run(fn);
+  }
+  if (this.files.length) this.loadFiles(run);
+  else run();
+  return runner;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -150,6 +150,17 @@ Runner.prototype.globals = function(arr){
   return this;
 };
 
+
+/**
+ * Initialize default globals list.
+ *
+ * @api private
+ */
+
+Runner.prototype.initDefaultGlobals = function(){
+  this.globals(this.globalProps().concat(['errno']));
+};
+
 /**
  * Check for global variable leaks.
  *

--- a/test/runner.js
+++ b/test/runner.js
@@ -10,6 +10,7 @@ describe('Runner', function(){
   beforeEach(function(){
     suite = new Suite(null, 'root');
     runner = new Runner(suite);
+    runner.initDefaultGlobals();
   })
 
   describe('.grep()', function(){
@@ -18,6 +19,7 @@ describe('Runner', function(){
       suite.addTest(new Test('im another test about lions'));
       suite.addTest(new Test('im a test about bears'));
       var newRunner = new Runner(suite);
+      newRunner.initDefaultGlobals();
       newRunner.grep(/lions/);
       newRunner.total.should.equal(2);
     })
@@ -27,6 +29,7 @@ describe('Runner', function(){
       suite.addTest(new Test('im another test about lions'));
       suite.addTest(new Test('im a test about bears'));
       var newRunner = new Runner(suite);
+      newRunner.initDefaultGlobals();
       newRunner.grep(/lions/, true);
       newRunner.total.should.equal(1);
     })

--- a/test/semaphore.js
+++ b/test/semaphore.js
@@ -1,0 +1,15 @@
+var semaphore = wait();
+
+process.nextTick(function() {
+
+  describe('test', function() {
+
+    it('can be generated asynchronously', function(done) {
+      done();
+    });
+
+  });
+
+  semaphore.resume();
+
+});


### PR DESCRIPTION
This is @tarruda's #719 pull request from last year updated to cleanly merge. All tests pass.

From the original request:

> This should solve issue #362.
> 
> A global 'wait' function is added so the test files can pause mocha processing and generate
> tests asynchronously. The function returns a semaphore with a single method 'resume' to continue processing test files.

@travisjeffery This pull request implements [TJ's suggestion](https://github.com/visionmedia/mocha/issues/362#issuecomment-7660612) for fixing #362 and includes a test. Can this be included in Mocha? Deferred execution has [inspired Mocha forks](https://github.com/visionmedia/mocha/issues/362#issuecomment-6095691) and prevents test runners like [Yeti](http://yeti.cx) from [running async-defined Mocha tests](https://github.com/yui/yeti/pull/75). Thank you!

/cc @alex-seville
