### PR TITLE
Add to reporter mocha instance to get access to original options

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -356,8 +356,9 @@ Mocha.prototype.run = function(fn){
   if (this.files.length) this.loadFiles();
   var suite = this.suite;
   var options = this.options;
+  options.files = this.files;
   var runner = new exports.Runner(suite);
-  var reporter = new this._reporter(runner);
+  var reporter = new this._reporter(runner, options);
   runner.ignoreLeaks = false !== options.ignoreLeaks;
   runner.asyncOnly = options.asyncOnly;
   if (options.grep) runner.grep(options.grep, options.invert);


### PR DESCRIPTION
I am writing reporter and i need to get access to original options (colors, files and diff) and i am not using base reporter. Base reporter also does not contain file list. 
