### PR TITLE
Do not crash when reporting on circular structures

### DIFF
--- a/lib/json-stringify-safe.js
+++ b/lib/json-stringify-safe.js
@@ -1,0 +1,40 @@
+// Source: https://github.com/isaacs/json-stringify-safe
+module.exports = stringify;
+
+function getSerialize (fn, decycle) {
+  var seen = [], keys = [];
+  decycle = decycle || function(key, value) {
+    return '[Circular ' + getPath(value, seen, keys) + ']'
+  };
+  return function(key, value) {
+    var ret = value;
+    if (typeof value === 'object' && value) {
+      if (seen.indexOf(value) !== -1)
+        ret = decycle(key, value);
+      else {
+        seen.push(value);
+        keys.push(key);
+      }
+    }
+    if (fn) ret = fn(key, ret);
+    return ret;
+  }
+}
+
+function getPath (value, seen, keys) {
+  var index = seen.indexOf(value);
+  var path = [ keys[index] ];
+  for (index--; index >= 0; index--) {
+    if (seen[index][ path[0] ] === value) {
+      value = seen[index];
+      path.unshift(keys[index]);
+    }
+  }
+  return '~' + path.join('.');
+}
+
+function stringify(obj, fn, spaces, decycle) {
+  return JSON.stringify(obj, getSerialize(fn, decycle), spaces);
+}
+
+stringify.getSerialize = getSerialize;

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -6,7 +6,8 @@
 var tty = require('tty')
   , diff = require('diff')
   , ms = require('../ms')
-  , utils = require('../utils');
+  , utils = require('../utils')
+  , safeStringify = require('../json-stringify-safe');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -453,7 +454,7 @@ function colorLines(name, str) {
 
 function stringify(obj) {
   if (obj instanceof RegExp) return obj.toString();
-  return JSON.stringify(obj, null, 2);
+  return safeStringify(obj, null, 2);
 }
 
 /**

--- a/test/acceptance/reporting.js
+++ b/test/acceptance/reporting.js
@@ -1,0 +1,13 @@
+describe('reporting', function() {
+  it('reports diffs of circular structures without crashing', function() {
+    var error = new Error();
+    var actual = error.actual = {};
+    var expected = error.expected = {};
+    error.showDiff = true;
+    actual.self = actual;
+    expected.self = expected;
+
+    // uncomment
+    // throw error;
+  })
+})


### PR DESCRIPTION
Currently, Mocha attempts to stringify the `actual` and `expected`
properties of errors thrown by failing tests (when the `showDiff` flag
is set). If these structures contain circular references, the reporter
silently fails and Mocha exits with a status code of "0", hiding the
test failure.

Use the `json-stringify-safe` library to safely stringify objects that
may have circular references.
