### PR TITLE
work w/ grunt-cafemocha & grunt-contrib-watch w/ spawn: false

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -1532,6 +1532,9 @@ Mocha.prototype.loadFiles = function(fn){
   var pending = this.files.length;
   this.files.forEach(function(file){
     file = path.resolve(file);
+    if (require.cache[file]){
+      delete require.cache[file];
+    }
     suite.emit('pre-require', global, file, self);
     suite.emit('require', require(file), file, self);
     suite.emit('post-require', global, file, self);


### PR DESCRIPTION
- with 'spawn: false' as a grunt-config-watch config, 
  all loading of test files after the
  first run do not re-create the test suites while
  requiring the test files, zero tests get run after the first
  time suite is run.
  Need to clear the test file out of the require cache.
  
  Here is a Gruntfile watch config I was using...

``` javascript
watch: {
    testing: {
        files: ["controllers/*.js", "test/**/*.js", "models/**/*.js", "routes/**/*.js", "public/js/**/*.js"],
        tasks: ["cafemocha"],
        options: {
            spawn: false
        }
    }
}
```

Thanks!
