### PR TITLE
Less re-rendering with progress reporter

### DIFF
--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -36,7 +35,8 @@ function Progress(runner, options) {
     , width = Base.window.width * .50 | 0
     , total = runner.total
     , complete = 0
-    , max = Math.max;
+    , max = Math.max
+    , lastN = -1;
 
   // default chars
   options.open = options.open || '[';
@@ -58,6 +58,12 @@ function Progress(runner, options) {
       , percent = complete / total
       , n = width * percent | 0
       , i = width - n;
+
+    if (lastN === n && !options.verbose) {
+      // Don't re-render the line if it hasn't changed
+      return;
+    }
+    lastN = n;
 
     cursor.CR();
     process.stdout.write('\u001b[J');


### PR DESCRIPTION
With a large number of small tests a significant portion of the testing time is simply re-rendering the progress bar, this only re-renders the progress bar if the progress has changed.
