### PR TITLE
Support for environment with `global` and `window`

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -1,5 +1,5 @@
 // The global object is "self" in Web Workers.
-global = (function() { return this; })();
+var global = (function() { return this; })();
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).


### PR DESCRIPTION
Node-webkit has a global `global` object, while the global `this` is the
`window` object. Overwriting `global` with `window` breaks a lot of
things.
