### PR TITLE
Make sibling Suites have separate contexts

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -46,9 +46,11 @@ exports.create = function(parent, title){
  * @api private
  */
 
-function Suite(title, ctx) {
+function Suite(title, parentContext) {
   this.title = title;
-  this.ctx = ctx;
+  var context = function() {};
+  context.prototype = parentContext;
+  this.ctx = new context();
   this.suites = [];
   this.tests = [];
   this.pending = false;

--- a/mocha.js
+++ b/mocha.js
@@ -5065,9 +5065,11 @@ exports.create = function(parent, title){
  * @api private
  */
 
-function Suite(title, ctx) {
+function Suite(title, parentContext) {
   this.title = title;
-  this.ctx = ctx;
+  var context = function () {};
+  context.prototype = parentContext;
+  this.ctx = new context();
   this.suites = [];
   this.tests = [];
   this.pending = false;

--- a/test/acceptance/context.js
+++ b/test/acceptance/context.js
@@ -24,3 +24,44 @@ describe('Context', function(){
     this.calls.should.eql(['before', 'before two', 'test', 'after two']);
   })
 })
+
+describe('Context Siblings', function(){
+  beforeEach(function(){
+    this.calls = ['before'];
+  })
+
+  describe('sequestered sibling', function(){
+    beforeEach(function(){
+      this.calls.push('before two');
+      this.hiddenFromSibling = 'This should be hidden';
+    })
+
+    it('should work', function(){
+      this.hiddenFromSibling.should.eql('This should be hidden')
+    })
+  })
+
+  describe('sibling verifiction', function(){
+    beforeEach(function(){
+      this.calls.push('before sibling');
+    })
+
+    it('should not have value set within a sibling describe', function(){
+      'This should be hidden'.should.not.eql(this.hiddenFromSibling);
+      this.visibleFromTestSibling = 'Visible from test sibling';
+    })
+
+    it('should allow test siblings to modify shared context', function(){
+      'Visible from test sibling'.should.eql(this.visibleFromTestSibling);
+    })
+
+    it('should have reset this.calls before describe', function(){
+      this.calls.should.eql(['before', 'before sibling']);
+    })
+  })
+
+  after(function(){
+    this.calls.should.eql(['before', 'before sibling']);
+  })
+
+})


### PR DESCRIPTION
The main context in mocha is currently shared by all suites.  

This change makes it so that each suite can add values to it's own context without polluting the shared global context.   

This allows a layer of automatic cleanup to occur between test suites.  Making `after` mostly unnecessary if you are using the shared context to store setup rather than using the closure.
