### PR TITLE
#888 Fix for --watch+only() issue

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -228,7 +228,7 @@ mocha.suite.bail(program.bail);
 
 // --grep
 
-if (program.grep) mocha.grep(new RegExp(program.grep), true);
+if (program.grep) mocha.grep(new RegExp(program.grep));
 
 // --invert
 
@@ -335,7 +335,7 @@ if (program.watch) {
   function rerun() {
     purge();
     stop()
-    if (!mocha.options.grepAsOption)
+    if (!program.grep)
       mocha.grep(null);
     mocha.suite = mocha.suite.clone();
     mocha.suite.ctx = new Mocha.Context;


### PR DESCRIPTION
When .only() is used, mocha.grep is set to the title of the .only test. This means if the .only is removed --watch is on and it reruns the test, mocha.grep is still set to the same string (from the previous .only). We clear mocha.grep on rerun and that means if .only has been moved or remains mocha.grep will be set again or remain cleared allowing the rest of the tests to run again.
