### PR TITLE
#888 Fix for --watch+only() issue

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -335,6 +335,8 @@ if (program.watch) {
   function rerun() {
     purge();
     stop()
+    if (!program.grep)
+      mocha.grep(null);
     mocha.suite = mocha.suite.clone();
     mocha.suite.ctx = new Mocha.Context;
     mocha.ui(program.ui);


### PR DESCRIPTION
If mocha.grep is set via .only() we want to clear the grep on each --watch rerun(). If the grep is set vis option --grep we want it to persist. This resolves #888 
