### PR TITLE
Issue 950 - Export file on Mocha.Test objects

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -109,6 +109,7 @@ module.exports = function(suite){
       var suite = suites[0];
       if (suite.pending) var fn = null;
       var test = new Test(title, fn);
+      test.file = file;
       suite.addTest(test);
       return test;
     };

--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -28,7 +28,7 @@ module.exports = function(suite){
 
   suite.on('require', visit);
 
-  function visit(obj) {
+  function visit(obj, file) {
     var suite;
     for (var key in obj) {
       if ('function' == typeof obj[key]) {
@@ -47,7 +47,9 @@ module.exports = function(suite){
             suites[0].afterEach(fn);
             break;
           default:
-            suites[0].addTest(new Test(key, fn));
+            var test = new Test(key, fn);
+            test.file = file;
+            suites[0].addTest(test);
         }
       } else {
         var suite = Suite.create(suites[0], key);

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -97,6 +97,7 @@ module.exports = function(suite){
 
     context.test = function(title, fn){
       var test = new Test(title, fn);
+      test.file = file;
       suites[0].addTest(test);
       return test;
     };

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -113,6 +113,7 @@ module.exports = function(suite){
       var suite = suites[0];
       if (suite.pending) var fn = null;
       var test = new Test(title, fn);
+      test.file = file;
       suite.addTest(test);
       return test;
     };


### PR DESCRIPTION
This patch exposes a file property on `Test` objects. I've gone ahead and added a reporter that proves that the patch works. Running the mocha test suite with |REPORTER=file make test| prints

```
/home/gareth/Documents/mocha/test/hook.timeout.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/context.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/diffs.js => 9 tests
/home/gareth/Documents/mocha/test/acceptance/duration.js => 3 tests
/home/gareth/Documents/mocha/test/acceptance/fs.js => 2 tests
/home/gareth/Documents/mocha/test/acceptance/globals.js => 4 tests
/home/gareth/Documents/mocha/test/acceptance/http.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/multiple.done.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/pending.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/required-tokens.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/root.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/timeout.js => 2 tests
/home/gareth/Documents/mocha/test/acceptance/uncaught.js => 1 tests
/home/gareth/Documents/mocha/test/acceptance/utils.js => 5 tests
/home/gareth/Documents/mocha/test/grep.js => 6 tests
/home/gareth/Documents/mocha/test/hook.async.js => 3 tests
/home/gareth/Documents/mocha/test/hook.err.js => 21 tests
/home/gareth/Documents/mocha/test/hook.sync.js => 3 tests
/home/gareth/Documents/mocha/test/hook.sync.nested.js => 4 tests
/home/gareth/Documents/mocha/test/http.meta.2.js => 3 tests
/home/gareth/Documents/mocha/test/http.meta.js => 3 tests
/home/gareth/Documents/mocha/test/runnable.js => 21 tests
/home/gareth/Documents/mocha/test/runner.js => 21 tests
/home/gareth/Documents/mocha/test/suite.js => 36 tests
/home/gareth/Documents/mocha/test/utils.js => 3 tests
```

This patch fixes #950.
