### PR TITLE
Issue #1103 - add LICENSE to npm and add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "lib",
     "index.js",
     "mocha.css",
-    "mocha.js"
-  ]
+    "mocha.js",
+    "LICENSE"
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
Mocha is licensed under MIT, and there is a LICENSE file but its not published to NPM and package.json does not include the license name.

Mocha is hugely popular, its slightly problematic to me that the license cannot be discovered programmatically and it can be fixed easily by making two changes to package.json.
