### PR TITLE
base reporter: Use cson for stringification when diffing objects

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -6,7 +6,8 @@
 var tty = require('tty')
   , diff = require('diff')
   , ms = require('../ms')
-  , utils = require('../utils');
+  , utils = require('../utils')
+  , cson = require('cson');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -453,7 +454,7 @@ function colorLines(name, str) {
 
 function stringify(obj) {
   if (obj instanceof RegExp) return obj.toString();
-  return JSON.stringify(obj, null, 2);
+  return cson.stringifySync(obj, null, 2);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "commander": "2.0.0",
+    "cson": "1.4.5",
     "growl": "1.7.x",
     "jade": "0.26.3",
     "diff": "1.0.7",


### PR DESCRIPTION
This produces more compact output and prevents lines that only differ due to a dangling comma in the JSON.stringify output from showing up.

Before you would get a diff like this when the ASCIIbetically last property is missing from `e.actual`:

```
    + expected - actual

     {
       "a": 123,
    +  "b": 456
    -  "b": 456,
    -  "c": 789
     }
```

With this patch you'll get:

```
    + expected - actual

     {
       a: 123
       b: 456
    -  c: 789
     }
```
