### PR TITLE
base reporter: Strip commas from the JSON.stringify output before diffing

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -453,7 +453,8 @@ function colorLines(name, str) {
 
 function stringify(obj) {
   if (obj instanceof RegExp) return obj.toString();
-  return JSON.stringify(obj, null, 2).replace(/,(\n|$)/g, '$1');
+  // Add dangling commas to get shorter string-based diffs:
+  return JSON.stringify(obj, null, 2).replace(/,?(\n\s*[\}\]])/g, ',$1');
 }
 
 /**


### PR DESCRIPTION
(This is a less controversial version of https://github.com/visionmedia/mocha/pull/1181 because it doesn't introduce a new dependency)

This produces more compact output and prevents lines that only differ due to a dangling comma from showing up.

Before you would get a diff like this when the ASCIIbetically last property is missing from `e.actual`:

```
    + expected - actual

     {
       "a": 123,
    +  "b": 456
    -  "b": 456,
    -  "c": 789
     }
```

With this patch you'll get:

```
    + expected - actual

     {
       "a": 123
       "b": 456
    -  "c": 789
     }
```
