### PR TITLE
Add browser script option to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git://github.com/visionmedia/mocha.git"
   },
   "main": "./index",
+  "browser": "./mocha.js",
   "bin": {
     "mocha": "./bin/mocha",
     "_mocha": "./bin/_mocha"


### PR DESCRIPTION
This will tell any browserify project to package the browser version of mocha and not the Node version.

Fixes issue #880

This will only cover the JavaScript packaging, CSS is still done manually through `<link>` tags.
