### PR TITLE
Fix regex that generates html for 'new' keyword

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -280,7 +280,7 @@ function highlight(js) {
     .replace(/('.*?')/gm, '<span class="string">$1</span>')
     .replace(/(\d+\.\d+)/gm, '<span class="number">$1</span>')
     .replace(/(\d+)/gm, '<span class="number">$1</span>')
-    .replace(/\bnew\s*(\w+)/gm, '<span class="keyword">new</span> <span class="init">$1</span>')
+    .replace(/\bnew[ \t]+(\w+)/gm, '<span class="keyword">new</span> <span class="init">$1</span>')
     .replace(/\b(function|new|throw|return|var|if|else)\b/gm, '<span class="keyword">$1</span>')
 }
 


### PR DESCRIPTION
When generating the html for tests, if a variable begins with the letters 'new', those letters are incorrectly separated from the rest of the string and appear as the 'new' keyword.  E.g. "newSolutionResult" becomes "new SolutionResult".  The fix was a one line change to a regex.  Below is an example:

Bug Example:
![incorrect html generation](https://cloud.githubusercontent.com/assets/608333/2798664/892ff060-cc53-11e3-9007-79baf2f3b3ad.png)

Fix Example:
![fixed html generation v1](https://cloud.githubusercontent.com/assets/608333/2798669/9666c3f8-cc53-11e3-9b3d-b8ea8bc2b82c.png)
