### PR TITLE
Fix dot reporter output bugs

### DIFF
--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -25,13 +25,14 @@ function Dot(runner) {
   var self = this
     , stats = this.stats
     , width = Base.window.width * .75 | 0
-    , n = 0;
+    , n = -1;
 
   runner.on('start', function(){
     process.stdout.write('\n  ');
   });
 
   runner.on('pending', function(test){
+    if (++n % width == 0) process.stdout.write('\n  ');
     process.stdout.write(color('pending', Base.symbols.dot));
   });
 


### PR DESCRIPTION
Fixed:
- Pending test dots not being counted (leading to longer rows of dots when containing pending tests)
- Off-by-one error on first dot row (first row always lacks a dot)
