### PR TITLE
small tweak to clean() to show failure details

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -66,6 +66,6 @@ function clean(test) {
       title: test.title
     , fullTitle: test.fullTitle()
     , duration: test.duration
-    , err: test.err || undefined
+    , err: test.err
   }
 }


### PR DESCRIPTION
In json output, there was no detail shown for the failures.  Adding line #69 results in failed tests showing the 'err' object.
