### PR TITLE
patch to include uncaught exceptions to error JSON

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -3,9 +3,9 @@
  * Module dependencies.
  */
 
-var Base = require('./base'),
-    cursor = Base.cursor,
-    color = Base.color;
+var Base = require('./base')
+  , cursor = Base.cursor
+  , color = Base.color;
 
 /**
  * Expose `JSON`.
@@ -24,9 +24,9 @@ function JSONReporter(runner) {
   var self = this;
   Base.call(this, runner);
 
-  var tests = [],
-      failures = [],
-      passes = [];
+  var tests = []
+    , failures = []
+    , passes = [];
 
   runner.on('test end', function(test){
     tests.push(test);


### PR DESCRIPTION
I found that uncaught exceptions didn't print the stack, only '{ uncaught: true }' so I borrowed shamelessly from base.js to process & include the stack message.  I also cleaned up some more of the comma-firsts
