### PR TITLE
Fix reporter output when running mocha from grunt-exec

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -573,8 +573,11 @@ Runner.prototype.run = function(fn){
   // callback
   this.on('end', function(){
     debug('end');
-    process.removeListener('uncaughtException', uncaught);
-    fn(self.failures);
+    // Leave time for the output from reporters to be flushed
+    setTimeout(function() {
+      process.removeListener('uncaughtException', uncaught);
+      fn(self.failures);
+    }, 0);
   });
 
   // run suites


### PR DESCRIPTION
Error details from spec reporter are not displayed on the console when running mocha from grunt-exec task.
Using a grunt-exec configuration like:

```
exec:{
  tests:{
    command:'node ./node_modules/mocha/bin/mocha ./tests --recursive --reporter spec'
  }
}
```

The output stops after ">>   14 failing", the error details for each failing test and the number of tests passing are missing.
