### PR TITLE
Replace non-standard colors in reporter #1200

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -47,23 +47,23 @@ exports.inlineDiffs = false;
  */
 
 exports.colors = {
-    'pass': 90
+    'pass': 30
   , 'fail': 31
-  , 'bright pass': 92
-  , 'bright fail': 91
-  , 'bright yellow': 93
+  , 'bright pass': 32
+  , 'bright fail': 31
+  , 'bright yellow': 33
   , 'pending': 36
   , 'suite': 0
   , 'error title': 0
   , 'error message': 31
-  , 'error stack': 90
+  , 'error stack': 30
   , 'checkmark': 32
-  , 'fast': 90
+  , 'fast': 30
   , 'medium': 33
   , 'slow': 31
   , 'green': 32
-  , 'light': 90
-  , 'diff gutter': 90
+  , 'light': 30
+  , 'diff gutter': 30
   , 'diff added': 42
   , 'diff removed': 41
 };


### PR DESCRIPTION
Color 90-99 are not standard and their implementations vary among
terminals.
See http://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes
This has caused many Solarized theme users unable to see some output.
