### PR TITLE
mocha.run() never return error status on browser

### DIFF
--- a/support/tail.js
+++ b/support/tail.js
@@ -135,12 +135,12 @@ mocha.run = function(fn){
   if (query.grep) mocha.grep(query.grep);
   if (query.invert) mocha.invert();
 
-  return Mocha.prototype.run.call(mocha, function(){
+  return Mocha.prototype.run.call(mocha, function(err){
     // The DOM Document is not available in Web Workers.
     if (global.document) {
       Mocha.utils.highlightTags('code');
     }
-    if (fn) fn();
+    if (fn) fn(err);
   });
 };
 


### PR DESCRIPTION
`Mocha.prototype.run([callback])` provide an error status to the callback (0/1).
But this value is not forwarded to the browser callback.

Example: 

```
mocha.run(function(err) {
  console.log(err); // Always undefined
})
```
