### PR TITLE
Catch empty throws

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -532,7 +532,13 @@ Runner.prototype.runSuite = function(suite, fn){
  */
 
 Runner.prototype.uncaught = function(err){
-  debug('uncaught exception %s', err.message);
+  if (err) {
+    debug('uncaught exception %s', err.message);
+  } else {
+    debug('uncaught undefined exception');
+    err = new Error('Catched undefined error, did you throw without specifying what?');
+  }
+  
   var runnable = this.currentRunnable;
   if (!runnable || 'failed' == runnable.state) return;
   runnable.clearTimeout();


### PR DESCRIPTION
I did the stupid misstake of writing my code as the following. The trained eye will notice that I'm essentially doing `throw undefined;`.

``` js
var guard = function (err) { throw err; };
try { ... } catch (e) { guard(err); }
```

This resulted in this strange error:

``` text
/usr/local/lib/node_modules/mocha/lib/runner.js:536
  debug('uncaught exception %s', err.message);
                                    ^
TypeError: Cannot read property 'message' of undefined
    at Runner.uncaught (/usr/local/lib/node_modules/mocha/lib/runner.js:536:37)
    at process.uncaught (/usr/local/lib/node_modules/mocha/lib/runner.js:568:10)
    at process.EventEmitter.emit (events.js:95:17)
    at process._fatalException (node.js:272:26)
```

This is because node.js simply forwards whatever has been thrown to `process.on('uncaughtException', ...)`, even if it's not really an error. The proposed changes outputs a more helpful error message that should help the user track down the error.
