### PR TITLE
Add filenames to Suite objects

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -69,6 +69,7 @@ module.exports = function(suite){
 
     context.describe = context.context = function(title, fn){
       var suite = Suite.create(suites[0], title);
+      suite.file = file;
       suites.unshift(suite);
       fn.call(suite);
       suites.shift();

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -76,6 +76,7 @@ module.exports = function(suite){
     context.suite = function(title){
       if (suites.length > 1) suites.shift();
       var suite = Suite.create(suites[0], title);
+      suite.file = file;
       suites.unshift(suite);
       return suite;
     };

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -77,6 +77,7 @@ module.exports = function(suite){
 
     context.suite = function(title, fn){
       var suite = Suite.create(suites[0], title);
+      suite.file = file;
       suites.unshift(suite);
       fn.call(suite);
       suites.shift();


### PR DESCRIPTION
In issue #950 we added 3dd1cdbb695f0489e03171c0874f4ccfb7347893 to export filenames on Test objects so that they could be made available to reporters which want to map failures to specific test files. That patch did not address the case where a test fails during a `setup` or `teardown` type block. This commit exports the filename directly on Suite objects in addition to Test ones so that test failures during `setup` and `teardown` routines may also be traced to specific test files.
