### PR TITLE
Fix #1191 - Tests succeed on rejected falsey promises

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -223,7 +223,13 @@ Runnable.prototype.run = function(fn){
     var result = fn.call(ctx);
     if (result && typeof result.then === 'function') {
       self.resetTimeout();
-      result.then(function(){ done() }, done);
+      result
+        .then(function() {
+          done()
+        },
+        function(reason) {
+          done(reason || new Error('Promise rejected with no or falsy reason'))
+        });
     } else {
       done();
     }

--- a/test/runnable.js
+++ b/test/runnable.js
@@ -299,6 +299,28 @@ describe('Runnable(title, fn)', function(){
         })
       })
 
+      describe('when the promise is rejected without a reason', function(){
+        var expectedErr = new Error('Promise rejected with no or falsy reason');
+        var rejectedPromise = {
+          then: function (fulfilled, rejected) {
+            process.nextTick(function () {
+              rejected();
+            });
+          }
+        };
+
+        it('should invoke the callback', function(done){
+          var test = new Runnable('foo', function(){
+            return rejectedPromise;
+          });
+
+          test.run(function(err){
+            err.should.eql(expectedErr);
+            done();
+          });
+        })
+      })
+
       describe('when the promise takes too long to settle', function(){
         var foreverPendingPromise = {
           then: function () { }


### PR DESCRIPTION
Make sure that a test case returning a promise fails if the promise is rejected without a reason (or a falsy one).
