### PR TITLE
Fix failing tests, upgrade to should 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "glob": "3.2.3"
   },
   "devDependencies": {
-    "should": ">= 2.0.x",
-    "coffee-script": "1.2"
+    "coffee-script": "1.2",
+    "should": "^4.0.0"
   },
   "files": [
     "bin",
@@ -49,9 +49,9 @@
     "LICENSE"
   ],
   "licenses": [
-      {
-        "type": "MIT",
-        "url": "https://raw.github.com/visionmedia/mocha/master/LICENSE"
-      }
-    ]
+    {
+      "type": "MIT",
+      "url": "https://raw.github.com/visionmedia/mocha/master/LICENSE"
+    }
+  ]
 }

--- a/test/acceptance/http.js
+++ b/test/acceptance/http.js
@@ -10,7 +10,7 @@ server.listen(8888);
 describe('http', function(){
   it('should provide an example', function(done){
     http.get({ path: '/', port: 8888 }, function(res){
-      res.should.have.status(200);
+      res.should.have.property('statusCode', 200);
       done();
     })
   })

--- a/test/http.meta.2.js
+++ b/test/http.meta.2.js
@@ -29,7 +29,7 @@ function get(url) {
   function request(done) {
     http.get({ path: url, port: 8899, headers: header }, function(res){
       var buf = '';
-      res.should.have.status(200);
+      res.should.have.property('statusCode', 200);
       res.setEncoding('utf8');
       res.on('data', function(chunk){ buf += chunk });
       res.on('end', function(){

--- a/test/http.meta.js
+++ b/test/http.meta.js
@@ -25,7 +25,7 @@ function get(url, body, header) {
   return function(done){
     http.get({ path: url, port: 8889, headers: header }, function(res){
       var buf = '';
-      res.should.have.status(200);
+      res.should.have.property('statusCode', 200);
       res.setEncoding('utf8');
       res.on('data', function(chunk){ buf += chunk });
       res.on('end', function(){

--- a/test/runner.js
+++ b/test/runner.js
@@ -53,12 +53,12 @@ describe('Runner', function(){
   describe('.globalProps()', function(){
     it('should include common non enumerable globals', function() {
       var props = runner.globalProps();
-      props.should.include('setTimeout');
-      props.should.include('clearTimeout');
-      props.should.include('setInterval');
-      props.should.include('clearInterval');
-      props.should.include('Date');
-      props.should.include('XMLHttpRequest');
+      props.should.containEql('setTimeout');
+      props.should.containEql('clearTimeout');
+      props.should.containEql('setInterval');
+      props.should.containEql('clearInterval');
+      props.should.containEql('Date');
+      props.should.containEql('XMLHttpRequest');
     });
   });
 
@@ -69,8 +69,8 @@ describe('Runner', function(){
 
     it('should white-list globals', function(){
       runner.globals(['foo', 'bar']);
-      runner.globals().should.include('foo');
-      runner.globals().should.include('bar');
+      runner.globals().should.containEql('foo');
+      runner.globals().should.containEql('bar');
     })
   })
 


### PR DESCRIPTION
When I tried to clone the repo and run the tests, 9 of them were failing. Needless to say, it's a little unsettling to use a testing framework with failing tests.

I fixed the failing tests and upgraded the `should` dev dependency to 4.0. Seems the tests were failing because they were looking for properties on should's `Assertion` object that were not present, namely `status` and `include`.
