### PR TITLE
add error message to failed test with json-stream reporter

### DIFF
--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -35,7 +35,9 @@ function List(runner) {
   });
 
   runner.on('fail', function(test, err){
-    console.log(JSON.stringify(['fail', clean(test)]));
+    test = clean(test);
+    test.err = err.message;
+    console.log(JSON.stringify(['fail', test]));
   });
 
   runner.on('end', function(){


### PR DESCRIPTION
A failed test is not much use without the error message.
