### PR TITLE
Allow local modules to work as UIs and Reporters

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -9,7 +9,9 @@
  */
 
 var path = require('path')
-  , utils = require('./utils');
+  , utils = require('./utils')
+  , join = path.join
+  , cwd = process.cwd();
 
 /**
  * Expose `Mocha`.
@@ -62,6 +64,7 @@ function image(name) {
  */
 
 function Mocha(options) {
+  module.paths.push(cwd, join(cwd, 'node_modules'));
   options = options || {};
   this.files = [];
   this.options = options;


### PR DESCRIPTION
(This was PR #1240, we are starting over)
The current way dependencies are handled forces us to have a ui interface (or reporter) installed globally.
I am trying to write another ui interface and unless I use an absolute path or install the module globally I can't load the ui interface. The ideal scenario is to do this per application, so when someone clones the repo the tests just work. The current way will force the developer to globally install mocha and also globally install the module I am writing with the custom ui interface.
This happens because when you `require` a name, the lookup starts from the executable file location, `mocha` (global `node_modules` dir). It doesn't do the lookup from the `node_modules` folder where the `mocha` command is ran (`pwd`).

https://github.com/visionmedia/mocha/blob/755f05410d8bdb1218073b74755089998b98a0ca/lib/mocha.js#L153

Currently mocha adds the cwd to modules.path on _mocha like so:

https://github.com/visionmedia/mocha/blob/755f05410d8bdb1218073b74755089998b98a0ca/bin/_mocha#L152

```
module.paths.push(cwd, join(cwd, 'node_modules'));
```

But not on mocha.js.

This will only work for immediate requires, only when they are `require`d directly from `_mocha`. When `mocha.js` tries to load the new ui interface later it can't find it, because its `module.paths` is different from `_mocha`'s `module.paths`.
To be able to load from a local `node_modules` folder it would be needed to set `module.paths` from where the `require` for the ui is set, at `mocha.js`.
This PR does just that.
