### PR TITLE
Suport ops path specify  (mocha.opts)

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -90,6 +90,7 @@ program
   .option('--no-deprecation', 'silence deprecation warnings')
   .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
   .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
+  .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
   .option('--prof', 'log statistical profiling information')
   .option('--recursive', 'include sub directories')
   .option('--reporters', 'display available reporters')
@@ -169,10 +170,14 @@ program.on('require', function(mod){
   requires.push(mod);
 });
 
-// mocha.opts support
+// --opts
+
+var opsPath = process.argv.indexOf('--opts') !== -1
+    ? process.argv[process.argv.indexOf('--opts') + 1]
+    : 'test/mocha.opts';
 
 try {
-  var opts = fs.readFileSync('test/mocha.opts', 'utf8')
+  var opts = fs.readFileSync(opsPath, 'utf8')
     .trim()
     .split(/\s+/);
 


### PR DESCRIPTION
Hope to can be specified path of mocha.ops (optional).

**Behavior:**

Read specified file for configuration includes "--opts" CLI option.
By the default, read test/mocha.opts as before.

**Related issues:** #451 #674
