### PR TITLE
add livescript support to 'mocha --watch'

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -323,7 +323,7 @@ if (program.watch) {
   });
 
 
-  var watchFiles = utils.files(cwd, [ 'js', 'coffee', 'litcoffee', 'coffee.md' ].concat(program.watchExtensions));
+  var watchFiles = utils.files(cwd, [ 'js', 'ls', 'coffee', 'litcoffee', 'coffee.md' ].concat(program.watchExtensions));
   var runAgain = false;
 
   function loadAndRun() {


### PR DESCRIPTION
This adds support for watching livescript files. LiveScript is a dialect of coffee/coco which is pretty popular and deserves official support: http://livescript.net/
