### PR TITLE
bumping to 1.21.1 for missing build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": [
     "mocha.js",
     "mocha.css"

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "repo": "visionmedia/mocha",
   "description": "simple, flexible, fun test framework",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "simple, flexible, fun test framework",
   "keywords": [
     "mocha",


### PR DESCRIPTION
@travisjeffery it appears that when `1.21.0` was released, `make` didn't get run, so the "browser" version of `mocha.js` did not receive the updates.  I don't think this was intentional (but it might have been; I'm new here), so here's a PR.

This builds is on top of the 1.21.0 tag, which means the ~4 commits since then are not included.  If it's OK to just include that stuff and call it a patch, that's fine, and I'll take care of it.
