### PR TITLE
update coffee-script to 1.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ test-failing:
 test-compilers:
 	@./bin/mocha \
 		--reporter $(REPORTER) \
-		--compilers coffee:coffee-script,foo:./test/compiler/foo \
+		--compilers coffee:coffee-script/register,foo:./test/compiler/foo \
 		test/acceptance/test.coffee \
 		test/acceptance/test.foo
 
 test-requires:
 	@./bin/mocha \
 		--reporter $(REPORTER) \
-		--compilers coffee:coffee-script \
+		--compilers coffee:coffee-script/register \
 		--require test/acceptance/require/a.js \
 		--require test/acceptance/require/b.coffee \
 		--require test/acceptance/require/c.js \

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "glob": "3.2.3"
   },
   "devDependencies": {
-    "coffee-script": "1.2",
+    "coffee-script": "~1.7.1",
     "should": "~4.0.0"
   },
   "files": [


### PR DESCRIPTION
- modify targets in Makefile to use proper compiler

I don't know if there's any reason not to do this?
