### PR TITLE
resolves #1300: passing 0 to timeout() will disable timeouts

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -64,6 +64,7 @@ Runnable.prototype.__proto__ = EventEmitter.prototype;
 
 Runnable.prototype.timeout = function(ms){
   if (0 == arguments.length) return this._timeout;
+  if (ms === 0) this._enableTimeouts = false;
   if ('string' == typeof ms) ms = milliseconds(ms);
   debug('timeout %d', ms);
   this._timeout = ms;

--- a/test/acceptance/timeout.js
+++ b/test/acceptance/timeout.js
@@ -25,5 +25,11 @@ describe('timeouts', function(){
       this.timeout(1);
       setTimeout(done, 2);
     });
+    
+    it('should work with timeout(0)', function(done) {
+      this.timeout(0);
+      setTimeout(done, 1);
+    })
   });
+  
 })


### PR DESCRIPTION
After 5dad9a3, it seems `this.timeout(0)` stopped working.  

I re-enabled it inasmuch as I understood how it works, and added a test.

I was unsure whether or not @travisjeffery had intended to change the API, so that's why this is a PR.
