### PR TITLE
Fix reporter name in github page

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,7 +725,7 @@ testCase('Array', function(){
 <p>This will default the reporter to <code>dot</code>, require the <code>should</code> library,
   and use <code>bdd</code> as the interface. With this you may then invoke <code>mocha(1)</code>
   with additional arguments, here enabling growl support and changing
-  the reporter to <code>spec</code>:</p>
+  the reporter to <code>list</code>:</p>
 
 <pre><code>$ mocha --reporter list --growl
 </code></pre>

--- a/index.md
+++ b/index.md
@@ -673,7 +673,7 @@ Testing asynchronous code with Mocha could not be simpler! Simply invoke the cal
   This will default the reporter to `dot`, require the `should` library,
   and use `bdd` as the interface. With this you may then invoke `mocha(1)`
   with additional arguments, here enabling growl support and changing
-  the reporter to `spec`:
+  the reporter to `list`:
 
     $ mocha --reporter list --growl
 


### PR DESCRIPTION
The example case set reporter to list, but description is spec.
