### PR TITLE
Fail when test resolution method is overspecified

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -181,7 +181,8 @@ Runnable.prototype.run = function(fn){
     , start = new Date
     , ctx = this.ctx
     , finished
-    , emitted;
+    , emitted
+    , result;
 
   // Some times the ctx exists but it is not runnable
   if (ctx && ctx.runnable) ctx.runnable(this);
@@ -213,7 +214,7 @@ Runnable.prototype.run = function(fn){
     this.resetTimeout();
 
     try {
-      this.fn.call(ctx, function(err){
+      result = this.fn.call(ctx, function(err){
         if (err instanceof Error || toString.call(err) === "[object Error]") return done(err);
         if (null != err) {
           if (Object.prototype.toString.call(err) === '[object Object]') {
@@ -224,6 +225,10 @@ Runnable.prototype.run = function(fn){
         }
         done();
       });
+
+      if (result && typeof result.then === 'function') {
+        return done(new Error('Asynchronous resolution method is overspecified. Specify a callback *or* return a Promise, not both.'));
+      }
     } catch (err) {
       done(err);
     }

--- a/test/acceptance/overspecified-async.js
+++ b/test/acceptance/overspecified-async.js
@@ -1,0 +1,8 @@
+describe('overspecified asynchronous resolution method', function() {
+  it('should fail when multiple methods are used', function(done) {
+    setTimeout(done, 0);
+
+    // uncomment
+    // return { then: function() {} };
+  });
+});


### PR DESCRIPTION
Users may register `Runnable`s as asynchronous in one of two ways:
- Via callback (by defining the body function to have an arity of one)
- Via promise (by returning a Promise object from the body function)

When both a callback function is specified _and_ a Promise object is
returned, the `Runnable`'s resolution condition is ambiguous.
Practically speaking, users are most likely to make this mistake as they
transition between asynchronous styles.

Currently, Mocha silently prefers the callback amd ignores the Promise
object. Update the implementation of the `Runnable` class to fail
immediately when the test resolution method is over-specified in this
way.
