### PR TITLE
Don't report timeouts while enableTimeouts=false

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -202,7 +202,6 @@ Runnable.prototype.run = function(fn){
     self.clearTimeout();
     self.duration = new Date - start;
     finished = true;
-    if (!err && self.duration > ms && self._enableTimeouts) err = new Error('timeout of ' + ms + 'ms exceeded');
     fn(err);
   }
 

--- a/test/acceptance/timeout.js
+++ b/test/acceptance/timeout.js
@@ -55,9 +55,29 @@ describe('timeouts', function(){
       this.timeout(4);
 
       it('should suppress timeout(4)', function(done) {
-        // The test is in the before() call.
         this.enableTimeouts(false);
         setTimeout(done, 50);
+      })
+    })
+
+    describe('using enableTimeouts(false) and enableTimeouts(true)', function() {
+      this.timeout(4);
+
+      it('should error on timeout', function(done) {
+        this.enableTimeouts(false);
+        this.enableTimeouts(true);
+        // uncomment
+        // setTimeout(done, 50);
+        done();
+      })
+
+      it('should suppress timeout(4)', function(done) {
+        this.enableTimeouts(false);
+        var self = this;
+        setTimeout(function() {
+          self.enableTimeouts(true);
+          done();
+        }, 50);
       })
     })
 


### PR DESCRIPTION
Timeouts that occcur while enableTimeouts = false should not be
reported when timeouts are enabled again before calling the callback.