### PR TITLE
added empty object to errorJSON() call to catch when no error is present

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -68,7 +68,7 @@ function clean(test) {
     title: test.title,
     fullTitle: test.fullTitle(),
     duration: test.duration,
-    err: errorJSON(test.err)
+    err: errorJSON(test.err || {})
   }
 }
 


### PR DESCRIPTION
When using the json reporter (`-R json`), the `errorJSON()` function quietly dies if there is no `test.err` property.  Feeding it an empty object allows it to succeed.

This also addresses #1314.
