### PR TITLE
Scoping highlighting tags to the mocha element

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -295,7 +295,7 @@ function highlight(js) {
  */
 
 exports.highlightTags = function(name) {
-  var code = document.getElementsByTagName(name);
+  var code = document.getElementById('mocha').getElementsByTagName(name);
   for (var i = 0, len = code.length; i < len; ++i) {
     code[i].innerHTML = highlight(code[i].innerHTML);
   }


### PR DESCRIPTION
I'm not sure whether I'm missing an edge case or not, but this solves my issue and it makes sense to me that this is what we would want it to be anyway. Everything should be scoped to the `#mocha` element anyway. My use case is I have a collection of components and I have tests for them. I have a site that shows the component, an example, and the test. The example and test is interactive and runs on the page. Without this change, mocha will highlight all my other code tags on the page which messes things up. Here's an example of this change working on my page: http://kent.doddsfamily.us/kcd-angular/#/kcd-dynamic-attr#spec (see the spec toward the bottom)
