### PR TITLE
resolves #1066: generate better async trace if done() is called multiple times

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -45,6 +45,7 @@ function Runnable(title, fn) {
   this._slow = 75;
   this._enableTimeouts = true;
   this.timedOut = false;
+  this._trace = new Error('done() called multiple times')
 }
 
 /**
@@ -190,14 +191,14 @@ Runnable.prototype.run = function(fn){
   function multiple(err) {
     if (emitted) return;
     emitted = true;
-    self.emit('error', err || new Error('done() called multiple times'));
+    self.emit('error', err || new Error('done() called multiple times; stacktrace may be inaccurate'));
   }
 
   // finished
   function done(err) {
     var ms = self.timeout();
     if (self.timedOut) return;
-    if (finished) return multiple(err);
+    if (finished) return multiple(err || self._trace);
     self.clearTimeout();
     self.duration = new Date - start;
     finished = true;

--- a/test/acceptance/multiple.done.js
+++ b/test/acceptance/multiple.done.js
@@ -12,4 +12,12 @@ describe('multiple calls to done()', function(){
       // done();
     });
   })
+
+  it('should produce a reasonable trace', function (done) {
+    process.nextTick(function() {
+      done();
+      // uncomment
+      // done()
+    })
+  });
 })


### PR DESCRIPTION
Wasn't sure the best way to test a stack trace, but if you uncomment the acceptance test you'll see a better trace.

Before:

```
Error: done() called multiple times
    at multiple (/Volumes/samara/projects/boneskull/mocha/lib/runnable.js:194:31)
    at done (/Volumes/samara/projects/boneskull/mocha/lib/runnable.js:201:26)
    at /Volumes/samara/projects/boneskull/mocha/lib/runnable.js:226:9
    at process._tickCallback (node.js:419:13)
```

After:

```
Error: done() called multiple times
    at new Runnable (/Volumes/samara/projects/boneskull/mocha/lib/runnable.js:49:17)
    at Context.<anonymous> (/Volumes/samara/projects/boneskull/mocha/test/runnable.js:166:24)
    at Test.Runnable.run (/Volumes/samara/projects/boneskull/mocha/lib/runnable.js:220:15)
    at Runner.runTest (/Volumes/samara/projects/boneskull/mocha/lib/runner.js:373:10)
    at /Volumes/samara/projects/boneskull/mocha/lib/runner.js:451:12
    at next (/Volumes/samara/projects/boneskull/mocha/lib/runner.js:298:14)
    at /Volumes/samara/projects/boneskull/mocha/lib/runner.js:308:7
    at next (/Volumes/samara/projects/boneskull/mocha/lib/runner.js:246:23)
    at Object._onImmediate (/Volumes/samara/projects/boneskull/mocha/lib/runner.js:275:5)
    at processImmediate [as _immediateCallback] (timers.js:345:15)
```
