### PR TITLE
Custom font family for HTML progress indicator

### DIFF
--- a/lib/browser/progress.js
+++ b/lib/browser/progress.js
@@ -8,11 +8,14 @@ module.exports = Progress;
  * Initialize a new `Progress` indicator.
  */
 
-function Progress() {
+function Progress(fontFamily) {
+  if (typeof fontFamily != 'string') {
+    fontFamily = '"Helvetica Neue", Helvetica, Arial, sans-serif';
+  }
   this.percent = 0;
   this.size(0);
   this.fontSize(11);
-  this.font('helvetica, arial, sans-serif');
+  this.font(fontFamily);
 }
 
 /**

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -62,18 +62,21 @@ function HTML(runner) {
     , ctx
     , root = document.getElementById('mocha');
 
+  if (!root) return error('#mocha div missing, add it to your document');
+
   if (canvas.getContext) {
     var ratio = window.devicePixelRatio || 1;
+    var fontFamily = window.getComputedStyle ? window.getComputedStyle(root).fontFamily
+                                             : '"Helvetica Neue", Helvetica, Arial, sans-serif';
+
     canvas.style.width = canvas.width;
     canvas.style.height = canvas.height;
     canvas.width *= ratio;
     canvas.height *= ratio;
     ctx = canvas.getContext('2d');
     ctx.scale(ratio, ratio);
-    progress = new Progress;
+    progress = new Progress(fontFamily);
   }
-
-  if (!root) return error('#mocha div missing, add it to your document');
 
   // pass toggle
   on(passesLink, 'click', function(){


### PR DESCRIPTION
Uses `window.getComputedStyle` to get the font family from `div#mocha`.

Example:

``` html
<style>
  #mocha { font-family: "Source Sans Pro"; }
  #mocha .test pre { font-family: "Source Code Pro";  }
</style>
```

This is fully backwards compatible.
