### PR TITLE
HTML reporter: Allow the error to contain a formatted HTML error message

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -157,7 +157,13 @@ function HTML(runner) {
 
       stackString = stackString || '';
 
-      el.appendChild(fragment('<pre class="error">%e%e</pre>', message, stackString));
+      if (test.err.htmlMessage && stackString) {
+        el.appendChild(fragment('<div class="html-error">%s\n<pre class="error">%e</pre></div>', test.err.htmlMessage, stackString));
+      } else if (test.err.htmlMessage) {
+        el.appendChild(fragment('<div class="html-error">%s</div>', test.err.htmlMessage));
+      } else {
+        el.appendChild(fragment('<pre class="error">%e%e</pre>', message, stackString));
+      }
     }
 
     // toggle code

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -136,23 +136,28 @@ function HTML(runner) {
       var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
       var el = fragment('<li class="test fail"><h2>%e <a href="%e" class="replay">‣</a></h2></li>', test.title, self.testURL(test));
-      var str = test.err.stack || test.err.toString();
-
-      // FF / Opera do not add the message
-      if (!~str.indexOf(test.err.message)) {
-        str = test.err.message + '\n' + str;
-      }
+      var stackString, // Note: Includes leading newline
+          message = test.err.toString();
 
       // <=IE7 stringifies to [Object Error]. Since it can be overloaded, we
       // check for the result of the stringifying.
-      if ('[object Error]' == str) str = test.err.message;
+      if ('[object Error]' === message) message = test.err.message;
 
-      // Safari doesn't give you a stack. Let's at least provide a source line.
-      if (!test.err.stack && test.err.sourceURL && test.err.line !== undefined) {
-        str += "\n(" + test.err.sourceURL + ":" + test.err.line + ")";
+      if (test.err.stack) {
+        var indexOfMessage = test.err.stack.indexOf(test.err.message);
+        if (indexOfMessage === -1) {
+          stackString = test.err.stack;
+        } else {
+          stackString = test.err.stack.substr(test.err.message.length + indexOfMessage);
+        }
+      } else if (test.err.sourceURL && test.err.line !== undefined) {
+        // Safari doesn't give you a stack. Let's at least provide a source line.
+        stackString = "\n(" + test.err.sourceURL + ":" + test.err.line + ")";
       }
 
-      el.appendChild(fragment('<pre class="error">%e</pre>', str));
+      stackString = stackString || '';
+
+      el.appendChild(fragment('<pre class="error">%e%e</pre>', message, stackString));
     }
 
     // toggle code

--- a/mocha.css
+++ b/mocha.css
@@ -136,6 +136,41 @@ body {
   overflow: auto;
 }
 
+#mocha .test .html-error {
+  overflow: auto;
+  color: black;
+  line-height: 1.5;
+  display: block;
+  float: left;
+  clear: left;
+  font: 12px/1.5 monaco, monospace;
+  margin: 5px;
+  padding: 15px;
+  border: 1px solid #eee;
+  max-width: 85%; /*(1)*/
+  max-width: calc(100% - 42px); /*(2)*/
+  max-height: 300px;
+  word-wrap: break-word;
+  border-bottom-color: #ddd;
+  -webkit-border-radius: 3px;
+  -webkit-box-shadow: 0 1px 3px #eee;
+  -moz-border-radius: 3px;
+  -moz-box-shadow: 0 1px 3px #eee;
+  border-radius: 3px;
+}
+
+#mocha .test .html-error pre.error {
+  border: none;
+  -webkit-border-radius: none;
+  -webkit-box-shadow: none;
+  -moz-border-radius: none;
+  -moz-box-shadow: none;
+  padding: 0;
+  margin: 0;
+  margin-top: 18px;
+  max-height: none;
+}
+
 /**
  * (1): approximate for browsers not supporting calc
  * (2): 42 = 2*15 + 2*10 + 2*1 (padding + margin + border)


### PR DESCRIPTION
For the next version of the [Unexpected](https://github.com/sunesimonsen/unexpected/tree/v5) assertion library we're focusing on adding colored object diffs to error messages in "deep equal" and related cases. We have reached the limits of mocha's current approach with serializing `err.actual` and `err.expected` as JSON and then doing a line-based diff. It imposes too many restrictions on the quality of the output, especially when attempting to shoehorn other types of nested diffs (eg. binary `Buffer` or `Uint8Array`) into the resulting output.

Also, we have implemented a [lightweight type system](https://github.com/sunesimonsen/unexpected/blob/v5/lib/types.js) that allows "userland" to introduce new types and control exactly how they they equal, inspect and diff. It's awkward to make that interoperate with the test framework rendering the diffs.

When running in node.js nothing is preventing us from omitting `err.actual` and `err.expected` and including an ansi-colored diff in `err.message`. We have that working fine already. We also want this to work in the browser, though, where mocha currently doesn't render diffs at all for some reason. We found that the simplest way of accomplishing that in mocha-land is for the HTML reporter to look for an HTML-formatted message on the error object and use it if available.

What do you think, is this something you would consider merging in?

Alternatively, the type system and all formatting of output could be adopted by mocha and maybe other test runners, but we're afraid that would be a premature standardization that would make it too cumbersome to iterate the concept further.

Here's a showcase of some of the diffs we have implemented so far (we temporarily removed the scrollbars for a better overview):

![unexpectedobjectdiff](https://cloud.githubusercontent.com/assets/373545/4198830/39e5f006-37fe-11e4-8ddc-ff166d56bf56.png)

![unexpectedhexdiff](https://cloud.githubusercontent.com/assets/373545/4198831/3ea44b24-37fe-11e4-9fde-a3e749220857.png)

![unexpectedfunction](https://cloud.githubusercontent.com/assets/373545/4198833/42c14400-37fe-11e4-9b42-688511a8c50f.png)
