### PR TITLE
changed 'Catched' to 'Caught'

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -538,7 +538,7 @@ Runner.prototype.uncaught = function(err){
     }.call(err) ? err : ( err.message || err ));
   } else {
     debug('uncaught undefined exception');
-    err = new Error('Catched undefined error, did you throw without specifying what?');
+    err = new Error('Caught undefined error, did you throw without specifying what?');
   }
   err.uncaught = true;
 

--- a/mocha.js
+++ b/mocha.js
@@ -4991,7 +4991,7 @@ Runner.prototype.uncaught = function(err){
     }.call(err) ? err : ( err.message || err ));
   } else {
     debug('uncaught undefined exception');
-    err = new Error('Catched undefined error, did you throw without specifying what?');
+    err = new Error('Caught undefined error, did you throw without specifying what?');
   }
   err.uncaught = true;
 


### PR DESCRIPTION
I changed 'Catched' to 'Caught' in uncaught exception error handler messages, because that's more grammatically correct.
