### PR TITLE
utils.js: significant modification of diff behavior

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -292,18 +292,100 @@ exports.highlightTags = function(name) {
   }
 };
 
+/**
+ * If a value could have properties, and has none, this function is called, which returns
+ * a string representation of the empty value.
+ *
+ * Functions w/ no properties return `'[Function]'`
+ * Arrays w/ length === 0 return `'[]'`
+ * Objects w/ no properties return `'{}'`
+ * All else: return result of `value.toString()`
+ *
+ * @param {*} value Value to inspect
+ * @param {string} [type] The type of the value, if known.
+ * @returns {string}
+ */
+var emptyRepresentation = function emptyRepresentation(value, type) {
+  type = type || exports.type(value);
+
+  switch(type) {
+    case 'function':
+      return '[Function]';
+    case 'object':
+      return '{}';
+    case 'array':
+      return '[]';
+    default:
+      return value.toString();
+  }
+};
 
 /**
- * Stringify `obj`.
+ * Takes some variable and asks `{}.toString()` what it thinks it is.
+ * @param {*} value Anything
+ * @example
+ * type({}) // 'object'
+ * type([]) // 'array'
+ * type(1) // 'number'
+ * type(false) // 'boolean'
+ * type(Infinity) // 'number'
+ * type(null) // 'null'
+ * type(new Date()) // 'date'
+ * type(/foo/) // 'regexp'
+ * type('type') // 'string'
+ * type(global) // 'global'
+ * @api private
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
+ * @returns {string}
+ */
+exports.type = function type(value) {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+    return 'buffer';
+  }
+  return Object.prototype.toString.call(value)
+    .replace(/^\[.+\s(.+?)\]$/, '$1')
+    .toLowerCase();
+};
+
+/**
+ * @summary Stringify `value`.
+ * @description Different behavior depending on type of value.
+ * - If `value` is undefined or null, return `'[undefined]'` or `'[null]'`, respectively.
+ * - If `value` is not an object, function or array, return result of `value.toString()` wrapped in double-quotes.
+ * - If `value` is an *empty* object, function, or array, return result of function
+ *   {@link emptyRepresentation}.
+ * - If `value` has properties, call {@link exports.canonicalize} on it, then return result of
+ *   JSON.stringify().
  *
- * @param {Object} obj
- * @return {String}
+ * @see exports.type
+ * @param {*} value
+ * @return {string}
  * @api private
  */
 
-exports.stringify = function(obj) {
-  if (obj instanceof RegExp) return obj.toString();
-  return JSON.stringify(exports.canonicalize(obj), null, 2).replace(/,(\n|$)/g, '$1');
+exports.stringify = function(value) {
+  var prop,
+    type = exports.type(value);
+
+  if (type === 'null' || type === 'undefined') {
+    return '[' + type + ']';
+  }
+
+  if (type === 'date') {
+    return '[Date: ' + value.toISOString() + ']';
+  }
+
+  if (!~exports.indexOf(['object', 'array', 'function'], type)) {
+    return value.toString();
+  }
+
+  for (prop in value) {
+    if (value.hasOwnProperty(prop)) {
+      return JSON.stringify(exports.canonicalize(value), null, 2).replace(/,(\n|$)/g, '$1');
+    }
+  }
+
+  return emptyRepresentation(value, type);
 };
 
 /**
@@ -313,45 +395,89 @@ exports.stringify = function(obj) {
  * @api private
  */
 exports.isBuffer = function (arg) {
-  return typeof Buffer !== 'undefined' && arg instanceof Buffer;
+  return typeof Buffer !== 'undefined' && Buffer.isBuffer(arg);
 };
 
 /**
- * Return a new object that has the keys in sorted order.
- * @param {Object} obj
- * @param {Array} [stack]
- * @return {Object}
+ * @summary Return a new Thing that has the keys in sorted order.  Recursive.
+ * @description If the Thing...
+ * - has already been seen, return string `'[Circular]'`
+ * - is `undefined`, return string `'[undefined]'`
+ * - is `null`, return value `null`
+ * - is some other primitive, return the value
+ * - is not a primitive or an `Array`, `Object`, or `Function`, return the value of the Thing's `toString()` method
+ * - is a non-empty `Array`, `Object`, or `Function`, return the result of calling this function again.
+ * - is an empty `Array`, `Object`, or `Function`, return the result of calling `emptyRepresentation()`
+ *
+ * @param {*} value Thing to inspect.  May or may not have properties.
+ * @param {Array} [stack=[]] Stack of seen values
+ * @return {(Object|Array|Function|string|undefined)}
+ * @see {@link exports.stringify}
  * @api private
  */
 
-exports.canonicalize = function(obj, stack) {
+exports.canonicalize = function(value, stack) {
+  var canonicalizedObj,
+    type = exports.type(value),
+    prop,
+    withStack = function withStack(value, fn) {
+      stack.push(value);
+      fn();
+      stack.pop();
+    };
+
   stack = stack || [];
 
-  if (exports.indexOf(stack, obj) !== -1) return '[Circular]';
+  if (exports.indexOf(stack, value) !== -1) {
+    return '[Circular]';
+  }
 
-  var canonicalizedObj;
-
-  if(exports.isBuffer(obj)) {
-    return obj;
-  } else if ({}.toString.call(obj) === '[object Array]') {
-    stack.push(obj);
-    canonicalizedObj = exports.map(obj, function (item) {
-      return exports.canonicalize(item, stack);
-    });
-    stack.pop();
-  } else if (typeof obj === 'object' && obj !== null) {
-    stack.push(obj);
-    canonicalizedObj = {};
-    exports.forEach(exports.keys(obj).sort(), function (key) {
-      canonicalizedObj[key] = exports.canonicalize(obj[key], stack);
-    });
-    stack.pop();
-  } else {
-    canonicalizedObj = obj;
+  switch(type) {
+    case 'undefined':
+      canonicalizedObj = '[undefined]';
+      break;
+    case 'buffer':
+    case 'null':
+      canonicalizedObj = value;
+      break;
+    case 'array':
+      withStack(value, function () {
+        canonicalizedObj = exports.map(value, function (item) {
+          return exports.canonicalize(item, stack);
+        });
+      });
+      break;
+    case 'date':
+      canonicalizedObj = '[Date: ' + value.toISOString() + ']';
+      break;
+    case 'function':
+      for (prop in value) {
+        canonicalizedObj = {};
+        break;
+      }
+      if (!canonicalizedObj) {
+        canonicalizedObj = emptyRepresentation(value, type);
+        break;
+      }
+    /* falls through */
+    case 'object':
+      canonicalizedObj = canonicalizedObj || {};
+      withStack(value, function () {
+        exports.forEach(exports.keys(value).sort(), function (key) {
+          canonicalizedObj[key] = exports.canonicalize(value[key], stack);
+        });
+      });
+      break;
+    case 'number':
+    case 'boolean':
+      canonicalizedObj = value;
+      break;
+    default:
+      canonicalizedObj = value.toString();
   }
 
   return canonicalizedObj;
- };
+};
 
 /**
  * Lookup file names at the given `path`.


### PR DESCRIPTION
I think it's better, anyway.  I was becoming frustrated by seeing my `Date`s and `Function`s represented as objects within the diffs.  Even more frustrating is when the diff result _appears to be exactly the same_ but the assertion failed anyway.  So this is my attempt at making the diffs more friendly and understandable.

Summary of changes:
- Added inner function `emptyRepresentation()`, which is called in the case that your `Object`, `Function` or `Array` has nothing "in" it.  It attempts to make a unique representation of that empty value.
- Added private API function `exports.type()`, which can be used to deduce the type of any given value.  _I exported this function mainly for testing purposes_
- Modified `exports.stringify()` to avoid `JSON.stringify()` in circumstances where `JSON.stringify()` may not be much help.  My only concern here is whether or not we should display a string in double-quotes, as to coincide with `JSON.stringify()` behavior.
  - If `value` is `undefined` or `null`, return `'[undefined]'` or `'[null]'`, respectively.   _It's possible to have strings with these same values, which may lead to confusion, but this is an edge case._
  - If `value` is not an `Object`, `Function` or `Array`, return result of `value.toString()`.
  - If `value` is an _empty_ `Object`, `Function` or `Array`, return result of function `emptyRepresentation()`.
  - If `value` has properties, call `exports.canonicalize()` on it, then return result of `JSON.stringify()`.
- Modified `exports.canonicalize()` to support the above strategy, with a couple slight differences.  The strategy is as follows.  If the value...
  - has already been seen, return string `'[Circular]'`
  - is `undefined`, return string `'[undefined]'`
  - is `null`, return value `null`.  This differs from the `stringify()` behavior, as to provide a valid JSON representation.
  - is a primitive, return the value
  - is not a primitive or an `Array`, `Object`, or `Function`, return the value of the Thing's `toString()` method
  - is a non-empty `Array`, `Object`, or `Function`, return the result of calling this function again.
  - is an empty `Array`, `Object`, or `Function`, return the result of calling `emptyRepresentation()`
- Added many tests

Before:

```
      AssertionError: expected { Object (path, $explicit_fields, ...) } to deeply equal { Object ($accessed, $explicit_fields, ...) }
      + expected - actual
```

After:

```
      AssertionError: expected { Object (path, $explicit_fields, ...) } to deeply equal { Object ($accessed, $explicit_fields, ...) }
      + expected - actual

       {
      +  "$accessed": {}
      -  "$accessed": "Fri Sep 12 2014 23:00:10 GMT-0700 (PDT)"
         "$explicit_fields": []
      +  "$registered": {}
      -  "$registered": "Fri Sep 12 2014 23:00:10 GMT-0700 (PDT)"
         "author": "Christopher Hiller <chiller@badwing.com>"
         "author.email": "chiller@badwing.com"
         "author.name": "Christopher Hiller"
         "authors": [
           "Christopher Hiller <chiller@badwing.com>"
         ]
      -  "description": "[undefined]"
         "license": "Copyright 2014 Christopher Hiller <chiller@badwing.com>"
         "name": "riffraff"
         "path": "/Volumes/samara/projects/boneskull/test"
      -  "repository": "[undefined]"
         "repository.type": "git"
      -  "repository.url": "[undefined]"
      -  "version": "[undefined]"
       }
```
