### PR TITLE
HTML reporter: preserve query params when navigating to suites/tests

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -178,13 +178,22 @@ function HTML(runner) {
 }
 
 /**
+ * Makes a URL, preserving querystring ("search") parameters.
+ * @param {string} s
+ * @returns {string} your new URL
+ */
+var makeUrl = function makeUrl(s) {
+  var search = window.location.search;
+  return (search ? search + '&' : '?' ) + 'grep=' + encodeURIComponent(s);
+};
+
+/**
  * Provide suite URL
  *
  * @param {Object} [suite]
  */
-
 HTML.prototype.suiteURL = function(suite){
-  return '?grep=' + encodeURIComponent(suite.fullTitle());
+  return makeUrl(suite.fullTitle());
 };
 
 /**
@@ -194,7 +203,7 @@ HTML.prototype.suiteURL = function(suite){
  */
 
 HTML.prototype.testURL = function(test){
-  return '?grep=' + encodeURIComponent(test.fullTitle());
+  return makeUrl(test.fullTitle());
 };
 
 /**


### PR DESCRIPTION
PR #830 is woefully out-of-date, but we never fixed the issue, so this fixes the issue.  To test:
1.  Open browser test
   
   ``` sh
   $ open test/browser/index.html
   ```
2.  Assert clicking on a suite drills-down to the suite
3.  Assert clicking on a test drills-down to the test
4.  Repeat step 1; ensure no querystring is present in URL
5.  Append `?foo=bar` to URL in browser
6.  Repeat steps 2-3, asserting `?foo=bar` remains in URL
