### PR TITLE
adding json-spec reporter

### DIFF
--- a/lib/reporters/json-spec.js
+++ b/lib/reporters/json-spec.js
@@ -1,0 +1,170 @@
+/**
+ * Module dependencies.
+ */
+
+var Base = require('./base'),
+  cursor = Base.cursor,
+  color = Base.color,
+  ms = require('../ms');
+
+/**
+ * Expose `JSON`.
+ */
+
+exports = module.exports = JSONSpecReporter;
+
+/**
+ * Initialize a new `JSON` reporter.
+ *
+ * @param {Runner} runner
+ * @api public
+ */
+
+function JSONSpecReporter(runner) {
+  Base.call(this, runner);
+
+  // from spec.js
+  var self = this,
+    stats = this.stats,
+    indents = 1,
+    n = 0;
+
+  // from spec.js
+  function indent() {
+    return Array(indents).join('  ')
+  }
+
+  var tests = [],
+    failures = [],
+    passes = [];
+
+  // from spec.js
+  runner.on('start', function () {
+    console.warn();
+  });
+
+  // from spec.js
+  runner.on('suite', function (suite) {
+    ++indents;
+    console.warn(color('suite', '%s%s'), indent(), suite.title);
+  });
+
+  // from spec.js
+  runner.on('suite end', function (suite) {
+    --indents;
+    if (1 == indents) console.warn();
+  });
+
+  // from spec.js
+  runner.on('pending', function (test) {
+    var fmt = indent() + color('pending', '  - %s');
+    console.warn(fmt, test.title);
+  });
+
+  runner.on('test end', function (test) {
+    tests.push(test);
+  });
+
+  runner.on('pass', function (test) {
+    passes.push(test);
+    // from spec.js
+    if ('fast' == test.speed) {
+      var fmt = indent() + color('checkmark', '  ' + Base.symbols.ok) + color('pass', ' %s ');
+      cursor.CR();
+      console.warn(fmt, test.title);
+    } else {
+      var fmt = indent() + color('checkmark', '  ' + Base.symbols.ok) + color('pass', ' %s ') + color(test.speed, '(%dms)');
+      cursor.CR();
+      console.warn(fmt, test.title, test.duration);
+    }
+  });
+
+  runner.on('fail', function (test) {
+    failures.push(test);
+    // from spec.js
+    cursor.CR();
+    console.warn(indent() + color('fail', '  %d) %s'), ++n, test.title);
+  });
+
+  runner.on('end', function () {
+    var obj = {
+      stats: self.stats,
+      tests: tests.map(clean),
+      failures: failures.map(clean),
+      passes: passes.map(clean)
+    };
+
+    runner.testResults = obj;
+
+    self.epilogue.call(self);
+
+    process.stdout.write(JSON.stringify(obj, null, 2));
+  });
+}
+
+JSONSpecReporter.prototype.epilogue = function () {
+  var stats = this.stats;
+  var tests;
+  var fmt;
+
+  console.warn();
+
+  // passes
+  fmt = color('bright pass', ' ') + color('green', ' %d passing') + color('light', ' (%s)');
+
+  console.warn(fmt,
+    stats.passes || 0,
+    ms(stats.duration));
+
+  // pending
+  if (stats.pending) {
+    fmt = color('pending', ' ') + color('pending', ' %d pending');
+
+    console.warn(fmt, stats.pending);
+  }
+
+  // failures
+  if (stats.failures) {
+    fmt = color('fail', '  %d failing');
+
+    console.error(fmt,
+      stats.failures);
+
+    Base.list(this.failures);
+    console.error();
+  }
+
+  console.warn();
+}
+
+/**
+ * Return a plain-object representation of `test`
+ * free of cyclic properties etc.
+ *
+ * @param {Object} test
+ * @return {Object}
+ * @api private
+ */
+
+function clean(test) {
+  return {
+    title: test.title,
+    fullTitle: test.fullTitle(),
+    duration: test.duration,
+    err: errorJSON(test.err || {})
+  }
+}
+
+/**
+ * Transform `error` into a JSON object.
+ * @param {Error} err
+ * @return {Object}
+ */
+
+function errorJSON(err) {
+  var res = {};
+  Object.getOwnPropertyNames(err).forEach(function (key) {
+    res[key] = err[key];
+  }, err);
+  return res;
+}

--- a/test/reporters/json-spec.js
+++ b/test/reporters/json-spec.js
@@ -1,0 +1,54 @@
+var child = require('child_process');
+
+describe('json-spec reporter', function () {
+  this.timeout(5000);
+
+  var mocha, stdout, stderr;
+
+  beforeEach(function (done) {
+    var cmd = 'node',
+      args = [__dirname + '/../../bin/mocha', '-R', 'json-spec', __dirname + '/simplepass.js'],
+      options = {};
+
+    stdout = '';
+    stderr = '';
+    mocha = child.spawn(cmd, args, options);
+
+    done();
+  });
+
+  it('should produce stdout that is JSON.parseable', function (done) {
+
+    mocha.stdout.on('data', function (data) {
+      stdout += data;
+    });
+
+    mocha.stderr.on('data', function (data) {
+      stderr += data;
+    });
+
+    mocha.on('close', function (code) {
+      (JSON.parse(stdout)).should.be.ok;
+      done();
+    });
+
+  });
+
+  it('should produce stderr that is the spec output', function (done) {
+
+    mocha.stdout.on('data', function (data) {
+      stdout += data;
+    });
+
+    mocha.stderr.on('data', function (data) {
+      stderr += data;
+    });
+
+    mocha.on('close', function (code) {
+      (/feeder/.test(stderr)).should.be.true;
+      done();
+    });
+
+  });
+
+});

--- a/test/reporters/simplepass.js
+++ b/test/reporters/simplepass.js
@@ -1,0 +1,5 @@
+describe('this is just a feeder for json-spec.js', function () {
+  it('should pass', function (done) {
+    done();
+  });
+});


### PR DESCRIPTION
The intended use of this reporter is to make it possible for a hybrid of manual/automated tests to be executed.  In some cases, we want to be able to run tests and observe the results in real time via the `spec` reporter, but we also want to be able to capture the results in `json` so that they can be archived and reported on in our CI system.

The `json-spec` reporter allows for this by having the `spec` output sent to stderr and the `json` output sent to stdout.  Exit codes are left unaffected.  This makes it possible to run tests like this:

```
$ mocha -R json-spec >> ~/testresults/mytest.json
/* stderr =>
 * {{ spec reporter output here }}
 */
$ cat ~/testresults/mytest.json
/* stdout =>
 * {{ json output here }}
 */
```
