### PR TITLE
adding fileoutput option

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -72,6 +72,7 @@ program
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
   .option('-gc', '--expose-gc', 'expose gc extension')
   .option('-i, --invert', 'inverts --grep matches')
+  .option('-o, --output <file>', 'specify the file to output the JSON results to')
   .option('-r, --require <name>', 'require the given module')
   .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
   .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
@@ -270,6 +271,10 @@ if (program.asyncOnly) mocha.asyncOnly();
 // --globals
 
 mocha.globals(globals);
+
+// --output
+
+if (program.output) mocha.output(program.output);
 
 // custom compiler support
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -382,6 +382,16 @@ Mocha.prototype.noHighlighting = function() {
 };
 
 /**
+ * Enable JSON file output
+ * @return {Mocha}
+ * @api public
+ */
+Mocha.prototype.output = function(file) {
+  this.options.output = file;
+  return this;
+};
+
+/**
  * Run tests and invoke `fn()` when complete.
  *
  * @param {Function} fn
@@ -401,6 +411,7 @@ Mocha.prototype.run = function(fn){
   if (options.grep) runner.grep(options.grep, options.invert);
   if (options.globals) runner.globals(options.globals);
   if (options.growl) this._growl(runner, reporter);
+  if (options.output) runner.output(options.output);
   exports.reporters.Base.useColors = options.useColors;
   exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
   return runner.run(fn);

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -220,7 +220,9 @@ exports.list = function(failures){
 function Base(runner) {
   var self = this
     , stats = this.stats = { suites: 0, tests: 0, passes: 0, pending: 0, failures: 0 }
-    , failures = this.failures = [];
+    , failures = this.failures = []
+    , passes = []
+    , tests = [];
 
   if (!runner) return;
   this.runner = runner;
@@ -239,6 +241,7 @@ function Base(runner) {
   runner.on('test end', function(test){
     stats.tests = stats.tests || 0;
     stats.tests++;
+    tests.push(test);
   });
 
   runner.on('pass', function(test){
@@ -252,6 +255,7 @@ function Base(runner) {
         : 'fast';
 
     stats.passes++;
+    passes.push(test);
   });
 
   runner.on('fail', function(test, err){
@@ -264,6 +268,15 @@ function Base(runner) {
   runner.on('end', function(){
     stats.end = new Date;
     stats.duration = new Date - stats.start;
+
+    var obj = {
+      stats: stats,
+      tests: tests.map(clean),
+      failures: failures.map(clean),
+      passes: passes.map(clean)
+    };
+
+    runner.testResults = obj;
   });
 
   runner.on('pending', function(){
@@ -456,4 +469,36 @@ function sameType(a, b) {
   a = Object.prototype.toString.call(a);
   b = Object.prototype.toString.call(b);
   return a == b;
+}
+
+/**
+ * Return a plain-object representation of `test`
+ * free of cyclic properties etc.
+ *
+ * @param {Object} test
+ * @return {Object}
+ * @api private
+ */
+
+function clean(test) {
+  return {
+    title: test.title,
+    fullTitle: test.fullTitle(),
+    duration: test.duration,
+    err: errorJSON(test.err || {})
+  }
+}
+
+/**
+ * Transform `error` into a JSON object.
+ * @param {Error} err
+ * @return {Object}
+ */
+
+function errorJSON(err) {
+  var res = {};
+  Object.getOwnPropertyNames(err).forEach(function(key) {
+    res[key] = err[key];
+  }, err);
+  return res;
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -7,7 +7,8 @@ var EventEmitter = require('events').EventEmitter
   , Test = require('./test')
   , utils = require('./utils')
   , filter = utils.filter
-  , keys = utils.keys;
+  , keys = utils.keys
+  , fs = require('fs');
 
 /**
  * Non-enumerable globals.
@@ -91,6 +92,18 @@ Runner.prototype.grep = function(re, invert){
   this._grep = re;
   this._invert = invert;
   this.total = this.grepTotal(this.suite);
+  return this;
+};
+
+/**
+ * Output the testResults to a file
+ * @param {String} file
+ * @return {Runner} for chaining
+ * @api public
+ */
+
+Runner.prototype.output = function(file) {
+  this._output = file;
   return this;
 };
 
@@ -586,6 +599,8 @@ Runner.prototype.run = function(fn){
   this.on('end', function(){
     debug('end');
     process.removeListener('uncaughtException', uncaught);
+    if (self._output)
+      fs.writeFileSync(self._output, JSON.stringify(self.testResults, null, 2));
     fn(self.failures);
   });
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -242,4 +242,15 @@ describe('Runner', function(){
       done();
     })
   })
+
+  describe('.output(file)', function(){
+    it('should update the runner._output with provided value', function(){
+      suite.addTest(new Test('im a test about lions'));
+      suite.addTest(new Test('im another test about lions'));
+      suite.addTest(new Test('im a test about bears'));
+      var newRunner = new Runner(suite);
+      newRunner.output('output.json');
+      newRunner._output.should.equal('output.json');
+    })
+  })
 })


### PR DESCRIPTION
This PR adds a new command line option (`-o, --output <file>`) that will output the JSON test results to the specified `<file>`.  All reporter functionality should be unaffected.
