### PR TITLE
replaced non-ANSI.SYS escape sequence in landing reporter, fixes #211

### DIFF
--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -56,7 +56,7 @@ function Landing(runner) {
   }
 
   runner.on('start', function(){
-    stream.write('\n  ');
+    stream.write('\n\n\n  ');
     cursor.hide();
   });
 
@@ -73,7 +73,7 @@ function Landing(runner) {
     }
 
     // render landing strip
-    stream.write('\u001b[4F\n\n');
+    stream.write('\u001b['+(width+1)+'D\u001b[2A');
     stream.write(runway());
     stream.write('\n  ');
     stream.write(color('runway', Array(col).join('⋅')));


### PR DESCRIPTION
The landing reporter breaks in iTerm2. I guessed the cause was using `\u001b[4F`, the not-ANSI.SYS CPL (Cursor Previous Line) escape sequence. I've replaced it with two ANSI.SYS escape sequences, CUB (Cursor Back) and CUU (Cursor Up).

I've also fixed an issue in which executing mocha using the landing reporter in any terminal line but the first one was erasing one line more than intended. In case of executing the mocha command directly, it was erasing the mocha prompt line. Two images are worth 2000 words:
![image](https://cloud.githubusercontent.com/assets/1260830/4564169/0e7e03da-4f15-11e4-916b-a1cae5407222.png)
after executing mocha:
(notice the missing `mocha -u tdd --reporter landing` line)
![image](https://cloud.githubusercontent.com/assets/1260830/4564185/21ee249a-4f15-11e4-8a97-734bde1ed0eb.png)
