### PR TITLE
bin: use `stdio: 'inherit'` for child process spawn

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -44,7 +44,7 @@ process.argv.slice(2).forEach(function(arg){
   }
 });
 
-var proc = spawn(process.argv[0], args, { customFds: [0,1,2] });
+var proc = spawn(process.argv[0], args, { stdio: 'inherit' });
 proc.on('exit', function (code, signal) {
   process.on('exit', function(){
     if (signal) {


### PR DESCRIPTION
Fixes deprecation warning in node v0.11.x:

```
child_process: customFds option is deprecated, use stdio instead.
```
