### PR TITLE
Use fancy diffs for node's assert.deepEqual

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -176,15 +176,17 @@ exports.list = function(failures){
       msg = 'Uncaught ' + msg;
     }
 
-    // explicitly show diff
-    if (err.showDiff && sameType(actual, expected)) {
+    var diff = (err.showDiff || err.operator == 'deepEqual');
+
+    // explicitly show diff (or node deepEqual)
+    if (diff && sameType(actual, expected)) {
       escape = false;
       err.actual = actual = utils.stringify(actual);
       err.expected = expected = utils.stringify(expected);
     }
 
     // actual / expected diff
-    if (err.showDiff && 'string' == typeof actual && 'string' == typeof expected) {
+    if (diff && 'string' == typeof actual && 'string' == typeof expected) {
       fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -34,6 +34,41 @@ describe('Base reporter', function () {
 
   });
 
+  it('should show diffs for node deepEqual', function () {
+    var err,
+      stderr = [],
+      stderrWrite = process.stderr.write,
+      errOut;
+
+    try {
+      require('assert').deepEqual({a: 1}, {b: 2});
+    } catch (ex) {
+      err = ex;
+    }
+
+    var test = {
+      err: err,
+      fullTitle: function () {
+        return 'title';
+      }
+    };
+
+    process.stderr.write = function (string) {
+      stderr.push(string);
+    };
+
+    Base.list([test]);
+
+    process.stderr.write = stderrWrite;
+
+    errOut = stderr.join('\n');
+
+    errOut.should.match(/test/);
+    errOut.should.match(/actual/);
+    errOut.should.match(/expected/);
+
+  });
+
   it('should not show diffs when showDiff property set', function () {
     var err = new Error('test'),
       stderr = [],


### PR DESCRIPTION
Is there a reason why only opted-in 3rd-party libraries get the fancy coloured/unified diff feature?

I wasn't sure, so here's a PR that detects node core's `deepEqual` and lets it get the nice diff behaviour. :tada: 