### PR TITLE
update npm before testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "0.11"
   - "0.10"
   - "0.8"
+before_install:
+  - npm install -g npm

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "_mocha": "./bin/_mocha"
   },
   "engines": {
-    "node": ">= 0.8.x"
+    "node": ">= 0.8.x",
+    "npm": ">=1.4.3"
   },
+  "engineStrict": true,
   "scripts": {
     "test": "make test-all"
   },


### PR DESCRIPTION
The only problem in [this error](https://travis-ci.org/mochajs/mocha/jobs/38422941) is that npm v1.2 doesn’t support `^` version specifier. It's not the problem of Node v0.8 itself.

So I added `before_install` command to install the latest version of [npm](https://github.com/npm/npm), before installing the dependencies of mocha.

[The Grunt plugins maintained by Grunt team](https://github.com/gruntjs?query=grunt-contrib-+only%3Asources+) get benefit from this solution, such as [the nodeunit plugin](https://github.com/gruntjs/grunt-contrib-nodeunit/blob/eec8316f58224da4cf9f651200f345eb35a666cb/.travis.yml#L5-L8) and [the requirejs plugin](https://github.com/gruntjs/grunt-contrib-requirejs/blob/master/.travis.yml#L5-L8).

After merging this PR, you can also merge #1396.
