### PR TITLE
fixes #1093: missing hooks after failed test with bail

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -246,7 +246,6 @@ Runner.prototype.hook = function(name, fn){
   function next(i) {
     var hook = hooks[i];
     if (!hook) return fn();
-    if (self.failures && suite.bail()) return fn();
     self.currentRunnable = hook;
 
     hook.ctx.currentTest = self.test;

--- a/test/runner.js
+++ b/test/runner.js
@@ -181,6 +181,20 @@ describe('Runner', function(){
     })
   })
 
+  describe('.hook(name, fn)', function(){
+    it('should execute hooks after failed test if suite bail is true', function(done){
+      runner.fail({});
+      suite.bail(true);
+      suite.afterEach(function(){
+        suite.afterAll(function() {
+          done();
+        })
+      });
+      runner.hook('afterEach', function(){});
+      runner.hook('afterAll', function(){});
+    })
+  })
+
   describe('.fail(test, err)', function(){
     it('should increment .failures', function(){
       runner.failures.should.equal(0);


### PR DESCRIPTION
Issue #1093.

Line `247` in `lib/runner.js` (which was causing the bug) is pointless:
- If a test fails and the suite has bail, no more tests will be executed due to line `419`. After finishing the hooks for the current failed test and since no more tests will be executed, no more hooks will be executed in the suite.
- Independently of having bail or not, if `beforeAll` fails, the suite will be ended due to line `521`.
- If `beforeEach` fails, runner will proceed with `afterEach` due to `447`. If the suite has bail, no more tests will be ran due to line `419` and the suite will end.
- If `afterEach` fails and the suit has bail, the suite will end due to line `419`.

All tests pass after removing the line.

I've also added a test that checks that `afterEach` and `afterAll` hooks are called after a failed test if the suite has bail. I wasn't sure where to add the test, though. Is it good there? Suggestions?
