### PR TITLE
don't run util.inspect on strings

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -177,7 +177,7 @@ exports.list = function(failures){
     }
 
     // explicitly show diff
-    if (err.showDiff && sameType(actual, expected)) {
+    if (err.showDiff && sameType(actual, expected) && typeof actual !== 'string') {
       escape = false;
       err.actual = actual = utils.stringify(actual);
       err.expected = expected = utils.stringify(expected);


### PR DESCRIPTION
closes #1241, making the diffs work again:

![image](https://cloud.githubusercontent.com/assets/1049204/4999566/64f81b68-69b1-11e4-964b-54e387b1e3b0.png)

...should probably have some tests written for it to prevent another regression like this in the future
