### PR TITLE
Fix test running output truncation on async STDIO

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -377,10 +377,30 @@ if (program.watch) {
 // load
 
 mocha.files = files;
-runner = mocha.run(program.exit ? process.exit : exitLater);
+runner = mocha.run(program.exit ? exit : exitLater);
 
 function exitLater(code) {
   process.on('exit', function() { process.exit(code) })
+}
+
+function exit(code) {
+  // flush output for Node.js Windows pipe bug
+  // https://github.com/joyent/node/issues/6247 is just one bug example
+  // https://github.com/visionmedia/mocha/issues/333 has a good discussion
+  function done() {
+    if (!(draining--)) process.exit(code);
+  }
+
+  var draining = 0;
+  var streams = [process.stdout, process.stderr];
+
+  streams.forEach(function(stream){
+    // submit empty write request and wait for completion
+    draining += 1;
+    stream.write('', done);
+  });
+
+  done();
 }
 
 process.on('SIGINT', function() { runner.abort(); })


### PR DESCRIPTION
For issue https://github.com/mochajs/mocha/issues/333

Note: this does not address the issues with `mocha interfaces` and other non-test commands, because if we actually waited for the output to get flushed, the default `mocha` action (running tests) would start to occur. Refactoring needs to happen to fix this.

But this solves the output being cut when the STDIO is async, which is the main use-case.