### PR TITLE
Kill the child process ('_mocha') when the parent receives SIGINT (ctrl-c)

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -54,3 +54,8 @@ proc.on('exit', function (code, signal) {
     }
   });
 });
+
+process.on('SIGINT', function() {
+  proc.kill('SIGTERM');
+  process.exit(1);
+});


### PR DESCRIPTION
If I run a mocha test that for some reason is taking too much time, and I want to kill it by pressing ctrl-c, the underlining process does not die and keeps running in the background and it will write to the output when it finishes. As examples of all the possible problems that this can cause, consider buffer matching (it is really slow in writing the difference to the output), stuck tests, ecc.

Also, this causes VIM interface to mess up when running commands with '! mocha' inside VIM, here is a picture:
![messed up vim](https://cloud.githubusercontent.com/assets/52195/5153981/a3899fa2-7242-11e4-8d1d-2a3be1674875.png)

I propose to trap SIGINT (ctrl-c) in the 'mocha' process, so that it sends SIGTERM to the child process.

Done with @bajtos at Oneshot Nodeconf Budapest.
