### PR TITLE
Support for --tags to include/exclude tests based on some optional tagging

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -98,6 +98,8 @@ program
   .option('--trace', 'trace function calls')
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
+  .option('--tags <tags>', 'only include tests with the given tags', list, [])
+  .option('--skip-tags <tags>', 'exclude all tests with the given tags', list, [])
 
 program.name = 'mocha';
 
@@ -254,6 +256,14 @@ if (program.grep) mocha.grep(new RegExp(program.grep));
 // --invert
 
 if (program.invert) mocha.invert();
+
+// --tags
+
+if (program.tags) mocha.tags(program.tags);
+
+// --skip-tags
+
+if (program.skipTags) mocha.skipTags(program.skipTags);
 
 // --check-leaks
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -10,7 +10,9 @@ module.exports = Context;
  * @api private
  */
 
-function Context(){}
+function Context(){
+  this._tags = [];
+}
 
 /**
  * Set or get the context `Runnable` to `runnable`.

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,0 +1,36 @@
+var utils = require('./utils');
+
+module.exports = Filter;
+
+function Filter() {
+  this.grep = /.*/;
+  this.invertGrep = false;
+  this.tags = [];
+  this.skipTags = [];
+}
+
+Filter.prototype.count = function(suite) {
+  var self = this;
+  var total = 0;
+  suite.eachTest(function(test){
+    if (self.shouldRun(test)) total++;
+  });
+  return total;
+};
+
+Filter.prototype.shouldRun = function(test) {
+  // --grep
+  var grepMatch = this.grep.test(test.fullTitle());
+  if (this.invertGrep) grepMatch = !grepMatch;
+  // --tags --skip-tags
+  var include = (!this.tags.length) || matchTags(test.ctx._tags, this.tags);
+  var exclude = this.skipTags.length && matchTags(test.ctx._tags, this.skipTags);
+  // final decision
+  return grepMatch && include && !exclude;
+};
+
+function matchTags(actualTags, against) {
+  return utils.some(against, function(tag) {
+    return utils.indexOf(actualTags, tag) !== -1;
+  });
+}

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -67,6 +67,8 @@ function image(name) {
  *   - `slow` milliseconds to wait before considering a test slow
  *   - `ignoreLeaks` ignore global leaks
  *   - `grep` string or regexp to filter tests with
+ *   - `tags` array of tags to be included when filtering
+ *   - `skipTags` array of tags to be excluded when filtering
  *
  * @param {Object} options
  * @api public
@@ -239,6 +241,26 @@ Mocha.prototype.invert = function(){
 };
 
 /**
+ * Set a list of tags to include
+ * @returns {Mocha}
+ * @api public
+ */
+Mocha.prototype.tags = function(tags) {
+  this.options.tags = tags;
+  return this;
+};
+
+/**
+ * Set a list of tags to exclude
+ * @returns {Mocha}
+ * @api public
+ */
+Mocha.prototype.skipTags = function(tags) {
+  this.options.skipTags = tags;
+  return this;
+};
+
+/**
  * Ignore global leaks.
  *
  * @param {Boolean} ignore
@@ -399,6 +421,8 @@ Mocha.prototype.run = function(fn){
   runner.ignoreLeaks = false !== options.ignoreLeaks;
   runner.asyncOnly = options.asyncOnly;
   if (options.grep) runner.grep(options.grep, options.invert);
+  if (options.tags) runner.tags(options.tags);
+  if (options.skipTags) runner.skipTags(options.skipTags);
   if (options.globals) runner.globals(options.globals);
   if (options.growl) this._growl(runner, reporter);
   exports.reporters.Base.useColors = options.useColors;

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -29,8 +29,7 @@ function TAP(runner) {
     , failures = 0;
 
   runner.on('start', function(){
-    var total = runner.grepTotal(runner.suite);
-    console.log('%d..%d', 1, total);
+    console.log('%d..%d', 1, runner.total);
   });
 
   runner.on('test end', function(){

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -5,6 +5,7 @@
 var EventEmitter = require('events').EventEmitter
   , debug = require('debug')('mocha:runner')
   , Test = require('./test')
+  , Filter = require('./filter')
   , utils = require('./utils')
   , filter = utils.filter
   , keys = utils.keys;
@@ -54,12 +55,12 @@ function Runner(suite) {
   var self = this;
   this._globals = [];
   this._abort = false;
+  this._filter = new Filter();
   this.suite = suite;
   this.total = suite.total();
   this.failures = 0;
   this.on('test end', function(test){ self.checkGlobals(test); });
   this.on('hook end', function(hook){ self.checkGlobals(hook); });
-  this.grep(/.*/);
   this.globals(this.globalProps().concat(extraGlobals()));
 }
 
@@ -88,34 +89,42 @@ Runner.prototype.__proto__ = EventEmitter.prototype;
  * @api public
  */
 
-Runner.prototype.grep = function(re, invert){
-  debug('grep %s', re);
-  this._grep = re;
-  this._invert = invert;
-  this.total = this.grepTotal(this.suite);
+Runner.prototype.grep = function(re, invert) {
+  debug('grep %s (%s)', re, invert);
+  this._filter.grep = re;
+  this._filter.invertGrep = invert;
+  this.total = this._filter.count(this.suite);
   return this;
 };
 
 /**
- * Returns the number of tests matching the grep search for the
- * given suite.
+ * Only run tests matching the given tags
  *
- * @param {Suite} suite
- * @return {Number}
+ * @param {Array} tags
+ * @return {Runner} for chaining
  * @api public
  */
 
-Runner.prototype.grepTotal = function(suite) {
-  var self = this;
-  var total = 0;
+Runner.prototype.tags = function(tags){
+  debug('include tags: %s', tags);
+  this._filter.tags = tags;
+  this.total = this._filter.count(this.suite);
+  return this;
+};
 
-  suite.eachTest(function(test){
-    var match = self._grep.test(test.fullTitle());
-    if (self._invert) match = !match;
-    if (match) total++;
-  });
+/**
+ * Exclude tests matching the given tags
+ *
+ * @param {Array} tags
+ * @return {Runner} for chaining
+ * @api public
+ */
 
-  return total;
+Runner.prototype.skipTags = function(tags){
+  debug('skip tags: %s', tags);
+  this._filter.skipTags = tags;
+  this.total = this._filter.count(this.suite);
+  return this;
 };
 
 /**
@@ -430,10 +439,8 @@ Runner.prototype.runTests = function(suite, fn){
     // all done
     if (!test) return fn();
 
-    // grep
-    var match = self._grep.test(test.fullTitle());
-    if (self._invert) match = !match;
-    if (!match) return next();
+    // filter
+    if (!self._filter.shouldRun(test)) return next();
 
     // pending
     if (test.pending) {
@@ -480,7 +487,7 @@ Runner.prototype.runTests = function(suite, fn){
  */
 
 Runner.prototype.runSuite = function(suite, fn){
-  var total = this.grepTotal(suite)
+  var total = this._filter.count(suite)
     , self = this
     , i = 0;
 

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -151,6 +151,24 @@ Suite.prototype.bail = function(bail){
   return this;
 };
 
+/*
+ * Sets tags on the suite's context,
+ * inheriting any parent tags
+ *
+ * @param {String...} tags
+ * @return {Suite} for chaining
+ * @api private
+ */
+
+Suite.prototype.tag = function(tags) {
+  if (this.parent) {
+    this.ctx._tags = Array.prototype.concat.apply(this.parent.ctx._tags, arguments);
+  } else {
+    this.ctx._tags = Array.prototype.slice.apply(arguments);
+  }
+  return this;
+};
+
 /**
  * Run `fn(test[, done])` before running tests.
  *

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,6 +118,21 @@ exports.filter = function(arr, fn){
 };
 
 /**
+ * Array#some
+ *
+ * @param {Array} array
+ * @param {Function} fn
+ * @api private
+ */
+
+exports.some = function(arr, fn) {
+  for (var i = 0, l = arr.length; i < l; ++i) {
+    if (fn(arr[i], i, arr)) return true;
+  }
+  return false;
+};
+
+/**
  * Object.keys (<=IE8)
  *
  * @param {Object} obj

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,117 @@
+var mocha = require('../')
+  , Filter = require('../lib/filter')
+  , Context = mocha.Context
+  , Suite = mocha.Suite
+  , Test = mocha.Test;
+
+describe('filter', function() {
+
+  var root, fruit, veggies, apple, pear, beans;
+
+  beforeEach(function() {
+    root    = new Suite('root', new Context);
+    apples  = new Test('apples');
+    pears   = new Test('pears');
+    beans   = new Test('beans');
+    fruit   = Suite.create(root, 'some fruit')
+                   .tag('fruit')
+                   .addTest(apples)
+                   .addTest(pears);
+    veggies = Suite.create(root, 'some veggies')
+                   .tag('veggies', 'green')
+                   .addTest(beans);
+  });
+
+  describe('shouldRun', function() {
+
+    it('runs all tests by default', function() {
+      var filter = new Filter();
+      filter.shouldRun(apples).should.eql(true);
+    });
+
+    describe('grep', function() {
+
+      it('can grep with a regex on the test name', function() {
+        var filter = new Filter();
+        filter.grep = /p/;
+        filter.shouldRun(apples).should.eql(true);
+        filter.shouldRun(pears).should.eql(true);
+        filter.shouldRun(beans).should.eql(false);
+      });
+
+      it('can grep with a regex on the full test title', function() {
+        var filter = new Filter();
+        filter.grep = /fruit/;
+        filter.shouldRun(apples).should.eql(true);
+        filter.shouldRun(beans).should.eql(false);
+      });
+
+      it('can invert a grep match', function() {
+        var filter = new Filter();
+        filter.grep = /fruit/;
+        filter.invertGrep = true;
+        filter.shouldRun(apples).should.eql(false);
+        filter.shouldRun(beans).should.eql(true);
+      });
+
+    });
+
+    describe('tags', function() {
+
+      it('only runs test with specified tags', function() {
+        var filter = new Filter();
+        filter.tags = ['veggies'];
+        filter.shouldRun(apples).should.eql(false);
+        filter.shouldRun(beans).should.eql(true);
+        filter.tags = ['fruit', 'veggies'];
+        filter.shouldRun(apples).should.eql(true);
+        filter.shouldRun(beans).should.eql(true);
+      });
+
+      it('can exclude certain tags', function() {
+        var filter = new Filter();
+        filter.skipTags = ['green'];
+        filter.shouldRun(apples).should.eql(true);
+        filter.shouldRun(beans).should.eql(false);
+      });
+
+      it('can exclude certain tags', function() {
+        var filter = new Filter();
+        filter.tags = ['fruit', 'veggies'];
+        filter.skipTags = ['green'];
+        filter.shouldRun(apples).should.eql(true);
+        filter.shouldRun(beans).should.eql(false);
+      });
+
+    });
+
+    describe('combination', function() {
+
+      it('can combines grep and tags', function() {
+        var filter = new Filter();
+        filter.grep = /some/;
+        filter.skipTags = ['green'];
+        filter.shouldRun(apples).should.eql(true);
+        filter.shouldRun(beans).should.eql(false);
+      });
+
+    });
+
+  });
+
+  describe('count', function() {
+
+    it('returns the number of tests matching the filter', function() {
+      var filter = new Filter();
+      filter.count(root).should.eql(3);
+      filter.tags = ['veggies'];
+      filter.count(root).should.eql(1);
+      filter.grep = /beans/;
+      filter.count(root).should.eql(1);
+      filter.skipTags = ['green'];
+      filter.count(root).should.eql(0);
+    });
+
+  });
+
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -31,24 +31,6 @@ describe('Runner', function(){
     })
   })
 
-  describe('.grepTotal()', function(){
-    it('should return the total number of matched tests', function(){
-      suite.addTest(new Test('im a test about lions'));
-      suite.addTest(new Test('im another test about lions'));
-      suite.addTest(new Test('im a test about bears'));
-      runner.grep(/lions/);
-      runner.grepTotal(suite).should.equal(2);
-    })
-
-    it('should return the total number of matched tests when inverted', function(){
-      suite.addTest(new Test('im a test about lions'));
-      suite.addTest(new Test('im another test about lions'));
-      suite.addTest(new Test('im a test about bears'));
-      runner.grep(/lions/, true);
-      runner.grepTotal(suite).should.equal(1);
-    })
-  })
-
   describe('.globalProps()', function(){
     it('should include common non enumerable globals', function() {
       var props = runner.globalProps();

--- a/test/suite.js
+++ b/test/suite.js
@@ -124,6 +124,27 @@ describe('Suite', function(){
     });
   });
 
+  describe('.tag()', function() {
+    it('starts with no tags', function() {
+      var suite = new Suite('A', new Context());
+      suite.ctx._tags.should.eql([]);
+    });
+    it('can add tags', function() {
+      var suite = new Suite('A', new Context());
+      suite.tag('unit', 'fast');
+      suite.ctx._tags.should.eql(['unit', 'fast']);
+    });
+    it('returns itself for easy chaining', function() {
+      var suite = new Suite('A', new Context());
+      suite.tag('unit').should.eql(suite);
+    });
+    it('inherits tags from the parent context', function() {
+      var parent = new Suite('parent', new Context()).tag('unit', 'fast');
+      var child = Suite.create(parent, 'child').tag('regression');
+      child.ctx._tags.should.eql(['unit', 'fast', 'regression']);
+    });
+  });
+
   describe('.beforeAll()', function(){
     beforeEach(function(){
       this.suite = new Suite('A Suite');

--- a/test/utils.js
+++ b/test/utils.js
@@ -23,4 +23,23 @@ describe('utils', function() {
       isBuffer({}).should.equal(false);
     })
   });
+  describe('Array#some', function() {
+    function odd(item) { return item % 2 !== 0; }
+    it('returns false if no items match', function() {
+      utils.some([2, 4, 6], odd).should.eql(false);
+    });
+    it('returns true if any item matches', function() {
+      utils.some([2, 4, 5, 6], odd).should.eql(true);
+    });
+  });
+  describe('Array#indexOf', function() {
+    it('returns the index of the first matching item', function() {
+      utils.indexOf([2, 4, 6], 6).should.eql(2);
+      utils.indexOf([2, 4, 2], 2).should.eql(0);
+      utils.indexOf(['hello', 'world'], 'world').should.eql(1);
+    });
+    it('returns -1 if no item matches', function() {
+      utils.indexOf([2, 4, 6], 3).should.eql(-1);
+    });
+  });
 });


### PR DESCRIPTION
:warning:  **Before you read**
_the suggested tagging API has changed since the initial proposal, see new comments further down_

---

As discussed in #928, this is a tentative PR for tagging support in the `bdd` interface. I hope this is not against the guidelines (PR for a new feature), but it will be easier to discuss what's feasible with some visibility on the code changes.
- you can optionally pass an array of tags as the first argument to `describe` and `it`
- by default, all tests always run
- you can specify `--tags` to run a subset of the tests
- tests that don't match the filter are marked as pending

``` js
describe('my service', function() {
  it('test 1', function() {});
  describe(['integration'], 'backend connectivity', function() {
    describe(['fast'], 'quick tests', function() {
      it('test 2', function() {});
    });
    it(['slow'], 'test 3', function() {});
  });
});
```
- `mocha` runs everything
- `mocha --tags "not:integration"` runs test `1`
- `mocha --tags "is:integration"` runs tests `2` and `3`
- `mocha --tags "is:integration not:slow"` runs test `2`

You can also programmatically update the filter with 

``` js
if (/* out of business hours */) {
  require('mocha').options.tags.add('not:backend');
}
```

If this looks good, happy to look into how to unit test & document it.
Cheers

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1445)

<!-- Reviewable:end -->
