### PR TITLE
Async errors from sync tests

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -114,7 +114,7 @@ function HTML(runner) {
   });
 
   runner.on('fail', function(test, err){
-    if ('hook' == test.type) runner.emit('test end', test);
+    if ('hook' == test.type || test.wasAlreadyDone) runner.emit('test end', test);
   });
 
   runner.on('test end', function(test){

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -192,6 +192,7 @@ Runner.prototype.checkGlobals = function(test){
 
 Runner.prototype.fail = function(test, err){
   ++this.failures;
+  test.wasAlreadyDone = !!test.state;
   test.state = 'failed';
 
   if ('string' == typeof err) {
@@ -546,12 +547,11 @@ Runner.prototype.uncaught = function(err){
   var runnable = this.currentRunnable;
   if (!runnable) return;
 
-  var wasAlreadyDone = runnable.state;
   this.fail(runnable, err);
 
   runnable.clearTimeout();
 
-  if (wasAlreadyDone) return;
+  if (runnable.wasAlreadyDone) return;
 
   // recover from test
   if ('test' == runnable.type) {

--- a/test/runner.js
+++ b/test/runner.js
@@ -210,6 +210,14 @@ describe('Runner', function(){
       test.state.should.equal('failed');
     })
 
+    it('should set test.wasAlreadyDone', function() {
+      var test = {};
+      runner.fail(test, 'some error');
+      test.wasAlreadyDone.should.be.false;
+      runner.fail(test, 'some other error');
+      test.wasAlreadyDone.should.be.true;
+    })
+
     it('should emit "fail"', function(done){
       var test = {}, err = {};
       runner.on('fail', function(test, err){


### PR DESCRIPTION
We recently encountered an issue where a test was written synchronously (no `done` argument) but failed to return a promise.

The test in question was failing an assertion, but after its success was already reported. The failure was tallied, and so we saw one failure reported in the UI, but had no connection between that number and the source of the failure.

This change first exposes a `wasAlreadyDone` property on the test instance, and second, re-displays the failing test in the html reporter when the runner emits a `fail` event.