### PR TITLE
Preserve pathname when linking to individual tests in HTML reporter

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -183,7 +183,7 @@ function HTML(runner) {
  */
 var makeUrl = function makeUrl(s) {
   var search = window.location.search;
-  return (search ? search + '&' : '?' ) + 'grep=' + encodeURIComponent(s);
+  return window.location.pathname + (search ? search + '&' : '?' ) + 'grep=' + encodeURIComponent(s);
 };
 
 /**


### PR DESCRIPTION
When I use Mocha in the browser in an Ember CLI application via [ember-cli-mocha](https://github.com/switchfly/ember-cli-mocha), the links to run individual tests are broken. The tests run from here: `http://localhost:4200/tests`

The test links look like this:

``` html
<a href="?grep=Edit%20an%20issue">Edit an issue</a>
```

Sadly, an `href` beginning with `?` doesn’t link to a query on the current path, but instead to a query on the root. In the above example, it links to `http://localhost:4200/?grep=Edit%20an%20issue`.

I can click the link and put `/tests` back at the beginning of the path, but this patch would fix the links for me and anyone using Mocha with Ember CLI. The tests all still pass, I can’t imagine it having a negative impact anywhere.
