### PR TITLE
Use existing test URL builder in failed replay links

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -135,7 +135,7 @@ function HTML(runner) {
     } else if (test.pending) {
       var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
-      var el = fragment('<li class="test fail"><h2>%e <a href="?grep=%e" class="replay">‣</a></h2></li>', test.title, encodeURIComponent(test.fullTitle()));
+      var el = fragment('<li class="test fail"><h2>%e <a href="%e" class="replay">‣</a></h2></li>', test.title, self.testURL(test));
       var str = test.err.stack || test.err.toString();
 
       // FF / Opera do not add the message


### PR DESCRIPTION
When I submitted #1464, I didn’t notice that the reporter wasn’t using the shared `testURL` code to generate links to replay failed tests. This corrects that. I searched and found no other unique link construction, so everything should be using the same URL generation now.
