### PR TITLE
showDiff: don’t stringify strings + tests

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -178,13 +178,13 @@ exports.list = function(failures){
 
     // explicitly show diff
     if (err.showDiff && sameType(actual, expected)) {
-      escape = false;
-      err.actual = actual = utils.stringify(actual);
-      err.expected = expected = utils.stringify(expected);
-    }
 
-    // actual / expected diff
-    if (err.showDiff && 'string' == typeof actual && 'string' == typeof expected) {
+      if ('string' !== typeof actual) {
+        escape = false;
+        err.actual = actual = utils.stringify(actual);
+        err.expected = expected = utils.stringify(expected);
+      }
+
       fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -34,6 +34,74 @@ describe('Base reporter', function () {
 
   });
 
+
+  it('should not stringify strings', function () {
+    var err = new Error('test'),
+      stdout = [],
+      stdoutWrite = process.stdout.write,
+      errOut;
+
+    err.actual = "a1";
+    err.expected = "e2";
+    err.showDiff = true;
+    var test = {
+      err: err,
+      fullTitle: function () {
+        return 'title';
+      }
+    };
+
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+
+    Base.list([test]);
+
+    process.stdout.write = stdoutWrite;
+
+    errOut = stdout.join('\n');
+
+    errOut.should.not.match(/"/);
+    errOut.should.match(/test/);
+    errOut.should.match(/actual/);
+    errOut.should.match(/expected/);
+
+  });
+
+
+  it('should stringify objects', function () {
+    var err = new Error('test'),
+      stdout = [],
+      stdoutWrite = process.stdout.write,
+      errOut;
+
+    err.actual = {key:"a1"};
+    err.expected = {key:"e1"};
+    err.showDiff = true;
+    var test = {
+      err: err,
+      fullTitle: function () {
+        return 'title';
+      }
+    };
+
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+
+    Base.list([test]);
+
+    process.stdout.write = stdoutWrite;
+
+    errOut = stdout.join('\n');
+
+    errOut.should.match(/"key"/);
+    errOut.should.match(/test/);
+    errOut.should.match(/actual/);
+    errOut.should.match(/expected/);
+
+  });
+
   it('should not show diffs when showDiff property set', function () {
     var err = new Error('test'),
       stdout = [],


### PR DESCRIPTION
The showDiff feature is stringifying strings as JSON, which flattens multi-line text with \n and surrounds them with quotes.

I refactored the code slightly to only call `utils.stringify` if the actual/expected values are _not_ strings.

You can see the bug by running mocha on the following .js file:

``` js
var test = require('mocha').it
var assert = require('assert')

assert.AssertionError.prototype.showDiff = true

test('compare multiline strings', function(){
    assert.equal("foo\ncar", "foo\nbar");
});
```

Current (mocha 2.0.1) output:

```
  1)  compare multiline strings:

      AssertionError: "foo\ncar" == "foo\nbar"
      + expected - actual

      +"foo\nbar"
      -"foo\ncar"
```

After patch:

```
  1)  compare multiline strings:

      AssertionError: "foo\ncar" == "foo\nbar"
      + expected - actual

       foo
      +bar
      -car  
```
