### PR TITLE
utils.stringify should handle objects without an Object prototype

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -380,7 +380,7 @@ exports.stringify = function(value) {
   }
 
   for (prop in value) {
-    if (value.hasOwnProperty(prop)) {
+    if (Object.prototype.hasOwnProperty.call(value, prop)) {
       return JSON.stringify(exports.canonicalize(value), null, 2).replace(/,(\n|$)/g, '$1');
     }
   }

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -212,6 +212,13 @@ stringify({foo: {bar: {baz: {quux: {herp: 'derp'}}}}}).should.equal('{\n  "foo":
       stringify(date).should.equal('[Date: 1970-01-01T00:00:00.000Z]');
       stringify({date: date}).should.equal('{\n  "date": "[Date: 1970-01-01T00:00:00.000Z]"\n}');
     });
+
+    it('should handle object without an Object prototype', function () {
+      var a = Object.create(null);
+      a.foo = 1;
+
+      stringify(a).should.equal('{\n  "foo": 1\n}');
+    });
   });
 
   describe('type', function () {


### PR DESCRIPTION
I use a lot of prototype-less objects (`Object.create(null)`) in my code. Sadly, mocha fails to display the diff when an error occurs.