### PR TITLE
Allow --async-only to be satisfied by returning a promise

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -57,7 +57,7 @@ var images = {
 program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage('[debug] [options] [files]')
-  .option('-A, --async-only', "force all tests to take a callback (async)")
+  .option('-A, --async-only', "force all tests to take a callback (async) or return a promise")
   .option('-c, --colors', 'force enabling of colors')
   .option('-C, --no-colors', 'force disabling of colors')
   .option('-G, --growl', 'enable growl notification support')

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -232,10 +232,6 @@ Runnable.prototype.run = function(fn){
     return;
   }
 
-  if (this.asyncOnly) {
-    return done(new Error('--async-only option in use without declaring `done()`'));
-  }
-
   // sync or promise-returning
   try {
     if (this.pending) {
@@ -259,6 +255,10 @@ Runnable.prototype.run = function(fn){
           done(reason || new Error('Promise rejected with no or falsy reason'))
         });
     } else {
+      if (self.asyncOnly) {
+        return done(new Error('--async-only option in use without declaring `done()` or returning a promise'));
+      }
+
       done();
     }
   }

--- a/test/acceptance/misc/asyncOnly.js
+++ b/test/acceptance/misc/asyncOnly.js
@@ -6,4 +6,23 @@ describe('asyncOnly', function(){
   it('should pass', function(done){
     done();
   })
+
+  it('should ignore pending tests')
+
+  it('should fail when test throws an error', function(){
+    // the async warning only applies if the test would have otherwise passed
+    throw Error('you should see this error');
+  })
+
+  describe('with a function that returns a promise', function() {
+    it('should pass', function(){
+      var fulfilledPromise = {
+        then: function (fulfilled, rejected) {
+          process.nextTick(fulfilled);
+        }
+      };
+
+      return fulfilledPromise;
+    })
+  })
 })


### PR DESCRIPTION
The --async-only flag is intended to catch programmer error where omitting the done callback from the test function arguments causes it to become a synchronous test instead, that does nothing. However, it complains if the test returns a promise, which is unhelpful/unusable when using promises or a mix of async (callback) functions and promises.

This PR proposes changing the behavior of --async-only so that it only fails if the function does not accept a done callback or return a promise. This makes the flag even more useful since forgetting to return a promise will now report an error when using --async-only.

This results in a slight change to the behavior of --async-only: instead of failing immediately for synchronous functions, check to see if the test function returned a promise (or otherwise failed due to an assert, etc) before complaining about not having a done callback.