### PR TITLE
[Fix]: Diff viewer(#1229, #1132, ...)

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -175,7 +175,6 @@ exports.list = function(failures){
     if (err.uncaught) {
       msg = 'Uncaught ' + msg;
     }
-
     // explicitly show diff
     if (err.showDiff && sameType(actual, expected)) {
 
@@ -386,7 +385,7 @@ function unifiedDiff(err, escape) {
   function notBlank(line) {
     return line != null;
   }
-  msg = diff.createPatch('string', err.actual, err.expected);
+  var msg = diff.createPatch('string', err.actual, err.expected);
   var lines = msg.split('\n').splice(4);
   return '\n      '
          + colorLines('diff added',   '+ expected') + ' '

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,7 +127,7 @@ exports.filter = function(arr, fn){
 
 exports.keys = Object.keys || function(obj) {
   var keys = []
-    , has = Object.prototype.hasOwnProperty // for `window` on <=IE8
+    , has = Object.prototype.hasOwnProperty; // for `window` on <=IE8
 
   for (var key in obj) {
     if (has.call(obj, key)) {
@@ -158,6 +158,26 @@ exports.watch = function(files, fn){
 };
 
 /**
+ * Array.isArray (<=IE8)
+ *
+ * @param {Object} obj
+ * @return {Boolean}
+ * @api private
+ */
+var isArray = Array.isArray || function (obj) {
+  return '[object Array]' == {}.toString.call(obj);
+};
+
+/**
+ * @description
+ * Buffer.prototype.toJSON polyfill
+ * @type {Function}
+ */
+Buffer.prototype.toJSON = Buffer.prototype.toJSON || function () {
+  return Array.prototype.slice.call(this, 0);
+};
+
+/**
  * Ignored files.
  */
 
@@ -179,15 +199,15 @@ exports.files = function(dir, ext, ret){
   var re = new RegExp('\\.(' + ext.join('|') + ')$');
 
   fs.readdirSync(dir)
-  .filter(ignored)
-  .forEach(function(path){
-    path = join(dir, path);
-    if (fs.statSync(path).isDirectory()) {
-      exports.files(path, ext, ret);
-    } else if (path.match(re)) {
-      ret.push(path);
-    }
-  });
+    .filter(ignored)
+    .forEach(function(path){
+      path = join(dir, path);
+      if (fs.statSync(path).isDirectory()) {
+        exports.files(path, ext, ret);
+      } else if (path.match(re)) {
+        ret.push(path);
+      }
+    });
 
   return ret;
 };
@@ -364,29 +384,93 @@ exports.type = function type(value) {
  */
 
 exports.stringify = function(value) {
-  var prop,
-    type = exports.type(value);
-
-  if (type === 'null' || type === 'undefined') {
-    return '[' + type + ']';
-  }
-
-  if (type === 'date') {
-    return '[Date: ' + value.toISOString() + ']';
-  }
+  var type = exports.type(value);
 
   if (!~exports.indexOf(['object', 'array', 'function'], type)) {
-    return value.toString();
+    if(type != 'buffer') {
+      return jsonStringify(value);
+    }
+    var json = value.toJSON();
+    // Based on the toJSON result
+    return jsonStringify(json.data && json.type ? json.data : json, 2)
+      .replace(/,(\n|$)/g, '$1');
   }
 
-  for (prop in value) {
+  for (var prop in value) {
     if (Object.prototype.hasOwnProperty.call(value, prop)) {
-      return JSON.stringify(exports.canonicalize(value), null, 2).replace(/,(\n|$)/g, '$1');
+      return jsonStringify(exports.canonicalize(value), 2).replace(/,(\n|$)/g, '$1');
     }
   }
 
   return emptyRepresentation(value, type);
 };
+
+/**
+ * @description
+ * like JSON.stringify but more sense.
+ * @param {Object}  object
+ * @param {Number=} spaces
+ * @param {number=} depth
+ * @returns {*}
+ * @private
+ */
+function jsonStringify(object, spaces, depth) {
+  if(typeof spaces == 'undefined') return _stringify(object);  // primitive types
+
+  depth = depth || 1;
+  var space = spaces * depth
+    , str = isArray(object) ? '[' : '{'
+    , end = isArray(object) ? ']' : '}'
+    , length = object.length || exports.keys(object).length
+    , repeat = function(s, n) { return new Array(n).join(s); }; // `.repeat()` polyfill
+
+  function _stringify(val) {
+    switch (exports.type(val)) {
+      case 'null':
+      case 'undefined':
+        val = '[' + val + ']';
+        break;
+      case 'array':
+      case 'object':
+        val = jsonStringify(val, spaces, depth + 1);
+        break;
+      case 'boolean':
+      case 'regexp':
+      case 'number':
+        val = val === 0 && (1/val) === -Infinity // `-0`
+          ? '-0'
+          : val.toString();
+        break;
+      case 'date':
+        val = '[Date: ' + val.toISOString() + ']';
+        break;
+      case 'buffer':
+        var json = val.toJSON();
+        // Based on the toJSON result
+        json = json.data && json.type ? json.data : json;
+        val = '[Buffer: ' + jsonStringify(json, 2, depth + 1) + ']';
+        break;
+      default:
+        val = (val == '[Function]' || val == '[Circular]')
+          ? val
+          : '"' + val + '"'; //string
+    }
+    return val;
+  }
+
+  for(var i in object) {
+    if(!object.hasOwnProperty(i)) continue;        // not my business
+    --length;
+    str += '\n ' + repeat(' ', space)
+      + (isArray(object) ? '' : '"' + i + '": ') // key
+      +  _stringify(object[i])                   // value
+      + (length ? ',' : '');                     // comma
+  }
+
+  return str + (str.length != 1                    // [], {}
+    ? '\n' + repeat(' ', --space) + end
+    : end);
+}
 
 /**
  * Return if obj is a Buffer
@@ -434,8 +518,6 @@ exports.canonicalize = function(value, stack) {
 
   switch(type) {
     case 'undefined':
-      canonicalizedObj = '[undefined]';
-      break;
     case 'buffer':
     case 'null':
       canonicalizedObj = value;
@@ -446,9 +528,6 @@ exports.canonicalize = function(value, stack) {
           return exports.canonicalize(item, stack);
         });
       });
-      break;
-    case 'date':
-      canonicalizedObj = '[Date: ' + value.toISOString() + ']';
       break;
     case 'function':
       for (prop in value) {
@@ -468,7 +547,9 @@ exports.canonicalize = function(value, stack) {
         });
       });
       break;
+    case 'date':
     case 'number':
+    case 'regexp':
     case 'boolean':
       canonicalizedObj = value;
       break;


### PR DESCRIPTION
This PR should fix some issues in the __Diff viewer__ that depends on the `stringify` function
for example: 
* #1229:
```js
expect(-0).eql(0);  // assert with empty representation
expect({ n: -0 }).eql({ n: 0 });  // same with the canonical behavior
expect(-0).eql(1);
/* representation:
  +expected: 1
  -actual: 0
```
* buffer diff #1132 :
```js
expect(new Buffer([0x01])).eql(new Buffer([0x02])); // asset with empty representation
```
* Infinity,NaN:
```js
expect({ infi: Infinity, nan: NaN }).eql({});
/* representation:
-{
-  "infi": null
-  "nan": null
-}
this happens because JSON.stringify(NaN/Infinity) returns `null`(could fixed with `replacer` function)
```
* Date, RegExp, Function and Circular represents as a string:
```js
var actual = {
  string: "string",
  regex: /^[a-z]/,
  func: function() {},
  date: new Date(0)
};
actual.circular =  actual;
expect(actual).eql({});
/* should represent without the `"` sign(that indicating to string representation)
 -{
 -  "circular": "[Circular]"
 -  "date": "[Date: 1970-01-01T00:00:00.000Z]"
 -  "func": "[Function]"
 -  "regex": "/^[a-z]/"
 -  "string": "string"
 -}

- This PR fixed that and the result will be like so:
 -{
 -  "circular": [Circular]
 -  "date": [Date: 1970-01-01T00:00:00.000Z]
 -  "func": [Function]
 -  "regex": /^[a-z]/
 -  "string": "string"
 -}
```
I changed the current specs, created more tests to get full coverage and did some DRY refactoring