### PR TITLE
Prevent multiple 'grep=' querystring params in html reporter

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -183,6 +183,12 @@ function HTML(runner) {
  */
 var makeUrl = function makeUrl(s) {
   var search = window.location.search;
+
+  // Remove previous grep query parameter if present
+  if (search) {
+    search = search.replace(/[?&]grep=[^&\s]*/g, '').replace(/^&/, '?');
+  }
+
   return window.location.pathname + (search ? search + '&' : '?' ) + 'grep=' + encodeURIComponent(s);
 };
 


### PR DESCRIPTION
Fixes #1494