### PR TITLE
Only use colors if the $TERM has been set to allow for colors

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -33,7 +33,7 @@ exports = module.exports = Base;
  * Enable coloring by default.
  */
 
-exports.useColors = isatty || (process.env.MOCHA_COLORS !== undefined);
+exports.useColors = (isatty && /color/.test(process.env['TERM'])) || (process.env.MOCHA_COLORS !== undefined);
 
 /**
  * Inline diffs instead of +/-


### PR DESCRIPTION
This environment variable has been used historically to tell programs whether the
program may write escape sequences which encode color to stdout and stderr.

TTY detection only determines whether the file descriptor is interactive. It says nothing about
whether it's fit for colors.

Calling `mocha` from within vim, for example, causes some problems:

![screen shot 2015-01-13 at 4 16 52 pm](https://cloud.githubusercontent.com/assets/237985/5732007/dda12590-9b3f-11e4-9d4a-c547507e93d3.png)