### PR TITLE
Fixed the display of the mocha stats bar

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -220,12 +220,16 @@ body {
   font-size: 12px;
   margin: 0;
   color: #888;
+  background-color: #FFF;
+  border: 1px solid #000;
+  box-shadow: 0 0 10px #333;
   z-index: 1;
 }
 
 #mocha-stats .progress {
   float: right;
   padding-top: 0;
+  height: auto;
 }
 
 #mocha-stats em {


### PR DESCRIPTION
Before:
![mocha_before](https://cloud.githubusercontent.com/assets/1090826/5783571/219a19e2-9d92-11e4-9912-bfb464eaa491.PNG)

After:
![mocha_after](https://cloud.githubusercontent.com/assets/1090826/5783573/2790da5c-9d92-11e4-9150-8d6ac6887ece.PNG)
