### PR TITLE
Add randomization support

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -64,6 +64,7 @@ program
   .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
   .option('-R, --reporter <name>', 'specify the reporter to use', 'spec')
   .option('-S, --sort', "sort test files")
+  .option('-a, --randomize <mode>[:seed]', "randomize tests")
   .option('-b, --bail', "bail after first test failure")
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
@@ -267,6 +268,13 @@ if (program.grep) mocha.grep(new RegExp(program.grep));
 // --invert
 
 if (program.invert) mocha.invert();
+
+// --randomize
+
+if (program.randomize) {
+  var matches = program.randomize.split(':');
+  mocha.randomize(matches[0], matches[1]);
+}
 
 // --check-leaks
 

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -91,11 +91,31 @@ module.exports = function(suite){
     };
 
     /**
+     * Do not randomize.
+     */
+    context.describe.noRandom = function func(title, fn) {
+      var suite = context.describe(title, fn);
+      suite.enableRandomize(false);
+      return suite;
+    };
+    // these three are disabled anyway, so don't actually implement noRandom
+    context.describe.noRandom.skip =
+    context.describe.skip.noRandom =
+    context.xdescribe.noRandom     =
+    context.describe.skip;
+
+    /**
      * Exclusive suite.
      */
 
     context.describe.only = function(title, fn){
       var suite = context.describe(title, fn);
+      mocha.grep(suite.fullTitle());
+      return suite;
+    };
+    context.describe.only.noRandom =
+    context.describe.noRandom.only = function(title, fn){
+      var suite = context.describe.noRandom(title, fn);
       mocha.grep(suite.fullTitle());
       return suite;
     };

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -82,11 +82,25 @@ module.exports = function(suite){
     };
 
     /**
+     * Do not randomize.
+     */
+    context.suite.noRandom = function(title, fn) {
+      var suite = context.suite(title, fn);
+      suite.enableRandomize(false);
+      return suite;
+    };
+
+    /**
      * Exclusive test-case.
      */
 
     context.suite.only = function(title, fn){
       var suite = context.suite(title, fn);
+      mocha.grep(suite.fullTitle());
+    };
+    context.suite.only.noRandom =
+    context.suite.noRandom.only = function(title, fn){
+      var suite = context.suite.noRandom(title, fn);
       mocha.grep(suite.fullTitle());
     };
 

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -96,11 +96,26 @@ module.exports = function(suite){
     };
 
     /**
+     * Do not randomize.
+     */
+    context.suite.noRandom = function(title, fn) {
+      var suite = context.suite(title, fn);
+      suite.enableRandomize(false);
+      return suite;
+    };
+    context.suite.noRandom.skip = context.suite.skip;
+
+    /**
      * Exclusive test-case.
      */
 
     context.suite.only = function(title, fn){
       var suite = context.suite(title, fn);
+      mocha.grep(suite.fullTitle());
+    };
+    context.suite.only.noRandom =
+    context.suite.noRandom.only = function(title, fn){
+      var suite = context.suite.noRandom(title, fn);
       mocha.grep(suite.fullTitle());
     };
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -67,6 +67,8 @@ function image(name) {
  *   - `slow` milliseconds to wait before considering a test slow
  *   - `ignoreLeaks` ignore global leaks
  *   - `grep` string or regexp to filter tests with
+ *   - `randomMode` mode for randomization of tests
+ *   - `randomSeed` seed for randomization of tests
  *
  * @param {Object} options
  * @api public
@@ -240,6 +242,24 @@ Mocha.prototype.invert = function(){
 };
 
 /**
+ * Apply randomization to the tests
+ *
+ * @param {String} mode
+ * @param          seed
+ * @return {Mocha}
+ * @api public
+ */
+
+Mocha.prototype.randomize = function(mode, seed){
+  if (mode !== 'tests' /* && mode !== 'suites' && mode !== 'both' */) {
+    throw new Error('unrecognized randomization mode "' + mode + '"');
+  }
+  this.options.randomizeMode = mode;
+  this.options.randomizeSeed = seed != null ? seed : Math.random();
+  return this;
+};
+
+/**
  * Ignore global leaks.
  *
  * @param {Boolean} ignore
@@ -401,6 +421,9 @@ Mocha.prototype.run = function(fn){
   runner.asyncOnly = options.asyncOnly;
   if (options.grep) runner.grep(options.grep, options.invert);
   if (options.globals) runner.globals(options.globals);
+  if (options.randomizeMode !== undefined) {
+    runner.randomize(options.randomizeMode, options.randomizeSeed);
+  }
   if (options.growl) this._growl(runner, reporter);
   if (options.useColors !== undefined) {
     exports.reporters.Base.useColors = options.useColors;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,7 @@
 
 var EventEmitter = require('events').EventEmitter
   , debug = require('debug')('mocha:runner')
+  , randomize = require('knuth-shuffle-seeded')
   , Test = require('./test')
   , utils = require('./utils')
   , filter = utils.filter
@@ -180,6 +181,25 @@ Runner.prototype.checkGlobals = function(test){
   } else if (leaks.length) {
     this.fail(test, new Error('global leak detected: ' + leaks[0]));
   }
+};
+
+/**
+ * Randomize tests in a suite.
+ *
+ * @param seed
+ * @return {Runner} for chaining
+ * @api public
+ */
+
+Runner.prototype.randomize = function(mode, seed){
+  debug('randomize mode: "' + mode + '"; seed: ' + seed);
+  if (mode !== 'tests') return this;
+  this._randomize = function(suite){
+    debug('randomize: ', suite.title, suite._enableRandomize);
+    if (!suite._enableRandomize) return suite.tests;
+    return randomize(suite.tests, seed);
+  }
+  return this;
 };
 
 /**
@@ -388,9 +408,10 @@ Runner.prototype.runTest = function(fn){
 
 Runner.prototype.runTests = function(suite, fn){
   var self = this
-    , tests = suite.tests.slice()
+    , tests
     , test;
-
+  if (self._randomize) self._randomize(self.suite);
+  tests = suite.tests.slice();
 
   function hookErr(err, errSuite, after) {
     // before/after Each hook for errSuite failed:

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -62,6 +62,7 @@ function Suite(title, parentContext) {
   this._enableTimeouts = true;
   this._slow = 75;
   this._bail = false;
+  this._enableRandomize = true;
 }
 
 /**
@@ -85,6 +86,7 @@ Suite.prototype.clone = function(){
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
   suite.bail(this.bail());
+  suite.enableRandomize(this.enableRandomize());
   return suite;
 };
 
@@ -148,6 +150,24 @@ Suite.prototype.bail = function(bail){
   if (0 == arguments.length) return this._bail;
   debug('bail %s', bail);
   this._bail = bail;
+  return this;
+};
+
+/**
+  * Set randomization `enabled`.
+  *
+  * Do NOT use `this.enableRandomize()` in your test; use `describe.noRandom`
+  * instead.
+  *
+  * @param {Boolean} enabled
+  * @return {Suite|Boolean} self or enabled
+  * @api private
+  */
+
+Suite.prototype.enableRandomize = function(enabled){
+  if (arguments.length === 0) return this._enableRandomize;
+  debug('enableRandomize %s', enabled);
+  this._enableRandomize = enabled;
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "glob": "3.2.3",
     "growl": "1.8.1",
     "jade": "0.26.3",
+    "knuth-shuffle-seeded": "~1.0.5",
     "mkdirp": "0.5.0"
   },
   "devDependencies": {

--- a/test/hook.async.js
+++ b/test/hook.async.js
@@ -1,4 +1,4 @@
-describe('async', function(){
+describe.noRandom('async', function(){
   var calls = [];
 
   before(function(){
@@ -43,7 +43,7 @@ describe('async', function(){
     calls.push('parent after' );
   })
 
-  describe('hooks', function(){
+  describe.noRandom('hooks', function(){
     before(function(){
       calls.push('before all');
     });

--- a/test/hook.sync.js
+++ b/test/hook.sync.js
@@ -1,4 +1,4 @@
-describe('serial', function(){
+describe.noRandom('serial', function(){
   var calls = [];
 
   beforeEach(function(){
@@ -9,7 +9,7 @@ describe('serial', function(){
     calls.push('parent after');
   })
 
-  describe('hooks', function(){
+  describe.noRandom('hooks', function(){
     beforeEach(function(){
       calls.push('before');
       if (this.currentTest) {

--- a/test/hook.sync.nested.js
+++ b/test/hook.sync.nested.js
@@ -1,5 +1,5 @@
-describe('serial', function(){
-  describe('nested', function(){
+describe.noRandom('serial', function(){
+  describe.noRandom('nested', function(){
     var calls = [];
 
     beforeEach(function(){
@@ -34,7 +34,7 @@ describe('serial', function(){
         , 'parent before test bar']);
     })
 
-    describe('hooks', function(){
+    describe.noRandom('hooks', function(){
       beforeEach(function(){
         calls.push('before');
         if (this.currentTest) {

--- a/test/runner.js
+++ b/test/runner.js
@@ -73,7 +73,7 @@ describe('Runner', function(){
     })
   })
 
-  describe('.checkGlobals(test)', function(){
+  describe.noRandom('.checkGlobals(test)', function(){
     it('should allow variables that match a wildcard', function(done) {
       runner.globals(['foo*', 'giz*']);
       global.foo = 'baz';


### PR DESCRIPTION
## Big Fat Warning

This is a **WIP**. I just wanted to throw the idea out there and see if there's any feedback before I start writing tests and docs.

## How to use it?

The array shuffling is done with the [knuth-shuffle-seeded](https://www.npmjs.com/package/knuth-shuffle-seeded), my fork of [knuth-shuffle](https://www.npmjs.com/package/knuth-shuffle) that supports seeding.

```
mocha --randomization tests
mocha -a tests
mocha -a tests:mySeed123ee456eeed
```

```js
{
  randomizeMode: 'test'
, randomizeSeed: 'mySeed'
}
```

If your test needs to be tested in a particular order, add `noRandom`:

```js
describe.noRandom('my test', function () {
  [...]
})
```

`noRandom` plays nicely with other modifiers (although I admit the implementation is a little ugly):

```js
describe.noRandom.only()
describe.only.noRandom()
describe.noRandom.skip()
describe.skip.noRandom()
xdescribe.noRandom()
```

## Current state

Currently it only supports test-level randomization (`mode === 'tests'`), which means that only the order of tests within a suite is randomized.

## TODO

- tests
- docs
- suite-level randomization (might be added after this PR)

Fixes #902.