### PR TITLE
In .run(fn), check if fn exists before executing the callback, fixes #1496

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,11 @@ test-sort:
 		--sort \
 		test/acceptance/sort
 
+test-mocha:
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		test/mocha
+
 non-tty:
 	@./bin/mocha \
 		--reporter dot \

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -410,9 +410,7 @@ Mocha.prototype.run = function(fn){
   function done(failures) {
       if (reporter.done) {
           reporter.done(failures, fn);
-      } else {
-          fn(failures);
-      }
+      } else fn && fn(failures);
   }
 
   return runner.run(done);

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -1,0 +1,33 @@
+var Mocha = require('../');
+var Test = Mocha.Test;
+
+describe('Mocha', function(){
+  var blankOpts = { reporter: function(){} }; // no output
+
+  describe('.run(fn)', function(){
+    it('should not raise errors if callback was not provided', function(){
+      var mocha = new Mocha(blankOpts);
+      mocha.run();
+    })
+
+    it('should execute the callback when complete', function(done) {
+      var mocha = new Mocha(blankOpts);
+      mocha.run(function(){
+        done();
+      })
+    })
+
+    it('should execute the callback with the number of failures '+
+      'as parameter', function(done) {
+      var mocha = new Mocha(blankOpts);
+      var failingTest = new Test('failing test', function(){
+        throw new Error('such fail');
+      });
+      mocha.suite.addTest(failingTest);
+      mocha.run(function(failures) {
+        failures.should.equal(1);
+        done();
+      });
+    })
+  })
+})


### PR DESCRIPTION
See issue #1496.