### PR TITLE
Ignore asynchronous errors after global failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ test-outputs/issue1327/case-out.json: test/regression/issue1327/case.js
 test-failing:
 	./bin/mocha \
 		--reporter $(REPORTER) \
-		test/acceptance/failing/timeout.js > /dev/null 2>&1 ; \
+		test/acceptance/failing > /dev/null 2>&1 ; \
 		failures="$$?" ; \
-		if [ "$$failures" != '2' ] ; then \
+		if [ "$$failures" != '3' ] ; then \
 			echo 'test-failing:' ; \
-			echo "  expected 2 failing tests but saw $$failures" ; \
+			echo "  expected 3 failing tests but saw $$failures" ; \
 			exit 1 ; \
 		fi
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -211,6 +211,10 @@ Runnable.prototype.run = function(fn){
     var ms = self.timeout();
     if (self.timedOut) return;
     if (finished) return multiple(err || self._trace);
+
+    // Discard the resolution if this test has already failed asynchronously
+    if (self.state) return;
+
     self.clearTimeout();
     self.duration = new Date - start;
     finished = true;

--- a/test/acceptance/failing/uncaught-and-async.js
+++ b/test/acceptance/failing/uncaught-and-async.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * This file should only generate one test error despite the fact that Mocha is
+ * capable of detecting two distinct exceptions during test execution.
+ */
+
+it('fails exactly once', function(done) {
+  setTimeout(function() {
+    setTimeout(function() {
+      done(new Error('test error'));
+    }, 0);
+    throw new Error('global error');
+  }, 0);
+});


### PR DESCRIPTION
`Runner#uncaught` labels the currently-executing `Runnable` instance as
"failed" in response to uncaught exceptions. If the the `Runnable`
instance later signals failure through Mocha's asynchronous interface,
the `Runner` counts this as a distinct test failure. Consequently,
reporters generate inaccurate reports (and in some cases, this triggers
uncaught exceptions causing the process itself to crash).

When a runnabe completes, explicitly check that it has not already been
labeled as failing before reporting any additional errors.