### PR TITLE
reporters/base: use supports-color to detect colorable term

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -5,7 +5,8 @@
 var tty = require('tty')
   , diff = require('diff')
   , ms = require('../ms')
-  , utils = require('../utils');
+  , utils = require('../utils')
+  , supportsColor = require('supports-color');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -33,7 +34,7 @@ exports = module.exports = Base;
  * Enable coloring by default.
  */
 
-exports.useColors = isatty || (process.env.MOCHA_COLORS !== undefined);
+exports.useColors = supportsColor || (process.env.MOCHA_COLORS !== undefined);
 
 /**
  * Inline diffs instead of +/-

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "glob": "3.2.3",
     "growl": "1.8.1",
     "jade": "0.26.3",
-    "mkdirp": "0.5.0"
+    "mkdirp": "0.5.0",
+    "supports-color": "~1.2.0"
   },
   "devDependencies": {
     "coffee-script": "~1.8.0",


### PR DESCRIPTION
This replaces https://github.com/mochajs/mocha/pull/1497.

Detecting whether a terminal is TTY is not enough
to ensure that it can also support color.
This module, supports-color, is a wholistic solution
which captures the greatest range of possible terminals
with the greatest accuracy. The module is extremely
lightweight and does not represent a burdern to Mocha
users.