### PR TITLE
travis: use docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - '0.11'
 - '0.10'
 - '0.8'
+sudo: false
 notifications:
   slack:
     secure: Xov4Q/jpmTr6p5E/kYeC0HF1tWm0YqBWvCUbNuJiti3CtFpVmOwXEvxGFcvZNAXApEVrs1uhLZLifuL3oJ/TNdqzM5nT5jDGawPYgf8ly+fTaEiCpsRCdQhFLVqYoN671eyx7QILtre9b51SeaFVVksMrfTmvh4aKJCN01iuJm4=


### PR DESCRIPTION
The docker containers are far more abundant and
offer vastly reduced boot time and some increased
CPU power. As long as you don't require 'sudo',
this is the way to go.

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/