### PR TITLE
index: Use custom Gitter badge from shields.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       <p id="tag"><em>simple</em>, <em>flexible</em>, <em>fun</em></p>
 <p>Mocha is a feature-rich JavaScript test framework running on <a href="http://nodejs.org">node.js</a> and the browser, making asynchronous testing simple and fun. Mocha tests run serially, allowing for flexible and accurate reporting, while mapping uncaught exceptions to the correct test cases. Hosted on <a href="https://github.com/mochajs/mocha">GitHub</a>.</p>
 
-<p><a href="https://gitter.im/mochajs/mocha" alt="Gitter" class="badge"><img src="https://badges.gitter.im/Join%20Chat.svg" /></a></p>
+<p><a href="https://gitter.im/mochajs/mocha" alt="Gitter" class="badge"><img src="https://img.shields.io/badge/Gitter-join_chat_%E2%86%92-8A6343.svg?style=flat-square" /></a></p>
 
 <h2 id="features">Features</h2>
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 Mocha is a feature-rich JavaScript test framework running on [node.js](http://nodejs.org) and the browser, making asynchronous testing simple and fun. Mocha tests run serially, allowing for flexible and accurate reporting, while mapping uncaught exceptions to the correct test cases. Hosted on [GitHub](https://github.com/mochajs/mocha).
 
-<a href="https://gitter.im/mochajs/mocha" alt="Gitter" class="badge"><img src="https://badges.gitter.im/Join%20Chat.svg" /></a>
+<a href="https://gitter.im/mochajs/mocha" alt="Gitter" class="badge"><img src="https://img.shields.io/badge/Gitter-join_chat_%E2%86%92-8A6343.svg?style=flat-square" /></a>
 
 <h2 id="features">Features</h2>
 


### PR DESCRIPTION
Prettier, and more consistent with the general color scheme.

Old:
<a href="https://gitter.im/mochajs/mocha" alt="Gitter" class="badge"><img src="https://badges.gitter.im/Join%20Chat.svg" /></a>

New:
<a href="https://gitter.im/mochajs/mocha" alt="Gitter" class="badge"><img src="https://img.shields.io/badge/Gitter-join_chat_%E2%86%92-8A6343.svg?style=flat-square" /></a></p>
 