### PR TITLE
Escape error messages and suite/test URLs in the HTML reporter, not just suite/test titles.

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -100,7 +100,7 @@ function HTML(runner) {
 
     // suite
     var url = self.suiteURL(suite);
-    var el = fragment('<li class="suite"><h1><a href="%s">%s</a></h1></li>', url, escape(suite.title));
+    var el = fragment('<li class="suite"><h1><a href="%e">%e</a></h1></li>', url, suite.title);
 
     // container
     stack[0].appendChild(el);
@@ -131,7 +131,7 @@ function HTML(runner) {
     // test
     if ('passed' == test.state) {
       var url = self.testURL(test);
-      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="%s" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, url);
+      var el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="%e" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, url);
     } else if (test.pending) {
       var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
@@ -216,7 +216,7 @@ HTML.prototype.testURL = function(test){
  */
 
 function error(msg) {
-  document.body.appendChild(fragment('<div id="mocha-error">%s</div>', msg));
+  document.body.appendChild(fragment('<div id="mocha-error">%e</div>', msg));
 }
 
 /**


### PR DESCRIPTION
Needed to get mocha working on an XHTML page.

For a specific example, the arrow that sets the grep parameter in the querystring has a URL with an ampersand. If not escaped, the anchor cannot be added to the page - assigning div.innerHTML fails because the string is not valid XML.