### PR TITLE
Fix trying to unhide suites in the HTML reporter would leave every other suite still hidden.

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -257,8 +257,8 @@ function hideSuitesWithout(classname) {
 
 function unhide() {
   var els = document.getElementsByClassName('suite hidden');
-  for (var i = 0; i < els.length; ++i) {
-    els[i].className = els[i].className.replace('suite hidden', 'suite');
+  while (els.length > 0) {
+    els[0].className = els[0].className.replace('suite hidden', 'suite');
   }
 }
 


### PR DESCRIPTION
document.getElementsByClassName returns a live list, so unhiding a suite would remove it from the list, and incrementing the array index would cause the next hidden suite to be skipped.