### PR TITLE
Fixing errors that prevent mocha.js from loading in the browser - fixes #1558

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -6,7 +6,7 @@ var tty = require('tty')
   , diff = require('diff')
   , ms = require('../ms')
   , utils = require('../utils')
-  , supportsColor = require('supports-color');
+  , supportsColor = process.env ? require('supports-color') : null;
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -31,10 +31,12 @@ var isatty = tty.isatty(1) && tty.isatty(2);
 exports = module.exports = Base;
 
 /**
- * Enable coloring by default.
+ * Enable coloring by default, except in the browser interface.
  */
 
-exports.useColors = supportsColor || (process.env.MOCHA_COLORS !== undefined);
+exports.useColors = process.env
+  ? (supportsColor || (process.env.MOCHA_COLORS !== undefined))
+  : false;
 
 /**
  * Inline diffs instead of +/-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -173,7 +173,7 @@ var isArray = Array.isArray || function (obj) {
  * Buffer.prototype.toJSON polyfill
  * @type {Function}
  */
-if(Buffer && Buffer.prototype) {
+if(typeof Buffer !== 'undefined' && Buffer.prototype) {
   Buffer.prototype.toJSON = Buffer.prototype.toJSON || function () {
     return Array.prototype.slice.call(this, 0);
   };

--- a/mocha.js
+++ b/mocha.js
@@ -1974,7 +1974,7 @@ var tty = require('browser/tty')
   , diff = require('browser/diff')
   , ms = require('../ms')
   , utils = require('../utils')
-  , supportsColor = require('supports-color');
+  , supportsColor = process.env ? require('supports-color') : null;
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -1999,10 +1999,12 @@ var isatty = tty.isatty(1) && tty.isatty(2);
 exports = module.exports = Base;
 
 /**
- * Enable coloring by default.
+ * Enable coloring by default, except in the browser interface.
  */
 
-exports.useColors = supportsColor || (process.env.MOCHA_COLORS !== undefined);
+exports.useColors = process.env
+  ? (supportsColor || (process.env.MOCHA_COLORS !== undefined))
+  : false;
 
 /**
  * Inline diffs instead of +/-
@@ -5845,7 +5847,7 @@ var isArray = Array.isArray || function (obj) {
  * Buffer.prototype.toJSON polyfill
  * @type {Function}
  */
-if(Buffer && Buffer.prototype) {
+if(typeof Buffer !== 'undefined' && Buffer.prototype) {
   Buffer.prototype.toJSON = Buffer.prototype.toJSON || function () {
     return Array.prototype.slice.call(this, 0);
   };


### PR DESCRIPTION
Fixing a few issues caused by recent commits that break when mocha.js is loaded in the browser:

https://github.com/mochajs/mocha/commit/eab389f3f106290e8386520a2f3b8206c18c486e introduced `require('supports-color')`, which is not available in the browser.

https://github.com/mochajs/mocha/commit/00ef54cd41d46b1c29358942dc0874e2ae7da0ff added `if(Buffer && ...)` usage, which doesn't work in browsers.