### PR TITLE
optionally set suite name in xunit reporter

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -57,7 +57,7 @@ function XUnit(runner, options) {
 
   runner.on('end', function(){
     self.write(tag('testsuite', {
-        name: 'Mocha Tests'
+        name: (options.reporterOptions && options.reporterOptions.suiteName) || 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
       , errors: stats.failures


### PR DESCRIPTION
My use case is that I am running the same tests in different browsers, and so it would be useful for reporting in our CI system to have the suites named "ie_11" and "firefox_33", etc.