### PR TITLE
Fix passing of args intended for node/iojs.

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -7,7 +7,7 @@
 
 var spawn = require('child_process').spawn,
   path = require('path'),
-  args = [process.execPath, path.join(__dirname, '_mocha')];
+  args = [path.join(__dirname, '_mocha')];
 
 process.argv.slice(2).forEach(function(arg){
   var flag = arg.split('=')[0];
@@ -48,7 +48,7 @@ process.argv.slice(2).forEach(function(arg){
   }
 });
 
-var proc = spawn(args[0], args.slice(1), { stdio: 'inherit' });
+var proc = spawn(process.execPath, args, { stdio: 'inherit' });
 proc.on('exit', function (code, signal) {
   process.on('exit', function(){
     if (signal) {


### PR DESCRIPTION
The recent commit 1430c2b5102e9d355119a643e9b2be2e76e91d1f inadvertently broke the ability pass arguments to node/iojs before running mocha -- note that arguments intended for the executable are _prepended_ to args; the previous commit assumes that args[0] will be the executable, but that is only correct if no args intended for the executable have been `unshift`ed onto args.

So, if you try, for instance:

`mocha --harmony ...`

... you'll get an `ENOENT` error as `spawn` tries to execute a file named `--harmony`.


See #1548 for the origin of this issue.
