### PR TITLE
Prevent default browser behavior for failure/pass links

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -29,8 +29,8 @@ exports = module.exports = HTML;
 
 var statsTemplate = '<ul id="mocha-stats">'
   + '<li class="progress"><canvas width="40" height="40"></canvas></li>'
-  + '<li class="passes"><a href="#">passes:</a> <em>0</em></li>'
-  + '<li class="failures"><a href="#">failures:</a> <em>0</em></li>'
+  + '<li class="passes"><a href="javascript://">passes:</a> <em>0</em></li>'
+  + '<li class="failures"><a href="javascript://">failures:</a> <em>0</em></li>'
   + '<li class="duration">duration: <em>0</em>s</li>'
   + '</ul>';
 

--- a/mocha.js
+++ b/mocha.js
@@ -2650,8 +2650,8 @@ exports = module.exports = HTML;
 
 var statsTemplate = '<ul id="mocha-stats">'
   + '<li class="progress"><canvas width="40" height="40"></canvas></li>'
-  + '<li class="passes"><a href="#">passes:</a> <em>0</em></li>'
-  + '<li class="failures"><a href="#">failures:</a> <em>0</em></li>'
+  + '<li class="passes"><a href="javascript://">passes:</a> <em>0</em></li>'
+  + '<li class="failures"><a href="javascript://">failures:</a> <em>0</em></li>'
   + '<li class="duration">duration: <em>0</em>s</li>'
   + '</ul>';
 


### PR DESCRIPTION
Changed href in HTML reporter to prevent default behavior. 

This can be an issue when using mocha in integration testing with a booted application (ember in my case)