### PR TITLE
Add Promise & Coroutine support to Runnable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 script: travis_retry npm test
 node_js:
+- 'iojs'
 - '0.12'
 - '0.11'
 - '0.10'

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -5,6 +5,7 @@
 var EventEmitter = require('events').EventEmitter
   , debug = require('debug')('mocha:runnable')
   , Pending = require('./pending')
+  , co = require('co')
   , milliseconds = require('./ms')
   , utils = require('./utils');
 
@@ -40,8 +41,8 @@ module.exports = Runnable;
 
 function Runnable(title, fn) {
   this.title = title;
-  this.fn = fn;
-  this.async = fn && fn.length;
+  this.fn = this.normalize(fn);
+  this.async = this.fn && (this.fn.then || this.fn.length);
   this.sync = ! this.async;
   this._timeout = 2000;
   this._slow = 75;
@@ -55,6 +56,35 @@ function Runnable(title, fn) {
  */
 
 Runnable.prototype.__proto__ = EventEmitter.prototype;
+
+/**
+ * Wraps any passed Promise or GeneratorFunction in a thunk.
+ *
+ * @param {Function} fn
+ * @return {Function}
+ * @api private
+ */
+Runnable.prototype.normalize = function(fn) {
+  if (!fn) return fn;
+
+  // Promises need to be wrapped to avoid errors from use of fn.call
+  // with a non-promise scope
+  if (typeof fn.then === 'function') {
+    return function(done) {
+      fn.then(function() {
+        done();
+      }, function(err) {
+        done(err || new Error('Promise.reject called without error'));
+      });
+    };
+  } else if (fn.constructor && fn.constructor.name === 'GeneratorFunction') {
+    return function(done) {
+      co(fn).then(done, done);
+    };
+  }
+
+  return fn;
+};
 
 /**
  * Set & get timeout `ms`.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test": "make test-all"
   },
   "dependencies": {
+    "co": "~4.4.0",
     "commander": "2.3.0",
     "debug": "2.0.0",
     "diff": "1.0.8",

--- a/test/harmony/runnable.generators.js
+++ b/test/harmony/runnable.generators.js
@@ -1,0 +1,53 @@
+var mocha = require('../../')
+  , utils = mocha.utils
+  , Runnable = mocha.Runnable
+  , EventEmitter = require('events').EventEmitter
+  , should = require('should');
+
+module.exports = function() {
+  describe('when fn is a GeneratorFunction', function() {
+    it('should invoke the callback', function(done) {
+      var invoked = false;
+      var test = new Runnable('foo', function* () {
+        yield new Promise(function(resolve, reject) {
+          var cb = function() {
+            invoked = true;
+            resolve();
+          };
+          process.nextTick(cb);
+        });
+      });
+
+      test.run(function(err) {
+        should(!err).ok;
+        invoked.should.equal(true);
+        done();
+      });
+    });
+
+    it('should invoke the callback with an error if thrown', function(done) {
+      var expectedErr = new Error('GeneratorFunction test');
+      var test = new Runnable('foo', function* () {
+        throw expectedErr;
+      });
+
+      test.run(function(err) {
+        err.should.equal(expectedErr);
+        done();
+      });
+    });
+
+    it('does not require the callback', function(done) {
+      var invoked = false;
+      var test = new Runnable('foo', function* () {
+        invoked = true;
+      });
+
+      test.run(function(err) {
+        should(!err).ok;
+        invoked.should.equal(true);
+        done();
+      });
+    });
+  });
+};


### PR DESCRIPTION
Hi! Sorry in advance for not creating an issue to discuss this idea. I only just read the contribution guidelines. Would love to hear what people think about this though! I'm finding it pretty useful already. :)

So quick overview. This adds coroutine (via co) and promise support to runnables (specs and hooks). I really only wanted to take advantage of coroutines for my test suite, but promises were a freebie.

``` javascript
it('Example Coroutine', function* () {
  // Coroutines are free of callbacks!
  yield somePromise("It's beautiful");
});

it('A longer example', function* () {
  // Get user
  var user = yield getUserAsync(1);
  // Get all their posts
  var posts = yield user.getPostsAsync();

  // Get a unique list of category names to which
  // the posts belong
  var categories = posts.map(function() {
    return yield post.getCategoryName();
  }).sort().filter(function(name, pos) {
    return !pos || name != a[pos - 1];
  });

  categories.should.equal(['general', 'programming']);
});

it('Example Promise', new Promise(function(resolve, reject) {
  // Promises get double the callbacks
  console.log("I don't know why anyone would use promises for this");
  resolve();
}).then(function() {
  return Promise.resolve();
}));
```

Here's a bit more of a demo:

``` javascript
var assert = require('assert');

describe('This Pull Request', function() {
  it('enables the use of GeneratorFunctions for coroutines', function* () {
    var str = yield new Promise(function(res) {
      process.nextTick(function() {res('foo'); });
    });

    assert.equal(str, 'foo');
  });

  it('allowing us to avoid some nesting in specs', function* () {
    // We can use synchronous-looking logic!
    var str1 = yield Promise.resolve('foo');
    var str2 = yield Promise.resolve('foo');
    var str3 = yield new Promise(function(res) {
      process.nextTick(function() {res('bar'); });
    });

    // Showing an error
    assert.equal(str1, str2);
    assert.equal(str2, str3, 'Intentional error');
  });

  it('also enables the use of promises', new Promise(function(resolve, reject) {
    resolve();
  }));

  it('which is less important', new Promise(function(resolve, reject) {
    reject(new Error('Intentional error'));
  }));
});
```

```
$ ./mocha/bin/mocha exampleSpec.js


  This Pull Request
    ✓ enables the use of GeneratorFunctions for coroutines
    1) allowing us to avoid some nesting in specs
    ✓ also enables the use of promises
    2) which is less important


  2 passing (12ms)
  2 failing

  1) This Pull Request allowing us to avoid some nesting in specs:
     AssertionError: Intentional error
      at /Users/danielstjules/git/exampleSpec.js:22:12
      at GeneratorFunctionPrototype.next (native)
      at onFulfilled (/Users/danielstjules/git/mocha/node_modules/co/index.js:61:19)
      at runMicrotasksCallback (node.js:331:7)
      at process._tickCallback (node.js:350:11)

  2) This Pull Request which is less important:
     Error: Intentional error
      at /Users/danielstjules/git/exampleSpec.js:30:12
      at Suite.<anonymous> (/Users/danielstjules/git/exampleSpec.js:29:33)
      at context.describe.context.context (/Users/danielstjules/git/mocha/lib/interfaces/bdd.js:49:10)
      at Object.<anonymous> (/Users/danielstjules/git/exampleSpec.js:3:1)
      at Module._compile (module.js:444:26)
      at Object.Module._extensions..js (module.js:462:10)
      at Module.load (module.js:339:32)
      at Function.Module._load (module.js:294:12)
      at Module.require (module.js:349:17)
      at require (module.js:368:17)
      at /Users/danielstjules/git/mocha/lib/mocha.js:186:27
      at Array.forEach (native)
      at Mocha.loadFiles (/Users/danielstjules/git/mocha/lib/mocha.js:183:14)
      at Mocha.run (/Users/danielstjules/git/mocha/lib/mocha.js:404:31)
      at Object.<anonymous> (/Users/danielstjules/git/mocha/bin/_mocha:400:16)
      at Module._compile (module.js:444:26)
      at Object.Module._extensions..js (module.js:462:10)
      at Module.load (module.js:339:32)
      at Function.Module._load (module.js:294:12)
      at Function.Module.runMain (module.js:485:10)
      at startup (node.js:112:16)
      at node.js:863:3
```