### PR TITLE
Ignore asynchronous failures after spec resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ test-failing:
 		--reporter $(REPORTER) \
 		test/acceptance/failing > /dev/null 2>&1 ; \
 		failures="$$?" ; \
-		if [ "$$failures" != '3' ] ; then \
+		if [ "$$failures" != '4' ] ; then \
 			echo 'test-failing:' ; \
-			echo "  expected 3 failing tests but saw $$failures" ; \
+			echo "  expected 4 failing tests but saw $$failures" ; \
 			exit 1 ; \
 		fi
 

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ test-outputs/issue1327/case-out.json: test/regression/issue1327/case.js
 test-failing:
 	./bin/mocha \
 		--reporter $(REPORTER) \
-		test/acceptance/failing/timeout.js > /dev/null 2>&1 ; \
+		test/acceptance/failing > /dev/null 2>&1 ; \
 		failures="$$?" ; \
-		if [ "$$failures" != '2' ] ; then \
+		if [ "$$failures" != '3' ] ; then \
 			echo 'test-failing:' ; \
-			echo "  expected 2 failing tests but saw $$failures" ; \
+			echo "  expected 3 failing tests but saw $$failures" ; \
 			exit 1 ; \
 		fi
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -211,6 +211,10 @@ Runnable.prototype.run = function(fn){
     var ms = self.timeout();
     if (self.timedOut) return;
     if (finished) return multiple(err || self._trace);
+
+    // Discard the resolution if this test has already failed asynchronously
+    if (self.state) return;
+
     self.clearTimeout();
     self.duration = new Date - start;
     finished = true;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -569,12 +569,11 @@ Runner.prototype.uncaught = function(err){
   var runnable = this.currentRunnable;
   if (!runnable) return;
 
-  var wasAlreadyDone = runnable.state;
-  this.fail(runnable, err);
-
   runnable.clearTimeout();
 
-  if (wasAlreadyDone) return;
+  // Ignore errors if complete
+  if (runnable.state) return;
+  this.fail(runnable, err);
 
   // recover from test
   if ('test' == runnable.type) {

--- a/test/acceptance/failing/uncaught-and-async.js
+++ b/test/acceptance/failing/uncaught-and-async.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * This file should only generate one test error despite the fact that Mocha is
+ * capable of detecting two distinct exceptions during test execution.
+ */
+
+it('fails exactly once', function(done) {
+  setTimeout(function() {
+    setTimeout(function() {
+      done(new Error('test error'));
+    }, 0);
+    throw new Error('global error');
+  }, 0);
+});

--- a/test/acceptance/failing/uncaught-and-async.js
+++ b/test/acceptance/failing/uncaught-and-async.js
@@ -1,15 +1,26 @@
 'use strict';
 
 /**
- * This file should only generate one test error despite the fact that Mocha is
- * capable of detecting two distinct exceptions during test execution.
+ * This file should only generate one failure per spec despite the fact that
+ * Mocha is capable of detecting two distinct exceptions during test execution.
  */
 
-it('fails exactly once', function(done) {
+it('fails exactly once when a global error is thrown first', function(done) {
   setTimeout(function() {
+    throw new Error('global error');
+
     setTimeout(function() {
       done(new Error('test error'));
     }, 0);
+  }, 0);
+});
+
+it('fails exactly once when a global error is thrown second', function(done) {
+  setTimeout(function() {
+    done(new Error('test error'));
+  }, 0);
+
+  setTimeout(function() {
     throw new Error('global error');
   }, 0);
 });


### PR DESCRIPTION
This improves on https://github.com/mochajs/mocha/pull/1540 From that thread:

Given the following test, which only has one spec:

``` javascript
it('fails exactly once when a global error is thrown first', function(done) {
  setTimeout(function() {
    throw new Error('global error');

    setTimeout(function() {
      done(new Error('test error'));
    }, 0);
  }, 0);
});
```

You get two two failures:

``` javascript
$ ./bin/mocha pr1540.js

  ․․

  0 passing (6ms)
  2 failing

  1)  fails exactly once:
     Error: test error
      at null._onTimeout (/Users/danielstjules/git/mocha/pr1540.js:10:12)
      at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
      at timers.js:117:18
      at process._tickCallback (node.js:415:13)
      at process._tickFromSpinner (node.js:390:15)

  2)  fails exactly once:
     Error: test error
      at null._onTimeout (/Users/danielstjules/git/mocha/pr1540.js:10:12)
      at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
      at timers.js:117:18
      at process._tickCallback (node.js:415:13)
      at process._tickFromSpinner (node.js:390:15)
```

But after this PR, it correctly only shows one failure, and highlights the error thrown first ("global error"):

``` javascript
$ ./bin/mocha pr1540.js

  ․

  0 passing (6ms)
  1 failing

  1)  fails exactly once:
     Uncaught Error: global error
      at null._onTimeout (/Users/danielstjules/git/mocha/pr1540.js:12:11)
      at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```

In addition to the above fix, this PR improves on #1540 by also correctly handling the following test case:

``` javascript
it('fails exactly once when a global error is thrown second', function(done) {
  setTimeout(function() {
    done(new Error('test error'));
  }, 0);

  setTimeout(function() {
    throw new Error('global error');
  }, 0);
});
```

It now also only reports a single failing spec, rather than two.