### PR TITLE
Add --fgrep. Use grep for RegExp, fgrep for str

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -65,8 +65,9 @@ program
   .option('-b, --bail', "bail after first test failure")
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-f, --fgrep <string>', 'only run tests containing <string>')
   .option('-gc, --expose-gc', 'expose gc extension')
-  .option('-i, --invert', 'inverts --grep matches')
+  .option('-i, --invert', 'inverts --grep and --fgrep matches')
   .option('-r, --require <name>', 'require the given module')
   .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
   .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
@@ -265,6 +266,10 @@ mocha.suite.bail(program.bail);
 // --grep
 
 if (program.grep) mocha.grep(new RegExp(program.grep));
+
+// --fgrep
+
+if (program.fgrep) mocha.grep(program.fgrep);
 
 // --invert
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -76,7 +76,8 @@ function Mocha(options) {
   options = options || {};
   this.files = [];
   this.options = options;
-  this.grep(options.grep);
+  if (options.grep) this.grep(new RegExp(options.grep));
+  if (options.fgrep) this.grep(options.fgrep);
   this.suite = new exports.Suite('', new exports.Context);
   this.ui(options.ui);
   this.bail(options.bail);

--- a/support/tail.js
+++ b/support/tail.js
@@ -140,6 +140,7 @@ mocha.run = function(fn){
 
   var query = Mocha.utils.parseQuery(global.location.search || '');
   if (query.grep) mocha.grep(new RegExp(query.grep));
+  if (query.fgrep) mocha.grep(query.fgrep);
   if (query.invert) mocha.invert();
 
   return Mocha.prototype.run.call(mocha, function(err){

--- a/test/grep.js
+++ b/test/grep.js
@@ -3,13 +3,20 @@ var Mocha = require('../');
 describe('Mocha', function(){
   describe('"grep" option', function(){
     it('should add a RegExp to the mocha.options object', function(){
-      var mocha = new Mocha({ grep: /foo/ });
-      mocha.options.grep.toString().should.equal('/foo/');
+      var mocha = new Mocha({ grep: /foo.*/ });
+      mocha.options.grep.toString().should.equal('/foo.*/');
     })
 
-    it('should convert grep string to a RegExp', function(){
-      var mocha = new Mocha({ grep: 'foo' });
-      mocha.options.grep.toString().should.equal('/foo/');
+    it('should convert string to a RegExp', function(){
+      var mocha = new Mocha({ grep: 'foo.*' });
+      mocha.options.grep.toString().should.equal('/foo.*/');
+    })
+  })
+
+  describe('"fgrep" option', function(){
+    it('should escape and convert string to a RegExp', function(){
+      var mocha = new Mocha({ fgrep: 'foo.*' });
+      mocha.options.grep.toString().should.equal('/foo\\.\\*/');
     })
   })
 


### PR DESCRIPTION
Finished https://github.com/mochajs/mocha/pull/632, which had already been +1'ed. This also updates the names to be in line with the following comment: https://github.com/mochajs/mocha/pull/632#issuecomment-54741917

``` javascript
$ cat example.js
it('foo()', function(done) {
  done();
});
$ ./bin/mocha --grep 'foo.*' example.js

  ․

  1 passing (3ms)

$ ./bin/mocha --fgrep 'foo.*' example.js


  0 passing (1ms)
$ ./bin/mocha -i --fgrep 'foo.*' example.js

  ․

  1 passing (3ms)
$ ./bin/mocha --fgrep 'foo' example.js

  ․

  1 passing (3ms)
```