### PR TITLE
[Fix] Exclude not own properties when looping on options

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -6437,7 +6437,11 @@ mocha.ui = function(ui){
 
 mocha.setup = function(opts){
   if ('string' == typeof opts) opts = { ui: opts };
-  for (var opt in opts) this[opt](opts[opt]);
+  for (var opt in opts) {
+    if (opts.hasOwnProperty(opt)) {
+        this[opt](opts[opt]);
+    }
+  }
   return this;
 };
 


### PR DESCRIPTION
I've been using [mocha-phantomjs][1] along with chai to unit test my Javascript libraries and it appears that Mocha ends up in error when one of those libraries adds a property to Object's prototype.

For instance, when adding a function myMethod to the prototype :
```javascript
Object.prototype.myMethod = function () { // ... };
```

running mocha-phantomjs outputs :
```sh
$ mocha-phantomjs my-runner.html
Unable to open file 'spec'
```

Excluding extra properties from the setup loop seems to solve the problem.

[1]: https://github.com/metaskills/mocha-phantomjs