### PR TITLE
Stricter .only for suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lib-cov:
 
 test: test-unit
 
-test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers test-sort test-glob test-requires test-reporters test-only test-failing test-regression
+test-all: test-bdd test-tdd test-qunit test-exports test-unit test-grep test-jsapi test-compilers test-sort test-glob test-requires test-reporters test-only test-suite-only test-failing test-regression
 
 test-jsapi:
 	@node test/jsapi
@@ -163,6 +163,22 @@ test-only:
 		--reporter $(REPORTER) \
 		--ui qunit \
 		test/acceptance/misc/only/qunit
+
+test-suite-only:
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		--ui tdd \
+		test/acceptance/misc/only/suite-tdd
+
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		--ui bdd \
+		test/acceptance/misc/only/suite-bdd
+
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		--ui qunit \
+		test/acceptance/misc/only/suite-qunit
 
 test-sort:
 	@./bin/mocha \

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -71,7 +71,8 @@ module.exports = function(suite){
 
     context.describe.only = function(title, fn){
       var suite = context.describe(title, fn);
-      mocha.grep(suite.fullTitle());
+      var reString = '^' + escapeRe(suite.fullTitle()) + ' ';
+      mocha.grep(new RegExp(reString));
       return suite;
     };
 

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -62,7 +62,8 @@ module.exports = function(suite){
 
     context.suite.only = function(title, fn){
       var suite = context.suite(title, fn);
-      mocha.grep(suite.fullTitle());
+      var reString = '^' + escapeRe(suite.fullTitle()) + ' ';
+      mocha.grep(new RegExp(reString));
     };
 
     /**

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -76,7 +76,8 @@ module.exports = function(suite){
 
     context.suite.only = function(title, fn){
       var suite = context.suite(title, fn);
-      mocha.grep(suite.fullTitle());
+      var reString = '^' + escapeRe(suite.fullTitle()) + ' ';
+      mocha.grep(new RegExp(reString));
     };
 
     /**

--- a/test/acceptance/misc/only/bdd.js
+++ b/test/acceptance/misc/only/bdd.js
@@ -7,7 +7,11 @@ describe('should only run .only test in this bdd suite', function() {
     var zero = 0;
     zero.should.equal(0, 'this .only test should run');
   });
-  it('should run this test, not (includes the title of the .only test)', function() {
+  it('should run this test, not (title of the .only test is a prefix of this)', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+  it('(title of the .only test is a suffix of this) NOT should run this test', function() {
     var zero = 0;
     zero.should.equal(1, 'this test should have been skipped');
   });

--- a/test/acceptance/misc/only/qunit.js
+++ b/test/acceptance/misc/only/qunit.js
@@ -10,6 +10,9 @@ test('should not run this test', function() {
 test.only('should run this test', function() {
   ok(0 === 0, 'this .only test should run');
 });
-test('should run this test, not (includes the title of the .only test)', function() {
+test('should run this test, not (title of the .only test is a prefix of this)', function() {
+  ok(0 === 1, 'this test should have been skipped');
+});
+test('(title of the .only test is a suffix of this) NOT should run this test', function() {
   ok(0 === 1, 'this test should have been skipped');
 });

--- a/test/acceptance/misc/only/suite-bdd.js
+++ b/test/acceptance/misc/only/suite-bdd.js
@@ -1,0 +1,27 @@
+describe('should not run this bdd suite', function() {
+  it('should not run this test', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+});
+
+describe.only('should run this .only bdd suite', function() {
+  it('should run this test', function() {
+    var zero = 0;
+    zero.should.equal(0, 'this test in a .only suite should run');
+  });
+});
+
+describe('should run this .only bdd suite, not (title of the .only suite is a prefix of this with no space)', function() {
+  it('should not run this test', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+});
+
+describe('(title of the .only suite is a suffix of this) NOT should run this .only bdd suite', function() {
+  it('should not run this test', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+});

--- a/test/acceptance/misc/only/suite-qunit.js
+++ b/test/acceptance/misc/only/suite-qunit.js
@@ -1,0 +1,27 @@
+function ok(expr, msg) {
+  if (!expr) throw new Error(msg);
+}
+
+suite('should not run this qunit suite');
+
+test('should not run this test', function() {
+  ok(0 === 1, 'this test should have been skipped');
+});
+
+suite.only('should run this .only qunit suite');
+
+test('should run this test', function() {
+  ok(0 === 0, 'this test in a .only suite should run');
+});
+
+suite('should run this .only qunit suite, not (title of the .only suite is a prefix of this with no space)');
+
+test('should not run this test', function() {
+  ok(0 === 1, 'this test should have been skipped');
+});
+
+suite('(title of the .only suite is a suffix of this) NOT should run this .only qunit suite');
+
+test('should not run this test', function() {
+  ok(0 === 1, 'this test should have been skipped');
+});

--- a/test/acceptance/misc/only/suite-tdd.js
+++ b/test/acceptance/misc/only/suite-tdd.js
@@ -1,0 +1,27 @@
+suite('should not run this tdd suite', function() {
+  test('should not run this test', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+});
+
+suite.only('should run this .only tdd suite', function() {
+  test.only('should run this test', function() {
+    var zero = 0;
+    zero.should.equal(0, 'this test in a .only suite should run');
+  });
+});
+
+suite('should run this .only tdd suite, not (title of the .only suite is a prefix of this with no space)', function() {
+  test('should not run this test', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+});
+
+suite('(title of the .only suite is a suffix of this) NOT should run this .only tdd suite', function() {
+  test('should not run this test', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+});

--- a/test/acceptance/misc/only/tdd.js
+++ b/test/acceptance/misc/only/tdd.js
@@ -7,7 +7,11 @@ suite('should only run .only test in this tdd suite', function() {
     var zero = 0;
     zero.should.equal(0, 'this .only test should run');
   });
-  test('should run this test, not (includes the title of the .only test)', function() {
+  test('should run this test, not (title of the .only test is a prefix of this)', function() {
+    var zero = 0;
+    zero.should.equal(1, 'this test should have been skipped');
+  });
+  test('(title of the .only test is a suffix of this) NOT should run this test', function() {
     var zero = 0;
     zero.should.equal(1, 'this test should have been skipped');
   });


### PR DESCRIPTION
Suites whose names are a superset of the .only suite shouldn't wind up also running.

Similar to PR #941, an earlier fix for .only on tests.

Unlike 941, this doesn't _fully_ fix the bug for suite names -- because test names are concatenated to suite names, the grep can't be as strict. When the name of the .only suite + `" "` is a prefix of another suite's name, that other suite will still run even with this fix.  But it's still an improvement, and fixes the specific unexpected behavior I was running into (when suites are named after the classes they test, and base classes / interfaces are often a prefix of the names of other classes).