### PR TITLE
Remove trailing whitespace from reporter output

### DIFF
--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -27,7 +27,7 @@ function Dot(runner) {
     , n = -1;
 
   runner.on('start', function(){
-    process.stdout.write('\n  ');
+    process.stdout.write('\n');
   });
 
   runner.on('pending', function(test){

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -54,14 +54,14 @@ function Spec(runner) {
     if ('fast' == test.speed) {
       var fmt = indent()
         + color('checkmark', '  ' + Base.symbols.ok)
-        + color('pass', ' %s ');
+        + color('pass', ' %s');
       cursor.CR();
       console.log(fmt, test.title);
     } else {
       var fmt = indent()
         + color('checkmark', '  ' + Base.symbols.ok)
-        + color('pass', ' %s ')
-        + color(test.speed, '(%dms)');
+        + color('pass', ' %s')
+        + color(test.speed, ' (%dms)');
       cursor.CR();
       console.log(fmt, test.title, test.duration);
     }


### PR DESCRIPTION
Fixes https://github.com/mochajs/mocha/issues/1574

```
$ cat example.js
it('test', function() {});
it('test2', function() {});
it('test3', function(done) { setTimeout(done, 180); });

$ ./bin/mocha example.js > output.txt

# Output

  <- two spaces here
  ․․․

  3 passing (185ms)

$ ./bin/mocha --reporter spec example.js > output.txt

# Output


  ✓ test <- space here
  ✓ test2 <- another space
  ✓ test3 (182ms)

  3 passing (185ms)
```

After the PR:

```
$ ./bin/mocha example.js > output.txt
# Output


  ․․․

  3 passing (185ms)

$ ./bin/mocha --reporter spec example.js > output.txt


  ✓ test
  ✓ test2
  ✓ test3 (182ms)

  3 passing (187ms)
```