### PR TITLE
Fix #1582, adding global object save/restore capabilities

### DIFF
--- a/lib/global-object.js
+++ b/lib/global-object.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var utils = require('./utils');
+
+/**
+ * Expose `GlobalObject`.
+ */
+
+module.exports = GlobalObject;
+
+/**
+ * Initialize `GlobalObject`.
+ *
+ */
+function GlobalObject() {
+  if (!(this instanceof GlobalObject)) {
+    return new GlobalObject();
+  }
+  this._cache = null;
+}
+
+/**
+ * Cache all functions in the `global object.
+ *
+ * @api public
+ */
+
+GlobalObject.prototype.save = function(){
+  if (!this._cache) {
+    this._cache = saveGlobalObject(global);
+  }
+  return this._cache;
+};
+
+/**
+ * Restore cached functions back to the global object.
+ *
+ * @api public
+ */
+
+GlobalObject.prototype.restore = function(){
+  if (this._cache) {
+    restoreGlobalObject(this._cache, global);
+  }
+}
+
+function saveGlobalObject(object, checklist) {
+  var checklist = checklist ? checklist : [];
+  var val = {};
+
+  if (utils.type(object) === 'global' && arguments.length > 1) {
+    return;
+  }
+
+  for(var i=0; i<checklist.length; i++) {
+    if (checklist === checklist[i]) {
+      return;
+    }
+  }
+  checklist.push(object);
+
+  for(var prop in object) {
+    if(utils.type(object[prop]) === 'object' || utils.type(object[prop]) === 'process') {
+      val[prop] = saveGlobalObject(object[prop], checklist);
+    }
+
+    if(utils.type(object[prop]) === 'function') {
+      val[prop] = object[prop];
+    }
+  }
+
+  return val;
+}
+
+
+function restoreGlobalObject(source, target) {
+  for(var prop in source) {
+    if(utils.type(source[prop]) === 'object' || utils.type(source[prop]) === 'process') {
+      if ('object' !== typeof target[prop]) {
+        target[prop] = {};
+      }
+      restoreGlobalObject(source[prop], target[prop]);
+    }
+    
+    if(utils.type(source[prop]) === 'function') {
+      target[prop] = source[prop]
+    }
+  }
+}
+

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -6,7 +6,8 @@ var EventEmitter = require('events').EventEmitter
   , debug = require('debug')('mocha:runnable')
   , Pending = require('./pending')
   , milliseconds = require('./ms')
-  , utils = require('./utils');
+  , utils = require('./utils')
+  , GlobalObject = require('./global-object');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -194,7 +195,8 @@ Runnable.prototype.run = function(fn){
     , start = new Date
     , ctx = this.ctx
     , finished
-    , emitted;
+    , emitted
+    , globalObject = GlobalObject();
 
   // Some times the ctx exists but it is not runnable
   if (ctx && ctx.runnable) ctx.runnable(this);
@@ -208,6 +210,8 @@ Runnable.prototype.run = function(fn){
 
   // finished
   function done(err) {
+    // restore global object
+    globalObject.restore();
     var ms = self.timeout();
     if (self.timedOut) return;
     if (finished) return multiple(err || self._trace);
@@ -224,6 +228,9 @@ Runnable.prototype.run = function(fn){
 
   // for .resetTimeout()
   this.callback = done;
+
+  // save global object
+  globalObject.save();
 
   // explicit async with `done` argument
   if (this.async) {

--- a/test/global-object.js
+++ b/test/global-object.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var mocha = require('../')
+  , Suite = mocha.Suite
+  , Runner = mocha.Runner
+  , Runnable = mocha.Runnable
+  , Test = mocha.Test
+  , GlobalObject = require('../lib/global-object');
+
+describe('GlobalObject()', function() {
+  var globalObject = GlobalObject();
+  var original, dummyFn;
+
+  before(function() {
+    globalObject.save();
+    original = {
+      consoleLog: console.log,
+      consoleError: console.error,
+      processStdoutWrite: process.stdout.write
+    };
+    dummyFn = function() {};
+  })
+
+  it('should restore global object upon calling .restore()', function() {
+    console.log = dummyFn;
+    console.error = dummyFn;
+    process.stdout.write = dummyFn;
+
+    globalObject.restore();
+
+    console.log.should.not.equal(dummyFn);
+    console.log.should.equal(original.consoleLog);
+
+    console.error.should.not.equal(dummyFn);
+    console.error.should.equal(original.consoleError);
+
+    process.stdout.write.should.not.equal(dummyFn);
+    process.stdout.write.should.equal(original.processStdoutWrite);
+  });
+
+  it('should restore global object on sync test completion', function(done){
+    var test = new Runnable('foo', function(){
+      console.log = dummyFn;
+      console.error = dummyFn;
+      process.stdout.write = dummyFn;
+    });
+
+    test.run(function() {
+      console.log.should.not.equal(dummyFn);
+      console.log.should.equal(original.consoleLog);
+
+      console.error.should.not.equal(dummyFn);
+      console.error.should.equal(original.consoleError);
+
+      process.stdout.write.should.not.equal(dummyFn);
+      process.stdout.write.should.equal(original.processStdoutWrite);
+      done();
+    });
+  });
+
+  it('should restore global object on async test completion', function(done){
+    var test = new Runnable('foo', function(testDone){
+      console.log = dummyFn;
+      console.error = dummyFn;
+      process.stdout.write = dummyFn;
+      process.nextTick(testDone);
+    });
+
+    test.run(function() {
+      console.log.should.not.equal(dummyFn);
+      console.log.should.equal(original.consoleLog);
+
+      console.error.should.not.equal(dummyFn);
+      console.error.should.equal(original.consoleError);
+
+      process.stdout.write.should.not.equal(dummyFn);
+      process.stdout.write.should.equal(original.processStdoutWrite);
+      done();
+    });
+  });
+
+  it('should restore global object on test failure', function(done){
+    var test = new Runnable('foo', function(){
+      console.log = dummyFn;
+      console.error = dummyFn;
+      process.stdout.write = dummyFn;
+      throw new Error('Test failed.')
+    });
+
+    test.run(function() {
+      console.log.should.not.equal(dummyFn);
+      console.log.should.equal(original.consoleLog);
+
+      console.error.should.not.equal(dummyFn);
+      console.error.should.equal(original.consoleError);
+
+      process.stdout.write.should.not.equal(dummyFn);
+      process.stdout.write.should.equal(original.processStdoutWrite);
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
This is a fix for issue #1582, which reports that functions in the `global` object that were poisoned during a test (e.g. stubbed or otherwise altered) were not restored upon test completion.

The PR creates a module that provides for saving/caching the `global` object (during the first call to `GlobalObject.save()`), as well as restoring it from cache when needed (by calling `GlobalObject.restore()`).

`Runnable` now includes a call to `GlobalObject.save()` just before kicking off a test, and a call to `GlobalObject.restore()` on the callback invoked upon test completion (whether successful or not).

#### Example
In the example below, every test stubs the `console.log()` method, rendering it useless, unless it is explicitly restored.
```js
$ cat example.js
describe('suite', function() {
  before(function() {
    console.log('before: should work');
  });
  it('example 1', function() {
    console.log('example1: should work');
    console.log = function() {};
    console.log('example1: should not work');
  });
  it('example 2', function() {
    console.log('example2: should work');
    console.log = function() {};
    console.log('example2: should not work');
  });
  after(function() {
    console.log('after: should work');
  });
});
```

#### Before Fix
When `console.log()` is stubbed in test `example 1`, it remains so, even after the test is complete. As a result, output from successive tests, the `after()` hook, and the reporter are all suppressed.
```bash
$ ./bin/mocha -R spec example.js

  suite
before: should work
example1: should work
```

#### After Fix
I corrected this by restoring the global object, upon test completion. In my example, now `console.log()` functionality is restored on every successive test, as well as the `after()` hook. Reporter output is, likewise, no longer suppresed.
```bash
$ ./bin/mocha -R spec example.js

  suite
before: should work
example1: should work
    ✓ example 1 
example2: should work
    ✓ example 2 
after: should work


  2 passing (35ms)
```