### PR TITLE
fix issue where menu overlaps content.

### DIFF
--- a/lib/reporters/templates/style.html
+++ b/lib/reporters/templates/style.html
@@ -8,7 +8,7 @@ body {
 }
 
 #coverage {
-  padding: 60px;
+  padding: 60px 400px 60px 60px;
 }
 
 h1 a {
@@ -124,6 +124,10 @@ footer span {
   padding: 15px 0;
   text-align: right;
   border-left: 1px solid #eee;
+  max-width: 400px;
+  overflow: auto;
+  white-space: nowrap;
+  
   -moz-box-shadow: 0 0 2px #888
      , inset 5px 0 20px rgba(0,0,0,.5)
      , inset 5px 0 3px rgba(0,0,0,.3);


### PR DESCRIPTION
There are more improvements that could be made, for example it'd be nice to be able to collapse the menu all together, but at least the fixes the current issue I'm having which is, if my file names are long, the menu covers up the content and I am not able to scroll so my content is completely hidden.