### PR TITLE
support --es_staging flag for iojs

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -79,6 +79,7 @@ program
   .option('--debug-brk', "enable node's debugger breaking on the first line")
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--harmony', 'enable all harmony features (except typeof)')
+  .option('--es_staging', 'enable all staged features')
   .option('--harmony-collections', 'enable harmony collections (sets, maps, and weak maps)')
   .option('--harmony-generators', 'enable harmony generators')
   .option('--harmony-proxies', 'enable harmony proxies')

--- a/bin/mocha
+++ b/bin/mocha
@@ -51,6 +51,7 @@ process.argv.slice(2).forEach(function(arg){
       break;
     case '--gc-global':
     case '--harmony':
+    case '--es_staging':
     case '--harmony-proxies':
     case '--harmony-collections':
     case '--harmony-generators':


### PR DESCRIPTION
As per https://iojs.org/en/es6.html this is a (prefered) synonym for --harmony.