### PR TITLE
Mocha should now exit active domains after the completion of a test

### DIFF
--- a/lib/browser/domain.js
+++ b/lib/browser/domain.js
@@ -1,0 +1,7 @@
+/**
+ * Browse shim for node.js domain module
+ */
+
+module.exports = {
+	active : false
+}

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -3,7 +3,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter
-  , domain = require("domain")
+  , domain = require('domain')
   , debug = require('debug')('mocha:runnable')
   , Pending = require('./pending')
   , milliseconds = require('./ms')

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -209,7 +209,7 @@ Runnable.prototype.run = function(fn){
 
   // finished
   function done(err) {
-    // if (domain.active) { domain.active.exit(); }
+    if (domain.active) { domain.active.exit(); }
     
     var ms = self.timeout();
     if (self.timedOut) return;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -3,6 +3,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter
+  , domain = require("domain")
   , debug = require('debug')('mocha:runnable')
   , Pending = require('./pending')
   , milliseconds = require('./ms')
@@ -208,6 +209,8 @@ Runnable.prototype.run = function(fn){
 
   // finished
   function done(err) {
+    // if (domain.active) { domain.active.exit(); }
+    
     var ms = self.timeout();
     if (self.timedOut) return;
     if (finished) return multiple(err || self._trace);

--- a/support/compile.js
+++ b/support/compile.js
@@ -49,7 +49,8 @@ function parseRequires(js) {
     .replace(/require\('tty'\)/g                  , "require('browser/tty')")
     .replace(/require\('escape-string-regexp'\)/g , "require('browser/escape-string-regexp')")
     .replace(/require\('glob'\)/g                 , "require('browser/glob')")
-    .replace(/require\('fs'\)/g                   , "require('browser/fs')");
+    .replace(/require\('fs'\)/g                   , "require('browser/fs')")
+    .replace(/require\('domain'\)/g               , "require('browser/domain')");
 }
 
 /**


### PR DESCRIPTION
Due to the way the callbacks chain in Node, if a domain was entered within a test, no matter how deep, then that domain would propagate to other tests later in the suite and cause lots of confusing conditions.

In order to correct this I simply check for an active domain and exit. Pull request includes a test for this condition.