### PR TITLE
Fixed broken link on html-cov reporter

### DIFF
--- a/lib/reporters/templates/menu.jade
+++ b/lib/reporters/templates/menu.jade
@@ -10,4 +10,4 @@
         if segments.length
           span.dirname= segments.join('/') + '/'
         span.basename= basename
-  a#logo(href='http://visionmedia.github.io/mocha/') m
+  a#logo(href='http://mochajs.org/') m


### PR DESCRIPTION
The icon link on a html-cov reporter leads to a 404'd page I changed it to go to the website instead.