### PR TITLE
Fix 1585: make _mocha executable again

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Module dependencies.
  */


### PR DESCRIPTION
This is for https://github.com/mochajs/mocha/issues/1585

After merging, I think it'd be a good idea to push a new patch release, since both 2.2.0/2.2.1 broke backwards compatibility for those relying on `_mocha` being executable.

To show that it's compatible with https://github.com/mochajs/mocha/commit/1430c2b5102e9d355119a643e9b2be2e76e91d1f

``` javascript
$ cat example.js
it('test', function() {
  var gen = function*() {};
});

$ node --version
v0.12.0

$ ./bin/mocha --harmony-generators example.js

  ․

  1 passing (4ms)

$ nvm use 0.10
Now using node v0.10.20

# Env has node 0.10, but using node 0.12
$ /Users/danielstjules/.nvm/versions/node/v0.12.0/bin/node ./bin/mocha --harmony-generators example.js

  ․

  1 passing (5ms)

# Env has node 0.10, using node 0.10
$ ./bin/mocha --harmony-generators example.js
Error: unrecognized flag --harmony-generators
Try --help for options

/Users/danielstjules/git/mocha/example.js:2
  var gen = function*() {};
```