### PR TITLE
Fix 1606: fix err handling in IE <= 8 and non-ES5 browsers

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -206,7 +206,7 @@ Runner.prototype.fail = function(test, err) {
     err = new Error('the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)');
   }
 
-  err.stack = this.fullStackTrace
+  err.stack = (this.fullStackTrace || !err.stack)
     ? err.stack
     : stackFilter(err.stack);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -677,7 +677,7 @@ exports.stackTraceFilter = function() {
   return function(stack) {
     stack = stack.split('\n');
 
-    stack = stack.reduce(function (list, line) {
+    stack = exports.reduce(stack, function(list, line) {
       if (is.node && (isNodeModule(line) ||
         isMochaInternal(line) ||
         isNodeInternal(line)))

--- a/mocha.js
+++ b/mocha.js
@@ -4779,7 +4779,7 @@ Runner.prototype.fail = function(test, err) {
     err = new Error('the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)');
   }
 
-  err.stack = this.fullStackTrace
+  err.stack = (this.fullStackTrace || !err.stack)
     ? err.stack
     : stackFilter(err.stack);
 
@@ -6372,7 +6372,7 @@ exports.stackTraceFilter = function() {
   return function(stack) {
     stack = stack.split('\n');
 
-    stack = stack.reduce(function (list, line) {
+    stack = exports.reduce(stack, function(list, line) {
       if (is.node && (isNodeModule(line) ||
         isMochaInternal(line) ||
         isNodeInternal(line)))


### PR DESCRIPTION
Fixes #1606

``` html
<html>
<head>
  <meta charset="utf-8">
  <title>Mocha Tests</title>
  <link rel="stylesheet" href="mocha.css" />
</head>
<body>
  <div id="mocha"></div>
  <script src="mocha.js"></script>
  <script>mocha.setup('bdd')</script>
  <script>
    it('test', function() {
      throw new Error('uh oh!');
    });
  </script>
  <script>
    mocha.run();
  </script>
</body>
</html>
```

**Before**

![screen shot 2015-03-22 at 11 09 57 pm](https://cloud.githubusercontent.com/assets/817212/6775141/f7fddf52-d0e9-11e4-991f-35a750e5471b.png)

**After**

![screen shot 2015-03-22 at 11 08 51 pm](https://cloud.githubusercontent.com/assets/817212/6775143/fd15fbaa-d0e9-11e4-90ba-453ecda3bad8.png)


Edit: Ugly PR screenshots :(