### PR TITLE
Fix 1604: Add support for async skip()

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -659,7 +659,15 @@ Runner.prototype.runSuite = function(suite, fn) {
  * @api private
  */
 Runner.prototype.uncaught = function(err) {
-  if (err) {
+  var runnable = this.currentRunnable;
+  var pending;
+
+  if (err instanceof Pending) {
+    if (runnable.type === 'test') {
+      runnable.pending = true;
+    }
+    pending = true;
+  } else if (err) {
     debug('uncaught exception %s', err !== function() {
       return this;
     }.call(err) ? err : (err.message || err));
@@ -668,8 +676,6 @@ Runner.prototype.uncaught = function(err) {
     err = undefinedError();
   }
   err.uncaught = true;
-
-  var runnable = this.currentRunnable;
 
   if (!runnable) {
     runnable = new Runnable('Uncaught error outside test suite');
@@ -693,7 +699,16 @@ Runner.prototype.uncaught = function(err) {
   if (runnable.state) {
     return;
   }
-  this.fail(runnable, err);
+
+  if (pending && runnable.type === 'test') {
+    // Async skip() call from test
+    this.emit('pending', runnable);
+  } else if (pending) {
+    // Async skip() call from hook
+    runnable.callback(err);
+  } else {
+    this.fail(runnable, err);
+  }
 
   // recover from test
   if (runnable.type === 'test') {
@@ -717,8 +732,10 @@ Runner.prototype.uncaught = function(err) {
     return this.nextSuite(errSuite);
   }
 
-  // bail
-  this.emit('end');
+  // bail on hooks if not skipped
+  if (!pending) {
+    this.emit('end');
+  }
 };
 
 /**

--- a/test/integration/fixtures/pending/skip.async.before.js
+++ b/test/integration/fixtures/pending/skip.async.before.js
@@ -1,0 +1,17 @@
+describe('skip in asynchronous before', function() {
+  before(function(done){
+    var hook = this;
+    setTimeout(function() {
+      hook.skip();
+      throw new Error('never thrown');
+    }, 0);
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+});

--- a/test/integration/fixtures/pending/skip.async.beforeEach.js
+++ b/test/integration/fixtures/pending/skip.async.beforeEach.js
@@ -1,0 +1,17 @@
+describe('skip in asynchronous beforeEach', function() {
+  beforeEach(function(done){
+    var hook = this;
+    setTimeout(function() {
+      hook.skip();
+      throw new Error('never thrown');
+    }, 0);
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+});

--- a/test/integration/fixtures/pending/skip.async.spec.js
+++ b/test/integration/fixtures/pending/skip.async.spec.js
@@ -1,0 +1,11 @@
+describe('skip in asynchronous test', function() {
+  it('should skip when called from a test', function(done) {
+    var test = this;
+    setTimeout(function() {
+      test.skip();
+      throw new Error('never thrown');
+    }, 0);
+  });
+
+  it('should run other tests in the suite', function() {});
+});

--- a/test/integration/pending.js
+++ b/test/integration/pending.js
@@ -60,4 +60,47 @@ describe('pending', function() {
       });
     });
   });
+
+  describe('asynchronous skip()', function() {
+    this.timeout(1000);
+
+    describe('in spec', function() {
+      it('should immediately skip the spec and run all others', function(done) {
+        run('pending/skip.async.spec.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 1);
+          assert.equal(res.stats.passes, 1);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+
+    describe('in before', function() {
+      it('should skip all suite specs', function(done) {
+        run('pending/skip.async.before.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.passes, 0);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+
+    describe('in beforeEach', function() {
+      it('should skip all suite specs', function(done) {
+        run('pending/skip.async.beforeEach.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.passes, 0);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This is for https://github.com/mochajs/mocha/issues/1604

``` javascript
it('should skip', function(done) {
  var test = this;

  setTimeout(function() {
    test.skip();
  }, 0);
});

it('should run', function() {
  // do nothing
});
```

```
dstjules:~/git/mocha (master=)
$ ./bin/mocha example.js

  ․․

  1 passing (14ms)
  1 failing

  1)  should skip:
     Error: the object {
  "message": [undefined]
  "uncaught": true
} was thrown, throw an Error :)
      at Runner.fail (lib/runner.js:206:11)
      at Runner.uncaught (lib/runner.js:583:8)
      at process.uncaught (lib/runner.js:612:10)

dstjules:~/git/mocha (master=)
$ git checkout issue-1604
Switched to branch 'issue-1604'

dstjules:~/git/mocha (issue-1604)
$ ./bin/mocha example.js

  ․․

  1 passing (6ms)
  1 pending
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1618)
<!-- Reviewable:end -->
