### PR TITLE
Fix 1556: Update utils.clean to handle newlines in func declarations

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -237,7 +237,7 @@ exports.slug = function(str){
 exports.clean = function(str) {
   str = str
     .replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, '')
-    .replace(/^function *\(.*\) *{|\(.*\) *=> *{?/, '')
+    .replace(/^function *\(.*\)\s*{|\(.*\) *=> *{?/, '')
     .replace(/\s+\}$/, '');
 
   var spaces = str.match(/^\n?( *)/)[1].length

--- a/mocha.js
+++ b/mocha.js
@@ -5932,7 +5932,7 @@ exports.slug = function(str){
 exports.clean = function(str) {
   str = str
     .replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, '')
-    .replace(/^function *\(.*\) *{|\(.*\) *=> *{?/, '')
+    .replace(/^function *\(.*\)\s*{|\(.*\) *=> *{?/, '')
     .replace(/\s+\}$/, '');
 
   var spaces = str.match(/^\n?( *)/)[1].length

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,6 +8,10 @@ describe('utils', function() {
       clean('function  (one, two, three)  {\n//code\n}').should.equal('//code');
     });
 
+    it('should handle newlines in the function declaration', function() {
+      clean('function  (one, two, three)\n  {\n//code\n}').should.equal('//code');
+    });
+
     it('should remove space character indentation from the function body', function() {
       clean('  //line1\n    //line2').should.equal('//line1\n  //line2');
     });


### PR DESCRIPTION
Fixes https://github.com/mochajs/mocha/issues/1556

``` html
<html>
<head>
  <meta charset="utf-8">
  <title>Mocha Tests</title>
  <link rel="stylesheet" href="mocha.css" />
</head>
<body>
  <div id="mocha"></div>
  <script src="mocha.js"></script>
  <script>mocha.setup('bdd')</script>
  <script>
    it(
        'test case',
        function ()
        {
            say('hi!');
        }
    );
  </script>
  <script>
    mocha.checkLeaks();
    mocha.globals(['jQuery']);
    mocha.run();
  </script>
</body>
</html>
```

**Before**

![screen shot 2015-03-23 at 12 53 30 am](https://cloud.githubusercontent.com/assets/817212/6776177/b1855d48-d0f8-11e4-9568-3ec326de54a7.png)


**After**

![screen shot 2015-03-23 at 12 59 14 am](https://cloud.githubusercontent.com/assets/817212/6776176/af6f275a-d0f8-11e4-8302-6c6024ed2301.png)