### PR TITLE
Pass `--allow-natives-syntax` flag to node.

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -63,6 +63,7 @@ process.argv.slice(2).forEach(function(arg){
     case '--prof':
     case '--throw-deprecation':
     case '--trace-deprecation':
+    case '--allow-natives-syntax':
       args.unshift(arg);
       break;
     default:


### PR DESCRIPTION
This allows the passing of the `--allow-natives-syntax` flag into the node binary.

[Some literature about allow-natives-syntax](http://dailyjs.com/2014/06/26/optimization-killers/)