### PR TITLE
Add support for some underscored harmony flags as well

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -53,8 +53,11 @@ process.argv.slice(2).forEach(function(arg){
     case '--harmony':
     case '--es_staging':
     case '--harmony-proxies':
+    case '--harmony_proxies':
     case '--harmony-collections':
+    case '--harmony_collections':
     case '--harmony-generators':
+    case '--harmony_generators':
     case '--harmony_shipping':
     case '--harmony_arrow_functions':
     case '--harmony_proxies':


### PR DESCRIPTION
This adds support for both hyphen and underscored flags. (at least a few of them)

Here's my reasoning: I'm trying to run CI tests against several versions of node. (0.10, 0.11, 0.12 and iojs to be precise) I'm using generators in my code, so:

 * iojs breaks if I add `--harmony-generators`
 * 0.11 and 0.12 require `--harmony-generators`
 * 0.10 doesn't support generators at all, but I'm using gnode as a last-resort fallback

Rather than doing fancy "version sniffing", I've opted to use a clever shell script to determine if the `node` executable supports the generators flag, and using that to make my determination: 

```sh
$ node --v8-options | grep generators | cut -d ' ' -f 3
--harmony_generators
```

Unfortunately, passing this value directly to `mocha` breaks, since `v8-options` uses the underscores instead of the hyphens. (but the node exe definitely acknowledges both in all cases I've tested)

**tl;dr**: I know it's ugly, but I think this pattern will be useful to others while transitioning between node 0.10/11/12+ and iojs. Thanks :)