### PR TITLE
fix(reporter/base): don't assume error message is first line of stack

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -168,11 +168,18 @@ exports.list = function(failures){
     var err = test.err
       , message = err.message || ''
       , stack = err.stack || message
-      , index = stack.indexOf(message) + message.length
-      , msg = stack.slice(0, index)
+      , index = stack.indexOf(message)
       , actual = err.actual
       , expected = err.expected
       , escape = true;
+    if (index === -1) {
+      msg = message;
+    } else {
+      index += message.length;
+      msg = stack.slice(0, index);
+      // remove msg from stack
+      stack = stack.slice(index + 1);
+    }
 
     // uncaught
     if (err.uncaught) {
@@ -198,9 +205,8 @@ exports.list = function(failures){
       }
     }
 
-    // indent stack trace without msg
-    stack = stack.slice(index ? index + 1 : index)
-      .replace(/^/gm, '  ');
+    // indent stack trace
+    stack = stack.replace(/^/gm, '  ');
 
     console.log(fmt, (i + 1), test.fullTitle(), msg, stack);
   });

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -186,7 +186,8 @@ exports.list = function(failures){
       msg = 'Uncaught ' + msg;
     }
     // explicitly show diff
-    if (err.showDiff !== false && sameType(actual, expected)) {
+    if (err.showDiff !== false && sameType(actual, expected)
+        && expected !== undefined) {
 
       if ('string' !== typeof actual) {
         escape = false;

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -40,8 +40,8 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.match(/actual/);
-      errOut.should.match(/expected/);
+      errOut.should.match(/\- actual/);
+      errOut.should.match(/\+ expected/);
     });
 
     it('should show diffs if property set to `true`', function () {
@@ -55,8 +55,8 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.match(/actual/);
-      errOut.should.match(/expected/);
+      errOut.should.match(/\- actual/);
+      errOut.should.match(/\+ expected/);
     });
 
     it('should not show diffs when showDiff property set to `false`', function () {
@@ -69,9 +69,23 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.not.match(/actual/);
-      errOut.should.not.match(/expected/);
+      errOut.should.not.match(/\- actual/);
+      errOut.should.not.match(/\+ expected/);
     });
+
+    it('should not show diffs when expected is not defined', function () {
+      var err = new Error('ouch')
+        , errOut;
+
+      var test = makeTest(err);
+
+      Base.list([test]);
+
+      errOut = stdout.join('\n');
+      errOut.should.not.match(/\- actual/);
+      errOut.should.not.match(/\+ expected/);
+    });
+
   });
 
   it('should not stringify strings', function () {
@@ -88,8 +102,8 @@ describe('Base reporter', function () {
     errOut = stdout.join('\n');
     errOut.should.not.match(/"/);
     errOut.should.match(/test/);
-    errOut.should.match(/actual/);
-    errOut.should.match(/expected/);
+    errOut.should.match(/\- actual/);
+    errOut.should.match(/\+ expected/);
   });
 
   it('should stringify objects', function () {
@@ -106,8 +120,8 @@ describe('Base reporter', function () {
     errOut = stdout.join('\n');
     errOut.should.match(/"key"/);
     errOut.should.match(/test/);
-    errOut.should.match(/actual/);
-    errOut.should.match(/expected/);
+    errOut.should.match(/\- actual/);
+    errOut.should.match(/\+ expected/);
   });
 
   it('should remove message from stack', function () {

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -1,29 +1,43 @@
 var Base   = require('../../lib/reporters/base')
   , Assert = require('assert').AssertionError;
 
+function makeTest(err) {
+  return {
+    err: err,
+    fullTitle: function () {
+      return 'test title';
+    }
+  };
+}
+
 describe('Base reporter', function () {
+  var stdout
+    , stdoutWrite
+    , useColors;
+
+  beforeEach(function () {
+    stdout = [];
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+    useColors = Base.useColors;
+    Base.useColors = false;
+  });
+
+  afterEach(function () {
+    process.stdout.write = stdoutWrite;
+    Base.useColors = useColors;
+  });
 
   describe('showDiff', function() {
     it('should show diffs by default', function () {
       var err = new Assert({ actual: 'foo', expected: 'bar' })
-        , stdout = []
-        , stdoutWrite = process.stdout.write
         , errOut;
 
-      var test = {
-        err: err,
-        fullTitle: function () {
-          return 'test title';
-        }
-      };
-
-      process.stdout.write = function (string) {
-        stdout.push(string);
-      };
+      var test = makeTest(err);
 
       Base.list([test]);
-
-      process.stdout.write = stdoutWrite;
 
       errOut = stdout.join('\n');
       errOut.should.match(/actual/);
@@ -32,25 +46,13 @@ describe('Base reporter', function () {
 
     it('should show diffs if property set to `true`', function () {
       var err = new Assert({ actual: 'foo', expected: 'bar' })
-        , stdout = []
-        , stdoutWrite = process.stdout.write
         , errOut;
 
       err.showDiff = true;
-      var test = {
-        err: err,
-        fullTitle: function () {
-          return 'test title';
-        }
-      };
+      var test = makeTest(err);
 
-      process.stdout.write = function (string) {
-        stdout.push(string);
-      };
 
       Base.list([test]);
-
-      process.stdout.write = stdoutWrite;
 
       errOut = stdout.join('\n');
       errOut.should.match(/actual/);
@@ -59,25 +61,12 @@ describe('Base reporter', function () {
 
     it('should not show diffs when showDiff property set to `false`', function () {
       var err = new Assert({ actual: 'foo', expected: 'bar' })
-        , stdout = []
-        , stdoutWrite = process.stdout.write
         , errOut;
 
       err.showDiff = false;
-      var test = {
-        err: err,
-        fullTitle: function () {
-          return 'test title';
-        }
-      };
-
-      process.stdout.write = function (string) {
-        stdout.push(string);
-      };
+      var test = makeTest(err);
 
       Base.list([test]);
-
-      process.stdout.write = stdoutWrite;
 
       errOut = stdout.join('\n');
       errOut.should.not.match(/actual/);
@@ -87,67 +76,38 @@ describe('Base reporter', function () {
 
   it('should not stringify strings', function () {
     var err = new Error('test'),
-      stdout = [],
-      stdoutWrite = process.stdout.write,
       errOut;
 
     err.actual = "a1";
     err.expected = "e2";
     err.showDiff = true;
-    var test = {
-      err: err,
-      fullTitle: function () {
-        return 'title';
-      }
-    };
-
-    process.stdout.write = function (string) {
-      stdout.push(string);
-    };
+    var test = makeTest(err);
 
     Base.list([test]);
 
-    process.stdout.write = stdoutWrite;
-
     errOut = stdout.join('\n');
-
     errOut.should.not.match(/"/);
     errOut.should.match(/test/);
     errOut.should.match(/actual/);
     errOut.should.match(/expected/);
-
   });
-
 
   it('should stringify objects', function () {
     var err = new Error('test'),
-      stdout = [],
-      stdoutWrite = process.stdout.write,
       errOut;
 
     err.actual = {key:"a1"};
     err.expected = {key:"e1"};
     err.showDiff = true;
-    var test = {
-      err: err,
-      fullTitle: function () {
-        return 'title';
-      }
-    };
-
-    process.stdout.write = function (string) {
-      stdout.push(string);
-    };
+    var test = makeTest(err);
 
     Base.list([test]);
 
-    process.stdout.write = stdoutWrite;
-
     errOut = stdout.join('\n');
-
     errOut.should.match(/"key"/);
     errOut.should.match(/test/);
     errOut.should.match(/actual/);
     errOut.should.match(/expected/);
   });
+
 });

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -110,4 +110,32 @@ describe('Base reporter', function () {
     errOut.should.match(/expected/);
   });
 
+  it('should remove message from stack', function () {
+    var err = {
+      message: 'Error',
+      stack: 'Error\nfoo\nbar',
+      showDiff: false
+    };
+    var test = makeTest(err);
+
+    Base.list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar')
+  });
+
+  it('should not modify stack if it does not contain message', function () {
+    var err = {
+      message: 'Error',
+      stack: 'foo\nbar',
+      showDiff: false
+    };
+    var test = makeTest(err);
+
+    Base.list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar')
+  });
+
 });


### PR DESCRIPTION
The current implementation assumes that the first line of the err.stack is the error message. This is not the case for Safari. When using Mocha with a different HTML generator (e.g. Consolify) this produces weirdly formatted output with no error message.

I don't know how to come up with a test case for this. Please advise if there is anything I can provide.
The attached screenshot was produced with `mochify --consolify runner.html`.

![stacktrace](https://cloud.githubusercontent.com/assets/332271/6859707/6e322108-d41c-11e4-93b9-72a0a32ed6aa.png)
