### PR TITLE
Reverse multi-line diffs to standard order

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -384,8 +384,8 @@ function unifiedDiff(err, escape) {
     if (escape) {
       line = escapeInvisibles(line);
     }
-    if (line[0] === '+') return indent + colorLines('diff added', line);
-    if (line[0] === '-') return indent + colorLines('diff removed', line);
+    if (line[0] === '+') return indent + '-' + colorLines('diff removed', line.substring(1));
+    if (line[0] === '-') return indent + '+' + colorLines('diff added', line.substring(1));
     if (line.match(/\@\@/)) return null;
     if (line.match(/\\ No newline/)) return null;
     else return indent + line;
@@ -393,11 +393,11 @@ function unifiedDiff(err, escape) {
   function notBlank(line) {
     return line != null;
   }
-  var msg = diff.createPatch('string', err.actual, err.expected);
+  var msg = diff.createPatch('string', err.expected, err.actual);
   var lines = msg.split('\n').splice(4);
   return '\n      '
-         + colorLines('diff added',   '+ expected') + ' '
-         + colorLines('diff removed', '- actual')
+         + colorLines('diff removed', '- actual') + ' '
+         + colorLines('diff added',   '+ expected')
          + '\n\n'
          + lines.map(cleanUp).filter(notBlank).join('\n');
 }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -384,8 +384,8 @@ function unifiedDiff(err, escape) {
     if (escape) {
       line = escapeInvisibles(line);
     }
-    if (line[0] === '+') return indent + '-' + colorLines('diff removed', line.substring(1));
-    if (line[0] === '-') return indent + '+' + colorLines('diff added', line.substring(1));
+    if (line[0] === '+') return indent + colorLines('diff removed', '-' + line.substring(1));
+    if (line[0] === '-') return indent + colorLines('diff added', '+' + line.substring(1));
     if (line.match(/\@\@/)) return null;
     if (line.match(/\\ No newline/)) return null;
     else return indent + line;


### PR DESCRIPTION
Display multi-line diffs in the same standard order as `diff`, `git`, etc:

```diff
- actual / removed
+ expected / added
```

The current order is unintuitive which makes it harder to read at a glance:

```diff
+ expected / added
- actual / removed
```

Pending resolution of https://github.com/kpdecker/jsdiff/issues/14 this works by reversing the `added` and `removed` strings passed to `diff.createPatch`, and then reversing the `+` and `-` status of each change.