### PR TITLE
Fix diff colors

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -66,8 +66,8 @@ exports.colors = {
   , 'green': 32
   , 'light': 90
   , 'diff gutter': 90
-  , 'diff added': 42
-  , 'diff removed': 41
+  , 'diff added': 32
+  , 'diff removed': 31
 };
 
 /**


### PR DESCRIPTION
This fixes diffs being unnecessarily hard to read:

Before
![screen shot 2015-04-08 at 2 19 29 pm](https://cloud.githubusercontent.com/assets/227022/7053484/21374a02-ddfb-11e4-9074-4ef54629e1a3.png)

After
![screen shot 2015-04-08 at 2 22 03 pm](https://cloud.githubusercontent.com/assets/227022/7053485/26f375ce-ddfb-11e4-8cb8-93f786f16cb1.png)

Others are experiencing the same issue with standard terminal color schemes too:  https://github.com/mochajs/mocha/issues/1200#issuecomment-59562618

- Fixes #802
- Fixes #1200
- Fixes #1212 for diff output
