### PR TITLE
Throw an exception when timeout too large.

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -65,6 +65,7 @@ Runnable.prototype.__proto__ = EventEmitter.prototype;
 Runnable.prototype.timeout = function(ms){
   if (0 == arguments.length) return this._timeout;
   if (ms === 0) this._enableTimeouts = false;
+  if (ms > Math.pow(2, 31)) throw new RangeError('Timeout too large, must be less than 2^31');
   if ('string' == typeof ms) ms = milliseconds(ms);
   debug('timeout %d', ms);
   this._timeout = ms;

--- a/test/runnable.js
+++ b/test/runnable.js
@@ -40,6 +40,13 @@ describe('Runnable(title, fn)', function(){
     })
   })
 
+  describe('#timeout(ms) when ms>2^31', function(){
+    it('should throw an error', function () {
+      var run = new Runnable;
+      run.timeout.bind(run, 1e10).should.throw(/Timeout too large/);
+    });
+  });
+
   describe('#enableTimeouts(enabled)', function(){
     it('should set enabled', function(){
       var run = new Runnable;


### PR DESCRIPTION
closes #1644

I'm not sure if the error should be thrown or passed to something—let me know if it needs changing.