### PR TITLE
fix 'location is not defined' error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -647,7 +647,7 @@ exports.stackTraceFilter = function() {
       : { browser: true }
     , cwd = is.node
       ? process.cwd() + slash
-      : location.href.replace(/\/[^\/]*$/, '/');
+      : window.location.href.replace(/\/[^\/]*$/, '/');
 
   function isNodeModule (line) {
     return (~line.indexOf('node_modules'));


### PR DESCRIPTION
I receive the error `ReferenceError: location is not defined` when running Mocha tests via Gulp. I'm using jsdom to mock the `document` and `window`, which is resulting in the global `location` being undefined unless I explicitly do `global.location = '{};` (or utilize this fix).