### PR TITLE
Added option to allow unhandled exceptions to propagate in the browser (rel #1659)

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -402,6 +402,18 @@ Mocha.prototype.noHighlighting = function() {
 };
 
 /**
+ * Enable uncaught errors to propagate (in browser).
+ *
+ * @return {Mocha}
+ * @api public
+ */
+
+Mocha.prototype.allowUncaught = function(){
+  this.options.allowUncaught = true;
+  return this;
+};
+
+/**
  * Delay root suite execution.
  * @returns {Mocha}
  * @api public
@@ -428,6 +440,7 @@ Mocha.prototype.run = function(fn){
   runner.ignoreLeaks = false !== options.ignoreLeaks;
   runner.fullStackTrace = options.fullStackTrace;
   runner.asyncOnly = options.asyncOnly;
+  runner.allowUncaught = options.allowUncaught;
   if (options.grep) runner.grep(options.grep, options.invert);
   if (options.globals) runner.globals(options.globals);
   if (options.growl) this._growl(runner, reporter);

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -229,21 +229,19 @@ Runnable.prototype.run = function(fn){
   if (this.async) {
     this.resetTimeout();
 
-    try {
-      this.fn.call(ctx, function(err){
-        if (err instanceof Error || toString.call(err) === "[object Error]") return done(err);
-        if (null != err) {
-          if (Object.prototype.toString.call(err) === '[object Object]') {
-            return done(new Error('done() invoked with non-Error: ' + JSON.stringify(err)));
-          } else {
-            return done(new Error('done() invoked with non-Error: ' + err));
-          }
-        }
-        done();
-      });
+    if (this.allowUncaught) {
+      callFnAsync(this.fn);
+    } else try {
+      callFnAsync(this.fn);
     } catch (err) {
       done(utils.getError(err));
     }
+    return;
+  }
+
+  if (this.allowUncaught) {
+    callFn(this.fn);
+    done();
     return;
   }
 
@@ -276,5 +274,19 @@ Runnable.prototype.run = function(fn){
 
       done();
     }
+  }
+
+  function callFnAsync(fn) {
+    fn.call(ctx, function(err){
+      if (err instanceof Error || toString.call(err) === "[object Error]") return done(err);
+      if (null != err) {
+        if (Object.prototype.toString.call(err) === '[object Object]') {
+          return done(new Error('done() invoked with non-Error: ' + JSON.stringify(err)));
+        } else {
+          return done(new Error('done() invoked with non-Error: ' + err));
+        }
+      }
+      done();
+    });
   }
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -383,7 +383,10 @@ Runner.prototype.runTest = function(fn){
 
   if (this.asyncOnly) test.asyncOnly = true;
 
-  try {
+  if (this.allowUncaught) {
+    test.allowUncaught = true;
+    test.run(fn);
+  } else try {
     test.on('error', function(err){
       self.fail(test, err);
     });

--- a/support/tail.js
+++ b/support/tail.js
@@ -53,7 +53,7 @@ process.on = function(e, fn){
   if ('uncaughtException' == e) {
     global.onerror = function(err, url, line){
       fn(new Error(err + ' (' + url + ':' + line + ')'));
-      return true;
+      return !mocha.allowUncaught;
     };
     uncaughtExceptionHandlers.push(fn);
   }

--- a/test/runnable.js
+++ b/test/runnable.js
@@ -132,6 +132,20 @@ describe('Runnable(title, fn)', function(){
           })
         })
       })
+
+      describe('when an exception is thrown and is allowed to remain uncaught', function(){
+        it('throws an error when it is allowed', function(done) {
+          var test = new Runnable('foo', function(){
+            throw new Error('fail');
+          });
+          test.allowUncaught = true;
+          function fail() {
+            test.run(function(err) {});
+          }
+          fail.should.throw('fail');
+          done();
+        })
+      })
     })
 
     describe('when timeouts are disabled', function() {
@@ -237,6 +251,21 @@ describe('Runnable(title, fn)', function(){
             done();
           })
         });
+      })
+
+      describe('when an exception is thrown and is allowed to remain uncaught', function(){
+        it('throws an error when it is allowed', function(done) {
+          var test = new Runnable('foo', function(done){
+            throw new Error('fail');
+            process.nextTick(done);
+          });
+          test.allowUncaught = true;
+          function fail() {
+            test.run(function(err) {});
+          }
+          fail.should.throw('fail');
+          done();
+        })
       })
 
       describe('when an error is passed', function(){

--- a/test/runner.js
+++ b/test/runner.js
@@ -292,6 +292,21 @@ describe('Runner', function(){
     })
   });
 
+  describe('allowUncaught', function() {
+    it('should allow unhandled errors to propagate through', function(done) {
+      var newRunner = new Runner(suite);
+      newRunner.allowUncaught = true;
+      newRunner.test = new Test('failing test', function() {
+        throw new Error('allow unhandled errors');
+      });
+      function fail() {
+        newRunner.runTest();
+      }
+      fail.should.throw('allow unhandled errors');
+      done();
+    });
+  });
+
   describe('stackTrace', function() {
     var stack = [ 'AssertionError: foo bar'
       , 'at EventEmitter.<anonymous> (/usr/local/dev/test.js:16:12)'


### PR DESCRIPTION
- added allowUncaught option (#553)
- allows unhandled exceptions to propagate in the browser
- added tests for allowUncaught option
- global error handler prints to dom with allowUncaught