### PR TITLE
Add {request,cancel}AnimationFrame to ignored globals

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -4607,7 +4607,9 @@ var globals = [
   'setImmediate',
   'clearImmediate',
   'requestAnimationFrame',
-  'cancelAnimationFrame'
+  'cancelAnimationFrame',
+  'webkitRequestAnimationFrame',
+  'webkitCancelRequestAnimationFrame'
 ];
 
 /**

--- a/mocha.js
+++ b/mocha.js
@@ -4605,7 +4605,9 @@ var globals = [
   'XMLHttpRequest',
   'Date',
   'setImmediate',
-  'clearImmediate'
+  'clearImmediate',
+  'requestAnimationFrame',
+  'cancelAnimationFrame'
 ];
 
 /**


### PR DESCRIPTION
Like setImmediate/clearImmediate,
requestAnimationFrame/cancelAnimationFrame is another time like global
javascript function. Some tests need to mock them out.