### PR TITLE
Use a Standard-Compliant License Identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "Ariel Mashraki <ariel@mashraki.co.il>",
     "Pawel Kozlowski <pkozlowski.opensource@gmail.com>"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/mochajs/mocha.git"


### PR DESCRIPTION
This pull request changes the value of the license property in `package.json` to a standard, machine-readable SPDX license identifier, [`"MIT"`](https://spdx.org/licenses/MIT).

npm doesn't require that you use a valid SPDX identifier, but it's strongly recommended. (Try `npm help 7 package.json` and search for “License”.) Other source code package managers, like Maven for Java and RubyGems for Ruby, recommend the same. I can't give legal advice via GitHub, but I'm happy to answer questions about SPDX or point you to good resources.

Why care about SPDX? A machine-readable standard makes it possible for programs, rather than just people, to review a module or even an entire codebase to make sure that licenses are compatible. Whatever the reason—strong personal conviction, company policy, terms of a business deal—SPDX makes it easier to collaborate with others when licenses can be a problem, and helps take open-source software to more places. Given that [npm has a ton of modules](http://www.modulecounts.com/) but also handles dependencies in a novel way, I think a little license hygiene could help npm build amazing new relationships between communities that lawyers have long kept apart.

Thanks for your contribution to open-source software!

K