### PR TITLE
Add stack to json-stream reporter

### DIFF
--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -36,6 +36,7 @@ function List(runner) {
   runner.on('fail', function(test, err){
     test = clean(test);
     test.err = err.message;
+    test.stack = err.stack || null;
     console.log(JSON.stringify(['fail', test]));
   });
 


### PR DESCRIPTION
Extremely useful for running mocha on a CI server. The JSON reporter already has it, just updating the stream reporter.