### PR TITLE
Upgrade jsdiff to v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "commander": "2.3.0",
     "debug": "2.0.0",
-    "diff": "1.0.8",
+    "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",
     "growl": "1.8.1",

--- a/test/integration/fixtures/diffs/output
+++ b/test/integration/fixtures/diffs/output
@@ -1,67 +1,67 @@
 // DIFF
-      +foo bar baz
       -foo rar baz
+      +foo bar baz
 
 // DIFF
        {
          "age": 23
-      +  "name": "travis"
       -  "name": "travis j"
+      +  "name": "travis"
        }
 
 // DIFF
        foo bar baz
-      +foo bar baz
-      +foo bar baz
       -foo rar baz
       -foo bar raz
+      +foo bar baz
+      +foo bar baz
 
 // DIFF
        {
          "address": {
            "city": "new york"
-      +    "country": "us"
       -    "country": "usa"
+      +    "country": "us"
          }
          "age": 30
-      +  "name": "joe"
       -  "name": "joel"
+      +  "name": "joe"
        }
 
 // DIFF
        one two three
-      +four five six
       -four zzzz six
+      +four five six
        seven eight nine
 
 // DIFF
        {
          "address": {
            "city": "new york"
-      +    "country": "us"
       -    "country": "usa"
+      +    "country": "us"
          }
          "age": 30
-      +  "name": "joe"
       -  "name": "joel"
+      +  "name": "joe"
        }
 
 // DIFF
        one	tab
-      +two		tabs
       -two			tabs
+      +two		tabs
 
 // DIFF
        body {
          font: "Helvetica Neue", Helvetica, arial, sans-serif;
          background: black;
-      +  color: #fff;
       -  color: white;
+      +  color: #fff;
        }
        
        a {
-      +  color: blue;
       -  color: blue
+      +  color: blue;
        }
       +
       +foo {
@@ -71,10 +71,10 @@
 // DIFF
        {
          "age": 2
-      +  "color": "brown"
-      +  "name": "loki"
       -  "color": "white"
       -  "name": "tobi"
+      +  "color": "brown"
+      +  "name": "loki"
          "species": "ferret"
        }
 
@@ -86,6 +86,6 @@
 
 // DIFF
        [
-      +  2
       -  1
+      +  2
        ]


### PR DESCRIPTION
`jsdiff` v1.4.0 contains a fix for https://github.com/kpdecker/jsdiff/issues/14.  Upgrading will display multi-line diffs in the same standard order as `diff`, `git`, etc:

```diff
- actual / removed
+ expected / added
```

The current order is unintuitive which makes it harder to read at a glance:

```diff
+ expected / added
- actual / removed
```

Supersedes #1647.  cc @danielstjules @boneskull