### PR TITLE
add more friendly output for dot reporter in colorless mode

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -95,12 +95,13 @@ if ('win32' == process.platform) {
  *
  * @param {String} type
  * @param {String} str
+ * @param {String} noColorStr
  * @return {String}
  * @api private
  */
 
-var color = exports.color = function(type, str) {
-  if (!exports.useColors) return String(str);
+var color = exports.color = function(type, str, noColorStr) {
+  if (!exports.useColors) return String(noColorStr === undefined ? str : noColorStr);
   return '\u001b[' + exports.colors[type] + 'm' + str + '\u001b[0m';
 };
 

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -32,13 +32,13 @@ function Dot(runner) {
 
   runner.on('pending', function(test){
     if (++n % width == 0) process.stdout.write('\n  ');
-    process.stdout.write(color('pending', Base.symbols.dot));
+    process.stdout.write(color('pending', Base.symbols.dot, 'P'));
   });
 
   runner.on('pass', function(test){
     if (++n % width == 0) process.stdout.write('\n  ');
     if ('slow' == test.speed) {
-      process.stdout.write(color('bright yellow', Base.symbols.dot));
+      process.stdout.write(color('bright yellow', Base.symbols.dot, 'S'));
     } else {
       process.stdout.write(color(test.speed, Base.symbols.dot));
     }
@@ -46,7 +46,7 @@ function Dot(runner) {
 
   runner.on('fail', function(test, err){
     if (++n % width == 0) process.stdout.write('\n  ');
-    process.stdout.write(color('fail', Base.symbols.dot));
+    process.stdout.write(color('fail', Base.symbols.dot, 'F'));
   });
 
   runner.on('end', function(){


### PR DESCRIPTION
Currently when using dot reporter with `no-colors` option the _dot-matrix_ output has no use.

To resolve that I want to introduce an extra parameter to the base reporter's `color` function which is a fallback string if colors are disabled. If this parameter is given the function will return that instead of the original string.

Using this parameter the dot reporter can easily signal the difference between tests and it will output the following:
 - the default dot if the test passes
 - `P` if the test is pending
 - `S` if the test is slow
 - `F` on failure