### PR TITLE
fix emit "pending" when running pending test

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -196,6 +196,10 @@ Runnable.prototype.run = function(fn){
     , finished
     , emitted;
 
+  // Runner expects to catch an instance of Pending if a pending test is ran
+  if (this.pending)
+    throw new Pending();
+
   // Some times the ctx exists but it is not runnable
   if (ctx && ctx.runnable) ctx.runnable(this);
 
@@ -253,11 +257,7 @@ Runnable.prototype.run = function(fn){
 
   // sync or promise-returning
   try {
-    if (this.pending) {
-      done();
-    } else {
-      callFn(this.fn);
-    }
+    callFn(this.fn);
   } catch (err) {
     done(utils.getError(err));
   }

--- a/test/runner.js
+++ b/test/runner.js
@@ -337,4 +337,39 @@ describe('Runner', function(){
       });
     });
   });
+
+  describe('.run', function(){
+    it('should emit "pending" for each pending test', function(done){
+      var pendingCount = 0;
+
+      var pendingTest = new Test('a pending test', function (){});
+      pendingTest.pending = true;
+
+      var skippedTest = new Test('a test that will be skipped', function(){
+        this.skip();
+      });
+
+      var otherPendingTest = new Test('a test that will be marked as pending',
+      function(){});
+
+      suite.addTest(pendingTest);
+      suite.addTest(skippedTest);
+      suite.addTest(otherPendingTest);
+
+      runner.on('test', function (test) {
+        if (test === otherPendingTest)
+          otherPendingTest.pending = true;
+      });
+
+      runner.on('pending', function () {
+        pendingCount++;
+      });
+
+      runner.run(function (){
+        pendingCount.should.equal(3);
+        done();
+      });
+    })
+  })
+
 });


### PR DESCRIPTION
Closes #1706.

`Runnable.run(fn)` wasn't passing an instance of `Pending` to the
callback when a `pending` test was ran. Therefore, `Runner` was not
firing a "pending" event.

Added a test which currently fails due to the `skippedTest`:
`[TypeError: Object #<Object> has no method 'skip']`. How does
one skip the current running test synchronously?

Also: why are we throwing a `Pending` instance? Couldn't we set `pending = true` in `.skip()`, and then check `test.pending` again at https://github.com/mochajs/mocha/blob/master/lib/runner.js#L475 ?