### PR TITLE
Fix missing variable 'done'

### DIFF
--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ function usedToBeAsync (cb) {
   cb()
 }
 
-it('test', function() {
+it('test', function(done) {
   this.timeout(4294967296);
   usedToBeAsync(done)
 });


### PR DESCRIPTION
Fix running `mocha test.js` fail because variable `done` is not defined