### PR TITLE
Add note on allowUncaught method in the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,6 +859,12 @@ mocha.setup({
 
 <p><code>noHighlighting</code> : If set to <code>true</code>, do not attempt to use syntax highlighting on output test code.</p>
 
+<h3 id="browser-specific-methods">Browser-specific method(s)</h3>
+
+<p>The following method(s) <em>only</em> function in a browser context:</p>
+
+<p><code>mocha.allowUncaught()</code> : If called, uncaught errors will not be absorbed by the error handler.</p>
+
 <h2 id="mocha.opts">mocha.opts</h2>
 
 <p>Mocha will attempt to load <code>./test/mocha.opts</code>, these are concatenated with <code>process.argv</code>, though command-line args will take precedence. For example suppose you have the following <em>mocha.opts</em> file:</p>

--- a/index.md
+++ b/index.md
@@ -807,6 +807,12 @@ Testing asynchronous code with Mocha could not be simpler! Simply invoke the cal
 
   `noHighlighting` : If set to `true`, do not attempt to use syntax highlighting on output test code.
 
+<h3 id="browser-specific-methods">Browser-specific method(s)</h3>
+
+  The following method(s) <em>only</em> function in a browser context:
+
+  `mocha.allowUncaught()` : If called, uncaught errors will not be absorbed by the error handler.
+
 <h2 id="mocha.opts">mocha.opts</h2>
 
  Mocha will attempt to load `./test/mocha.opts`, these are concatenated with `process.argv`, though command-line args will take precedence. For example suppose you have the following _mocha.opts_ file:


### PR DESCRIPTION
This refers to the `allowUncaught` method added in #1662.