### PR TITLE
Fail hook emitter looses file context

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -235,7 +235,7 @@ Runner.prototype.fail = function(test, err) {
  */
 
 Runner.prototype.failHook = function(hook, err){
-  if(hook.parent && hook.parent.file){
+  if (hook.parent && hook.parent.file){
     hook.file = hook.parent.file;
   }
   this.fail(hook, err);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -235,6 +235,9 @@ Runner.prototype.fail = function(test, err) {
  */
 
 Runner.prototype.failHook = function(hook, err){
+  if(hook.parent && hook.parent.file){
+    hook.file = hook.parent.file;
+  }
   this.fail(hook, err);
   if (this.suite.bail()) {
     this.emit('end');


### PR DESCRIPTION
When receiving fail emitters you do not get the file where the fail hook occurred, as you do with regular test failures.  This pull https://github.com/mochajs/mocha/pull/1447 handles the title issue, but the file issue remains outstanding.