### PR TITLE
Maximum call stack issue for large test suite

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -71,7 +71,8 @@ function Runner(suite, delay) {
   this.on('hook end', function(hook) {
     self.checkGlobals(hook);
   });
-  this.grep(/.*/);
+  this._defaultGrep = /.*/;
+  this.grep(this._defaultGrep);
   this.globals(this.globalProps().concat(extraGlobals()));
 }
 
@@ -470,7 +471,20 @@ Runner.prototype.runTests = function(suite, fn) {
       match = !match;
     }
     if (!match) {
-      return next();
+      // Run immediately only if we have defined a grep. When we
+      // define a grep — It can cause maximum callstack error if
+      // the grep is doing a large recursive loop by neglecting
+      // all tests. The run immediately function also comes with
+      // a performance cost. So we don't want to run immediately
+      // if we run the whole test suite, because running the whole
+      // test suite don't do any immediate recursive loops. Thus,
+      // allowing a JS runtime to breathe.
+      if (self._grep !== self._defaultGrep) {
+        Runner.immediately(next);
+      } else {
+        next();
+      }
+      return;
     }
 
     // pending
@@ -563,7 +577,17 @@ Runner.prototype.runSuite = function(suite, fn) {
     if (!curr) {
       return done();
     }
-    self.runSuite(curr, next);
+
+    // Avoid grep neglecting large number of tests causing a
+    // huge recursive loop and thus a maximum call stack error.
+    // See comment in `this.runTests()` for more information.
+    if (self._grep !== self._defaultGrep) {
+      Runner.immediately(function() {
+        self.runSuite(curr, next);
+      });
+    } else {
+      self.runSuite(curr, next);
+    }
   }
 
   function done(errSuite) {


### PR DESCRIPTION
The TypeScript repo is running into some scalability issues with Mocha. We pinned down the problem in this line of code https://github.com/mochajs/mocha/blob/master/lib/runner.js#L541. It does a huge recursive loop if there are is a large amount of test suites and thus causing a maximum call stack error. 

This PR fixes that problem.

Related issue in TypeScript repo:
https://github.com/Microsoft/TypeScript/pull/3511