### PR TITLE
Stop runner sending SIGINT to itself from within SIGINT handler

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -81,5 +81,4 @@ proc.on('exit', function (code, signal) {
 process.on('SIGINT', function () {
   proc.kill('SIGINT'); // calls runner.abort()
   proc.kill('SIGTERM'); // if that didn't work, we're probably in an infinite loop, so make it die.
-  process.kill(process.pid, 'SIGINT');
 });


### PR DESCRIPTION
This prevents an infinite loop when the child process (the target of the runner, ie your tests) installs a SIGINT / SIGTERM handler. You might want to do this, for example, if you need to ensure clean shutdown of your tests when the user presses Ctrl+C. I ran into this problem when spawning a subprocess from the setup portion of my tests, and trying to capture SIGINT in the test suite.