### PR TITLE
_mocha: Allow boolean --reporter-options

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -195,10 +195,13 @@ var reporterOptions = {};
 if (program.reporterOptions !== undefined) {
     program.reporterOptions.split(",").forEach(function(opt) {
         var L = opt.split("=");
-        if (L.length != 2) {
+        if (L.length > 2 || L.length === 0) {
             throw new Error("invalid reporter option '" + opt + "'");
+        } else if (L.length === 2) {
+            reporterOptions[L[0]] = L[1];
+        } else {
+            reporterOptions[L[0]] = true;
         }
-        reporterOptions[L[0]] = L[1];
     });
 }
 


### PR DESCRIPTION
Previously "mocha --reporter-options foo" would blow up because an equal sign is required. This is quite unhandy for reporters that need to accept boolean (flag-ish) options.

This commit changes that so that a value-less reporter option will be interpreted as having a value of true.

This means that --reporter-options foo=bar,quux will turn into { foo: 'bar', quux: true }