### PR TITLE
Add cross-frame compatible Error checking for fail

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -202,7 +202,7 @@ Runner.prototype.fail = function(test, err) {
   ++this.failures;
   test.state = 'failed';
 
-  if (!(err instanceof Error)) {
+  if (!(err instanceof Error || err && typeof err.message == 'string')) {
     err = new Error('the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)');
   }
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -229,8 +229,17 @@ describe('Runner', function(){
       runner.fail(test, err);
     })
 
-    it('should emit a the error when failed with an Error', function(done){
+    it('should emit a the error when failed with an Error instance', function(done){
       var test = {}, err = new Error('an error message');
+      runner.on('fail', function(test, err){
+        err.message.should.equal('an error message');
+        done();
+      });
+      runner.fail(test, err);
+    })
+
+    it('should emit the error when failed with an Error-like object', function(done){
+      var test = {}, err = {message: 'an error message'};
       runner.on('fail', function(test, err){
         err.message.should.equal('an error message');
         done();


### PR DESCRIPTION
When passing errors through between frames, AssertionErrors and the like will fail an instanceof check against Error. We need a compatible check. According to [Mozilla Error Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), Error prototype will always have message defined.

All tests pass: https://travis-ci.org/outdooricon/mocha/builds/67555897

It's worth noting that this currently prevents us from upgrading the Konacha project to use latest Mocha.