### PR TITLE
Explicitly check `null` and `undefined` values in exports.type

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -372,7 +372,11 @@ var emptyRepresentation = function emptyRepresentation(value, type) {
  * @returns {string}
  */
 exports.type = function type(value) {
-  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+  if (value === undefined) {
+    return 'undefined';
+  } else if (value === null) {
+    return 'null';
+  } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
     return 'buffer';
   }
   return Object.prototype.toString.call(value)

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -348,6 +348,26 @@ describe('lib/utils', function () {
       type(global).should.equal('global');
       type(true).should.equal('boolean');
     });
+
+    describe('when toString on null or undefined stringifies window', function () {
+      var toString = Object.prototype.toString;
+
+      beforeEach(function () {
+        // some JS engines such as PhantomJS 1.x exhibit this behavior
+        Object.prototype.toString = function () {
+          return '[object DOMWindow]';
+        };
+      });
+
+      it('should recognize null and undefined', function () {
+        type(null).should.equal('null');
+        type(undefined).should.equal('undefined');
+      });
+
+      afterEach(function () {
+        Object.prototype.toString = toString;
+      });
+    });
   });
 
   describe('lookupFiles', function () {

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -341,6 +341,7 @@ describe('lib/utils', function () {
       type(1).should.equal('number');
       type(Infinity).should.equal('number');
       type(null).should.equal('null');
+      type(undefined).should.equal('undefined');
       type(new Date()).should.equal('date');
       type(/foo/).should.equal('regexp');
       type('type').should.equal('string');


### PR DESCRIPTION
Some older JS engines, such as PhantomJS, return the `window` object instead of "[object Null]", as would be expected here, crashing the test runner.