### PR TITLE
Implement support for multiple reporters

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -63,7 +63,7 @@ program
   .option('-C, --no-colors', 'force disabling of colors')
   .option('-G, --growl', 'enable growl notification support')
   .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
-  .option('-R, --reporter <name>', 'specify the reporter to use', 'spec')
+  .option('-R, --reporter <name>,...', 'specify the reporters to use', list, ['spec'])
   .option('-S, --sort', "sort test files")
   .option('-b, --bail', "bail after first test failure")
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
@@ -193,13 +193,44 @@ Error.stackTraceLimit = Infinity; // TODO: config
 
 var reporterOptions = {};
 if (program.reporterOptions !== undefined) {
-    program.reporterOptions.split(",").forEach(function(opt) {
-        var L = opt.split("=");
-        if (L.length != 2) {
-            throw new Error("invalid reporter option '" + opt + "'");
+
+   program.reporterOptions.split(",").forEach(
+
+    // Two possible formats ...
+     /\w+{(\w+:\w+)+}/.test(program.reporterOptions) ?
+
+     // per-reporter config:
+     //   spec{a:1,b:2},dot{c:3,d:4}
+     function(opt) {
+       var m = opt.match(/(\w+){(\w+:\w+)+}/);
+       if (m.length !== 3) {
+         throw new("invalid reporter option '" + opt + "'");
+       }
+
+       var reporterName = m[1]
+        , reporterOptStr = m[2];
+
+      reporterOptStr.split(",").forEach(function (reporterOpt) {
+        var L = reporterOpt.split(':');
+        if (L.length !== 2) {
+          throw new Error("invalid reporter option '" + opt + "'");
         }
-        reporterOptions[L[0]] = L[1];
-    });
+        reporterOptions[reporterName] = reporterOptions[reporterName] || {};
+        reporterOptions[reporterName][L[0]] = L[1];
+      });
+     } :
+
+     // single reporter config:
+     //   a=1,b=2
+     function(opt) {
+       var L = opt.split("=");
+       if (L.length != 2) {
+         throw new Error("invalid reporter option '" + opt + "'");
+       }
+       reporterOptions._default = reporterOptions._default || {};
+       reporterOptions._default[L[0]] = L[1];
+     }
+   );
 }
 
 // reporter
@@ -212,15 +243,19 @@ mocha.ui(program.ui);
 
 // load reporter
 
-try {
-  Reporter = require('../lib/reporters/' + program.reporter);
-} catch (err) {
+program.reporter.forEach(function (reporterConfig) {
+  var reporterName;
   try {
-    Reporter = require(program.reporter);
+    reporterName = reporterConfig.split(':')[0];
+    Reporter = require('../lib/reporters/' + reporterName);
   } catch (err) {
-    throw new Error('reporter "' + program.reporter + '" does not exist');
+    try {
+      Reporter = require(reporterName);
+    } catch (err) {
+      throw new Error('reporter "' + reporterName + '" does not exist');
+    }
   }
-}
+});
 
 // --no-colors
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -131,32 +131,63 @@ Mocha.prototype.addFile = function(file){
 };
 
 /**
- * Set reporter to `reporter`, defaults to "spec".
+ * Set reporters to `reporters`, defaults to "spec".
  *
- * @param {String|Function} reporter name or constructor
- * @param {Object} reporterOptions optional options
+ * @param {String|Function|Array of strings|Array of functions} reporter name as string,
+ * reporter constructor, or array of constructors or reporter names as strings.
+ * @param {Object} reporterOptions optional options TODO FIXME
  * @api public
  */
-Mocha.prototype.reporter = function(reporter, reporterOptions){
-  if ('function' == typeof reporter) {
-    this._reporter = reporter;
-  } else {
-    reporter = reporter || 'spec';
-    var _reporter;
-    try { _reporter = require('./reporters/' + reporter); } catch (err) {}
-    if (!_reporter) try { _reporter = require(reporter); } catch (err) {
-      err.message.indexOf('Cannot find module') !== -1
-        ? console.warn('"' + reporter + '" reporter not found')
-        : console.warn('"' + reporter + '" reporter blew up with error:\n' + err.stack);
+
+Mocha.prototype.reporter = function(reporters, reporterOptions){
+  // if no reporter is given as input, default to spec reporter
+  reporters = reporters || ['spec'];
+  reporterOptions = reporterOptions || {};
+
+  // If reporters argument is not a list, turn it into a list of reporter names
+  // or constructors that we'll iterate on right after to initialize them
+  if (!Array.isArray(reporters)) {
+    if (('string' == typeof reporters) ||
+        ('function' == typeof reporters)) {
+      reporters = [reporters];
     }
-    if (!_reporter && reporter === 'teamcity')
-      console.warn('The Teamcity reporter was moved to a package named ' +
-        'mocha-teamcity-reporter ' +
-        '(https://npmjs.org/package/mocha-teamcity-reporter).');
-    if (!_reporter) throw new Error('invalid reporter "' + reporter + '"');
-    this._reporter = _reporter;
   }
-  this.options.reporterOptions = reporterOptions;
+
+  // Load each reporter
+  this._reporters = reporters.map(function (reporterConfig) {
+    if ('function' == typeof reporterConfig) {
+      return {
+        fn: reporterConfig,
+        options: reporterOptions
+      };
+    } else {
+      var reporterName
+        , path;
+
+      reporterName = reporterConfig.split(':');
+      if (reporterName.length > 1) {
+        path = reporterName[1];
+        reporterName = reporterName[0];
+      }
+      try { _reporter = require('./reporters/' + reporterName); } catch (err) {};
+      if (!_reporter) try { _reporter = require(reporterName); } catch (err) {
+        err.message.indexOf('Cannot find module') !== -1
+          ? console.warn('"' + reporterName + '" reporter not found')
+          : console.warn('"' + reporterName + '" reporter blew up with error:\n' + err.stack);
+      }
+      if (!_reporter && reporterName === 'teamcity')
+        console.warn('The Teamcity reporter was moved to a package named ' +
+          'mocha-teamcity-reporter ' +
+          '(https://npmjs.org/package/mocha-teamcity-reporter).');
+      if (!_reporter) throw new Error('invalid reporter "' + reporterName + '"');
+      return {
+        fn: _reporter,
+        path: path,
+        options: reporterOptions[reporterName] || reporterOptions._default || {}
+      };
+    }
+  }, this);
+
   return this;
 };
 
@@ -424,23 +455,45 @@ Mocha.prototype.run = function(fn){
   var options = this.options;
   options.files = this.files;
   var runner = new exports.Runner(suite, options.delay);
-  var reporter = new this._reporter(runner, options);
+  // For each loaded reporter constructor, create
+  // an instance and initialize it with the runner
+  var reporters = this._reporters.map(function (reporterConfig) {
+    var _reporter = reporterConfig.fn
+      , path = reporterConfig.path;
+
+    options.reporterOptions = reporterConfig.options;
+    return new _reporter(runner, options, path);
+  });
   runner.ignoreLeaks = false !== options.ignoreLeaks;
   runner.fullStackTrace = options.fullStackTrace;
   runner.asyncOnly = options.asyncOnly;
   if (options.grep) runner.grep(options.grep, options.invert);
   if (options.globals) runner.globals(options.globals);
-  if (options.growl) this._growl(runner, reporter);
+
+  // Use only the first reporter for growl, since we don't want to
+  // send several notifications for the same test suite
+  if (options.growl) this._growl(runner, reporters[0]);
+
   if (options.useColors !== undefined) {
     exports.reporters.Base.useColors = options.useColors;
   }
+
   exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
 
-  function done(failures) {
+  function runnerDone(failures) {
+    var remain = reporters.length
+      , reporterDone = function(failures) {
+        if (--remain === 0) fn && fn(failures);
+      };
+
+    reporters.forEach(function (reporter) {
       if (reporter.done) {
-          reporter.done(failures, fn);
-      } else fn && fn(failures);
+        reporter.done(failures, reporterDone);
+      } else {
+        reporterDone(failures);
+      }
+    });
   }
 
-  return runner.run(done);
+  return runner.run(runnerDone);
 };

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -3,6 +3,7 @@
  */
 
 var tty = require('tty')
+  , fs = require('fs')
   , diff = require('diff')
   , ms = require('../ms')
   , utils = require('../utils')
@@ -225,10 +226,20 @@ exports.list = function(failures){
  * @api public
  */
 
-function Base(runner) {
+function Base(runner, options, path) {
   var self = this
     , stats = this.stats = { suites: 0, tests: 0, passes: 0, pending: 0, failures: 0 }
     , failures = this.failures = [];
+
+  this.options = options;
+  this.path = path;
+
+  if (path) {
+    if (!fs.createWriteStream) {
+      throw new Error('file output not supported in browser');
+    }
+    this.fileStream = fs.createWriteStream(path);
+  }
 
   if (!runner) return;
   this.runner = runner;
@@ -321,6 +332,32 @@ Base.prototype.epilogue = function(){
   }
 
   console.log();
+};
+
+
+/**
+ * Write to reporter output stream
+ */
+Base.prototype.write = function(str){
+  if (this.fileStream) {
+    this.fileStream.write(str);
+  } else {
+    process.stdout.write(str);
+  }
+};
+
+Base.prototype.writeLine = function(line) {
+  this.write(line + '\n');
+};
+
+Base.prototype.done = function(failures, fn) {
+  if (this.fileStream) {
+    this.fileStream.end(function() {
+      fn(failures);
+    });
+  } else {
+    fn(failures);
+  }
 };
 
 /**

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -19,9 +19,9 @@ exports = module.exports = JSONReporter;
  * @api public
  */
 
-function JSONReporter(runner) {
+function JSONReporter(runner, options, path) {
   var self = this;
-  Base.call(this, runner);
+  Base.call(this, runner, options, path);
 
   var tests = []
     , pending = []

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -30,18 +30,11 @@ exports = module.exports = XUnit;
  * @api public
  */
 
-function XUnit(runner, options) {
-  Base.call(this, runner);
+function XUnit(runner, options, path) {
+  Base.call(this, runner, options, path);
   var stats = this.stats
     , tests = []
     , self = this;
-
-  if (options.reporterOptions && options.reporterOptions.output) {
-      if (! fs.createWriteStream) {
-          throw new Error('file output not supported in browser');
-      }
-      self.fileStream = fs.createWriteStream(options.reporterOptions.output);
-  }
 
   runner.on('pending', function(test){
     tests.push(test);
@@ -56,7 +49,7 @@ function XUnit(runner, options) {
   });
 
   runner.on('end', function(){
-    self.write(tag('testsuite', {
+    self.writeLine(tag('testsuite', {
         name: 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
@@ -67,39 +60,15 @@ function XUnit(runner, options) {
     }, false));
 
     tests.forEach(function(t) { self.test(t); });
-    self.write('</testsuite>');
+    self.writeLine('</testsuite>');
   });
 }
-
-/**
- * Override done to close the stream (if it's a file).
- */
-XUnit.prototype.done = function(failures, fn) {
-    if (this.fileStream) {
-        this.fileStream.end(function() {
-            fn(failures);
-        });
-    } else {
-        fn(failures);
-    }
-};
 
 /**
  * Inherit from `Base.prototype`.
  */
 
 XUnit.prototype.__proto__ = Base.prototype;
-
-/**
- * Write out the given line
- */
-XUnit.prototype.write = function(line) {
-    if (this.fileStream) {
-        this.fileStream.write(line + '\n');
-    } else {
-        console.log(line);
-    }
-};
 
 /**
  * Output tag for the given `test.`
@@ -112,13 +81,14 @@ XUnit.prototype.test = function(test, ostream) {
     , time: (test.duration / 1000) || 0
   };
 
+
   if ('failed' == test.state) {
     var err = test.err;
-    this.write(tag('testcase', attrs, false, tag('failure', {}, false, cdata(escape(err.message) + "\n" + err.stack))));
+    this.writeLine(tag('testcase', attrs, false, tag('failure', {}, false, cdata(escape(err.message) + "\n" + err.stack))));
   } else if (test.pending) {
-    this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    this.writeLine(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    this.write(tag('testcase', attrs, true) );
+    this.writeLine(tag('testcase', attrs, true) );
   }
 };
 

--- a/test/reporters/json.js
+++ b/test/reporters/json.js
@@ -12,7 +12,7 @@ describe('json reporter', function(){
     });
     suite = new Suite('JSON suite', 'root');
     runner = new Runner(suite);
-    var mochaReporter = new mocha._reporter(runner);
+    var mochaReporter = new mocha._reporters[0].fn(runner);
   });
 
    it('should have 1 test failure', function(done){

--- a/test/reporters/multiple.js
+++ b/test/reporters/multiple.js
@@ -1,0 +1,97 @@
+
+var Mocha = require('../../')
+  , Suite = Mocha.Suite
+  , Runner = Mocha.Runner
+  , Test = Mocha.Test
+  , should = require('should');
+
+describe('multiple reporters', function(){
+  var suite, runner, specReporter, jsonReporter;
+
+  it('should have 1 test failure', function(done){
+    var mocha = new Mocha({
+      reporter: ['spec', 'json'],
+    });
+    suite = new Suite('Multiple reporters suite', 'root');
+    runner = new Runner(suite);
+    specReporter = new mocha._reporters[0].fn(runner);
+    jsonReporter = new mocha._reporters[1].fn(runner);
+
+    var testTitle = 'json test 1';
+    var error = { message: 'oh shit' };
+
+    suite.addTest(new Test(testTitle, function (done) {
+      done(new Error(error.message));
+    }));
+
+    runner.run(function(failureCount) {
+
+      // Verify that each reporter ran
+      specReporter.should.have.property('failures');
+      specReporter.failures.should.be.an.instanceOf(Array);
+      specReporter.failures.should.have.a.lengthOf(1);
+
+      jsonReporter.should.have.property('failures');
+      jsonReporter.failures.should.be.an.instanceOf(Array);
+      jsonReporter.failures.should.have.a.lengthOf(1);
+      done();
+    });
+  });
+
+  it('should pass correct reporter options and path to each reporter', function (done) {
+    var mocha = new Mocha({
+      reporter: [
+        'spec',
+        'dot:/var/log/dot.txt',
+        'json:json.json'
+      ],
+      reporterOptions: {
+        spec: { foo: 'bar' },
+        json: { bar: 'baz' }
+      }
+    });
+
+    // specReporter
+    mocha._reporters[0].fn = function (runner, options, path) {
+      options.reporterOptions.should.have.property('foo', 'bar');
+      should.equal(path, undefined);
+    }
+
+    // dot (no options)
+    mocha._reporters[1].fn = function (runner, options, path) {
+      options.reporterOptions.should.eql({});
+      path.should.equal('/var/log/dot.txt');
+    }
+
+    // json
+    mocha._reporters[2].fn = function (runner, options, path) {
+      options.reporterOptions.should.have.property('bar', 'baz');
+      path.should.equal('json.json');
+      done();
+    }
+
+    mocha.run();
+  });
+
+  it('should pass _default reporter options to each reporter', function (done) {
+    var mocha = new Mocha({
+      reporter: [ 'spec',  'json' ],
+      reporterOptions: {
+        _default: { 'foo': 'bar' }
+      }
+    });
+
+    // specReporter
+    mocha._reporters[0].fn = function (runner, options, path) {
+      options.reporterOptions.should.have.property('foo', 'bar');
+    }
+
+    // json
+    mocha._reporters[1].fn = function (runner, options, path) {
+      options.reporterOptions.should.have.property('foo', 'bar');
+      done();
+    }
+
+    mocha.run();
+  });
+});


### PR DESCRIPTION
Continuation of #1681, targeted against 2.x (master) instead of 3.x.

Necessary for completion:

  - [ ] support [distinct output streams for each reporter](https://github.com/mochajs/mocha/pull/1360#issuecomment-55513864) (e.g. 'spec' → stdout while 'json' → file)
  - [x] `--reporter-options` needs to be capable of [configuring each reporter](https://github.com/mochajs/mocha/pull/1360#issuecomment-72354839)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1772)
<!-- Reviewable:end -->
