### PR TITLE
support escaped spaces in cli options

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -21,8 +21,12 @@ function getOptions() {
 
   try {
     var opts = fs.readFileSync(optsPath, 'utf8')
+      .replace(/\\\s/g, '%20')
       .split(/\s/)
-      .filter(Boolean);
+      .filter(Boolean)
+      .map(function(value) {
+        return value.replace(/%20/g, ' ');
+      });
 
     process.argv = process.argv
       .slice(0, 2)


### PR DESCRIPTION
The current parsing of options does not allow spaces within an option so this fixes that. This is particularly useful in the case of reporter options where a custom reporter may want to accept a string option that contains a space.

See https://github.com/adamgruber/mochawesome/issues/20 for an example.

This patch would require any spaces to be escaped like `--option option\ with\ spaces`