### PR TITLE
Scope loading behaviour instead of using early return

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -401,6 +401,7 @@ if (program.watch) {
   runner = mocha.run(program.exit ? exit : exitLater);
   
 }
+
 function exitLater(code) {
   process.on('exit', function() { process.exit(code) })
 }

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -392,15 +392,15 @@ if (program.watch) {
       rerun();
     }
   });
-
-  return;
-}
+  
+} else {
 
 // load
 
-mocha.files = files;
-runner = mocha.run(program.exit ? exit : exitLater);
-
+  mocha.files = files;
+  runner = mocha.run(program.exit ? exit : exitLater);
+  
+}
 function exitLater(code) {
   process.on('exit', function() { process.exit(code) })
 }


### PR DESCRIPTION
Fails under babel_node node_modules/mocha/bin/_mocha
Transformation error; return original code
{ [SyntaxError: node_modules/mocha/bin/_mocha: 'return' outside of function (392:2)]
  pos: 9902,
  loc: { line: 392, column: 2 },
  raisedAt: 9908,
  _babel: true,
  codeFrame: '  390 |   });\n  391 | \n> 392 |   return;\n      |   ^\n  393 | }\n  394 | \n  395 | // load' }

based on advice from @oakfang