### PR TITLE
Fix: html-runner crashing because of missing process.stdout shim

### DIFF
--- a/support/browser-entry.js
+++ b/support/browser-entry.js
@@ -1,3 +1,9 @@
+/**
+ * Shim process.stdout.
+ */
+
+process.stdout = require('browser-stdout')();
+
 var Mocha = require('../');
 
 /**
@@ -139,12 +145,6 @@ mocha.run = function(fn){
     if (fn) fn(err);
   });
 };
-
-/**
- * Shim process.stdout.
- */
-
-process.stdout = require('browser-stdout')();
 
 /**
  * Expose the process shim.


### PR DESCRIPTION
Fixes: #1789

When running mocha in the browser you get a crash in the following code:

```js
if (isatty) {
  exports.window.width = process.stdout.getWindowSize
      ? process.stdout.getWindowSize(1)[0]
      : tty.getWindowSize()[1];
}
```

That is because we need to shim the process.stdout before requiring
mocha from browser-entry.js, I fixed that by moving it to the top of the
file.