### PR TITLE
Fix delay option in browser

### DIFF
--- a/support/browser-entry.js
+++ b/support/browser-entry.js
@@ -119,6 +119,9 @@ mocha.ui = function(ui){
 
 mocha.setup = function(opts){
   if ('string' == typeof opts) opts = { ui: opts };
+  if ('delay' in opts) {
+    this.delay(opts.delay);
+  }
   for (var opt in opts) this[opt](opts[opt]);
   return this;
 };

--- a/test/browser/delay.html
+++ b/test/browser/delay.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <title>Mocha</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../mocha.css" />
+    <script src="../../mocha.js"></script>
+    <script>
+      mocha.setup({
+        ui: 'bdd',
+        delay: true
+      })
+    </script>
+    <script>
+        function assert(expr, msg) {
+            if (!expr) throw new Error(msg);
+        }
+    </script>
+    <script src="delay.js"></script>
+    <script>
+        onload = function() {
+            mocha.run();
+        };
+    </script>
+</head>
+<body>
+<div id="mocha"></div>
+</body>
+</html>

--- a/test/browser/delay.js
+++ b/test/browser/delay.js
@@ -1,0 +1,25 @@
+var delay = 500;
+var start = new Date().getTime();
+
+describe('delayed execution', function() {
+  it('should define a global run function', function() {
+    assert(typeof run === 'function', 'run function is not defined');
+  });
+  it('should have waited ' + delay + 'ms to run this suite', function() {
+    assert(new Date().getTime() - delay >= start, 'did not delay');
+  });
+});
+
+setTimeout(function() {
+  describe('delayed execution', function() {
+    it('should be able to define a suite asynchronously', function() {
+      assert(true);
+    });
+  });
+
+  if (typeof run === 'function') {
+    run();
+  } else {
+    mocha.suite.run();
+  }
+}, delay);


### PR DESCRIPTION
This PR addresses #1799. It feels a bit weird to special-case the delay option like this, but it looks like that's the only option that's read from `mocha.options` prior to `mocha.run()` being called.

Totally open to better suggestions though.
