### PR TITLE
Set safe CSS for progress indicator which does not conflict with Bootstrap

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -261,6 +261,15 @@ body {
 #mocha-stats .progress {
   float: right;
   padding-top: 0;
+  
+  /**
+   * Set safe initial values, so mochas .progress does not inherit these
+   * properties from Bootstrap .progress (which causes .progress height to
+   * equal line height set in Bootstrap).
+   */
+  height: auto;
+  box-shadow: none;
+  background-color: initial;
 }
 
 #mocha-stats em {


### PR DESCRIPTION
This is not the best solution for a problem, mocha should not know anything about Bootstrap.

Proposed change would result in less conflicts. However it is made just to get the ball rolling.

In order to prevent such conflicts from happening, it is a good idea to avoid nesting in mochas CSS, e.g. by adapting BEM naming convention (see https://css-tricks.com/bem-101/).

Giving mocha elements classes named `mocha-stats-progress` will eliminate conflicts with other libraries entirely.