### PR TITLE
Call the inspect() function if message is not set

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -169,7 +169,14 @@ exports.list = function(failures) {
     // msg
     var msg;
     var err = test.err;
-    var message = err.message || '';
+    var message;
+    if (err.message) {
+      message = err.message;
+    } else if (typeof err.inspect === 'function') {
+      message = err.inspect();
+    } else {
+      message = '';
+    }
     var stack = err.stack || message;
     var index = stack.indexOf(message);
     var actual = err.actual;

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -140,7 +140,18 @@ describe('Base reporter', function () {
     Base.list([test]);
 
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar')
+    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar');
+  });
+
+  it('should use the inspect() property if `message` is not set', function () {
+    var err = {
+      showDiff: false,
+      inspect: function() { return 'an error happened'; },
+    };
+    var test = makeTest(err);
+    Base.list([test]);
+    var errOut = stdout.join('\n').trim();
+    errOut.should.equal('1) test title:\n     an error happened');
   });
 
   it('should not modify stack if it does not contain message', function () {
@@ -154,7 +165,7 @@ describe('Base reporter', function () {
     Base.list([test]);
 
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar')
+    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar');
   });
 
 });


### PR DESCRIPTION
Unfortunately some frameworks throw error objects which do not have a `message`
property but do have an `inspect()` function. This means Mocha reports a test
failure, but prints the empty string instead of any useful information about
the error message. For an example, see versions of the Waterline ORM before
v0.10.19: https://github.com/balderdashy/waterline/commit/0965d132

If the `message` key is not set on an error object, attempt to print the same
output as `console.log` in Node, by calling the object's `inspect()` function,
if it exists.

We could try to fallback to calling `util.inspect` on the `err` object and
logging that, but it would break outside of Node and I'm not sure the format would be appropriate.