### PR TITLE
Fix: Bail flag causes before() hooks to be run even after a failure

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -569,7 +569,7 @@ Runner.prototype.runSuite = function(suite, fn) {
 
   debug('run suite %s', suite.fullTitle());
 
-  if (!total) {
+  if (!total || (self.failures && suite._bail)) {
     return fn();
   }
 

--- a/test/integration/fixtures/options/bail.js
+++ b/test/integration/fixtures/options/bail.js
@@ -11,13 +11,9 @@ describe('suite1', function() {
 });
 
 describe('suite2', function() {
-  // TODO: When uncommented, the hook below is ran and throws an exception
-  // despite the previous failure with the bail flag. This is a bug. Uncomment
-  // once resolved
-
-  // before(function(done) {
-  //   throw new Error('this hook should not be displayed');
-  // });
+  before(function(done) {
+    throw new Error('this hook should not be displayed');
+  });
 
   it('should not display this error', function(done) {
     throw new Error('this should not be displayed');


### PR DESCRIPTION
Fixes #1812

Added a bail check to the runSuite method in runner.js. There was already a commented out check for a subsequent before block in the bail fixture so I just uncommented that for the test.