### PR TITLE
Fix stack trace display in FireFox and Safari

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -166,11 +166,10 @@ function HTML(runner) {
       }
 
       if (test.err.stack) {
-        var indexOfMessage = test.err.stack.indexOf(test.err.message);
-        if (indexOfMessage === -1) {
-          stackString = test.err.stack;
+        if (test.err.stack.substr(0, message.length) === message) {
+          stackString = test.err.stack.substring(message.length, test.err.stack.length);
         } else {
-          stackString = test.err.stack.substr(test.err.message.length + indexOfMessage);
+          stackString = '\n' + test.err.stack.replace(/^/gm, '    ');
         }
       } else if (test.err.sourceURL && test.err.line !== undefined) {
         // Safari doesn't give you a stack. Let's at least provide a source line.


### PR DESCRIPTION
Hi!

I encountered three problems using mocha in the browser with FireFox 40 and Safari 8 on Mac OS X:
1. There is no line break before the stack trace.
2. The track trace is not indented.
3. More subtle: the stack trace is wrongly trimmed if the error message is contained in the stack trace.

My solution looks like solving these three problems in FireFox 40 and Safari 8 and also works in Chrome 44, but I haven't tested it on any other plateforme nor did I test it in complexe situations (htmlMessage for exemple, see d71a5c6e0f17ab5b530388edf5b8cfb71ed75d33).

@jbnicolai Are there cases where `test.err.message` isn't at the beginning of the stack trace and where using `indexOf` is really useful?

Screenshot before:

![Screenshot before](https://cloud.githubusercontent.com/assets/777748/9671181/523872b0-5291-11e5-84b8-38debe98f02a.png)

Screenshot after:

![Screenshot afte](https://cloud.githubusercontent.com/assets/777748/9671191/624f58bc-5291-11e5-8df7-461bb3b57bee.png)

Best regards,

Matt
