### PR TITLE
Fix #1864: xunit missing output with --reporter-options output

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -78,6 +78,11 @@ function XUnit(runner, options) {
 }
 
 /**
+ * Inherit from `Base.prototype`.
+ */
+inherits(XUnit, Base);
+
+/**
  * Override done to close the stream (if it's a file).
  *
  * @param failures
@@ -92,11 +97,6 @@ XUnit.prototype.done = function(failures, fn) {
     fn(failures);
   }
 };
-
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(XUnit, Base);
 
 /**
  * Write out the given line.

--- a/test/integration/reporters.js
+++ b/test/integration/reporters.js
@@ -1,8 +1,12 @@
 var assert = require('assert');
+var os     = require('os');
+var fs     = require('fs');
+var crypto = require('crypto');
+var path   = require('path');
 var run    = require('./helpers').runMocha;
 
 describe('reporters', function() {
-  this.timeout(1000);
+  this.timeout(3000);
 
   describe('markdown', function() {
     var res;
@@ -26,6 +30,31 @@ describe('reporters', function() {
       ].join('\n');
 
       assert(res.output.indexOf(src) !== -1, 'No assert found');
+    });
+  });
+
+  describe('xunit', function() {
+    it('prints test cases with --reporter-options output (issue: 1864)', function(done) {
+      var randomStr = crypto.randomBytes(8).toString('hex');
+      var tmpDir = os.tmpDir().replace(new RegExp(path.sep + '$'), '');
+      var tmpFile = tmpDir + path.sep + 'test-issue-1864-' + randomStr + '.xml';
+
+      var args = ['--reporter=xunit', '--reporter-options', 'output=' + tmpFile];
+      var expectedOutput = [
+        '<testcase classname="suite" name="test1" time="0"/>',
+        '<testcase classname="suite" name="test2" time="0"/>',
+        '</testsuite>'
+      ].join('\n');
+
+      run('passing.js', args, function(err, result) {
+        if (err) return done(err);
+
+        var xml = fs.readFileSync(tmpFile, 'utf8');
+        fs.unlinkSync(tmpFile);
+
+        assert(xml.indexOf(expectedOutput) !== -1, 'Did not output all xml');
+        done(err);
+      });
     });
   });
 });


### PR DESCRIPTION
Fix for https://github.com/mochajs/mocha/issues/1864

``` javascript
./bin/mocha --reporter=xunit --reporter-options output=results.xml test.js; cat results.xml
<testsuite name="Mocha Tests" tests="2" failures="1" errors="1" skipped="0" timestamp="Wed, 09 Sep 2015 19:34:48 GMT" time="0.004">
<testcase classname="my test" name="should pass" time="0.001"/>
<testcase classname="my test" name="should fail" time="0.001"><failure><![CDATA[fail
Error: fail
    at Context.&lt;anonymous&gt; (test.js:7:14)
    at callFnAsync (/Users/danielstjules/git/mocha/lib/runnable.js:306:8)
    at Test.Runnable.run (/Users/danielstjules/git/mocha/lib/runnable.js:261:7)
    at Runner.runTest (/Users/danielstjules/git/mocha/lib/runner.js:417:10)
    at /Users/danielstjules/git/mocha/lib/runner.js:524:12
    at next (/Users/danielstjules/git/mocha/lib/runner.js:338:14)
    at /Users/danielstjules/git/mocha/lib/runner.js:348:7
    at next (/Users/danielstjules/git/mocha/lib/runner.js:281:14)
    at Object._onImmediate (/Users/danielstjules/git/mocha/lib/runner.js:316:5)]]></failure></testcase>
</testsuite>
```