### PR TITLE
Stackfilter fix: Don't remove modules/components from stack trace in the browser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -689,7 +689,7 @@ exports.getError = function(err) {
  * @description
  * When invoking this function you get a filter function that get the Error.stack as an input,
  * and return a prettify output.
- * (i.e: strip Mocha, node_modules, bower and componentJS from stack trace).
+ * (i.e: strip Mocha and internal node functions from stack trace).
  * @returns {Function}
  */
 exports.stackTraceFilter = function() {
@@ -701,14 +701,10 @@ exports.stackTraceFilter = function() {
       : (typeof location === 'undefined' ? window.location : location).href.replace(/\/[^\/]*$/, '/');
 
   function isMochaInternal(line) {
-    return (~line.indexOf('node_modules' + slash + 'mocha'))
-      || (~line.indexOf('components' + slash + 'mochajs'))
-      || (~line.indexOf('components' + slash + 'mocha'));
-  }
-
-  // node_modules, bower, componentJS
-  function isBrowserModule(line) {
-    return (~line.indexOf('node_modules')) || (~line.indexOf('components'));
+    return (~line.indexOf('node_modules' + slash + 'mocha' + slash))
+      || (~line.indexOf('components' + slash + 'mochajs' + slash))
+      || (~line.indexOf('components' + slash + 'mocha' + slash))
+      || (~line.indexOf(slash + 'mocha.js'));
   }
 
   function isNodeInternal(line) {
@@ -724,11 +720,11 @@ exports.stackTraceFilter = function() {
     stack = stack.split('\n');
 
     stack = exports.reduce(stack, function(list, line) {
-      if (is.node && (isMochaInternal(line) || isNodeInternal(line))) {
+      if (isMochaInternal(line)) {
         return list;
       }
 
-      if (is.browser && (isBrowserModule(line))) {
+      if (is.node && isNodeInternal(line)) {
         return list;
       }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -101,7 +101,7 @@ describe('utils', function() {
         filter(stack.join('\n')).should.equal(stack.slice(0,7).join('\n'));
       });
 
-      it('should ignore bower and components files', function() {
+      it('does not ignore other bower_components and components', function() {
         var stack = ['Error: failed'
           , 'at assert (index.html:11:26)'
           , 'at Context.<anonymous> (test.js:17:18)'
@@ -126,18 +126,18 @@ describe('utils', function() {
         global.location = { href: 'localhost:3000/foo/bar/index.html' };
         filter = utils.stackTraceFilter();
       });
-      it('should strip out bower and components too', function() {
+      it('does not strip out other bower_components and components', function() {
         var stack = ['Error: failed'
           , 'at assert (index.html:11:26)'
           , 'at Context.<anonymous> (test.js:17:18)'
           , 'at bower_components/should/should.js:4827:7'
-          , 'at next (localhost:3000/foo/bar/bower_components/should/should.js:4766:23)'
+          , 'at next (bower_components/should/should.js:4766:23)'
           , 'at components/should/5.0.0/should.js:4827:7'
-          , 'at next (localhost:3000/foo/bar/components/should/5.0.0/should.js:4766:23)'
-          , 'at Runner.require.register.Runner.runTest (localhost:3000/foo/bar/node_modules/mocha.js:4892:10)'
+          , 'at next (components/should/5.0.0/should.js:4766:23)'
+          , 'at Runner.require.register.Runner.runTest (node_modules/mocha.js:4892:10)'
           , 'at localhost:3000/foo/bar/node_modules/mocha.js:4970:12'
-          , 'at next (localhost:3000/foo/bar/node_modules/mocha.js:4817:14)'];
-        filter(stack.join('\n')).should.equal(stack.slice(0,3).join('\n'));
+          , 'at next (node_modules/mocha.js:4817:14)'];
+        filter(stack.join('\n')).should.equal(stack.slice(0,7).join('\n'));
       });
 
       after(function() {


### PR DESCRIPTION
Followup to https://github.com/mochajs/mocha/issues/1766 and https://github.com/mochajs/mocha/pull/1767

Makes the behavior consistent in the browser. We now only filter out mocha's own function calls, and don't touch calls from dependencies. Given how modularity is embraced in the node community, I think this is ideal.