### PR TITLE
Fix #1850: Reduce browser bundle size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ mocha.js: $(SRC) $(SUPPORT)
 		--ignore 'glob' \
 		--ignore 'jade' \
 		--ignore 'path' \
+		--ignore 'buffer' \
 		--ignore 'supports-color' \
 		--exclude './lib-cov/mocha' > $@
 


### PR DESCRIPTION
Fix for https://github.com/mochajs/mocha/issues/1850

Size before: 310647
Size after: 265222

**WIP: Will see how much smaller I can get it**