### PR TITLE
Revert jade to support npm < v1.3.7

### DIFF
--- a/lib/reporters/templates/coverage.jade
+++ b/lib/reporters/templates/coverage.jade
@@ -17,7 +17,7 @@ html
         .misses= cov.misses
 
       #files
-        each file in cov.files
+        for file in cov.files
           .file
             h2(id=file.filename)= file.filename
             #stats(class=coverageClass(file.coverage))
@@ -33,7 +33,7 @@ html
                   th Hits
                   th Source
               tbody
-                each line, number in file.source
+                for line, number in file.source
                   if line.coverage > 0
                     tr.hit
                       td.line= number

--- a/lib/reporters/templates/menu.jade
+++ b/lib/reporters/templates/menu.jade
@@ -1,12 +1,12 @@
 #menu
   li
     a(href='#overview') overview
-  each file in cov.files
+  for file in cov.files
     li
       span.cov(class=coverageClass(file.coverage)) #{file.coverage | 0}
       a(href='##{file.filename}')
-        - var segments = file.filename.split('/')
-        - var basename = segments.pop()
+        segments = file.filename.split('/')
+        basename = segments.pop()
         if segments.length
           span.dirname= segments.join('/') + '/'
         span.basename= basename

--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",
     "growl": "1.8.1",
-    "jade": "1.11.0",
+    "jade": "0.26.3",
     "mkdirp": "0.5.0",
     "supports-color": "1.2.0"
   },


### PR DESCRIPTION
Reverts https://github.com/outsideris/mocha/commit/d70759f1730a7cecf8f786715a74065db5b6638b for older npm versions, as discussed in https://github.com/mochajs/mocha/issues/1868