### PR TITLE
Fix #1798: Correctly attribute mutiple done err with hooks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -288,12 +288,13 @@ Runner.prototype.hook = function(name, fn) {
 
     self.emit('hook', hook);
 
-    hook.on('error', function(err) {
-      self.failHook(hook, err);
-    });
+    if (!hook.listeners('error').length) {
+      hook.on('error', function(err) {
+        self.failHook(hook, err);
+      });
+    }
 
     hook.run(function(err) {
-      hook.removeAllListeners('error');
       var testError = hook.error();
       if (testError) {
         self.fail(self.test, testError);

--- a/test/integration/fixtures/multiple.done.before.js
+++ b/test/integration/fixtures/multiple.done.before.js
@@ -1,0 +1,10 @@
+describe('suite', function() {
+  before(function(done) {
+    setTimeout(done, 10);
+    setTimeout(done, 30);
+  });
+
+  it('test1', function(done) {
+    setTimeout(done, 50);
+  });
+});

--- a/test/integration/fixtures/multiple.done.beforeEach.js
+++ b/test/integration/fixtures/multiple.done.beforeEach.js
@@ -1,0 +1,14 @@
+describe('suite', function() {
+  beforeEach(function(done) {
+    setTimeout(done, 10);
+    setTimeout(done, 20);
+  });
+
+  it('test1', function(done) {
+    setTimeout(done, 50);
+  });
+
+  it('test2', function(done) {
+    setTimeout(done, 50);
+  });
+});

--- a/test/integration/fixtures/multiple.done.specs.js
+++ b/test/integration/fixtures/multiple.done.specs.js
@@ -1,0 +1,10 @@
+describe('suite', function() {
+  it('test1', function(done) {
+    done();
+    setTimeout(done, 10);
+  });
+
+  it('test2', function(done) {
+    setTimeout(done, 20);
+  });
+});

--- a/test/integration/multiple.done.js
+++ b/test/integration/multiple.done.js
@@ -4,25 +4,95 @@ var args   = [];
 
 describe('multiple calls to done()', function() {
   var res;
-
   this.timeout(1000);
 
-  before(function(done) {
-    run('multiple.done.js', args, function(err, result) {
-      res = result;
-      done(err);
+  describe('from a spec', function() {
+    before(function(done) {
+      run('multiple.done.js', args, function(err, result) {
+        res = result;
+        done(err);
+      });
+    });
+
+    it('results in failures', function() {
+      assert.equal(res.stats.pending, 0);
+      assert.equal(res.stats.passes, 1);
+      assert.equal(res.stats.failures, 1);
+      assert.equal(res.code, 1);
+    });
+
+    it('throws a descriptive error', function() {
+      assert.equal(res.failures[0].err.message,
+        'done() called multiple times');
     });
   });
 
-  it('results in failures', function() {
-    assert.equal(res.stats.pending, 0);
-    assert.equal(res.stats.passes, 1);
-    assert.equal(res.stats.failures, 1);
-    assert.equal(res.code, 1);
+  describe('with multiple specs', function() {
+    before(function(done) {
+      run('multiple.done.specs.js', args, function(err, result) {
+        res = result;
+        done(err);
+      });
+    });
+
+    it('results in a failure', function() {
+      assert.equal(res.stats.pending, 0);
+      assert.equal(res.stats.passes, 2);
+      assert.equal(res.stats.failures, 1);
+      assert.equal(res.code, 1);
+    });
+
+    it('correctly attributes the error', function() {
+      assert.equal(res.failures[0].fullTitle, 'suite test1');
+      assert.equal(res.failures[0].err.message,
+        'done() called multiple times');
+    });
   });
 
-  it('throws a descriptive error', function() {
-    assert.equal(res.failures[0].err.message,
-      'done() called multiple times');
+  describe('from a before hook', function() {
+    before(function(done) {
+      run('multiple.done.before.js', args, function(err, result) {
+        res = result;
+        done(err);
+      });
+    });
+
+    it('results in a failure', function() {
+      assert.equal(res.stats.pending, 0);
+      assert.equal(res.stats.passes, 1);
+      assert.equal(res.stats.failures, 1);
+      assert.equal(res.code, 1);
+    });
+
+    it('correctly attributes the error', function() {
+      assert.equal(res.failures[0].fullTitle, 'suite "before all" hook');
+      assert.equal(res.failures[0].err.message,
+        'done() called multiple times');
+    });
+  });
+
+  describe('from a beforeEach hook', function() {
+    before(function(done) {
+      run('multiple.done.beforeEach.js', args, function(err, result) {
+        res = result;
+        done(err);
+      });
+    });
+
+    it('results in a failure', function() {
+      assert.equal(res.stats.pending, 0);
+      assert.equal(res.stats.passes, 2);
+      assert.equal(res.stats.failures, 2);
+      assert.equal(res.code, 2);
+    });
+
+    it('correctly attributes the errors', function() {
+      assert.equal(res.failures.length, 2);
+      res.failures.forEach(function(failure) {
+        assert.equal(failure.fullTitle, 'suite "before each" hook');
+        assert.equal(failure.err.message,
+          'done() called multiple times');
+      });
+    });
   });
 });


### PR DESCRIPTION
``` javascript
$ cat test.js
describe('suite', function() {
  before(function(done) {
    setTimeout(done, 30);
    setTimeout(done, 60);
  });

  it('test', function(done) {
    setTimeout(done, 100);
  });
});

// -------------------------------------------------------------
// Before PR, the error is incorrectly attributed to the spec,
// rather than the before hook. Furthermore, the error was
// uncaught, so that suite would stop
// -------------------------------------------------------------
$ mocha test.js


  suite
    1) test


  0 passing (67ms)
  1 failing

  1) suite test:
     Uncaught Error: done() called multiple times

// -------------------------------------------------------------
// After the PR, the error is correctly attributed to the hook
// -------------------------------------------------------------
$ mocha test.js


  ․․

  1 passing (141ms)
  1 failing

  1) suite "before all" hook:
     Error: done() called multiple times
```