### PR TITLE
emit require/post-require hooks in browser

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -136,6 +136,10 @@ mocha.run = function(fn){
   if (query.fgrep) mocha.grep(query.fgrep);
   if (query.invert) mocha.invert();
 
+  // require/post-require events usually emitted in Mocha.prototype.loadFiles
+  this.suite.emit('require', global, null, this);
+  this.suite.emit('post-require', global, null, this);
+
   return Mocha.prototype.run.call(mocha, function(err){
     // The DOM Document is not available in Web Workers.
     var document = global.document;


### PR DESCRIPTION
In node, the `Mocha.prototype.loadFiles` method [emits callback events](https://github.com/mochajs/mocha/blob/c4393c456839d6bf2cbb4abb1cd177010ee06458/lib/mocha.js#L215-L217) (`pre-require`,`require`, and `post-require`) around the require of each test file.

These callbacks are the hooks by which custom UIs register their APIs and do their magic. In the browser, no such files are loaded. The browser entry file overrides `Mocha.prototype.ui` to ensure the `pre-require` hook is [still invoked](https://github.com/mochajs/mocha/blob/c4393c456839d6bf2cbb4abb1cd177010ee06458/support/browser-entry.js#L112).

Thus, when a UI is set, the custom UI has a chance to register its API. Up until now, however, the `require` and `post-require` hooks haven't been invoked at all.

In node, the 3 hooks are invoked [right after one another](https://github.com/mochajs/mocha/blob/c4393c456839d6bf2cbb4abb1cd177010ee06458/lib/mocha.js#L453) inside the `loadFiles` method which is invoked by the `run` method.

In node, the `require`/`post-require` hooks are invoked after the file is required as part of a `run`. In the browser, `run` is already guaranteed to be invoked _after_ the tests have been loaded, thus the constraint that the tests be loaded prior to `require`/`post-require` hooks still holds. And they are invoked as part of the `run` flow which is the same as under node.
