### PR TITLE
Fix duplication of mocha.opts on process.argv

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -8,12 +8,7 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
   fs = require('fs'),
-  args = [path.join(__dirname, '_mocha')],
-  getOptions = require('./options');
-
-// load mocha.opts into process.argv
-
-getOptions();
+  args = [path.join(__dirname, '_mocha')];
 
 process.argv.slice(2).forEach(function(arg){
   var flag = arg.split('=')[0];

--- a/test/integration/regression.js
+++ b/test/integration/regression.js
@@ -1,4 +1,6 @@
 var assert = require('assert');
+var fs     = require('fs');
+var path   = require('path');
 var run    = require('./helpers').runMocha;
 
 describe('regressions', function() {
@@ -20,5 +22,12 @@ describe('regressions', function() {
       assert.equal(res.code, 1);
       done();
     });
+  });
+
+  it('should not duplicate mocha.opts args in process.argv', function() {
+    var processArgv = process.argv.join('');
+    var mochaOpts = fs.readFileSync(path.join(__dirname, '..', 'mocha.opts'), 'utf-8').split(/[\s]+/).join('');
+    assert.notEqual(processArgv.indexOf(mochaOpts), -1, 'process.argv missing mocha.opts');
+    assert.equal(processArgv.indexOf(mochaOpts), processArgv.lastIndexOf(mochaOpts), 'process.argv contains duplicated mocha.opts');
   });
 });


### PR DESCRIPTION
Found by @jameswomack (see [yargs issue 267](https://github.com/bcoe/yargs/issues/267)), mocha is reading options from `test/mocha.opts` and adding them to `process.argv` twice - once in `bin/mocha` and then again in `bin/_mocha`. This PR removes the 2nd one and adds a unit test to cover this scenario.

Wasn't quite sure where to put the unit test, but `test/integration/regression.js` seems like a decent place.

Let me know if there's anything you'd like me to change. Thanks.