### PR TITLE
#1417 - displaying actual error instead of incorrect done() called mu…

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -314,7 +314,11 @@ Runnable.prototype.run = function(fn) {
         }
         return done(new Error('done() invoked with non-Error: ' + err));
       }
-      done();
+      if (ctx && ctx.test) {
+        done(ctx.test.err);
+      } else {
+        done();
+      }
     });
   }
 };

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -314,7 +314,7 @@ Runnable.prototype.run = function(fn) {
         }
         return done(new Error('done() invoked with non-Error: ' + err));
       }
-      if (ctx && ctx.test) {
+      if (finished && ctx && ctx.test) {
         done(ctx.test.err);
       } else {
         done();

--- a/test/integration/fixtures/regression/issue-1417.js
+++ b/test/integration/fixtures/regression/issue-1417.js
@@ -1,0 +1,4 @@
+it('throwing an error after calling done()', function(done) {
+  setImmediate(done);
+  throw new Error('This error should not be masked');
+});

--- a/test/integration/regression.js
+++ b/test/integration/regression.js
@@ -21,4 +21,10 @@ describe('regressions', function() {
       done();
     });
   });
+
+  it('issue-1417: errors should be propagated properly', function () {
+    run('regression/issue-1417.js', [], function(err, res) {
+      assert(res.output.indexOf('This error should not be masked') > -1, 'Expected error was not displayed');
+    });
+  });
 });


### PR DESCRIPTION
Patch for issue 1417 - Error in "done() called multiple times" assumptions.

The error was hidden by not passing in the exiting error from the context which led to an incorrect error stating done() has been called multiple times.