### PR TITLE
Bug: fix `describe.only` to work

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -475,6 +475,12 @@ Mocha.prototype.run = function(fn) {
   }
   exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
 
+  runner.on('beforeSuite', function() {
+    if (options.grep) {
+      runner.grep(options.grep, options.invert);
+    }
+  });
+
   function done(failures) {
     if (reporter.done) {
       reporter.done(failures, fn);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -569,6 +569,7 @@ Runner.prototype.runSuite = function(suite, fn) {
   var total = this.grepTotal(suite);
   var afterAllHookCalled = false;
 
+  this.emit('beforeSuite');
   debug('run suite %s', suite.fullTitle());
 
   if (!total || (self.failures && suite._bail)) {


### PR DESCRIPTION
The `describe.only` seems not to be working currently. After researching something codes from the repository, I learn `only` is based on the awesome option `grep`. But the set to grep from `only` describe does after `runner.run(done)`(Essentially it's `grepTotal`), but the current source code attach grep at https://github.com/yorkie/mocha/blob/b0ce87c78e84d32008dcbc93fa32fd0cd3129845/lib/mocha.js#L465, so the grep from `describe.only` doesn't apply at this case.

I added a trigger `beforeSuite` and an `once` listen for doing re-grep. Now this change works for me :-)