### PR TITLE
Add ability to specify ignore patterns

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -313,7 +313,10 @@ var args = program.args;
 if (!args.length) args.push('test');
 
 args.forEach(function(arg){
-  files = files.concat(utils.lookupFiles(arg, extensions, program.recursive));
+  files = files.concat(utils.lookupFiles(arg, {
+    extensions: extensions,
+    recursive: program.recursive
+  }));
 });
 
 // resolve

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -97,6 +97,7 @@ program
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
   .option('--delay', 'wait for async suite definition')
+  .option('--ignore <pattern>,...', 'ignore patterns', list, []);
 
 program.name = 'mocha';
 
@@ -315,7 +316,8 @@ if (!args.length) args.push('test');
 args.forEach(function(arg){
   files = files.concat(utils.lookupFiles(arg, {
     extensions: extensions,
-    recursive: program.recursive
+    recursive: program.recursive,
+    ignore: program.ignore
   }));
 });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -609,13 +609,14 @@ exports.canonicalize = function(value, stack) {
  *
  * @api public
  * @param {string} path Base path to start searching from.
- * @param {string[]} extensions File extensions to look for.
- * @param {boolean} recursive Whether or not to recurse into subdirectories.
+ * @param {object} options Lookup options.
+ * @param {string[]} [options.extensions] File extensions to look for.
+ * @param {boolean} [options.recursive] Whether or not to recurse into subdirectories.
  * @return {string[]} An array of paths.
  */
-exports.lookupFiles = function lookupFiles(path, extensions, recursive) {
+exports.lookupFiles = function lookupFiles(path, options) {
   var files = [];
-  var re = new RegExp('\\.(' + extensions.join('|') + ')$');
+  var re = new RegExp('\\.(' + options.extensions.join('|') + ')$');
 
   if (!exists(path)) {
     if (exists(path + '.js')) {
@@ -644,8 +645,8 @@ exports.lookupFiles = function lookupFiles(path, extensions, recursive) {
     try {
       var stat = statSync(file);
       if (stat.isDirectory()) {
-        if (recursive) {
-          files = files.concat(lookupFiles(file, extensions, recursive));
+        if (options.recursive) {
+          files = files.concat(lookupFiles(file, options.extensions, options.recursive));
         }
         return;
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -612,6 +612,7 @@ exports.canonicalize = function(value, stack) {
  * @param {object} options Lookup options.
  * @param {string[]} [options.extensions] File extensions to look for.
  * @param {boolean} [options.recursive] Whether or not to recurse into subdirectories.
+ * @param {string[]} [options.ignore] Ignore patterns.
  * @return {string[]} An array of paths.
  */
 exports.lookupFiles = function lookupFiles(path, options) {
@@ -622,7 +623,7 @@ exports.lookupFiles = function lookupFiles(path, options) {
     if (exists(path + '.js')) {
       path += '.js';
     } else {
-      files = glob.sync(path);
+      files = glob.sync(path, { ignore: options.ignore });
       if (!files.length) {
         throw new Error("cannot resolve path (or pattern) '" + path + "'");
       }

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "browserify": "10.2.4",
     "coffee-script": "~1.8.0",
     "eslint": "^1.2.1",
+    "rimraf": "^2.4.3",
     "should": "~4.0.0",
     "through2": "~0.6.5"
   },

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.0.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": "~5.0.15",
     "growl": "1.8.1",
     "jade": "0.26.3",
     "mkdirp": "0.5.0",

--- a/test/acceptance/glob/glob.sh
+++ b/test/acceptance/glob/glob.sh
@@ -52,4 +52,14 @@ cat /tmp/mocha-glob.txt | grep -q -F 'cannot resolve path' || {
     exit 1
 }
 
+../../../bin/mocha -R json-stream './*.js' --ignore './*' 2> /tmp/mocha-glob.txt && {
+    echo Globbing './*.js' with specified ignore pattern './*' in `pwd` failed.
+    exit 1
+}
+
+cat /tmp/mocha-glob.txt | grep -q -F 'cannot resolve path' || {
+    echo Globbing './*.js' with specified ignore pattern './*' in `pwd` should match no files and run no tests.
+    exit 1
+}
+
 echo Glob-test passed.

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -381,14 +381,14 @@ describe('lib/utils', function () {
     });
 
     it('should not choke on symlinks', function () {
-      utils.lookupFiles('/tmp', ['js'], false)
+      utils.lookupFiles('/tmp', {extensions: ['js'], recursive: false})
         .should.containEql('/tmp/mocha-utils-link.js')
         .and.containEql('/tmp/mocha-utils.js')
         .and.have.lengthOf(2);
       existsSync('/tmp/mocha-utils-link.js').should.be.true;
       fs.renameSync('/tmp/mocha-utils.js', '/tmp/bob');
       existsSync('/tmp/mocha-utils-link.js').should.be.false;
-      utils.lookupFiles('/tmp', ['js'], false).should.eql([]);
+      utils.lookupFiles('/tmp', {extensions: ['js'], recursive: false}).should.eql([]);
     });
 
     afterEach(function () {

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -375,28 +375,80 @@ describe('lib/utils', function () {
       path = require('path'),
       existsSync = fs.existsSync || path.existsSync;
 
-    beforeEach(function () {
-      fs.writeFileSync('/tmp/mocha-utils.js', 'yippy skippy ying yang yow');
-      fs.symlinkSync('/tmp/mocha-utils.js', '/tmp/mocha-utils-link.js');
+    context('when specified path contains symlinks', function () {
+      beforeEach(function () {
+        fs.writeFileSync('/tmp/mocha-utils.js', 'yippy skippy ying yang yow');
+        fs.symlinkSync('/tmp/mocha-utils.js', '/tmp/mocha-utils-link.js');
+      });
+
+      it('should not choke on symlinks', function () {
+        utils.lookupFiles('/tmp', {extensions: ['js'], recursive: false})
+          .should.containEql('/tmp/mocha-utils-link.js')
+          .and.containEql('/tmp/mocha-utils.js')
+          .and.have.lengthOf(2);
+        existsSync('/tmp/mocha-utils-link.js').should.be.true;
+        fs.renameSync('/tmp/mocha-utils.js', '/tmp/bob');
+        existsSync('/tmp/mocha-utils-link.js').should.be.false;
+        utils.lookupFiles('/tmp', {extensions: ['js'], recursive: false}).should.eql([]);
+      });
+
+      afterEach(function () {
+        ['/tmp/mocha-utils.js', '/tmp/mocha-utils-link.js', '/tmp/bob'].forEach(function (path) {
+          try {
+            fs.unlinkSync(path);
+          }
+          catch (ignored) {}
+        });
+      });
     });
 
-    it('should not choke on symlinks', function () {
-      utils.lookupFiles('/tmp', {extensions: ['js'], recursive: false})
-        .should.containEql('/tmp/mocha-utils-link.js')
-        .and.containEql('/tmp/mocha-utils.js')
-        .and.have.lengthOf(2);
-      existsSync('/tmp/mocha-utils-link.js').should.be.true;
-      fs.renameSync('/tmp/mocha-utils.js', '/tmp/bob');
-      existsSync('/tmp/mocha-utils-link.js').should.be.false;
-      utils.lookupFiles('/tmp', {extensions: ['js'], recursive: false}).should.eql([]);
-    });
+    context('when ignore patterns are specified', function () {
+      var rmrf = require('rimraf');
 
-    afterEach(function () {
-      ['/tmp/mocha-utils.js', '/tmp/mocha-utils-link.js', '/tmp/bob'].forEach(function (path) {
-        try {
-          fs.unlinkSync(path);
-        }
-        catch (ignored) {}
+      var dirs = [
+        '/tmp/mocha_ignore',
+        '/tmp/mocha_ignore/nested_dir',
+        '/tmp/mocha_ignore/node_modules',
+        '/tmp/mocha_ignore/node_modules/nested_dir',
+        '/tmp/mocha_ignore/tmp'
+        ],
+        files = [
+          '/tmp/mocha_ignore/test.js',
+          '/tmp/mocha_ignore/nested_dir/test.js',
+          '/tmp/mocha_ignore/node_modules/test.js',
+          '/tmp/mocha_ignore/node_modules/nested_dir/test.js',
+          '/tmp/mocha_ignore/tmp/test.js'
+        ];
+
+      beforeEach(function (done) {
+        rmrf('/tmp/mocha_ignore', function () {
+          dirs.forEach(function (dir) {
+            fs.mkdirSync(dir);
+          });
+          files.forEach(function (file) {
+            fs.writeFileSync(file, '');
+          });
+          done();
+        });
+      });
+
+      it('ignores files matched by specified pattern if they also matches one of ignore patterns', function () {
+        var result = utils.lookupFiles('/tmp/mocha_ignore/**/test.js', {
+          extensions: ['js'],
+          recursive: false,
+          ignore: [
+            '/tmp/mocha_ignore/node_modules/**/*',
+            '/tmp/mocha_ignore/tmp/**/*'
+          ]
+        });
+        result.should.eql([
+          '/tmp/mocha_ignore/nested_dir/test.js',
+          '/tmp/mocha_ignore/test.js'
+        ]);
+      });
+
+      afterEach(function (done) {
+        rmrf('/tmp/mocha_ignore', done);
       });
     });
   });

--- a/test/integration/fixtures/options/ignore-1.js
+++ b/test/integration/fixtures/options/ignore-1.js
@@ -1,0 +1,1 @@
+it('should run', function(){});

--- a/test/integration/fixtures/options/ignore-2.js
+++ b/test/integration/fixtures/options/ignore-2.js
@@ -1,0 +1,1 @@
+it('should run', function(){});

--- a/test/integration/fixtures/options/ignore-3.ignored.js
+++ b/test/integration/fixtures/options/ignore-3.ignored.js
@@ -1,0 +1,3 @@
+it('should be ignored', function() {
+  throw new Error('ignore-3.ignored.js should be ignored');
+});

--- a/test/integration/fixtures/options/ignore-4.ignored.js
+++ b/test/integration/fixtures/options/ignore-4.ignored.js
@@ -1,0 +1,3 @@
+it('should be ignored', function() {
+  throw new Error('ignore-4.ignored.js should be ignored');
+});

--- a/test/integration/options.js
+++ b/test/integration/options.js
@@ -151,4 +151,34 @@ describe('options', function() {
       });
     });
   });
+
+  describe('--ignore', function() {
+    context('when single ignore pattern is specified', function() {
+      it('runs specs that match a passed pattern and do not match an ignore pattern', function(done) {
+        args = ['--ignore', '**/*.ignored.js']
+        run('options/ignore-*.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 0);
+          assert.equal(res.stats.passes, 2);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+
+    context('when few ignore patterns are specified', function() {
+      it('runs specs that match a passed pattern and do not match any of ignore patterns', function(done) {
+        args = ['--ignore', '**/*3.ignored.js,**/*4.ignored.js']
+        run('options/ignore-*.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 0);
+          assert.equal(res.stats.passes, 2);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
When the modular code structure approach is used (module container it's a dir, entry point it's `index.js`, and `test.js` lies next to the source code):

```
.
├── index.js
├── test.js
├── module-a
│   ├── index.js
│   └── test.js
├── module-b
│   ├── index.js
│   └── test.js
└── node_modules
│   ├── ...
```

... it's not possible to use `mocha "**/test.js"` because `node_modules` might also contain `test.js` files.

I've added `--ignore` option that sends ignore patters to `glob` function:

```
mocha "**/test.js" --ignore "node_modules/**/*"
```

It's also possible to ignore multiply patterns:

```
mocha "**/test.js" --ignore "node_modules/**/*","bower_components/**/*"
```