### PR TITLE
#1818: implement --production flag

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -97,6 +97,7 @@ program
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
   .option('--delay', 'wait for async suite definition')
+  .option('--production', 'causes pending tests, tests marked only, and tests with duplicate names to fail')
 
 program.name = 'mocha';
 
@@ -283,6 +284,9 @@ if (program.delay) mocha.delay();
 // --globals
 
 mocha.globals(globals);
+
+// --production
+if (program.production) mocha.productionMode();
 
 // custom compiler support
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -441,6 +441,15 @@ Mocha.prototype.delay = function delay() {
   return this;
 };
 
+/*
+* Fail skipped, pending, duplicate title and tests marked only
+* @returns {Mocha}
+*/
+Mocha.prototype.productionMode = function() {
+  this.options.productionMode = true;
+  return this;
+};
+
 /**
  * Run tests and invoke `fn()` when complete.
  *
@@ -461,6 +470,7 @@ Mocha.prototype.run = function(fn) {
   runner.fullStackTrace = options.fullStackTrace;
   runner.asyncOnly = options.asyncOnly;
   runner.allowUncaught = options.allowUncaught;
+  runner.productionMode = options.productionMode;
   if (options.grep) {
     runner.grep(options.grep, options.invert);
   }

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -250,6 +250,15 @@ Runnable.prototype.run = function(fn) {
   // for .resetTimeout()
   this.callback = done;
 
+  if (self.productionMode && (self.titleSeen || self.pending)) {
+    if (self.titleSeen) {
+      done(new Error('Tests with duplicate titles not allowed in production mode'));
+    } else {
+      done(new Error('Pending or skipped tests not allowed in production mode'));
+    }
+    return;
+  }
+
   // explicit async with `done` argument
   if (this.async) {
     this.resetTimeout();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -405,6 +405,9 @@ Runner.prototype.parents = function() {
 Runner.prototype.runTest = function(fn) {
   var self = this;
   var test = this.test;
+  var suite = this.suite;
+  test.titleSeen = suite.seenTestTitles[test.title];
+  test.productionMode = this.productionMode;
 
   if (this.asyncOnly) {
     test.asyncOnly = true;
@@ -422,6 +425,7 @@ Runner.prototype.runTest = function(fn) {
   } catch (err) {
     fn(err);
   }
+  suite.seenTestTitles[test.title] = true;
 };
 
 /**
@@ -489,6 +493,10 @@ Runner.prototype.runTests = function(suite, fn) {
     if (self._invert) {
       match = !match;
     }
+    if (match && self.productionMode && self._grep !== self._defaultGrep) {
+      self.fail(test, new Error('Tests marked only or grep not allowed in production mode'));
+      return next();
+    }
     if (!match) {
       // Run immediately only if we have defined a grep. When we
       // define a grep — It can cause maximum callstack error if
@@ -507,7 +515,7 @@ Runner.prototype.runTests = function(suite, fn) {
     }
 
     // pending
-    if (test.pending) {
+    if (!self.productionMode && test.pending) {
       self.emit('pending', test);
       self.emit('test end', test);
       return next();

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -61,6 +61,7 @@ function Suite(title, parentContext) {
   this._slow = 75;
   this._bail = false;
   this.delayed = false;
+  this.seenTestTitles = {};
 }
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -22,6 +22,7 @@ function Test(title, fn) {
   Runnable.call(this, title, fn);
   this.pending = !fn;
   this.type = 'test';
+  this.titleSeen = false;
 }
 
 /**

--- a/test/integration/fixtures/options/production-only.js
+++ b/test/integration/fixtures/options/production-only.js
@@ -1,0 +1,4 @@
+describe('production mode 2', function() {
+  it('should still not see other tests when one is marked only', function() {});
+  it.only('should fail tests marked only', function(){});
+});

--- a/test/integration/fixtures/options/production.js
+++ b/test/integration/fixtures/options/production.js
@@ -1,0 +1,14 @@
+var fn = function(){};
+
+describe('production mode', function() {
+  describe('suite 1', function() {
+    it('should not allow a pending test');
+    it('should only pass one test of a given title', fn);
+    it('should only pass one test of a given title', fn);
+    it('should pass the same title in a different suite', fn);
+    it.skip('should fail a test marked skip', fn);
+  });
+  describe('suite 2', function() {
+    it('should pass the same title in a different suite', fn);
+  });
+});

--- a/test/integration/options.js
+++ b/test/integration/options.js
@@ -151,4 +151,29 @@ describe('options', function() {
       });
     });
   });
+
+  describe('--production', function() {
+    before(function() {
+      args = ['--production'];
+    });
+    it('fails skipped tests, pending tests, and duplicate titles', function(done) {
+      run('options/production.js', args, function(err, res) {
+        assert(!err);
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 3);
+        assert.equal(res.stats.failures, 3);
+        done();
+      });
+    });
+
+    it('fails tests marked only', function(done) {
+      run('options/production-only.js', args, function(err, res) {
+        assert(!err);
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 0);
+        assert.equal(res.stats.failures, 1);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Addresses #1818 and #1759.

Adds a --production flag that fails tests that are: pending, marked as skipped, marked as only, or have a duplicate title.

Since only is determined by grep the only way I could think to catch them is to fail a test if it sees a grep. Since this is, in a way, a linter meant to be run over all the tests before a commit or the like I figured that wouldn't be an issue. At the moment it only catches at the test level, so it won't catch suites marked as skipped or only.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1935)
<!-- Reviewable:end -->
