### PR TITLE
Correctly skip tests when skipping in a suites before()

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -507,8 +507,12 @@ Runner.prototype.runTests = function(suite, fn) {
       return;
     }
 
+    function parentPending(suite) {
+      return suite.pending || (suite.parent && parentPending(suite.parent));
+    }
+
     // pending
-    if (test.pending) {
+    if (test.pending || parentPending(test.parent)) {
       self.emit('pending', test);
       self.emit('test end', test);
       return next();


### PR DESCRIPTION
Tests didn't get skipped when calling ``this.skip()`` in the ``before`` function of a suite.
e.g.

````js
describe('Suite', function(){
  before(function(){
    this.skip();
  });

  it('this is still ran', function(){
    //code
  });
});
````

I don't know if this is the best way of fixing the issue, or even if this is the intended behaviour. Suggestions welcome to improve this PR. :boom:

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1945)
<!-- Reviewable:end -->
