### PR TITLE
Update debug dependency to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
   },
   "dependencies": {
     "commander": "2.3.0",
-    "debug": "2.0.0",
+    "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",


### PR DESCRIPTION
debug@2.0.0 has a vulnerability in its dependency on ms@0.6.2.

debug@2.2.0 has updated its ms dependency to a version without this vulnerability.

![screen shot 2015-11-02 at 11 35 56 am](https://cloud.githubusercontent.com/assets/3885959/10890806/67e1ce28-8157-11e5-9c27-dcfcad7c0843.png)
