### PR TITLE
Add support --perf-basic-prof

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -89,6 +89,7 @@ program
   .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
   .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
+  .option('--perf-basic-prof', 'enable perf linux profiler (basic support)')
   .option('--prof', 'log statistical profiling information')
   .option('--recursive', 'include sub directories')
   .option('--reporters', 'display available reporters')

--- a/bin/mocha
+++ b/bin/mocha
@@ -35,6 +35,7 @@ process.argv.slice(2).forEach(function(arg){
     case '--throw-deprecation':
     case '--trace-deprecation':
     case '--allow-natives-syntax':
+    case '--perf-basic-prof':
       args.unshift(arg);
       break;
     default:


### PR DESCRIPTION
Very basic PR, adding support for --perf-basic-prof v8 option.
----
This supports creating flamegraphs on linux with mocha tests.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1963)
<!-- Reviewable:end -->
