### PR TITLE
Dont double install bdd ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,11 @@ test-only:
 	@./bin/mocha \
 		--reporter $(REPORTER) \
 		--ui qunit \
+		test/acceptance/misc/only/bdd-require
+
+	@./bin/mocha \
+		--reporter $(REPORTER) \
+		--ui qunit \
 		test/acceptance/misc/only/qunit
 
 test-mocha:

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -77,7 +77,7 @@ module.exports = function(suite) {
      * acting as a thunk.
      */
 
-    context.it = context.specify = function(title, fn) {
+    var it = context.it = context.specify = function(title, fn) {
       var suite = suites[0];
       if (suite.pending) {
         fn = null;
@@ -93,7 +93,7 @@ module.exports = function(suite) {
      */
 
     context.it.only = function(title, fn) {
-      var test = context.it(title, fn);
+      var test = it(title, fn);
       var reString = '^' + escapeRe(test.fullTitle()) + '$';
       mocha.grep(new RegExp(reString));
       return test;

--- a/test/acceptance/misc/only/bdd-require.js
+++ b/test/acceptance/misc/only/bdd-require.js
@@ -1,0 +1,18 @@
+/*jshint node: true */
+
+var mocha = require('../../../../lib/mocha');
+
+var beforeEach = mocha.beforeEach;
+var it = mocha.it;
+var describe = mocha.describe;
+
+describe('it.only via require("mocha")', function() {
+  beforeEach(function() {
+    this.didRunBeforeEach = true;
+  });
+  describe("nested within a describe/context", function() {
+    it.only('should run all enclosing beforeEach hooks', function() {
+      require('assert').equal(this.didRunBeforeEach, true);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #1964 

the bdd UI was being called twice, once from within the `Mocha` constructor, and also from the `_mocha` command line. This prevents a UI from being called twice, and it's `pre-require` hooks being called twice so that it partially clobbers itself.