### PR TITLE
Silence Bluebird js warnings

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -289,6 +289,9 @@ Runnable.prototype.run = function(fn) {
       result
         .then(function() {
           done();
+          // Return null so libraries like bluebird do not warn about
+          // subsequently constructed Promises.
+          return null;
         },
         function(reason) {
           done(reason || new Error('Promise rejected with no or falsy reason'));


### PR DESCRIPTION
Bluebird js now prints a warning message and stack trace when it discovers Promises that create other Promises but do not return them. Mocha trips this warning when the user chains together multiple hooks, and this PR eliminates the warning by explicitly returning null instead of undefined which signals that the warning should not be emitted.