### PR TITLE
safely stringify PhantomJS undefined value

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -598,7 +598,7 @@ exports.canonicalize = function(value, stack) {
       canonicalizedObj = value;
       break;
     default:
-      canonicalizedObj = value.toString();
+      canonicalizedObj = value + '';
   }
 
   return canonicalizedObj;


### PR DESCRIPTION
When running in PhantomJS, due to http://stackoverflow.com/questions/14218670/why-are-null-and-undefined-of-the-type-domwindow `canonicalize` can throw an exception, resulting from `Runner.prototype.uncaught` returning without emitting the `end` event (causing test mocha-phantomjs test runner to just hang and not exit).  I'm not sure whether it's better to alter logic in `Runner.prototype.uncaught` to ensure `end` is always emitting, as I don't really understand the logic there (why in certain cases it returns without emitting).

This patch just catches an exception stringifying the canonicalized value, which seems like a reasonable thing to do anyway.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1977)
<!-- Reviewable:end -->
