### PR TITLE
Fix HTML reporting display to show errors if done is called multiple times, or if an exception is thrown after done is called.

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -129,7 +129,10 @@ function HTML(runner) {
   });
 
   runner.on('fail', function(test) {
-    if (test.type === 'hook') {
+    // For type = 'test' its possible that the test failed due to multiple
+    // done() calls. So report the issue here.
+    if (test.type === 'hook'
+      || test.type === 'test') {
       runner.emit('test end', test);
     }
   });

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -14,6 +14,7 @@
     <script src="array.js"></script>
     <script src="../acceptance/duration.js"></script>
     <script src="../acceptance/timeout.js"></script>
+    <script src="multiple-done.js"></script>
     <script>
       onload = function(){
         mocha.checkLeaks();

--- a/test/browser/multiple-done.js
+++ b/test/browser/multiple-done.js
@@ -1,0 +1,16 @@
+describe('Multiple Done calls', function(){
+  it('should report an error if done was called more than once', function(done){
+    done();
+    done();
+  })
+
+  it('should report an error if an exception happened async after done was called', function (done) {
+    done();
+    setTimeout(done, 50);
+  })
+
+  it('should report an error if an exception happened after done was called', function(done){
+    done();
+    throw new Error("thrown error");
+  })
+})


### PR DESCRIPTION
In either of the test cases below, when using the HTML reporter, the failure details are not currently shown. The failure count is increased, but there's no specific details.

This patch adjusts the reporter so that failures after the initial done() are displayed. This doesn't seem to cause any regressions in the manual browser tests.

The output does show the test as passing, and then shows it as failing, but I think that's reasonable given what is happening and is better than not showing any errors.

Test cases:

```
describe('Multiple Done calls', function(){
  it('should report an error if done was called more than once', function(done){
    done();
    done();
  })

  it('should report an error if an exception happened after done was called', function(done){
    done();
    throw new Error("thrown error");
  })
})
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1981)
<!-- Reviewable:end -->
