### PR TITLE
Enable --log-timer-events option

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -90,6 +90,7 @@ program
   .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
   .option('--prof', 'log statistical profiling information')
+  .option('--log-timer-events', 'Time events including external callbacks')
   .option('--recursive', 'include sub directories')
   .option('--reporters', 'display available reporters')
   .option('--throw-deprecation', 'throw an exception anytime a deprecated function is used')

--- a/bin/mocha
+++ b/bin/mocha
@@ -32,6 +32,7 @@ process.argv.slice(2).forEach(function(arg){
     case '--es_staging':
     case '--no-deprecation':
     case '--prof':
+    case '--log-timer-events':
     case '--throw-deprecation':
     case '--trace-deprecation':
     case '--allow-natives-syntax':


### PR DESCRIPTION
This provides better insights when profiling application using `--prof` switch. Especially useful when the log is processed by [profviz tool](https://v8.googlecode.com/svn/branches/bleeding_edge/tools/profviz/profviz.html).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/1982)
<!-- Reviewable:end -->
