### PR TITLE
support for strict mode

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -95,6 +95,7 @@ program
   .option('--throw-deprecation', 'throw an exception anytime a deprecated function is used')
   .option('--trace', 'trace function calls')
   .option('--trace-deprecation', 'show stack traces on deprecations')
+  .option('--use_strict', 'enforce strict mode')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
   .option('--delay', 'wait for async suite definition')
 
@@ -207,6 +208,7 @@ mocha.ui(program.ui);
 
 // load reporter
 
+var Reporter = null;
 try {
   Reporter = require('../lib/reporters/' + program.reporter);
 } catch (err) {

--- a/bin/mocha
+++ b/bin/mocha
@@ -34,6 +34,7 @@ process.argv.slice(2).forEach(function(arg){
     case '--prof':
     case '--throw-deprecation':
     case '--trace-deprecation':
+    case '--use_strict':
     case '--allow-natives-syntax':
       args.unshift(arg);
       break;


### PR DESCRIPTION
Support for passing along the `--use_strict` flag from `mocha` to `_mocha`. Also fixes a strict code incompatibility with the undeclared variable `Reporter` in `_mocha`, as outlined in #1879.

Tests all pass and the lib works on node v4.2.3 and v5.1.1.