### PR TITLE
Use more visually-distinctive characters on the 'dot' reporter

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -78,7 +78,9 @@ exports.colors = {
 exports.symbols = {
   ok: '✓',
   err: '✖',
-  dot: '․'
+  dot: '․',
+  comma: ',',
+  bang: '!'
 };
 
 // With node.js on Windows: use symbols available in terminal default fonts

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -33,7 +33,7 @@ function Dot(runner) {
     if (++n % width === 0) {
       process.stdout.write('\n  ');
     }
-    process.stdout.write(color('pending', Base.symbols.dot));
+    process.stdout.write(color('pending', Base.symbols.comma));
   });
 
   runner.on('pass', function(test) {
@@ -51,7 +51,7 @@ function Dot(runner) {
     if (++n % width === 0) {
       process.stdout.write('\n  ');
     }
-    process.stdout.write(color('fail', Base.symbols.dot));
+    process.stdout.write(color('fail', Base.symbols.bang));
   });
 
   runner.on('end', function() {


### PR DESCRIPTION
I see that on non-Windows, the characters are usually some Unicode; is there any particular pretty characters people would rather see than `!` and `,`? (Personally, I think this looks really, really great even with those basic characters.)

<img width="601" alt="screen shot 2015-12-09 at 1 23 11 pm" src="https://cloud.githubusercontent.com/assets/200/11696239/fc74f9dc-9e78-11e5-8b50-0b501db73301.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2000)
<!-- Reviewable:end -->
