### PR TITLE
Should not throw error when files.length == 0

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -621,8 +621,10 @@ exports.lookupFiles = function lookupFiles(path, extensions, recursive) {
     if (exists(path + '.js')) {
       path += '.js';
     } else {
-      files = glob.sync(path);
-      if (!files.length) {
+      try {
+        files = glob.sync(path);
+      } catch (e) {
+        debug(e);
         throw new Error("cannot resolve path (or pattern) '" + path + "'");
       }
       return files;

--- a/test/acceptance/glob/glob.sh
+++ b/test/acceptance/glob/glob.sh
@@ -17,14 +17,13 @@ cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"p
     exit 1
 }
 
-../../../bin/mocha -R json-stream ./*-none.js 2> /tmp/mocha-glob.txt && {
+../../../bin/mocha -R json-stream ./*-none.js 1> /tmp/mocha-glob.txt || {
     echo Globbing './*-none.js' in `pwd` failed.
     exit 1
 }
 
-cat /tmp/mocha-glob.txt | grep -q -F 'cannot resolve path' || {
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":0,"tests":0,"passes":0,"pending":0,"failures":0,' && {
     echo Globbing './*-none.js' in `pwd` should match no files and run no tests.
-    exit 1
 }
 
 # Globbing in windows command-shell differs completely from unix-style globbing.
@@ -42,14 +41,14 @@ cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"p
     exit 1
 }
 
-../../../bin/mocha -R json-stream  './*-none.js' 2> /tmp/mocha-glob.txt && {
+../../../bin/mocha -R json-stream  './*-none.js' 1> /tmp/mocha-glob.txt || {
     echo Globbing './*-none.js' in `pwd` failed.
     exit 1
 }
 
-cat /tmp/mocha-glob.txt | grep -q -F 'cannot resolve path' || {
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":0,"tests":0,"passes":0,"pending":0,"failures":0,' && {
     echo Globbing './*-none.js' in `pwd` should match no files and run no tests.
-    exit 1
+    exit 0
 }
 
 echo Glob-test passed.


### PR DESCRIPTION
Directory structure likes below:

```
tests/
    units/
```

In `units`, there isn't any file. When I use mocha to run this path, it throws `can't resolve path`, but `glob(path)` returns `[]`. Maybe, it shouldn't throw error.

```
tests/
    units/
        lib-test.js
```

If directory structure likes above, it works well.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2001)

<!-- Reviewable:end -->
