### PR TITLE
XUnit Reporter Writes to stdout, falls back to console.log

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -109,6 +109,8 @@ XUnit.prototype.done = function(failures, fn) {
 XUnit.prototype.write = function(line) {
   if (this.fileStream) {
     this.fileStream.write(line + '\n');
+  } else if (typeof process === 'object' && typeof process.stdout === 'object') {
+    process.stdout.write(line + '\n');
   } else {
     console.log(line);
   }

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -109,7 +109,7 @@ XUnit.prototype.done = function(failures, fn) {
 XUnit.prototype.write = function(line) {
   if (this.fileStream) {
     this.fileStream.write(line + '\n');
-  } else if (typeof process === 'object' && typeof process.stdout === 'object') {
+  } else if (typeof process === 'object' && process.stdout) {
     process.stdout.write(line + '\n');
   } else {
     console.log(line);


### PR DESCRIPTION
Fixes #1674; provides support *much* needed for [mocha-phantomjs](https://github.com/nathanboktae/mocha-phantomjs) (see [#133](https://github.com/nathanboktae/mocha-phantomjs/issues/133), [#220](https://github.com/nathanboktae/mocha-phantomjs/issues/220), etc).  Maintains support for running the XUnit reporter in a browser (unlike the previously reverted PR #1068).

ping @alemangui, @nathanboktae

Thanks all.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2005)
<!-- Reviewable:end -->
