### PR TITLE
Add fields to json-stream reporter

### DIFF
--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -3,6 +3,7 @@
  */
 
 var Base = require('./base');
+var errorStackParser = require('error-stack-parser');
 
 /**
  * Expose `List`.
@@ -32,8 +33,18 @@ function List(runner) {
 
   runner.on('fail', function(test, err) {
     test = clean(test);
-    test.err = err.message;
-    test.stack = err.stack || null;
+    test.err = err;
+    if (err instanceof Error) {
+      test.err = {
+        actual: err.actual,
+        expected: err.expected,
+        message: err.message,
+        stack: errorStackParser.parse(err)
+      };
+      if (err.at) {
+        test.err.at = err.at.filename + ':' + err.at.line + ':' + err.at.column;
+      }
+    }
     console.log(JSON.stringify(['fail', test]));
   });
 
@@ -54,6 +65,14 @@ function clean(test) {
   return {
     title: test.title,
     fullTitle: test.fullTitle(),
-    duration: test.duration
+    duration: test.duration,
+    sync: test.sync,
+    async: test.async,
+    timedOut: test.timedOut,
+    pending: test.pending,
+    file: test.file,
+    parentTitle: test.parent.title,
+    state: test.state,
+    speed: test.speed
   };
 }

--- a/package.json
+++ b/package.json
@@ -278,6 +278,7 @@
     "commander": "2.3.0",
     "debug": "2.2.0",
     "diff": "1.4.0",
+    "error-stack-parser": "^1.3.1",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",
     "growl": "1.8.1",


### PR DESCRIPTION
I would like to consume the stream coming from the json logger, but is not yet possible because some information is missing from the reporter.

This adds the necessary information.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2009)
<!-- Reviewable:end -->
