### PR TITLE
Add the ability to tag test files when using the exports interface.

### DIFF
--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -25,7 +25,25 @@ var Test = require('../test');
 module.exports = function(suite) {
   var suites = [suite];
 
-  suite.on('require', visit);
+  suite.on('require', function(obj, file) {
+    if (suite.tags) {
+      if (obj.tags) {
+        var found = false;
+        for (var i = 0; i < suite.tags.length; i++) {
+          if (obj.tags.indexOf(suite.tags[i]) !== -1) {
+            found = true;
+            break;
+          }
+        }
+
+        if (found) {
+          visit(obj, file);
+        }
+      }
+    } else {
+      visit(obj, file);
+    }
+  });
 
   function visit(obj, file) {
     var suite;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -41,6 +41,7 @@ exports.Runner = require('./runner');
 exports.Suite = require('./suite');
 exports.Hook = require('./hook');
 exports.Test = require('./test');
+exports.Taggable = require('./taggable');
 
 /**
  * Return image `name` path.
@@ -67,6 +68,7 @@ function image(name) {
  *   - `ignoreLeaks` ignore global leaks
  *   - `fullTrace` display the full stack-trace on failing
  *   - `grep` string or regexp to filter tests with
+ *   - `tags` array of tags to look for in test files
  *
  * @param {Object} options
  * @api public
@@ -94,6 +96,9 @@ function Mocha(options) {
   }
   if (options.slow) {
     this.slow(options.slow);
+  }
+  if (options.tags) {
+    this.suite.tags = options.tags;
   }
 
   this.suite.on('pre-require', function(context) {

--- a/lib/taggable.js
+++ b/lib/taggable.js
@@ -1,0 +1,10 @@
+module.exports = function taggable(tags, obj) {
+  Object.defineProperty(obj, 'tags', {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: tags
+  });
+
+  return obj;
+};

--- a/mocha.js
+++ b/mocha.js
@@ -985,6 +985,7 @@ exports.Runner = require('./runner');
 exports.Suite = require('./suite');
 exports.Hook = require('./hook');
 exports.Test = require('./test');
+exports.Taggable = require('./taggable');
 
 /**
  * Return image `name` path.
@@ -12062,7 +12063,7 @@ var exec = require('child_process').exec
 function which(name) {
   var paths = process.env.PATH.split(':');
   var loc;
-  
+
   for (var i = 0, len = paths.length; i < len; ++i) {
     loc = path.join(paths[i], name);
     if (exists(loc)) return loc;

--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "Jordan Sexton <jordan@jordansexton.com>",
     "Jussi Virtanen <jussi.k.virtanen@gmail.com>",
     "Katie Gengler <katiegengler@gmail.com>",
-    "Kazuhito Hokamura <k.hokamura@gmail.com>"
+    "Kazuhito Hokamura <k.hokamura@gmail.com>",
+    "David Hunt <davidpaulhunt@gmail.com>"
   ],
   "license": "MIT",
   "repository": {

--- a/test/acceptance/misc/tags_array.js
+++ b/test/acceptance/misc/tags_array.js
@@ -1,0 +1,14 @@
+var Mocha = require('../../../');
+var Taggable = Mocha.Taggable;
+
+module.exports = Taggable(['array'], {
+  Array: {
+    '#indexOf()': {
+      'should return the correct index': function() {
+        [1, 2, 3].indexOf(1).should.equal(0);
+        [1, 2, 3].indexOf(2).should.equal(1);
+        [1, 2, 3].indexOf(3).should.equal(2);
+      }
+    }
+  }
+});

--- a/test/acceptance/misc/tags_number.js
+++ b/test/acceptance/misc/tags_number.js
@@ -1,0 +1,14 @@
+var Mocha = require('../../../');
+var Taggable = Mocha.Taggable;
+
+module.exports = Taggable(['number'], {
+  Number: {
+    '#isNaN() && ===': {
+      'should return the correct index': function() {
+        isNaN(1).should.equal(true);
+        isNaN(2).should.equal(true);
+        (1 === 2).should.equal(true);
+      }
+    }
+  }
+});

--- a/test/taggable.js
+++ b/test/taggable.js
@@ -1,0 +1,19 @@
+var path = require('path');
+var Mocha = require('../');
+
+describe('Taggable', function() {
+  var opts = { tags: ['array'] };
+
+  describe('tags', function() {
+    it('should run and pass tests', function(done) {
+      var testDir = 'test/acceptance/misc';
+      var mocha = new Mocha(opts).ui('exports');
+      mocha.addFile(path.join(testDir, 'tags_array.js'));
+      mocha.addFile(path.join(testDir, 'tags_number.js'));
+      mocha.run(function(failures) {
+        failures.should.equal(0);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is something we implemented in my current shop and it has been very useful. Our applications and their services have grown. This makes being able to test particular functionality out of context very useful (or in context if you so choose). To make this accessible to all, I've added a change to the exports ui that looks for an array of tags in options.

Example:
```js
// test/foo.js

var Taggable = require('mocha').Taggable;

module.exports = Taggable(['foo', 'bar'], {
  Foo: {
    '#new Foo()': {
      'foo should be of Foo': function() {
        var foo = foo();
        foo.should.be.instanceOf(Foo);
      }
    }
}
```

In your task runner you would do something like:
```js
// test/run

var args = process.argv.slice(2);
// some other things like get filenames
var opts = { tags: args };
var mocha = new Mocha(opts).ui('exports');
filenames.forEach(function(file) {
  mocha.addFile(path.join('test',file)).run(failureHandler);
});
```

And to run your tests:
`test/run foo bar other thing` which would result in all files tagged with foo, bar, other, or thing to be run. This doesn't affect tests when being run by `npm test` or `mocha` directly unless they call on your test runner `test/run`. 