### PR TITLE
Fix non ES5 compliant regexp

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -261,7 +261,7 @@ exports.slug = function(str) {
 exports.clean = function(str) {
   str = str
     .replace(/\r\n?|[\n\u2028\u2029]/g, '\n').replace(/^\uFEFF/, '')
-    .replace(/^function *\(.*\)\s*{|\(.*\) *=> *{?/, '')
+    .replace(/^function *\(.*\)\s*\{|\(.*\) *=> *\{?/, '')
     .replace(/\s+\}$/, '');
 
   var spaces = str.match(/^\n?( *)/)[1].length;


### PR DESCRIPTION
ES5 appears to require that `{` be escaped when not used as part of a quantifier. While this works fine in browsers it appears to choke less lenient runtimes (e.g. Duktape).

A similar case is discussed in Duktape (https://github.com/svaarala/duktape/issues/69 and https://github.com/svaarala/duktape/issues/74).

Please find attached a simple Duktape-powered C file that tries to parse the given argument file. [test.c.zip](https://github.com/mochajs/mocha/files/70018/test.c.zip)

Compile and run using:
```
$ gcc -std=c99 -o test test.c duktape-1.3.1/src/duktape.c -I duktape-1.3.1/src/  -lm && ./test mocha/mocha.js
```

When choking it produces a:
`eval failed: SyntaxError: invalid regexp quantifier (unknown char) (line 5755)`
when the parsing is fine it will produce (because I did not setup a complete environment):
`eval failed: ReferenceError: identifier 'window' undefined`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2021)
<!-- Reviewable:end -->
