### PR TITLE
adds tree/dynamic mocha.opts loading getoptions

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -16,18 +16,19 @@ module.exports = getOptions;
  */
 
 function getOptions() {
-  var lookupOptsPaths = ['mocha.opts', 'test/mocha.opts']
+  var lookupOptsPaths = ['mocha.opts', 'test/mocha.opts'];
 
   process.argv.slice(2)
     .forEach(function (arg, i, argv){
       var regex = /^\-\-?/
-        , isOptionArg = argv[i - 1] && regex.test(argv[i - 1]) || regex.test(arg)
+        , isOptionArg = argv[i - 1] && regex.test(argv[i - 1]) || regex.test(arg);
       if (isOptionArg) return;
       Array.prototype.unshift.apply(lookupOptsPaths, getOptionsLookupTree(arg));
     })
 
   if (~process.argv.indexOf('--opts')) {
-    lookupOptsPaths = process.argv[process.argv.indexOf('--opts') + 1]; // should have max priority
+    lookupOptsPaths.length = 0;
+    lookupOptsPaths.push(process.argv[process.argv.indexOf('--opts') + 1]); // max priority
   }
 
   try {
@@ -60,11 +61,11 @@ function getOptions() {
 
 function getOptionsLookupTree(filepath){
   try {
-    var dirname = fs.lstatSync(filepath).isDirectory() ? filepath : path.dirname(filepath)
+    var dirname = fs.lstatSync(filepath).isDirectory() ? filepath : path.dirname(filepath);
     return dirname.split(path.sep).map(function(_, index, array){
-      return path.join.apply(null, array.slice(0, array.length - index).concat('mocha.opts'))
+      return path.join.apply(null, array.slice(0, array.length - index).concat('mocha.opts'));
     })
   } catch (err) {
-    return [] // path does not exist
+    return []; // path does not exist
   }
 }

--- a/bin/options.js
+++ b/bin/options.js
@@ -2,7 +2,8 @@
  * Dependencies.
  */
 
-var fs = require('fs');
+var fs = require('fs')
+  , path = require('path');
 
 /**
  * Export `getOptions`.
@@ -15,25 +16,55 @@ module.exports = getOptions;
  */
 
 function getOptions() {
-  var optsPath = process.argv.indexOf('--opts') !== -1
-        ? process.argv[process.argv.indexOf('--opts') + 1]
-        : 'test/mocha.opts';
+  var lookupOptsPaths = ['mocha.opts', 'test/mocha.opts']
+
+  process.argv.slice(2)
+    .forEach(function (arg, i, argv){
+      var regex = /^\-\-?/
+        , isOptionArg = argv[i - 1] && regex.test(argv[i - 1]) || regex.test(arg)
+      if (isOptionArg) return;
+      Array.prototype.unshift.apply(lookupOptsPaths, getOptionsLookupTree(arg));
+    })
+
+  if (~process.argv.indexOf('--opts')) {
+    lookupOptsPaths = process.argv[process.argv.indexOf('--opts') + 1]; // should have max priority
+  }
 
   try {
-    var opts = fs.readFileSync(optsPath, 'utf8')
-      .replace(/\\\s/g, '%20')
-      .split(/\s/)
-      .filter(Boolean)
-      .map(function(value) {
-        return value.replace(/%20/g, ' ');
-      });
-
-    process.argv = process.argv
-      .slice(0, 2)
-      .concat(opts.concat(process.argv.slice(2)));
+    var optsPath;
+    while(optsPath = lookupOptsPaths.shift()){
+      if (!fs.existsSync(optsPath))
+        continue;
+      var opts = fs.readFileSync(optsPath, 'utf8')
+        .replace(/\\\s/g, '%20')
+        .split(/\s/)
+        .filter(Boolean)
+        .map(function(value) {
+          return value.replace(/%20/g, ' ');
+        });
+      process.argv = process.argv
+        .slice(0, 2)
+        .concat(opts.concat(process.argv.slice(2)));
+      break;
+    }
   } catch (err) {
     // ignore
   }
 
   process.env.LOADED_MOCHA_OPTS = true;
+}
+
+/**
+ * Get option's lookup tree.
+ */
+
+function getOptionsLookupTree(filepath){
+  try {
+    var dirname = fs.lstatSync(filepath).isDirectory() ? filepath : path.dirname(filepath)
+    return dirname.split(path.sep).map(function(_, index, array){
+      return path.join.apply(null, array.slice(0, array.length - index).concat('mocha.opts'))
+    })
+  } catch (err) {
+    return [] // path does not exist
+  }
 }


### PR DESCRIPTION
to me the way `mocha.opts` files are loaded should be more flexible and traverse the entire tree instead of pointing to `./test/mocha.opts` directly (or the specified file using the `--opts` flag). it sometimes happens, at least to me, that i test single files and folders with different configurations instead of an entire suite. so, as mentioned in a few issues the idea is to load `mocha.opts` files directly from where the tests get invoked without breaking backward compatibility nor api! 

running both files and folders would produce an option-lookup like below and the first file found would stop the chain and get loaded into `process.argv` (just like before):

mocha path/to/my/tests
mocha path/to/my/tests/spec.js

  > /path/to/my/tests/mocha.opts
  > /path/to/my/mocha.opts
  > /path/to/mocha.opts
  > /path/mocha.opts
  > /mocha.opts
  > /test/mocha.opts # not to break bakward compatibility

the code is quite straight forward but in order to add tests here i had to change the actual source a bit and didn't want those changes to be part of this pr; let me know if there's anything else i can do :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2032)
<!-- Reviewable:end -->
