### PR TITLE
add clone capability to test, fix async retry, fix #2045

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -224,6 +224,9 @@ Runnable.prototype.resetTimeout = function() {
  * @param {string[]} globals
  */
 Runnable.prototype.globals = function(globals) {
+  if (!arguments.length) {
+    return this._allowedGlobals;
+  }
   this._allowedGlobals = globals;
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -528,14 +528,14 @@ Runner.prototype.runTests = function(suite, fn) {
       self.currentRunnable = self.test;
       self.runTest(function(err) {
         test = self.test;
-
         if (err) {
           var retry = test.currentRetry();
           if (err instanceof Pending) {
             self.emit('pending', test);
           } else if (retry < test.retries()) {
-            test.currentRetry(retry + 1);
-            tests.unshift(test);
+            var clonedTest = test.clone();
+            clonedTest.currentRetry(retry + 1);
+            tests.unshift(clonedTest);
 
             // Early return + hook trigger so that it doesn't
             // increment the count wrong

--- a/lib/test.js
+++ b/lib/test.js
@@ -28,3 +28,17 @@ function Test(title, fn) {
  * Inherit from `Runnable.prototype`.
  */
 inherits(Test, Runnable);
+
+Test.prototype.clone = function() {
+  var test = new Test(this.title, this.fn);
+  test.timeout(this.timeout());
+  test.slow(this.slow());
+  test.enableTimeouts(this.enableTimeouts());
+  test.retries(this.retries());
+  test.currentRetry(this.currentRetry());
+  test.globals(this.globals());
+  test.parent = this.parent;
+  test.file = this.file;
+  test.ctx = this.ctx;
+  return test;
+};

--- a/test/integration/fixtures/retries/async.js
+++ b/test/integration/fixtures/retries/async.js
@@ -1,0 +1,28 @@
+describe('retries', function() {
+  var times = 0;
+  before(function () {
+    console.log('before');
+  });
+
+  after(function () {
+    console.log('after');
+  });
+
+  beforeEach(function() {
+    console.log('before each', times);
+  });
+
+  afterEach(function () {
+    console.log('after each', times);
+  });
+
+  it('should allow override and run appropriate hooks', function (done) {
+    this.timeout(200);
+    this.retries(2);
+    console.log('TEST', times);
+    if (++times < 3) {
+      return setTimeout(done, 300);
+    }
+    setTimeout(done, 50);
+  });
+});

--- a/test/integration/retries.js
+++ b/test/integration/retries.js
@@ -68,5 +68,40 @@ describe('retries', function() {
       assert.equal(res.code, 1);
       done();
     });
-  })
+  });
+
+  it.only('should not hang w/ async test', function (done) {
+    helpers.runMocha('retries/async.js', args, function(err, res) {
+      var lines, expected;
+
+      assert(!err);
+
+      lines = res.output.split(/[\n․]+/).map(function(line) {
+        return line.trim();
+      }).filter(function(line) {
+        return line.length;
+      }).slice(0, -1);
+
+      expected = [
+        'before',
+        'before each 0',
+        'TEST 0',
+        'after each 1',
+        'before each 1',
+        'TEST 1',
+        'after each 2',
+        'before each 2',
+        'TEST 2',
+        'after each 3',
+        'after'
+      ];
+
+      expected.forEach(function(line, i) {
+        assert.equal(lines[i], line);
+      });
+
+      assert.equal(res.code, 0);
+      done();
+    });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,55 @@
+var mocha = require('../')
+  , Context = mocha.Context
+  , Test = mocha.Test;
+
+describe('Test', function(){
+  describe('.clone()', function(){
+    beforeEach(function(){
+      this._test = new Test('To be cloned', function () {});
+      this._test._timeout = 3043;
+      this._test._slow = 101;
+      this._test._enableTimeouts = true;
+      this._test._retries = 3;
+      this._test._currentRetry = 1;
+      this._test._allowedGlobals = ['foo'];
+      this._test.parent = 'foo';
+      this._test.file = 'bar';
+    });
+
+    it('should copy the title', function(){
+      this._test.clone().title.should.equal('To be cloned');
+    });
+
+    it('should copy the timeout value', function(){
+      this._test.clone().timeout().should.equal(3043);
+    });
+
+    it('should copy the slow value', function(){
+      this._test.clone().slow().should.equal(101);
+    });
+
+    it('should copy the enableTimeouts value', function(){
+      this._test.clone().enableTimeouts().should.be.true;
+    });
+
+    it('should copy the retries value', function(){
+      this._test.clone().retries().should.equal(3);
+    });
+
+    it('should copy the currentRetry value', function(){
+      this._test.clone().currentRetry().should.equal(1);
+    });
+
+    it('should copy the globals value', function(){
+      this._test.clone().globals().should.not.be.empty;
+    });
+
+    it('should copy the parent value', function(){
+      this._test.clone().parent.should.equal('foo');
+    });
+
+    it('should copy the file value', function(){
+      this._test.clone().file.should.equal('bar');
+    });
+  });
+});


### PR DESCRIPTION
@danielstjules @boneskull 

The reason `retry` isn't working for timeout `async` test is because of internal state change within `test` (`timer`, `timedOut`...). Therefore, instead of trying to reuse the test & reset its state, I just clone it instead for a fresh state.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2047)
<!-- Reviewable:end -->
