### PR TITLE
Fix `this.skip` from spec with HTML reporter

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -531,6 +531,7 @@ Runner.prototype.runTests = function(suite, fn) {
         if (err) {
           var retry = test.currentRetry();
           if (err instanceof Pending) {
+            test.pending = true;
             self.emit('pending', test);
           } else if (retry < test.retries()) {
             var clonedTest = test.clone();


### PR DESCRIPTION
From https://github.com/mochajs/mocha/pull/1945#issuecomment-170399856 Fixes the following simple case for the HTML reporter:

```js
describe('skipping', function() {
  it('amazes', function() {
    this.skip()
    assert(true)
  })
})

// expected: "amazes" test shows as pending within test results
// actual outcome: "TypeError: Cannot read property 'toString' of undefined"
```

Before PR:

![screen shot 2016-01-11 at 5 12 24 am](https://cloud.githubusercontent.com/assets/817212/12234467/0b7ad380-b822-11e5-9ab4-69179c6569fc.png)

After PR: 

![screen shot 2016-01-11 at 5 11 59 am](https://cloud.githubusercontent.com/assets/817212/12234472/1275a34a-b822-11e5-99e4-c63fea05836d.png)
