### PR TITLE
Have global exports be compatible with Web Workers

### DIFF
--- a/support/browser-entry.js
+++ b/support/browser-entry.js
@@ -157,5 +157,5 @@ Mocha.process = process;
  * Expose mocha.
  */
 
-window.Mocha = Mocha;
-window.mocha = mocha;
+global.Mocha = Mocha;
+global.mocha = mocha;


### PR DESCRIPTION
Assigning to `window` only works in a normal browser environment; however, Web Workers don't have access to `window`. Instead, the global object inside Web Workers is `self`.

Browserify already ensures that `global` is present and dereferenced accordingly. It will equal to `window` unless `self` is defined.

This fixes Web Workers compatibility lost in a81e5558f086808b682b6d196b80893d2c8926f8 (v2.3.0).

/cc @jbnicolai @ndhoule

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2053)
<!-- Reviewable:end -->
