### PR TITLE
Fix #2071: Removed color code to fix Chalk colors

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -105,7 +105,7 @@ var color = exports.color = function(type, str) {
   if (!exports.useColors) {
     return String(str);
   }
-  return '\u001b[' + exports.colors[type](str) + '\u001b[0m';
+  return exports.colors[type](str);
 };
 
 /**


### PR DESCRIPTION
Removed extraneous color code that broke output on Windows as shown in https://github.com/mochajs/mocha/issues/2071

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2072)
<!-- Reviewable:end -->
