### PR TITLE
Bumps chalk from 0.4.0 to 1.1.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "test": "make test-all"
   },
   "dependencies": {
-    "chalk": "0.4.0",
+    "chalk": "1.1.1",
     "commander": "2.3.0",
     "debug": "2.2.0",
     "diff": "1.4.0",


### PR DESCRIPTION
See https://github.com/mochajs/mocha/issues/1844 and https://github.com/mochajs/mocha/issues/2064

Let's see if the CI is happy building this for older targets.

If so, I'll bump `supports-color` to `^2.0.0` to match the corresponding chalk subdependency.

```console
> npm ls supports-color
mocha@2.4.1 /Users/jbnicolai/projects/personal/mocha
├─┬ chalk@1.1.1
│ └── supports-color@2.0.0
└── supports-color@1.2.0
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mochajs/mocha/2075)
<!-- Reviewable:end -->
