### PR TITLE
Strenghten checks across the board for pending/skipped tests or suites

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -79,7 +79,7 @@ module.exports = function(suite) {
 
     var it = context.it = context.specify = function(title, fn) {
       var suite = suites[0];
-      if (suite.pending) {
+      if (suite.isPending()) {
         fn = null;
       }
       var test = new Test(title, fn);

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -81,7 +81,7 @@ module.exports = function(suite) {
      */
     context.test = function(title, fn) {
       var suite = suites[0];
-      if (suite.pending) {
+      if (suite.isPending()) {
         fn = null;
       }
       var test = new Test(title, fn);

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -155,7 +155,7 @@ function HTML(runner) {
     if (test.state === 'passed') {
       var url = self.testURL(test);
       el = fragment('<li class="test pass %e"><h2>%e<span class="duration">%ems</span> <a href="%s" class="replay">‣</a></h2></li>', test.speed, test.title, test.duration, url);
-    } else if (test.pending) {
+    } else if (test.isPending()) {
       el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     } else {
       el = fragment('<li class="test fail"><h2>%e <a href="%e" class="replay">‣</a></h2></li>', test.title, self.testURL(test));
@@ -193,7 +193,7 @@ function HTML(runner) {
 
     // toggle code
     // TODO: defer
-    if (!test.pending) {
+    if (!test.isPending()) {
       var h2 = el.getElementsByTagName('h2')[0];
 
       on(h2, 'click', function() {

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -131,7 +131,7 @@ XUnit.prototype.test = function(test) {
   if (test.state === 'failed') {
     var err = test.err;
     this.write(tag('testcase', attrs, false, tag('failure', {}, false, cdata(escape(err.message) + '\n' + err.stack))));
-  } else if (test.pending) {
+  } else if (test.isPending()) {
     this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
     this.write(tag('testcase', attrs, true));

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -54,6 +54,7 @@ function Runnable(title, fn) {
   this._trace = new Error('done() called multiple times');
   this._retries = -1;
   this._currentRetry = 0;
+  this.pending = false;
 }
 
 /**
@@ -128,6 +129,15 @@ Runnable.prototype.enableTimeouts = function(enabled) {
  */
 Runnable.prototype.skip = function() {
   throw new Pending();
+};
+
+/**
+ * Check if this runnable or its parent suite is marked as pending.
+ *
+ * @api private
+ */
+Runnable.prototype.isPending = function() {
+  return this.pending || (this.parent && this.parent.isPending());
 };
 
 /**
@@ -302,7 +312,7 @@ Runnable.prototype.run = function(fn) {
 
   // sync or promise-returning
   try {
-    if (this.pending) {
+    if (this.isPending()) {
       done();
     } else {
       callFn(this.fn);

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -125,7 +125,7 @@ Runnable.prototype.enableTimeouts = function(enabled) {
 /**
  * Halt and mark as pending.
  *
- * @api private
+ * @api public
  */
 Runnable.prototype.skip = function() {
   throw new Pending();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -507,12 +507,7 @@ Runner.prototype.runTests = function(suite, fn) {
       return;
     }
 
-    function parentPending(suite) {
-      return suite.pending || (suite.parent && parentPending(suite.parent));
-    }
-
-    // pending
-    if (test.pending || parentPending(test.parent)) {
+    if (test.isPending()) {
       self.emit('pending', test);
       self.emit('test end', test);
       return next();
@@ -521,7 +516,7 @@ Runner.prototype.runTests = function(suite, fn) {
     // execute test and hook(s)
     self.emit('test', self.test = test);
     self.hookDown('beforeEach', function(err, errSuite) {
-      if (suite.pending) {
+      if (suite.isPending()) {
         self.emit('pending', test);
         self.emit('test end', test);
         return next();

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -28,9 +28,6 @@ exports = module.exports = Suite;
 exports.create = function(parent, title) {
   var suite = new Suite(title, parent.ctx);
   suite.parent = parent;
-  if (parent.pending) {
-    suite.pending = true;
-  }
   title = suite.fullTitle();
   parent.addSuite(suite);
   return suite;
@@ -177,6 +174,15 @@ Suite.prototype.bail = function(bail) {
 };
 
 /**
+ * Check if this suite or its parent suite is marked as pending.
+ *
+ * @api private
+ */
+Suite.prototype.isPending = function() {
+  return this.pending || (this.parent && this.parent.isPending());
+};
+
+/**
  * Run `fn(test[, done])` before running tests.
  *
  * @api private
@@ -185,7 +191,7 @@ Suite.prototype.bail = function(bail) {
  * @return {Suite} for chaining
  */
 Suite.prototype.beforeAll = function(title, fn) {
-  if (this.pending) {
+  if (this.isPending()) {
     return this;
   }
   if (typeof title === 'function') {
@@ -215,7 +221,7 @@ Suite.prototype.beforeAll = function(title, fn) {
  * @return {Suite} for chaining
  */
 Suite.prototype.afterAll = function(title, fn) {
-  if (this.pending) {
+  if (this.isPending()) {
     return this;
   }
   if (typeof title === 'function') {
@@ -245,7 +251,7 @@ Suite.prototype.afterAll = function(title, fn) {
  * @return {Suite} for chaining
  */
 Suite.prototype.beforeEach = function(title, fn) {
-  if (this.pending) {
+  if (this.isPending()) {
     return this;
   }
   if (typeof title === 'function') {
@@ -275,7 +281,7 @@ Suite.prototype.beforeEach = function(title, fn) {
  * @return {Suite} for chaining
  */
 Suite.prototype.afterEach = function(title, fn) {
-  if (this.pending) {
+  if (this.isPending()) {
     return this;
   }
   if (typeof title === 'function') {

--- a/test/suite.js
+++ b/test/suite.js
@@ -288,6 +288,11 @@ describe('Suite', function(){
       this.first.suites.should.have.length(1);
       this.first.suites[0].should.equal(this.second);
     });
+
+    it('treats suite as pending if its parent is pending', function(){
+      this.first.pending = true
+      this.second.isPending.should.be.true
+    });
   });
 
   // describe('.addTest()', function(){

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var mocha = require('../')
+  , should = require('should')
   , Context = mocha.Context
   , Test = mocha.Test;
 
@@ -50,6 +51,26 @@ describe('Test', function(){
 
     it('should copy the file value', function(){
       this._test.clone().file.should.equal('bar');
+    });
+  });
+
+  describe('.isPending()', function(){
+    beforeEach(function(){
+      this._test = new Test('Is it skipped', function () {});
+    });
+
+    it('should not be pending by default', function(){
+      should(this._test.isPending()).not.be.ok();
+    });
+
+    it('should be pending when marked as such', function(){
+      this._test.pending = true;
+      should(this._test.isPending()).be.ok();
+    });
+
+    it('should be pending when its parent is pending', function(){
+      this._test.parent = { isPending: function(){ return true } };
+      should(this._test.isPending()).be.ok();
     });
   });
 });


### PR DESCRIPTION
Checking for boolean property `.pending` on Test or Suite objects was too brittle in a way that the caller often forgot to check whether any of the object's parents are marked as pending as well.

This moves all the pending checks to new `.isPending()` predicate method that is defined on all Suite and Runnable (and thus Test and Hook as well.)

Runners and reporters should always use this method to check for "pendingness" of test and suite objects.

Fixes #1760, fixes #1936

/cc @puzrin @danielstjules @Kirill89