### PR TITLE
Fix: html reporter crashing on before hook error

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -54,6 +54,7 @@ function Runnable(title, fn) {
   this._trace = new Error('done() called multiple times');
   this._retries = -1;
   this._currentRetry = 0;
+  this.body = (fn || '').toString();
 }
 
 /**

--- a/lib/test.js
+++ b/lib/test.js
@@ -22,7 +22,6 @@ function Test(title, fn) {
   Runnable.call(this, title, fn);
   this.pending = !fn;
   this.type = 'test';
-  this.body = (fn || '').toString();
 }
 
 /**


### PR DESCRIPTION
HTML reporter expects that Runnables have a `body` 

https://github.com/mochajs/mocha/blob/d59cc6c166d0d112a62016909b33e04ed08d2274/lib/reporters/html.js#L203