### PR TITLE
handle Symbol values in util.stringify()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -472,6 +472,7 @@ function jsonStringify(object, spaces, depth) {
         break;
       case 'boolean':
       case 'regexp':
+      case 'symbol':
       case 'number':
         val = val === 0 && (1 / val) === -Infinity // `-0`
           ? '-0'
@@ -597,6 +598,7 @@ exports.canonicalize = function(value, stack) {
     case 'number':
     case 'regexp':
     case 'boolean':
+    case 'symbol':
       canonicalizedObj = value;
       break;
     default:

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -331,6 +331,15 @@ describe('lib/utils', function () {
 
       stringify(a).should.equal('{\n  "foo": 1\n}');
     });
+
+    // In old version node.js, Symbol is not available by default.
+    if (typeof global.Symbol === 'function') {
+      it('should handle Symbol', function () {
+        var symbol = Symbol('value');
+        stringify(symbol).should.equal('Symbol(value)');
+        stringify({symbol: symbol}).should.equal('{\n  "symbol": Symbol(value)\n}')
+      });
+    }
   });
 
   describe('type', function () {


### PR DESCRIPTION
This PR fixes issue #2089.
It enables to generate diff of objects that have Symbol values.

Fixed output:

![mocha-symbol-after](https://cloud.githubusercontent.com/assets/12684251/12864551/fada264c-ccd1-11e5-8127-16207304df70.png)
