### PR TITLE
Ensure that errors happening after the test suite is done still get thown

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -67,6 +67,7 @@ function Runner(suite, delay) {
   this._delay = delay;
   this.suite = suite;
   this.started = false;
+  this.finished = false;
   this.total = suite.total();
   this.failures = 0;
   this.on('test end', function(test) {
@@ -674,7 +675,7 @@ Runner.prototype.uncaught = function(err) {
     runnable = new Runnable('Uncaught error outside test suite');
     runnable.parent = this.suite;
 
-    if (this.started) {
+    if (this.started && !this.finished) {
       this.fail(runnable, err);
     } else {
       // Can't recover from this failure
@@ -783,6 +784,8 @@ Runner.prototype.run = function(fn) {
     self.emit('start');
     self.runSuite(rootSuite, function() {
       debug('finished running');
+      self.currentRunnable = null;
+      self.finished = true;
       self.emit('end');
     });
   }

--- a/test/integration/fixtures/regression/issue-2089.js
+++ b/test/integration/fixtures/regression/issue-2089.js
@@ -1,0 +1,12 @@
+var assert = require('assert');
+
+describe('issue 2089', function() {
+  it('should fail', function() {
+    var d = new Date();
+    // Force an error during reporter rendering
+    d.toISOString = function() {
+      throw new Error('error caused on purpose');
+    };
+    assert.deepEqual([d], ['a']);
+  });
+});

--- a/test/integration/regression.js
+++ b/test/integration/regression.js
@@ -49,5 +49,14 @@ describe('regressions', function() {
       assert.equal(res.code, 0, 'Runnable fn (it/before[Each]/after[Each]) references should be deleted to avoid memory leaks');
       done();
     });
-  })
+  });
+
+  it('issue-2089: should stop capturing errors after the run is over', function(done) {
+    run('regression/issue-2089.js', ['-R', 'spec'], function(err, res) {
+      assert.ifError(err);
+      assert.equal(/error caused on purpose/.test(res.output), true, 'Expected to see the error in output: \n' + res.output);
+      assert.notEqual(res.code, 0, 'Expected test run to fail');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Most notably this happens if there are problems in a reporter's summary output, such as that described in #2089

I'd like to include a test for this - but I'm not sure where best to put it. Any thoughts?

Here's a sample which will reproduce the error even after #2094 is fixed:

``` js
var assert = require('assert');

describe('x', function() {
  it('should', function() {
    var d = new Date();
    // Force an error during rendering
    d.toISOString = function() { throw new Error("Can't display"); };
    assert.deepEqual([d], ['a']);
  });
});
```
