### PR TITLE
fix diff for objects with custom hasOwnProperty values

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -498,7 +498,7 @@ function jsonStringify(object, spaces, depth) {
   }
 
   for (var i in object) {
-    if (!object.hasOwnProperty(i)) {
+    if (!Object.prototype.hasOwnProperty.call(object, i)) {
       continue; // not my business
     }
     --length;

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -129,6 +129,26 @@ describe('Base reporter', function () {
     errOut.should.match(/\+ expected/);
   });
 
+  it('should stringify Object.create(null)', function () {
+    var err = new Error('test'),
+      errOut;
+
+    err.actual = Object.create(null);
+    err.actual.hasOwnProperty = 1;
+    err.expected = Object.create(null);
+    err.expected.hasOwnProperty = 2;
+    err.showDiff = true;
+    var test = makeTest(err);
+
+    Base.list([test]);
+
+    errOut = stdout.join('\n');
+    errOut.should.match(/"hasOwnProperty"/);
+    errOut.should.match(/test/);
+    errOut.should.match(/\- actual/);
+    errOut.should.match(/\+ expected/);
+  });
+
   it('should remove message from stack', function () {
     var err = {
       message: 'Error',


### PR DESCRIPTION
Instead of calling `hasOwnProperty` directly, it should be `Object.prototype.hasOwnProperty.call(object, prop)`. This is already the case further up in the `exports.stringify` implementation.