### PR TITLE
Non string error messages

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -170,8 +170,8 @@ exports.list = function(failures) {
     var msg;
     var err = test.err;
     var message;
-    if (err.message) {
-      message = err.message;
+    if (err.message && typeof err.message.toString === 'function') {
+      message = err.message + '';
     } else if (typeof err.inspect === 'function') {
       message = err.inspect() + '';
     } else {

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -1,3 +1,5 @@
+var assert = require('assert');
+
 var Base   = require('../../lib/reporters/base')
   , Assert = require('assert').AssertionError;
 
@@ -147,6 +149,27 @@ describe('Base reporter', function () {
     errOut.should.match(/test/);
     errOut.should.match(/\- actual/);
     errOut.should.match(/\+ expected/);
+  });
+
+  it('should handle error messages that are not strings', function () {
+    var errOut;
+
+    try {
+      assert(false, true);
+    } catch (err) {
+      err.actual = false;
+      err.expected = true;
+      err.showDiff = true;
+      var test = makeTest(err);
+
+      Base.list([test]);
+
+      errOut = stdout.join('\n');
+      errOut.should.match(/\+true/);
+      errOut.should.match(/\-false/);
+      errOut.should.match(/\- actual/);
+      errOut.should.match(/\+ expected/);
+    }
   });
 
   it('should remove message from stack', function () {


### PR DESCRIPTION
This PR checks that when handling assertion error messages in a reporter, the message is actually a string since if it isn't the `message.match` function (https://github.com/jkimbo/mocha/blob/2a1dc7a8f32d7eb65cdf645c30aac3cc37714ae7/lib/reporters/base.js#L208) fails and leads to the test suite failing silently.