### PR TITLE
Consistent assertion formatting

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -204,9 +204,8 @@ exports.list = function(failures) {
         err.expected = expected = utils.stringify(expected);
       }
 
-      fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
-      msg = '\n      ' + color('error message', match ? match[1] : msg);
+      msg = match ? match[1] : msg;
 
       if (exports.inlineDiffs) {
         msg += inlineDiff(err, escape);


### PR DESCRIPTION
Doing so wraps the error message in the color format string for the
error title, so that if the error message title were set to another
color code, e.g. '31;1' (bright red), that would leak into the error
message.

Also there was an extra newline before the error message when showing a
diff that wouldn't appear when there is no diff.

Before:
![before](https://cloud.githubusercontent.com/assets/462330/12976331/599853c2-d117-11e5-9585-de2b5fb2e6af.png)

After:
![after](https://cloud.githubusercontent.com/assets/462330/12976335/60fb21bc-d117-11e5-87a6-471229e57006.png)
