### PR TITLE
Fix #2109: stringify should handle objects with non-coercible length

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -454,7 +454,7 @@ function jsonStringify(object, spaces, depth) {
   var space = spaces * depth;
   var str = isArray(object) ? '[' : '{';
   var end = isArray(object) ? ']' : '}';
-  var length = object.length || exports.keys(object).length;
+  var length = typeof object.length === 'number' ? object.length : exports.keys(object).length;
   // `.repeat()` polyfill
   function repeat(s, n) {
     return new Array(n).join(s);

--- a/test/acceptance/utils.js
+++ b/test/acceptance/utils.js
@@ -340,6 +340,10 @@ describe('lib/utils', function () {
         stringify({symbol: symbol}).should.equal('{\n  "symbol": Symbol(value)\n}')
       });
     }
+
+    it('should handle length properties that cannot be coerced to a number', function () {
+      stringify({length: {toString: 0}}).should.equal('{\n  "length": {\n    "toString": 0\n  }\n}');
+    });
   });
 
   describe('type', function () {


### PR DESCRIPTION
Fix for #2109.  When comparing objects with certain length properties, the reporter throws when stringifying the diff:
```javascript
it('compare two objects', function () {
   assert.deepEqual({length: {toString: 0}}, {length: 1});
});
```

Root cause is that some JS objects cannot be coerced to a Number:
```javascript
> Number({toString: 0});
TypeError: Cannot convert object to primitive value

> Number({a: 0});
< NaN
```