### PR TITLE
package: update glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": "7.0.0",
     "growl": "1.8.1",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
older versions of glob use older version of `graceful-fs`, which will break on newer (future, i assume) versions of node