### PR TITLE
Fix hook error in browser reporter by moving body prop from test to runnable

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -45,6 +45,7 @@ module.exports = Runnable;
 function Runnable(title, fn) {
   this.title = title;
   this.fn = fn;
+  this.body = (fn || '').toString();
   this.async = fn && fn.length;
   this.sync = !this.async;
   this._timeout = 2000;

--- a/lib/test.js
+++ b/lib/test.js
@@ -22,7 +22,6 @@ function Test(title, fn) {
   Runnable.call(this, title, fn);
   this.pending = !fn;
   this.type = 'test';
-  this.body = (fn || '').toString();
 }
 
 /**


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot read property 'replace' of undefined` when an exception is thrown from a hook.

Example test suite that correctly renders after the PR:
``` javascript
before(function() {
  throw new Error('uh oh!');
});
it('test', function() {});
```

![screen shot 2016-02-16 at 6 25 46 pm](https://cloud.githubusercontent.com/assets/817212/13097968/bc7486b6-d4da-11e5-8fa5-b8e2676d5361.png)
