### PR TITLE
prevent html reporter updating url hash

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -80,7 +80,8 @@ function HTML(runner) {
   }
 
   // pass toggle
-  on(passesLink, 'click', function() {
+  on(passesLink, 'click', function(evt) {
+    evt.preventDefault();
     unhide();
     var name = (/pass/).test(report.className) ? '' : ' pass';
     report.className = report.className.replace(/fail|pass/g, '') + name;
@@ -90,7 +91,8 @@ function HTML(runner) {
   });
 
   // failure toggle
-  on(failuresLink, 'click', function() {
+  on(failuresLink, 'click', function(evt) {
+    evt.preventDefault();
     unhide();
     var name = (/fail/).test(report.className) ? '' : ' fail';
     report.className = report.className.replace(/fail|pass/g, '') + name;


### PR DESCRIPTION
I have noticed a small issue with the hash updating when the passed/failure filters are clicked on the html reporter. When testing an app that uses hash navigation this can cause the page to navigate.
Let me know thoughts. Thanks