### PR TITLE
Updated version of `glob` package to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": "7.0.0",
     "growl": "1.8.1",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "7.0.0",
+    "glob": "7.0.3",
     "growl": "1.8.1",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
NPM says `glob` dependency `graceful-fs@2.0.3` is deprecated and will cause newer versions of Node to crash.
![screen shot 2016-02-24 at 1 14 04 pm](https://cloud.githubusercontent.com/assets/1882429/13301426/a666c3f0-daf9-11e5-8a26-f42d9b4a9a75.png)
So I upgraded `glob` from version `@3.2.3` to `@7.0.0`, which is the [latest version](https://www.npmjs.com/package/glob). This version of `glob` also no longer uses `graceful-fs` as a dependency.

Finally, this update passed all of the tests.
![screen shot 2016-02-24 at 1 28 42 pm](https://cloud.githubusercontent.com/assets/1882429/13301595/8d069740-dafa-11e5-97e7-f386632a3043.png)
[mochaTestOutput.txt](https://github.com/mochajs/mocha/files/145444/mochaTestOutput.txt)

