### PR TITLE
updating growl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",
-    "growl": "^1.9.2",
+    "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",
     "supports-color": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",
-    "growl": "1.8.1",
+    "growl": "^1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",
     "supports-color": "1.2.0"


### PR DESCRIPTION
this updates to last version of growl ( from https://github.com/tj/node-growl/issues/57 )
this for example fixes the way notifications look in OSX (they don't show a success/fail icon currently), with this update now it looks like this:

<img width="345" alt="screenshot 2016-02-25 03 41 43" src="https://cloud.githubusercontent.com/assets/384553/13312032/08b6d8ce-db72-11e5-85e4-dfc928b074c9.png">
