### PR TITLE
Access to `mocha` instance created by the command-line executable

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -382,6 +382,7 @@ if (program.watch) {
       mocha.grep(null);
     mocha.suite = mocha.suite.clone();
     mocha.suite.ctx = new Mocha.Context;
+    mocha.suite._mocha = mocha;
     mocha.ui(program.ui);
     loadAndRun();
   }


### PR DESCRIPTION
So, I'm trying to write a (fairly hacky, but that's beside the point) extension to Mocha.

I need to switch some functionality on the value of `mocha._ui` (that is, expose different functions to map to the functionality I'm providing); but the problem is, I have no access to the `Mocha()` instaced created by the `_mocha` executable, as far as I can tell through a bit of code-spelunking.

Would a modification that does that be welcome?

(Ignore the commit; this probably isn't the way to go about it; it just wouldn't let me open a pull-requets without any changes, and I didn't want to open it as an Issue and then immediately open a second Issue for the pull-request if the response was in the affirmative.)