### PR TITLE
Bump up `glob` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": ">= 6.0",
     "growl": "1.8.1",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
That version removes `graceful_fs` dependency and thus this deprecated error:
```
npm WARN deprecated graceful-fs@2.0.3: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```