### PR TITLE
Updated glob to version 7.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": "7.0.0",
     "growl": "1.8.1",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
To get rid of the deprecation warning for graceful-fs 2.0.3. Mocha has a dependency on that package through glob 3.2.3. After updating to glob 7.0.0 I ran the test suite and no test was reported as failing.