### PR TITLE
Fix non standard ANSI colors

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -50,23 +50,23 @@ exports.inlineDiffs = false;
  */
 
 exports.colors = {
-  pass: 90,
+  pass: '30;1',
   fail: 31,
-  'bright pass': 92,
-  'bright fail': 91,
-  'bright yellow': 93,
+  'bright pass': '32;1',
+  'bright fail': '31;1',
+  'bright yellow': '33;1',
   pending: 36,
   suite: 0,
   'error title': 0,
   'error message': 31,
-  'error stack': 90,
+  'error stack': '30;1',
   checkmark: 32,
-  fast: 90,
+  fast: '30;1',
   medium: 33,
   slow: 31,
   green: 32,
-  light: 90,
-  'diff gutter': 90,
+  light: '30;1',
+  'diff gutter': '30;1',
   'diff added': 32,
   'diff removed': 31
 };


### PR DESCRIPTION
Replaces the non standard 90-97 color range to their standard 30-37 range. This should fix colors from not showing up, like on Travis.