### PR TITLE
Added support for multiple reporters.

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -66,10 +66,10 @@ program
   .option('-c, --colors', 'force enabling of colors')
   .option('-C, --no-colors', 'force disabling of colors')
   .option('-G, --growl', 'enable growl notification support')
-  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
-  .option('-R, --reporter <name>', 'specify the reporter to use', 'spec')
-  .option('-S, --sort', 'sort test files')
-  .option('-b, --bail', 'bail after first test failure')
+  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options, use name1:{k=v,k2=v2,...},name2:{...} for multiple reporters')
+  .option('-R, --reporter <name>', 'specify the reporter to use, or <name1>,<name2>,... for multiple reporters.', list, ['spec'])
+  .option('-S, --sort', "sort test files")
+  .option('-b, --bail', "bail after first test failure")
   .option('-d, --debug', "enable node's debugger, synonym for node --debug")
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
   .option('-f, --fgrep <string>', 'only run tests containing <string>')
@@ -196,16 +196,45 @@ Error.stackTraceLimit = Infinity; // TODO: config
 
 var reporterOptions = {};
 if (program.reporterOptions !== undefined) {
-  program.reporterOptions.split(',').forEach(function (opt) {
-    var L = opt.split('=');
-    if (L.length > 2 || L.length === 0) {
-      throw new Error("invalid reporter option '" + opt + "'");
-    } else if (L.length === 2) {
-      reporterOptions[L[0]] = L[1];
-    } else {
-      reporterOptions[L[0]] = true;
+  var reporterOptionsParser;
+  var multipleReporterFormat = /([^,:]+):{([^}]+)}/g;
+
+  var parseOptions = function (optionsStr) {
+    var options = {};
+    optionsStr.split(',').forEach(function (opt) {
+      var split = opt.split('=');
+      if (split.length > 2 || split.length === 0) {
+        throw new Error("invalid reporter option '" + opt + "'");
+      }
+
+      if (split.length === 2) {
+        options[split[0]] = split[1];
+      } else {
+        options[split[0]] = true;
+      }
+    });
+
+    return options;
+  };
+
+  if (program.reporterOptions.match(multipleReporterFormat)) {
+    // multiple reporter config:
+    //   spec:{a=1,b=2},dot:{c=3,d=4}
+    var match;
+    while ((match = multipleReporterFormat.exec(program.reporterOptions))) {
+      if (match.length !== 3) {
+        throw new Error("invalid multiple reporter options format '" + program.reporterOptions + "'");
+      }
+
+      var reporterName = match[1];
+      var reporterOptionStr = match[2];
+      reporterOptions[reporterName] = parseOptions(reporterOptionStr);
     }
-  });
+  } else {
+    // single reporter config:
+    //   a=1,b=2
+    reporterOptions._default = parseOptions(program.reporterOptions);
+  }
 }
 
 // reporter
@@ -214,16 +243,17 @@ mocha.reporter(program.reporter, reporterOptions);
 
 // load reporter
 
-var Reporter = null;
-try {
-  Reporter = require('../lib/reporters/' + program.reporter);
-} catch (err) {
+program.reporter.forEach(function (reporterName) {
   try {
-    Reporter = require(program.reporter);
-  } catch (err2) {
-    throw new Error('reporter "' + program.reporter + '" does not exist');
+    require('../lib/reporters/' + reporterName);
+  } catch (err) {
+    try {
+      require(reporterName);
+    } catch (err2) {
+      throw new Error('reporter "' + reporterName + '" does not exist');
+    }
   }
-}
+});
 
 // --no-colors
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -12,7 +12,7 @@
 
 var escapeRe = require('escape-string-regexp');
 var path = require('path');
-var reporters = require('./reporters');
+var builtInReporters = require('./reporters');
 var utils = require('./utils');
 
 /**
@@ -36,7 +36,7 @@ if (!process.browser) {
 
 exports.utils = utils;
 exports.interfaces = require('./interfaces');
-exports.reporters = reporters;
+exports.reporters = builtInReporters;
 exports.Runnable = require('./runnable');
 exports.Context = require('./context');
 exports.Runner = require('./runner');
@@ -129,23 +129,42 @@ Mocha.prototype.addFile = function (file) {
 };
 
 /**
- * Set reporter to `reporter`, defaults to "spec".
+ * Set reporters to `reporters`, defaults to ['spec'].
  *
- * @param {String|Function} reporter name or constructor
- * @param {Object} reporterOptions optional options
+ * @param {String|Function|Array of strings|Array of functions} reporter name as
+ * string, reporter constructor, or array of constructors or reporter names as
+ * strings.
+ * @param {Object} reporterOptions optional options, keyed by reporter name, or
+ * '_default' for options to use when per-name options are not given.
  * @api public
- * @param {string|Function} reporter name or constructor
- * @param {Object} reporterOptions optional options
  */
-Mocha.prototype.reporter = function (reporter, reporterOptions) {
-  if (typeof reporter === 'function') {
-    this._reporter = reporter;
-  } else {
-    reporter = reporter || 'spec';
+Mocha.prototype.reporter = function(reporters, reporterOptions) {
+  // if no reporter is given as input, default to spec reporter
+  reporters = reporters || ['spec'];
+  reporterOptions = reporterOptions || {};
+
+  if (!utils.isArray(reporters)) {
+    if ((typeof reporters === 'string')
+        || (typeof reporters === 'function')) {
+      reporters = [reporters];
+    } else {
+      throw new Error('invalid reporter "' + reporters + '"');
+    }
+  }
+
+  // Load each reporter, only passing the options for that reporter
+  this._reporters = reporters.map(function(reporter) {
+    if (typeof reporter === 'function') {
+      return {
+        fn: reporter,
+        options: reporterOptions
+      };
+    }
+
     var _reporter;
     // Try to load a built-in reporter.
-    if (reporters[reporter]) {
-      _reporter = reporters[reporter];
+    if (builtInReporters[reporter]) {
+      _reporter = builtInReporters[reporter];
     }
     // Try to load reporters from process.cwd() and node_modules
     if (!_reporter) {
@@ -165,9 +184,12 @@ Mocha.prototype.reporter = function (reporter, reporterOptions) {
     if (!_reporter) {
       throw new Error('invalid reporter "' + reporter + '"');
     }
-    this._reporter = _reporter;
-  }
-  this.options.reporterOptions = reporterOptions;
+    return {
+      fn: _reporter,
+      options: reporterOptions[reporter] || reporterOptions._default || {}
+    };
+  }, this);
+
   return this;
 };
 
@@ -490,7 +512,14 @@ Mocha.prototype.run = function (fn) {
   var options = this.options;
   options.files = this.files;
   var runner = new exports.Runner(suite, options.delay);
-  var reporter = new this._reporter(runner, options);
+
+  // For each loaded reporter constructor, create
+  // an instance and initialize it with the runner
+  var reporters = this._reporters.map(function(reporterConfig) {
+    var _reporter = reporterConfig.fn;
+    options.reporterOptions = reporterConfig.options;
+    return new _reporter(runner, options);
+  });
   runner.ignoreLeaks = options.ignoreLeaks !== false;
   runner.fullStackTrace = options.fullStackTrace;
   runner.hasOnly = options.hasOnly;
@@ -502,21 +531,32 @@ Mocha.prototype.run = function (fn) {
   if (options.globals) {
     runner.globals(options.globals);
   }
+  // Use only the first reporter for growl, since we don't want to
+  // send several notifications for the same test suite
   if (options.growl) {
-    this._growl(runner, reporter);
+    this._growl(runner, reporters[0]);
   }
   if (options.useColors !== undefined) {
     exports.reporters.Base.useColors = options.useColors;
   }
   exports.reporters.Base.inlineDiffs = options.useInlineDiffs;
 
-  function done (failures) {
-    if (reporter.done) {
-      reporter.done(failures, fn);
-    } else {
-      fn && fn(failures);
+  function runnerDone(failures) {
+    function reporterDone(reporterFailures) {
+      if (--remain === 0) {
+        fn && fn(reporterFailures);
+      }
     }
+
+    var remain = reporters.length;
+    reporters.forEach(function(reporter) {
+      if (reporter.done) {
+        reporter.done(failures, reporterDone);
+      } else {
+        reporterDone(failures);
+      }
+    });
   }
 
-  return runner.run(done);
+  return runner.run(runnerDone);
 };

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -5,6 +5,10 @@
  */
 
 var tty = require('tty');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
+var EOL = require('os').EOL;
 var diff = require('diff');
 var ms = require('../ms');
 var utils = require('../utils');
@@ -235,12 +239,15 @@ exports.list = function (failures) {
  * of tests passed / failed etc.
  *
  * @param {Runner} runner
+ * @param {Object} options runner optional options
  * @api public
  */
 
-function Base (runner) {
+function Base (runner, options) {
   var stats = this.stats = { suites: 0, tests: 0, passes: 0, pending: 0, failures: 0 };
   var failures = this.failures = [];
+
+  this.reporterOptions = options ? options.reporterOptions : null;
 
   if (!runner) {
     return;
@@ -334,6 +341,71 @@ Base.prototype.epilogue = function () {
   }
 
   console.log();
+};
+
+/**
+ * Opens for writing the file referenced on the `optionName` option
+ * of the reporter options, if any.
+ * Call this method to support writing to this file when calling
+ * write or writeLine.
+ *
+ * @param {string} optionName the name of the option, defaults to 'output'.
+ * @api public
+ */
+Base.prototype.openOutput = function (optionName) {
+  var output = this.reporterOptions && this.reporterOptions[optionName || 'output'];
+  if (output) {
+    if (!fs.createWriteStream) {
+      throw new Error('file output not supported in browser');
+    }
+
+    if (this.fileStream) {
+      throw new Error('file stream already opened');
+    }
+
+    mkdirp.sync(path.dirname(output));
+    this.fileStream = fs.createWriteStream(output);
+  }
+};
+
+/**
+ * Write to reporter output stream.
+ *
+ * @param {string} str
+ * @api public
+ */
+Base.prototype.write = function (str) {
+  if (this.fileStream) {
+    this.fileStream.write(str);
+  } else {
+    process.stdout.write(str);
+  }
+};
+
+/**
+ * Write to reporter output stream, adding an EOL at the end.
+ *
+ * @param {string} line
+ * @api public
+ */
+Base.prototype.writeLine = function (line) {
+  this.write(line + EOL);
+};
+
+/**
+ * Close the output stream and callback with failures.
+ *
+ * @param failures
+ * @param {Function} fn
+ */
+Base.prototype.done = function (failures, fn) {
+  if (this.fileStream) {
+    this.fileStream.end(function () {
+      fn(failures);
+    });
+  } else {
+    fn(failures);
+  }
 };
 
 /**

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -5,6 +5,7 @@
  */
 
 var Base = require('./base');
+var inherits = require('../utils').inherits;
 
 /**
  * Expose `JSON`.
@@ -17,15 +18,18 @@ exports = module.exports = JSONReporter;
  *
  * @api public
  * @param {Runner} runner
+ * @param {Object} options Runner optional options
  */
-function JSONReporter (runner) {
-  Base.call(this, runner);
+function JSONReporter (runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var tests = [];
   var pending = [];
   var failures = [];
   var passes = [];
+
+  this.openOutput();
 
   runner.on('test end', function (test) {
     tests.push(test);
@@ -54,9 +58,14 @@ function JSONReporter (runner) {
 
     runner.testResults = obj;
 
-    process.stdout.write(JSON.stringify(obj, null, 2));
+    self.write(JSON.stringify(obj, null, 2));
   });
 }
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+inherits(JSONReporter, Base);
 
 /**
  * Return a plain-object representation of `test`

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -6,6 +6,7 @@
 
 var Base = require('./base');
 var utils = require('../utils');
+var inherits = utils.inherits;
 
 /**
  * Constants
@@ -24,12 +25,16 @@ exports = module.exports = Markdown;
  *
  * @api public
  * @param {Runner} runner
+ * @param {Object} options runner optional options
  */
-function Markdown (runner) {
-  Base.call(this, runner);
+function Markdown (runner, options) {
+  Base.call(this, runner, options);
 
+  var self = this;
   var level = 0;
   var buf = '';
+
+  this.openOutput();
 
   function title (str) {
     return Array(level).join('#') + ' ' + str;
@@ -92,8 +97,13 @@ function Markdown (runner) {
   });
 
   runner.on('end', function () {
-    process.stdout.write('# TOC\n');
-    process.stdout.write(generateTOC(runner.suite));
-    process.stdout.write(buf);
+    self.write('# TOC\n');
+    self.write(generateTOC(runner.suite));
+    self.write(buf);
   });
 }
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+inherits(Markdown, Base);

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -7,10 +7,7 @@
 var Base = require('./base');
 var utils = require('../utils');
 var inherits = utils.inherits;
-var fs = require('fs');
 var escape = utils.escape;
-var mkdirp = require('mkdirp');
-var path = require('path');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -35,21 +32,16 @@ exports = module.exports = XUnit;
  *
  * @api public
  * @param {Runner} runner
+ * @param {Object} options Runner optional options
  */
 function XUnit (runner, options) {
-  Base.call(this, runner);
+  Base.call(this, runner, options);
 
   var stats = this.stats;
   var tests = [];
   var self = this;
 
-  if (options.reporterOptions && options.reporterOptions.output) {
-    if (!fs.createWriteStream) {
-      throw new Error('file output not supported in browser');
-    }
-    mkdirp.sync(path.dirname(options.reporterOptions.output));
-    self.fileStream = fs.createWriteStream(options.reporterOptions.output);
-  }
+  self.openOutput();
 
   runner.on('pending', function (test) {
     tests.push(test);
@@ -64,7 +56,7 @@ function XUnit (runner, options) {
   });
 
   runner.on('end', function () {
-    self.write(tag('testsuite', {
+    self.writeLine(tag('testsuite', {
       name: 'Mocha Tests',
       tests: stats.tests,
       failures: stats.failures,
@@ -78,7 +70,7 @@ function XUnit (runner, options) {
       self.test(t);
     });
 
-    self.write('</testsuite>');
+    self.writeLine('</testsuite>');
   });
 }
 
@@ -86,37 +78,6 @@ function XUnit (runner, options) {
  * Inherit from `Base.prototype`.
  */
 inherits(XUnit, Base);
-
-/**
- * Override done to close the stream (if it's a file).
- *
- * @param failures
- * @param {Function} fn
- */
-XUnit.prototype.done = function (failures, fn) {
-  if (this.fileStream) {
-    this.fileStream.end(function () {
-      fn(failures);
-    });
-  } else {
-    fn(failures);
-  }
-};
-
-/**
- * Write out the given line.
- *
- * @param {string} line
- */
-XUnit.prototype.write = function (line) {
-  if (this.fileStream) {
-    this.fileStream.write(line + '\n');
-  } else if (typeof process === 'object' && process.stdout) {
-    process.stdout.write(line + '\n');
-  } else {
-    console.log(line);
-  }
-};
 
 /**
  * Output tag for the given `test.`
@@ -132,11 +93,11 @@ XUnit.prototype.test = function (test) {
 
   if (test.state === 'failed') {
     var err = test.err;
-    this.write(tag('testcase', attrs, false, tag('failure', {}, false, escape(err.message) + '\n' + escape(err.stack))));
+    this.writeLine(tag('testcase', attrs, false, tag('failure', {}, false, escape(err.message) + '\n' + escape(err.stack))));
   } else if (test.isPending()) {
-    this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    this.writeLine(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    this.write(tag('testcase', attrs, true));
+    this.writeLine(tag('testcase', attrs, true));
   }
 };
 

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -60,4 +60,46 @@ describe('reporters', function () {
       });
     });
   });
+
+  describe('json', function () {
+    it('prints test cases with --reporter-options output', function (done) {
+      var randomStr = crypto.randomBytes(8).toString('hex');
+      var tmpDir = os.tmpDir().replace(new RegExp(path.sep + '$'), '');
+      var tmpFile = tmpDir + path.sep + 'test-json-reporter-options-' + randomStr + '.json';
+
+      var args = ['--reporter=json', '--reporter-options', 'output=' + tmpFile];
+      run('passing.fixture.js', args, function (err, result) {
+        if (err) return done(err);
+
+        var json = fs.readFileSync(tmpFile, 'utf8');
+        fs.unlinkSync(tmpFile);
+        var results = JSON.parse(json);
+        assert(results.passes, 'JSON did not contain the expected passes array.');
+        assert(results.passes.length === 2, 'JSON did not contain the expected number of results.');
+        done(err);
+      });
+    });
+  });
+
+  describe('multiple', function () {
+    it('supports multiple reporters and reporter options', function (done) {
+      var randomStr = crypto.randomBytes(8).toString('hex');
+      var tmpDir = os.tmpDir().replace(new RegExp(path.sep + '$'), '');
+      var tmpJsonFile = tmpDir + path.sep + 'test-multiple-reporters-' + randomStr + '.json';
+      var tmpXmlFile = tmpDir + path.sep + 'test-multiple-reporters-' + randomStr + '.xml';
+
+      var args = ['--reporter=json,xunit', '--reporter-options', 'xunit:{output=' + tmpXmlFile + '},json:{output=' + tmpJsonFile + '}'];
+      run('passing.fixture.js', args, function (err, result) {
+        if (err) return done(err);
+
+        var json = fs.readFileSync(tmpJsonFile, 'utf8');
+        fs.unlinkSync(tmpJsonFile);
+        var xml = fs.readFileSync(tmpXmlFile, 'utf8');
+        fs.unlinkSync(tmpXmlFile);
+        assert(json.length > 0, 'JSON file is empty.');
+        assert(xml.length > 0, 'XML file is empty');
+        done(err);
+      });
+    });
+  });
 });

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -15,7 +15,8 @@ describe('json reporter', function () {
     suite = new Suite('JSON suite', 'root');
     runner = new Runner(suite);
     /* eslint no-unused-vars: off */
-    var mochaReporter = new mocha._reporter(runner);
+    /* eslint new-cap: off */
+    var mochaReporter = new mocha._reporters[0].fn(runner);
   });
 
   it('should have 1 test failure', function (done) {

--- a/test/reporters/multiple.js
+++ b/test/reporters/multiple.js
@@ -1,0 +1,113 @@
+'use strict';
+
+var Mocha = require('../../');
+var Suite = Mocha.Suite;
+var Runner = Mocha.Runner;
+var Test = Mocha.Test;
+
+describe('multiple reporters', function () {
+  it('should have 1 test failure', function (done) {
+    var mocha = new Mocha({
+      reporter: ['spec', 'json']
+    });
+    var suite = new Suite('Multiple reporters suite', 'root');
+    var runner = new Runner(suite);
+
+    /* eslint-disable new-cap */
+    var specReporter = new mocha._reporters[0].fn(runner);
+    var jsonReporter = new mocha._reporters[1].fn(runner);
+    /* eslint-enable new-cap */
+
+    var testTitle = 'json test 1';
+    var error = { message: 'an error' };
+
+    suite.addTest(new Test(testTitle, function (done) {
+      done(new Error(error.message));
+    }));
+
+    runner.run(function () {
+      // Verify that each reporter ran
+      expect(specReporter).to.have.property('failures');
+      expect(specReporter.failures).to.be.an('array');
+      expect(specReporter.failures).to.have.length(1);
+
+      expect(jsonReporter).to.have.property('failures');
+      expect(jsonReporter.failures).to.be.an('array');
+      expect(jsonReporter.failures).to.have.length(1);
+      done();
+    });
+  });
+
+  it('should pass correct reporter options and path to each reporter', function (done) {
+    var mocha = new Mocha({
+      reporter: [
+        'spec',
+        'dot',
+        'json'
+      ],
+      reporterOptions: {
+        spec: { foo: 'bar' },
+        json: { bar: 'baz' }
+      }
+    });
+
+    var doneCnt = 0;
+    function reporterDone () {
+      doneCnt++;
+      if (doneCnt === 3) {
+        done();
+      }
+    }
+
+    // specReporter
+    mocha._reporters[0].fn = function (runner, options) {
+      expect(options.reporterOptions).to.have.property('foo', 'bar');
+      reporterDone();
+    };
+
+    // dot (no options)
+    mocha._reporters[1].fn = function (runner, options) {
+      expect(options.reporterOptions).to.eql({});
+      reporterDone();
+    };
+
+    // json
+    mocha._reporters[2].fn = function (runner, options) {
+      expect(options.reporterOptions).to.have.property('bar', 'baz');
+      reporterDone();
+    };
+
+    mocha.run();
+  });
+
+  it('should pass _default reporter options to each reporter', function (done) {
+    var mocha = new Mocha({
+      reporter: ['spec', 'json'],
+      reporterOptions: {
+        _default: { foo: 'bar' }
+      }
+    });
+
+    var doneCnt = 0;
+    function reporterDone () {
+      doneCnt++;
+      if (doneCnt === 2) {
+        done();
+      }
+    }
+
+    // specReporter
+    mocha._reporters[0].fn = function (runner, options) {
+      expect(options.reporterOptions).to.have.property('foo', 'bar');
+      reporterDone();
+    };
+
+    // json
+    mocha._reporters[1].fn = function (runner, options) {
+      expect(options.reporterOptions).to.have.property('foo', 'bar');
+      reporterDone();
+    };
+
+    mocha.run();
+  });
+});


### PR DESCRIPTION
Rework of #2091, rebased to master.

Includes work from @benvinegar & @misterdjules, this PR also:
- Removes support for `--reporter json:<outputfile>` which was added on previous PRs, instead reporters that  support output to files should use `--reporter-options`.
- Added utility methods on `Base` reporter to open an `output` option provided on reporter options as an output file, and write to it. This is a generalization of the mechanism used by the `xunit` reporter to other reporters: `json`, `json-cov`, `html-cov`, `markdown`. All those reporters, and the `xunit` reporter, now inherit from `Base` and use these utility methods to write their output.
- Fixes lint warnings.
- Fixed issues with parsing the reporterOptions when there were multiple reporters.
- Adds a test case to check that the `json` reporter writes to the file specified by the <reporter>:<outputPath> option.
- Adds method documentation.

Submitted as PR independent of #2091 since it's a somewhat different approach. I think this one is better, simpler, and makes more sense, but I leave the other PR in case we want to go the way @benvinegar was proposing (using the `--reporter <name>:<outputfile>` syntax.)
