### PR TITLE
[Fix] Exclude not own properties when looping on options

### DIFF
--- a/support/browser-entry.js
+++ b/support/browser-entry.js
@@ -119,7 +119,10 @@ mocha.ui = function(ui){
 
 mocha.setup = function(opts){
   if ('string' == typeof opts) opts = { ui: opts };
-  for (var opt in opts) this[opt](opts[opt]);
+  for (var opt in opts) {
+    if (opts.hasOwnProperty(opt)) {
+      this[opt](opts[opt]);
+    }
   return this;
 };
 


### PR DESCRIPTION
It seems this was a regression as it was added before -- https://github.com/mochajs/mocha/pull/1586