### PR TITLE
upgrade glob to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": "7.0.3",
     "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
This is necessary because the version of `graceful-fs` package used by `glob` 3.2.3 is
deprecated. This change would avoid the warning

```
npm WARN deprecated graceful-fs@2.0.3: graceful-fs version 3 and before
will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon
as possible.
```

when installing the latest version of mocha.