### PR TITLE
Bump glob patch version to remove warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.3",
+    "glob": "3.2.11",
     "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
When installing `mocha@2.4.5`, `glob@3.2.3` triggers the following warning:

```
npm WARN deprecated graceful-fs@2.0.3: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```

This commit bumps to the latest patch version before a major version.
Diff at https://github.com/isaacs/node-glob/compare/v3.2.3...v3.2.11.