### PR TITLE
Correct comment label in exports interface

### DIFF
--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -6,7 +6,7 @@ var Suite = require('../suite');
 var Test = require('../test');
 
 /**
- * TDD-style interface:
+ * Exports-style (as Node.js module) interface:
  *
  *     exports.Array = {
  *       '#indexOf()': {


### PR DESCRIPTION
Was "TDD-style interface", should refer to Export interface style. See issue #2204 for alternative suggestions.

Fixes #2204