### PR TITLE
Update README's header section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+<br><br>
+<p align="center">
+  <img src="https://cldup.com/xFVFxOioAU.svg" alt="Mocha test framework"/>
+</p>
+<br><br>
+
 [![Build Status](https://api.travis-ci.org/mochajs/mocha.svg?branch=master)](http://travis-ci.org/mochajs/mocha) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mochajs/mocha?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![OpenCollective](https://opencollective.com/mochajs/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/mochajs/sponsors/badge.svg)](#sponsors)
-
-
-
-  [![Mocha test framework](http://f.cl.ly/items/3l1k0n2A1U3M1I1L210p/Screen%20Shot%202012-02-24%20at%202.21.43%20PM.png)](http://mochajs.org)
 
   Mocha is a simple, flexible, fun JavaScript test framework for node.js and the browser. For more information view the [documentation](http://mochajs.org).
 


### PR DESCRIPTION
- Use new logo
- Centers logo
- Gives it some margin

I couldn't use the `.svg`'s we have in `/assets/` for some reason, maybe because of the way it was exported. You can try it out for yourselves. /cc @boneskull 

If we were to use an image, we need a `@2x` export (double size) for retina screens. Hmm, I can actually generate one of those myself. But I hope we can solve the issues our `svg` files have.

I'll squash (or use "squash & merge") as necessary once the PR is reviewed, just in case we want to easily revert a subset of the changes.