### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,9 +278,9 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "^7.0.3",
+    "glob": "7.0.3",
     "growl": "1.9.2",
-    "pug": "^1.11.0",
+    "pug": "1.11.0",
     "mkdirp": "0.5.1",
     "supports-color": "1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -278,9 +278,9 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.11",
+    "glob": "^7.0.3",
     "growl": "1.9.2",
-    "jade": "0.26.3",
+    "pug": "^1.11.0",
     "mkdirp": "0.5.1",
     "supports-color": "1.2.0"
   },


### PR DESCRIPTION
Jade has been renamed to Pug. You can find the new repo [here](https://github.com/pugjs/jade).
And glob looks pretty old..., + it's throwing errors about graceful-fs being deprecated