### PR TITLE
Update glob for node 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.11",
+    "glob": "7.0.3",
     "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Older version of glob uses a version of graceful-fs, which is deprecated and incompatible with node v6.

