### PR TITLE
Include beforeEach hooks in --slow timings

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -249,7 +249,12 @@ Runnable.prototype.globals = function(globals) {
  */
 Runnable.prototype.run = function(fn) {
   var self = this;
-  var start = new Date();
+  var start;
+  if (typeof self.start === 'number') {
+    start = self.start;
+  } else {
+    start = Date.now();
+  }
   var ctx = this.ctx;
   var finished;
   var emitted;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -406,6 +406,7 @@ Runner.prototype.parents = function() {
 Runner.prototype.runTest = function(fn) {
   var self = this;
   var test = this.test;
+  test.start = self.start;
 
   if (this.asyncOnly) {
     test.asyncOnly = true;
@@ -514,6 +515,7 @@ Runner.prototype.runTests = function(suite, fn) {
     }
 
     // execute test and hook(s)
+    self.start = Date.now();
     self.emit('test', self.test = test);
     self.hookDown('beforeEach', function(err, errSuite) {
       if (suite.isPending()) {


### PR DESCRIPTION
Previously `beforeEach` hook runtimes were excluded from test times. This is
misleading, since `beforeEach` hooks can take a significant amount of time.
It's better to report this accurately, especially since `beforeEach` hook costs
are not amortized over every test (like `before` hooks are).