### PR TITLE
(ab)use issue template to ward off duplicates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+####NOTE: Mocha is currently awaiting a release, pending further testing, and there are several unreleased fixes already in place. Before creating an issue, you may wish to try testing your problem against the current GitHub master branch and see if that resolves the issue. If your problem occurs in Node, simply use `npm i mochajs/mocha` to install the current in-progress version from GitHub. If it only occurs in the browser, you'll have to check out the source from GitHub and build the mocha.js file for the browser, as this file is only updated with each release. It might also be a good idea to skim through recent issues, both open and closed, to check for any that look like the same problem.
+
+####NOTE: the glob/graceful-fs deprecation has been resolved in master and will be fixed in the next release.
+
+**If you still have an issue to submit after following the above instructions, please delete all this text.** We apologize for the clutter; the delay in the current release has caused a lot of duplicate issue reports recently and we're hoping to avoid losing sight of the forest for the trees.


### PR DESCRIPTION
I'm not sure if this is actually a good idea (maybe putting it in CONTRIBUTING.md would be better? do we know if people actually read CONTRIBUTING.md?), and I'm pretty sure it's not the intended use case for issue templates, but I wanted to throw this out there in case it might help people avoid submitting duplicate issues while we're waiting for a new release. The glob/graceful-fs deprecation warning issue is an obvious example, but there have been a few other issues raised that were fixed in master months ago, such as the one about exceptions thrown by the reporter trying to clean a string for errors thrown out of hooks. Feel free to ignore, discard, edit to something completely different, or whatever else seems better.

TODO: if this is accepted create an issue/pull to delete it once we get back to a regular release schedule again.