### PR TITLE
Fix missing methods/globals in IE7, IE8 environments

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,4 +1,10 @@
 /**
+ * Module dependencies.
+ */
+
+var JSON = require('json3');
+
+/**
  * Expose `Context`.
  */
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -3,6 +3,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter;
+var JSON = require('json3');
 var Pending = require('./pending');
 var debug = require('debug')('mocha:runnable');
 var milliseconds = require('./ms');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+var JSON = require('json3');
 var basename = require('path').basename;
 var debug = require('debug')('mocha:watch');
 var exists = require('fs').existsSync || require('path').existsSync;
@@ -11,6 +12,7 @@ var glob = require('glob');
 var join = require('path').join;
 var readdirSync = require('fs').readdirSync;
 var statSync = require('fs').statSync;
+var toISOString = require('@segment/to-iso-string');
 var watchFile = require('fs').watchFile;
 
 /**
@@ -481,7 +483,7 @@ function jsonStringify(object, spaces, depth) {
       case 'date':
         var sDate = isNaN(val.getTime())        // Invalid date
           ? val.toString()
-          : val.toISOString();
+          : toISOString(val);
         val = '[Date: ' + sDate + ']';
         break;
       case 'buffer':

--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "test": "make test-all"
   },
   "dependencies": {
+    "@segment/to-iso-string": "0.0.2",
     "commander": "2.3.0",
     "debug": "2.2.0",
     "diff": "1.4.0",
@@ -276,6 +277,7 @@
     "glob": "3.2.11",
     "growl": "1.9.2",
     "jade": "0.26.3",
+    "json3": "^3.3.2",
     "mkdirp": "0.5.1",
     "supports-color": "1.2.0"
   },


### PR DESCRIPTION
This patch fixes two incompatibilities in pre-ES5 environments:

- Missing `JSON` global (IE7)
- Missing `Date#toISOString` method (IE7, IE8)