### PR TITLE
Uncaught exception should fail a passed test

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -688,10 +688,14 @@ Runner.prototype.uncaught = function(err) {
 
   runnable.clearTimeout();
 
-  // Ignore errors if complete
+  // If the test completed and failed, ignore a second failure
   if (runnable.state) {
+    if (runnable.state !== 'failed') {
+      this.fail(runnable, err);
+    }
     return;
   }
+
   this.fail(runnable, err);
 
   // recover from test

--- a/test/integration/regression.js
+++ b/test/integration/regression.js
@@ -9,17 +9,17 @@ describe('regressions', function() {
   it('issue-1327: should run all 3 specs exactly once', function(done) {
     var args = [];
     run('regression/issue-1327.js', args, function(err, res) {
-      var occurences = function(str) {
+      var occurrences = function(str) {
         var pattern = new RegExp(str, 'g');
         return (res.output.match(pattern) || []).length;
       };
 
       assert(!err);
-      assert.equal(occurences('testbody1'), 1);
-      assert.equal(occurences('testbody2'), 1);
-      assert.equal(occurences('testbody3'), 1);
+      assert.equal(occurrences('testbody1'), 1);
+      assert.equal(occurrences('testbody2'), 1);
+      assert.equal(occurrences('testbody3'), 1);
 
-      assert.equal(res.code, 1);
+      assert.equal(res.code, 2);
       done();
     });
   });


### PR DESCRIPTION
Commit 4067c0658e3e354b74a3614cfc4e50e4a8735512 addresses the case where a test
fails and a second uncaught exception is thrown. I believe if a test passes and
an uncaught exception is thrown, it should have its status changed to failed,
since this is now the first exception that's been thrown in the test.

One example: We try to prevent tests from making unexpected HTTP requests. Some
of these are made in the next tick, e.g. after a test has returned and has been
marked as complete. These are currently marked as passing, e.g. the failure is
ignored. I believe they should be marked as failed.