### PR TITLE
Move to-iso-string from dev dependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,7 +324,8 @@
     "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",
-    "supports-color": "1.2.0"
+    "supports-color": "1.2.0",
+    "to-iso-string": "0.0.2"
   },
   "devDependencies": {
     "browser-stdout": "^1.2.0",
@@ -342,7 +343,6 @@
     "phantomjs": "1.9.8",
     "should": "~8.0.0",
     "through2": "~0.6.5",
-    "to-iso-string": "0.0.2",
     "watchify": "^3.7.0"
   },
   "files": [


### PR DESCRIPTION
to-iso-string is used in lib/utils.js since #2231

Fixes #2272