### PR TITLE
Fix % always 0 in HTML reporter

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -125,6 +125,7 @@ function HTML(runner) {
 
   runner.on('suite end', function(suite) {
     if (suite.root) {
+      updateStats.call(this);
       return;
     }
     stack.shift();
@@ -137,7 +138,7 @@ function HTML(runner) {
     var el = fragment(markup, test.speed, test.title, test.duration, url);
     self.addCodeToggle(el, test.body);
     appendToStack(el);
-    updateStats();
+    updateStats.call(this);
   });
 
   runner.on('fail', function(test) {
@@ -177,13 +178,13 @@ function HTML(runner) {
 
     self.addCodeToggle(el, test.body);
     appendToStack(el);
-    updateStats();
+    updateStats.call(this);
   });
 
   runner.on('pending', function(test) {
     var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     appendToStack(el);
-    updateStats();
+    updateStats.call(this);
   });
 
   function appendToStack(el) {

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -125,7 +125,7 @@ function HTML(runner) {
 
   runner.on('suite end', function(suite) {
     if (suite.root) {
-      updateStats.call(this);
+      updateStats();
       return;
     }
     stack.shift();
@@ -138,7 +138,7 @@ function HTML(runner) {
     var el = fragment(markup, test.speed, test.title, test.duration, url);
     self.addCodeToggle(el, test.body);
     appendToStack(el);
-    updateStats.call(this);
+    updateStats();
   });
 
   runner.on('fail', function(test) {
@@ -178,13 +178,13 @@ function HTML(runner) {
 
     self.addCodeToggle(el, test.body);
     appendToStack(el);
-    updateStats.call(this);
+    updateStats();
   });
 
   runner.on('pending', function(test) {
     var el = fragment('<li class="test pass pending"><h2>%e</h2></li>', test.title);
     appendToStack(el);
-    updateStats.call(this);
+    updateStats();
   });
 
   function appendToStack(el) {
@@ -196,7 +196,7 @@ function HTML(runner) {
 
   function updateStats() {
     // TODO: add to stats
-    var percent = stats.tests / this.total * 100 | 0;
+    var percent = stats.tests / runner.total * 100 | 0;
     if (progress) {
       progress.update(percent).draw(ctx);
     }


### PR DESCRIPTION
Hi mocha team.
This is a small fix for the progress bar staying consistently at 0 when using the HTML reporter.
Seems like a regression that happened due to the "double-error" fix/refactor.

Reasoning for the changes:
updateStats() accesses this.total, but this === the global object (window) if not specified explicitly here.
Also added a missing update when all tests end.