### PR TITLE
Fix a small typo in the doc reporter that causes mocha to crash

### DIFF
--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -55,7 +55,7 @@ function Doc(runner) {
 
   runner.on('fail', function(test, err) {
     console.log('%s  <dt class="error">%s</dt>', indent(), utils.escape(test.title));
-    var code = utils.escape(utils.clean(test.fn.body));
+    var code = utils.escape(utils.clean(test.body));
     console.log('%s  <dd class="error"><pre><code>%s</code></pre></dd>', indent(), code);
     console.log('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
   });


### PR DESCRIPTION
This fixes the following scenario:

```js
describe('Mocha', function() {
  it('should fail', function() {
    throw Error('ouch');
  });
});
```

```
$ mocha example.js --reporter doc
    <section class="suite">
      <h1>Mocha</h1>
      <dl>
        <dt class="error">should fail</dt>
        <dt class="error">should fail</dt>
```

Expected output:
```
<section class="suite">
      <h1>Mocha</h1>
      <dl>
        <dt class="error">should fail</dt>
        <dd class="error"><pre><code>throw Error('ouch');</code></pre></dd>
        <dd class="error">Error: ouch</dd>
      </dl>
    </section>
```

The typo was introduced in d59cc6c166d0d112a62016909b33e04ed08d2274:
https://github.com/danielstjules/mocha/blob/d59cc6c166d0d112a62016909b33e04ed08d2274/lib/reporters/doc.js#L58