### PR TITLE
use custom glob; closes #2318

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -69,7 +69,7 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       configure: function configure(b) {
-        b.ignore('glob')
+        b.ignore('glob-mocha')
           .ignore('jade')
           .ignore('supports-color')
           .exclude('./lib-cov/mocha');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@
 var basename = require('path').basename;
 var debug = require('debug')('mocha:watch');
 var exists = require('fs').existsSync || require('path').existsSync;
-var glob = require('glob');
+var glob = require('glob-mocha');
 var join = require('path').join;
 var readdirSync = require('fs').readdirSync;
 var statSync = require('fs').statSync;

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.11",
+    "glob-mocha": "3.2.12-mocha",
     "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",
@@ -361,7 +361,7 @@
     "./index.js": "./browser-entry.js",
     "jade": false,
     "fs": false,
-    "glob": false,
+    "glob-mocha": false,
     "path": false,
     "supports-color": false
   },


### PR DESCRIPTION
This addresses the [security advisory](https://nodesecurity.io/advisories/118) in a non-breaking manner.  It upgrades `minimatch` to `1.0.0`, basically--but from what I can tell, the only meaningful change from `0.3.0` was a feature to support number padding in brace expansion.  

Generally speaking, what we're doing here should be avoided (forking old versions of modules and re-publishing them under new names).  Doing so could potentially expose us to security issues down the road--if an issue is detected in `minimatch` or `glob` and subsequently fixed, we will have to manually backport the fix--assuming we even know about any issue!

I could go either way here; I can't conceive of a manner in which it would affect users of Mocha via usage of `mocha` itself.  This issue does not affect Mocha in the browser.

See the forked/renamed modules [glob-mocha](/mochajs/node-glob) and [minimatch-mocha](/mochajs/minimatch), the latter of which contains a backport for the advisory fix.

cc @ScottFreeCode 

