### PR TITLE
update dependency of jade

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.11",
     "growl": "1.9.2",
-    "jade": "0.26.3",
+    "jade": "1.11.0",
     "mkdirp": "0.5.1",
     "supports-color": "1.2.0",
     "to-iso-string": "0.0.2"


### PR DESCRIPTION
Update Jade to the actual version, but should be replaced with pug in
the next time.

- There are some security issues with [Link](https://snyk.io/org/thomas-p/test/github/mochajs/mocha)
- Jade is renamed to Pug [Link](https://github.com/pugjs/pug)