### PR TITLE
allow skip() in async test context; closes #2334

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -298,6 +298,10 @@ Runnable.prototype.run = function(fn) {
       return callFnAsync(this.fn);
     }
     try {
+      // allows skip() to be used in an explicit async context
+      this.skip = function () {
+        done(new Pending());
+      };
       callFnAsync(this.fn);
     } catch (err) {
       done(utils.getError(err));

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -299,7 +299,7 @@ Runnable.prototype.run = function(fn) {
     }
     try {
       // allows skip() to be used in an explicit async context
-      this.skip = function () {
+      this.skip = function() {
         done(new Pending());
       };
       callFnAsync(this.fn);

--- a/test/integration/fixtures/pending/skip.async.before.js
+++ b/test/integration/fixtures/pending/skip.async.before.js
@@ -1,0 +1,16 @@
+describe('skip in before', function() {
+  before(function(done) {
+    var self = this;
+    setTimeout(function() {
+      self.skip();
+    }, 50);
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+});

--- a/test/integration/fixtures/pending/skip.async.beforeEach.js
+++ b/test/integration/fixtures/pending/skip.async.beforeEach.js
@@ -1,0 +1,16 @@
+describe('skip in beforeEach', function() {
+  beforeEach(function(done) {
+    var self = this;
+    setTimeout(function() {
+      self.skip();
+    }, 50);
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+
+  it('should never run this test', function() {
+    throw new Error('never thrown');
+  });
+});

--- a/test/integration/fixtures/pending/skip.async.spec.js
+++ b/test/integration/fixtures/pending/skip.async.spec.js
@@ -1,0 +1,12 @@
+describe('skip in test', function() {
+  it('should skip async', function(done) {
+    var self = this;
+    setTimeout(function() {
+      self.skip();
+    }, 50);
+  });
+
+  it('should run other tests in the suite', function() {
+    // Do nothing
+  });
+});

--- a/test/integration/pending.js
+++ b/test/integration/pending.js
@@ -60,4 +60,47 @@ describe('pending', function() {
       });
     });
   });
+
+  describe('asynchronous skip()', function() {
+    this.timeout(1000);
+
+    describe('in spec', function() {
+      it('should immediately skip the spec and run all others', function(done) {
+        run('pending/skip.async.spec.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 1);
+          assert.equal(res.stats.passes, 1);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+
+    describe('in before', function() {
+      it('should skip all suite specs', function(done) {
+        run('pending/skip.async.before.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.passes, 0);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+
+    describe('in beforeEach', function() {
+      it('should skip all suite specs', function(done) {
+        run('pending/skip.sync.beforeEach.js', args, function(err, res) {
+          assert(!err);
+          assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.passes, 0);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
I can't tell if this is an actual bug fix, regression, or what (because where are the tests for async `skip()` calls?), but it allows this test:

```js
it('should be skipped async', function (done) {
  const self = this
  setTimeout(function () {
    self.skip()
  }, 1000)
})
```

To be successfully marked as "pending".

cc @dasilvacontin @maggiesavovska