### PR TITLE
Updates dependency glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
-    "glob": "3.2.11",
+    "glob": "7.0.5",
     "growl": "1.9.2",
     "jade": "0.26.3",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
This removes the warning about the RegEx DoS in minitest.  Tests pass.

`npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`