### PR TITLE
Exclude the --inspect flag

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -26,6 +26,7 @@ process.argv.slice(2).forEach(function(arg){
     case 'debug':
     case '--debug':
     case '--debug-brk':
+    case '--inspect':
       args.unshift(arg);
       args.push('--no-timeouts');
       break;


### PR DESCRIPTION
PR: https://github.com/nodejs/node/pull/6792
Merged in Node v7.0: https://nodejs.org/download/nightly/v7.0.0-nightly20160619a92089b6bd/
Short article about it: https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27#.cs12vrlsa
Usage:

```bash
mocha --inspect --debug-brk hello.js
```

A quick patch release will be greatly appreciated! Thanks!