### PR TITLE
update `diff` package to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
   "dependencies": {
     "commander": "2.3.0",
     "debug": "2.2.0",
-    "diff": "1.4.0",
+    "diff": "2.2.3",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.11",
     "growl": "1.9.2",


### PR DESCRIPTION
According to https://github.com/kpdecker/jsdiff/blob/v2.2.3/release-notes.md, the changes mostly include bugfixes, no API changes. `make test` doesn't complain.

(aside: it looks like http://mochajs.org/#testing-mocha is outdated since `test-all` no longer appears in the makefile)