### PR TITLE
Add --preserve-symlinks flag for node

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -84,6 +84,7 @@ program
   .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
   .option('--es_staging', 'enable all staged features')
   .option('--harmony<_classes,_generators,...>', 'all node --harmony* flags are available')
+  .option('--preserve-symlinks', 'Instructs the module loader to preserve symbolic links when resolving and caching modules')
   .option('--icu-data-dir', 'include ICU data')
   .option('--inline-diffs', 'display actual/expected differences inline within each string')
   .option('--interfaces', 'display available interfaces')

--- a/bin/mocha
+++ b/bin/mocha
@@ -50,6 +50,7 @@ process.argv.slice(2).forEach(function(arg){
       else if (0 == arg.indexOf('--trace')) args.unshift(arg);
       else if (0 == arg.indexOf('--icu-data-dir')) args.unshift(arg);
       else if (0 == arg.indexOf('--max-old-space-size')) args.unshift(arg);
+      else if (0 == arg.indexOf('--preserve-symlinks')) args.unshift(arg);
       else args.push(arg);
       break;
   }


### PR DESCRIPTION
This is a new flag added in Node 6.2.0 https://github.com/nodejs/node/pull/6537

I would like to be able to use it with mocha!