### PR TITLE
don't truncate message-list Error in Base.list(); closes #2361

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -178,7 +178,7 @@ exports.list = function(failures) {
       message = '';
     }
     var stack = err.stack || message;
-    var index = stack.indexOf(message);
+    var index = message ? stack.indexOf(message) : -1;
     var actual = err.actual;
     var expected = err.expected;
     var escape = true;


### PR DESCRIPTION
when an `Error` is thrown *without* a message, we end up setting this `message` variable to an empty string.  But this seems to be a constant:

```js
anyString.indexOf('') === 0
```

We attempt to remove and format `message` as it exists within the `stack` [here](https://github.com/boneskull/mocha/blob/52d0268d5fab42c3d1f5636c85419c23edc9ab7d/lib/reporters/base.js#L190).  Since `index === 0`, we just end up removing the *first character* from `'Error'`.

This PR ensures that if `message === ''` then `index === -1`.