### PR TITLE
Update syntax for "border-radius" and "box-shadow", added vendor prefixes for calc()

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -91,13 +91,13 @@ body {
   padding: 2px 5px;
   color: #fff;
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
-  -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
+     -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
+          box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
   -webkit-border-radius: 5px;
-  -moz-border-radius: 5px;
-  -ms-border-radius: 5px;
-  -o-border-radius: 5px;
-  border-radius: 5px;
+     -moz-border-radius: 5px;
+      -ms-border-radius: 5px;
+       -o-border-radius: 5px;
+          border-radius: 5px;
 }
 
 #mocha .test.pass.fast .duration {
@@ -148,23 +148,28 @@ body {
   padding: 15px;
   border: 1px solid #eee;
   max-width: 85%; /*(1)*/
+  max-width: -webkit-calc(100% - 42px);
+  max-width: -moz-calc(100% - 42px);
   max-width: calc(100% - 42px); /*(2)*/
   max-height: 300px;
   word-wrap: break-word;
   border-bottom-color: #ddd;
-  -webkit-border-radius: 3px;
   -webkit-box-shadow: 0 1px 3px #eee;
-  -moz-border-radius: 3px;
-  -moz-box-shadow: 0 1px 3px #eee;
-  border-radius: 3px;
+     -moz-box-shadow: 0 1px 3px #eee;
+          box-shadow: 0 1px 3px #eee;
+  -webkit-border-radius: 3px;
+     -moz-border-radius: 3px;
+          border-radius: 3px;
 }
 
 #mocha .test .html-error pre.error {
   border: none;
-  -webkit-border-radius: none;
-  -webkit-box-shadow: none;
-  -moz-border-radius: none;
-  -moz-box-shadow: none;
+  -webkit-border-radius: 0;
+     -moz-border-radius: 0;
+          border-radius: 0;
+  -webkit-box-shadow: 0;
+     -moz-box-shadow: 0;
+          box-shadow: 0;
   padding: 0;
   margin: 0;
   margin-top: 18px;
@@ -185,14 +190,17 @@ body {
   padding: 15px;
   border: 1px solid #eee;
   max-width: 85%; /*(1)*/
+  max-width: -webkit-calc(100% - 42px);
+  max-width: -moz-calc(100% - 42px);
   max-width: calc(100% - 42px); /*(2)*/
   word-wrap: break-word;
   border-bottom-color: #ddd;
-  -webkit-border-radius: 3px;
   -webkit-box-shadow: 0 1px 3px #eee;
-  -moz-border-radius: 3px;
-  -moz-box-shadow: 0 1px 3px #eee;
-  border-radius: 3px;
+     -moz-box-shadow: 0 1px 3px #eee;
+          box-shadow: 0 1px 3px #eee;
+  -webkit-border-radius: 3px;
+     -moz-border-radius: 3px;
+          border-radius: 3px;
 }
 
 #mocha .test h2 {
@@ -212,10 +220,12 @@ body {
   text-align: center;
   background: #eee;
   font-size: 15px;
-  -moz-border-radius: 15px;
-  border-radius: 15px;
-  -webkit-transition: opacity 200ms;
-  -moz-transition: opacity 200ms;
+  -webkit-border-radius: 15px;
+     -moz-border-radius: 15px;
+          border-radius: 15px;
+  -webkit-transition:opacity 200ms;
+  -moz-transition:opacity 200ms;
+  -o-transition:opacity 200ms;
   transition: opacity 200ms;
   opacity: 0.3;
   color: #888;
@@ -261,14 +271,16 @@ body {
 #mocha-stats .progress {
   float: right;
   padding-top: 0;
-  
+
   /**
    * Set safe initial values, so mochas .progress does not inherit these
    * properties from Bootstrap .progress (which causes .progress height to
    * equal line height set in Bootstrap).
    */
   height: auto;
-  box-shadow: none;
+  -webkit-box-shadow: none;
+     -moz-box-shadow: none;
+          box-shadow: none;
   background-color: initial;
 }
 

--- a/mocha.css
+++ b/mocha.css
@@ -91,13 +91,13 @@ body {
   padding: 2px 5px;
   color: #fff;
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
-     -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
-          box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
+  -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
+  -box-shadow: inset 0 1px 1px rgba(0,0,0,.2);
   -webkit-border-radius: 5px;
-     -moz-border-radius: 5px;
-      -ms-border-radius: 5px;
-       -o-border-radius: 5px;
-          border-radius: 5px;
+  -moz-border-radius: 5px;
+  -ms-border-radius: 5px;
+  -o-border-radius: 5px;
+  border-radius: 5px;
 }
 
 #mocha .test.pass.fast .duration {
@@ -155,21 +155,21 @@ body {
   word-wrap: break-word;
   border-bottom-color: #ddd;
   -webkit-box-shadow: 0 1px 3px #eee;
-     -moz-box-shadow: 0 1px 3px #eee;
-          box-shadow: 0 1px 3px #eee;
+  -moz-box-shadow: 0 1px 3px #eee;
+  box-shadow: 0 1px 3px #eee;
   -webkit-border-radius: 3px;
-     -moz-border-radius: 3px;
-          border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
 }
 
 #mocha .test .html-error pre.error {
   border: none;
   -webkit-border-radius: 0;
-     -moz-border-radius: 0;
-          border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
   -webkit-box-shadow: 0;
-     -moz-box-shadow: 0;
-          box-shadow: 0;
+  -moz-box-shadow: 0;
+  box-shadow: 0;
   padding: 0;
   margin: 0;
   margin-top: 18px;
@@ -196,11 +196,11 @@ body {
   word-wrap: break-word;
   border-bottom-color: #ddd;
   -webkit-box-shadow: 0 1px 3px #eee;
-     -moz-box-shadow: 0 1px 3px #eee;
-          box-shadow: 0 1px 3px #eee;
+  -moz-box-shadow: 0 1px 3px #eee;
+  box-shadow: 0 1px 3px #eee;
   -webkit-border-radius: 3px;
-     -moz-border-radius: 3px;
-          border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
 }
 
 #mocha .test h2 {
@@ -221,8 +221,8 @@ body {
   background: #eee;
   font-size: 15px;
   -webkit-border-radius: 15px;
-     -moz-border-radius: 15px;
-          border-radius: 15px;
+  -moz-border-radius: 15px;
+  border-radius: 15px;
   -webkit-transition:opacity 200ms;
   -moz-transition:opacity 200ms;
   -o-transition:opacity 200ms;
@@ -279,8 +279,8 @@ body {
    */
   height: auto;
   -webkit-box-shadow: none;
-     -moz-box-shadow: none;
-          box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
   background-color: initial;
 }
 


### PR DESCRIPTION
Simple fixes to CSS syntax.  My editor was throwing errors on the CSS as border-radius:none is not a acceptable value (Should be "0"). I linted the CSS, kept all legacy css support, and added modern syntax for border-radius and box shadow.