### PR TITLE
Remove stdout: prefix

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -2,7 +2,7 @@
  * Shim process.stdout.
  */
 
-process.stdout = require('browser-stdout')();
+process.stdout = require('browser-stdout')({level: false});
 
 var Mocha = require('./lib/mocha');
 


### PR DESCRIPTION
Fixes #2095, by disabling the `stdout:` prefix with the browser shim.
