### PR TITLE
[WIP]Fix stackTraceFilter

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -702,7 +702,7 @@ exports.getError = function(err) {
  */
 exports.stackTraceFilter = function() {
   // TODO: Replace with `process.browser`
-  var slash = '/';
+  var slash = typeof document === 'undefined' ? require('path').sep : '/';
   var is = typeof document === 'undefined' ? { node: true } : { browser: true };
   var cwd = is.node
       ? process.cwd() + slash


### PR DESCRIPTION
I found stackTraceFilter did not work on Windows.

```
C:\Users\ishida\src\test>node_modules\.bin\mocha --version
2.5.3

C:\Users\ishida\src\test>node_modules\.bin\mocha


  a
    1) b


  0 passing (21ms)
  1 failing

  1) a b:

      AssertionError: false == true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (C:\Users\ishida\src\test\test\mytest.js:5:9)
      at callFn (C:\Users\ishida\src\test\node_modules\mocha\lib\runnable.js:326:21)
      at Test.Runnable.run (C:\Users\ishida\src\test\node_modules\mocha\lib\runnable.js:319:7)
      at Runner.runTest (C:\Users\ishida\src\test\node_modules\mocha\lib\runner.js:422:10)
      at C:\Users\ishida\src\test\node_modules\mocha\lib\runner.js:528:12
      at next (C:\Users\ishida\src\test\node_modules\mocha\lib\runner.js:342:14)
      at C:\Users\ishida\src\test\node_modules\mocha\lib\runner.js:352:7
      at next (C:\Users\ishida\src\test\node_modules\mocha\lib\runner.js:284:14)
      at Immediate._onImmediate (C:\Users\ishida\src\test\node_modules\mocha\lib\runner.js:320:5)
```

This patch will fix this:

```
C:\Users\ishida\src\test>node_modules\.bin\mocha


  a
    1) b


  0 passing (27ms)
  1 failing

  1) a b:

      AssertionError: false == true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (test\mytest.js:5:9)
```

But this patch break some test. Please give me some advice.