### PR TITLE
Append the cause() stacks to the main stack trace

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -165,9 +165,9 @@ exports.cursor = {
 exports.getFullErrorStack = function(err, message) {
   var ret = err.stack || message || '';
   if (err.cause && typeof (err.cause) === 'function') {
-    var cerr = err.cause();
-    if (cerr) {
-      ret += '\n' + '   ' + 'Caused by: ' + exports.getFullErrorStack(cerr);
+    var causeErr = err.cause();
+    if (causeErr) {
+      ret += '\n' + '   ' + 'Caused by: ' + exports.getFullErrorStack(causeErr);
     }
   }
   return ret;

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -152,6 +152,28 @@ exports.cursor = {
 };
 
 /**
+ * This function dumps long stack traces for exceptions having a cause()
+ * method. The error classes from
+ * [verror](https://github.com/davepacheco/node-verror) and
+ * [restify v2.0](https://github.com/mcavage/node-restify) are examples.
+ *
+ * @param {Error} ex
+ * @return {string}
+ * @api public
+ */
+
+exports.getFullErrorStack = function(err, message) {
+  var ret = err.stack || message || '';
+  if (err.cause && typeof (err.cause) === 'function') {
+    var cerr = err.cause();
+    if (cerr) {
+      ret += '\n' + '   ' + 'Caused by: ' + exports.getFullErrorStack(cerr);
+    }
+  }
+  return ret;
+};
+
+/**
  * Outut the given `failures` as a list.
  *
  * @param {Array} failures
@@ -177,7 +199,7 @@ exports.list = function(failures) {
     } else {
       message = '';
     }
-    var stack = err.stack || message;
+    var stack = exports.getFullErrorStack(err, message);
     var index = message ? stack.indexOf(message) : -1;
     var actual = err.actual;
     var expected = err.expected;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -226,9 +226,15 @@ Runner.prototype.fail = function(test, err) {
     err = new Error('the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)');
   }
 
-  err.stack = (this.fullStackTrace || !err.stack)
-    ? err.stack
-    : stackFilter(err.stack);
+  var causeErr = err;
+
+  while (causeErr) {
+    causeErr.stack = (this.fullStackTrace || !causeErr.stack)
+      ? causeErr.stack
+      : stackFilter(causeErr.stack);
+
+    causeErr = causeErr.cause && typeof (causeErr.cause) === 'function' ? causeErr.cause() : false;
+  }
 
   this.emit('fail', test, err);
 };

--- a/test/reporters/base.js
+++ b/test/reporters/base.js
@@ -197,6 +197,21 @@ describe('Base reporter', function () {
     errOut.should.equal('1) test title:\n     an error happened');
   });
 
+  it('should append the cause() property to stack trace when set', function () {
+    var err = {
+      message: 'Error',
+      stack: 'Error\nfoo\nbar',
+      showDiff: false,
+      cause: function() { return { stack: 'Cause Stack' }; }
+    };
+    var test = makeTest(err);
+
+    Base.list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause Stack');
+  });
+
   it('should not modify stack if it does not contain message', function () {
     var err = {
       message: 'Error',


### PR DESCRIPTION
Some `Error`:s support a `cause()` method that when called returns the error that caused it. Examples are VError, https://github.com/davepacheco/node-verror, and restify v2.0, https://github.com/mcavage/node-restify.

The `cause()` is useful when errors are wrapped by using something like `VError` as one can then preserve the full stack traces by appending the stack traces of the `cause()` to that of the original error.

This is something that eg. Bunyan does https://github.com/trentm/node-bunyan/blob/cbfaa9a7bd86c658dbb8333c894191d23b65be33/lib/bunyan.js#L1111 and this method is inspired by its implementation.

Bunyan in turn was inspired by extsprintf: https://github.com/davepacheco/node-extsprintf/blob/accc9f2774189a416f294546ed03b626eec3f80c/lib/extsprintf.js#L165

Currently when someone uses eg. `VError` to wrap errors (something suggested in eg. [this article from Joyent](https://www.joyent.com/node-js/production/design/errors#5-if-you-pass-a-lower-level-error-to-your-caller-consider-wrapping-it-instead)) the stack traces from Mocha can be fairly useless and it won't point on the actual cause of the issue but just at the last point that wraps it. This would fix that.
