### PR TITLE
Upgrade eslint package to 2.13 version fix for #2348

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -112,12 +112,11 @@ rules:
   radix: 2
   semi: [2, always]
   semi-spacing: [2, { before: false, after: true }]
-  space-after-keywords: [2, always]
   space-before-blocks: [2, always]
   space-before-function-paren: [2, never]
   space-in-parens: [2, never]
   space-infix-ops: 2
-  space-return-throw-case: 2
+  keyword-spacing: 2
   space-unary-ops: [2, { words: true, nonwords: false }]
   spaced-comment: [2, always, { exceptions: ['!'] }]
   strict: [0, global]                                                      # TODO: Change to error

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "browser-stdout": "^1.2.0",
     "browserify": "^13.0.0",
     "coffee-script": "^1.10.0",
-    "eslint": "^1.10.3",
+    "eslint": "^2.13.1",
     "expect.js": "^0.3.1",
     "karma": "^1.1.0",
     "karma-browserify": "^5.0.5",


### PR DESCRIPTION
Rules space-after-keywords and space-return-throw-case merged into keyword-spacing