### PR TITLE
Remove carriage return before each test line in spec reporter

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -5,7 +5,6 @@
 var Base = require('./base');
 var inherits = require('../utils').inherits;
 var color = Base.color;
-var cursor = Base.cursor;
 
 /**
  * Expose `Spec`.
@@ -57,20 +56,17 @@ function Spec(runner) {
       fmt = indent()
         + color('checkmark', '  ' + Base.symbols.ok)
         + color('pass', ' %s');
-      cursor.CR();
       console.log(fmt, test.title);
     } else {
       fmt = indent()
         + color('checkmark', '  ' + Base.symbols.ok)
         + color('pass', ' %s')
         + color(test.speed, ' (%dms)');
-      cursor.CR();
       console.log(fmt, test.title, test.duration);
     }
   });
 
   runner.on('fail', function(test) {
-    cursor.CR();
     console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 


### PR DESCRIPTION
The spec reporter would output a carriage return char at the beginning of each line in non-TTY's and delete and overwrite the current line in TTY's.

Since this cursor call was only ever used at the beginning of a line it serves no purpose.

See discussion starting at https://gitter.im/mochajs/mocha?at=579a7573ac80b5ea3f149512