### PR TITLE
Use original Error object for uncaught errors when provided

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -51,8 +51,11 @@ process.removeListener = function(e, fn){
 
 process.on = function(e, fn){
   if ('uncaughtException' == e) {
-    global.onerror = function(err, url, line){
-      fn(new Error(err + ' (' + url + ':' + line + ')'));
+    global.onerror = function(err, url, line, col, errObj){
+      if (!errObj) {
+        errObj = new Error(err + ' (' + url + ':' + line + ')');
+      }
+      fn(errObj);
       return !mocha.allowUncaught;
     };
     uncaughtExceptionHandlers.push(fn);


### PR DESCRIPTION
Include stack trace of async errors by not throwing away the Error passed by global.onerror.

Fixes #958, the same issue referenced at https://github.com/mochajs/mocha/issues/815#issuecomment-152226789.