### PR TITLE
Add error message for missing compiler extension. Closes #2320

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -331,6 +331,9 @@ program.compilers.forEach(function (c) {
   var ext = c.slice(0, idx);
   var mod = c.slice(idx + 1);
 
+  if (idx === -1) { 
+    throw new Error('Invalid compiler "' + c + '". Compiler options should take the form:  extension:compiler.');
+  }
   if (mod[0] === '.') {
     mod = join(process.cwd(), mod);
   }


### PR DESCRIPTION
Adds a check to see if ':' for a compiler is missing, and if it is, throw an error explaining there was an invalid compiler, and show the proper syntax for compilers.
