### PR TITLE
fix .only suites nested within each other

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -855,10 +855,10 @@ function filterOnly(suite) {
     // Otherwise, do not run any of the tests in this suite.
     suite.tests = [];
     suite._onlySuites.forEach(function(onlySuite) {
-      // If there are other `only` tests/suites nested in the current `only` suite, then filter the current suite.
+      // If there are other `only` tests/suites nested in the current `only` suite, then filter that `only` suite.
       // Otherwise, all of the tests on this `only` suite should be run, so don't filter it.
       if (hasOnly(onlySuite)) {
-        filterOnly(suite);
+        filterOnly(onlySuite);
       }
     });
     // Run the `only` suites, as well as any other suites that have `only` tests/suites as descendants.

--- a/test/integration/fixtures/regression/issue-2417.js
+++ b/test/integration/fixtures/regression/issue-2417.js
@@ -1,0 +1,7 @@
+describe('outer describe', function() {
+  describe.only('outer describe.only', function() {
+    it.only('inner it.only', function() {
+      // should run and exit without error
+    });
+  });
+});

--- a/test/integration/regression.js
+++ b/test/integration/regression.js
@@ -73,4 +73,14 @@ describe('regressions', function() {
       done();
     });
   });
+
+  it('issue-2417: should not recurse infinitely with .only suites nested within each other', function() {
+    runJSON('regression/issue-2417.js', [], function(err, res) {
+      assert(!err);
+      assert.equal(res.stats.pending, 0);
+      assert.equal(res.stats.passes, 1);
+      assert.equal(res.stats.failures, 0);
+      assert.equal(res.code, 0);
+    });
+  });
 });


### PR DESCRIPTION
fixes #2417

The issue was that instead calling itself with child suites, the function for filtering a `.only` suite was calling itself with the same suite. This resulted in infinite recursion.