### PR TITLE
avoid define() calls in dependencies; closes #2424

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all: mocha.js
 mocha.js: $(SRC) browser-entry.js
 	@printf "==> [Browser :: build]\n"
 	$(BROWSERIFY) ./browser-entry \
+		--plugin ./scripts/dedefine \
 		--ignore 'fs' \
 		--ignore 'glob' \
 		--ignore 'path' \

--- a/mocha.js
+++ b/mocha.js
@@ -9314,7 +9314,7 @@ function objectToString(o) {
   /*global module */
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = JsDiff;
-  } else if (typeof define === 'function' && define.amd) {
+  } else if (false) {
     /*global define */
     define([], function() { return JsDiff; });
   } else if (typeof global.JsDiff === 'undefined') {
@@ -10076,7 +10076,7 @@ module.exports = Array.isArray || function (arr) {
 ;(function () {
   // Detect the `define` function exposed by asynchronous module loaders. The
   // strict `define` check is necessary for compatibility with `r.js`.
-  var isLoader = typeof define === "function" && define.amd;
+  var isLoader = false;
 
   // A set of types used to distinguish objects from primitives.
   var objectTypes = {

--- a/scripts/dedefine.js
+++ b/scripts/dedefine.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * This is a transform stream we're using to strip AMD calls from
+ * dependencies in our Browserify bundle.
+ */
+
+var through = require('through2');
+var defineRx = /typeof define === ['"]function['"] && define\.amd/g;
+
+function createStream() {
+  return through.obj(function(chunk, enc, next) {
+    this.push(String(chunk)
+      .replace(defineRx, 'false'));
+    next();
+  });
+}
+
+module.exports = function(b) {
+  function wrap() {
+    b.pipeline.get('wrap').push(createStream());
+  }
+
+  b.on('reset', wrap);
+  wrap();
+};


### PR DESCRIPTION
added browserify transform to remove code which conflicts with AMD loaders.