### PR TITLE
Only check if stdout is a tty.

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -28,10 +28,10 @@ var clearInterval = global.clearInterval;
 /* eslint-enable no-unused-vars, no-native-reassign */
 
 /**
- * Check if both stdio streams are associated with a tty.
+ * Check if stdout streams is associated with a tty.
  */
 
-var isatty = tty.isatty(1) && tty.isatty(2);
+var isatty = tty.isatty(1);
 
 /**
  * Enable coloring by default, except in the browser interface.


### PR DESCRIPTION
Mocha only writes to `stdout`, and users may want to redirect `stderr`. Mocha ends up with unnecessarily constrained output in this case, since while `stderr` will be a pipe `stdout` will still be a tty. This PR changes the code to only check if `stdout` is a tty instead of checking both `stdout` and `stderr`.

In  the `master` branch try in bash:

```
bin/mocha 2> >(cat)
```

Mocha assumes `stdout` is a pipe and only uses the default 75 character screen width. 

If running the same command in this branch, Mocha will correctly detect the screen width.
