### PR TITLE
Exit process with correct error codes

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -442,7 +442,7 @@ if (program.watch) {
 
 function exitLater(code) {
   process.on('exit', function() {
-    process.exit(code);
+    process.exit(Math.min(code, 255));
   });
 }
 
@@ -452,7 +452,7 @@ function exit(code) {
   // https://github.com/visionmedia/mocha/issues/333 has a good discussion
   function done() {
     if (!(draining--)) {
-      process.exit(code);
+      process.exit(Math.min(code, 255));
     }
   }
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -384,7 +384,7 @@ if (program.watch) {
   process.on('SIGINT', function() {
     showCursor();
     console.log('\n');
-    process.exit();
+    process.exit(130);
   });
 
   var watchFiles = utils.files(cwd, [ 'js' ].concat(program.watchExtensions));
@@ -470,6 +470,11 @@ function exit(code) {
 
 process.on('SIGINT', function() {
   runner.abort();
+
+  // This is a hack:
+  // Instead of `process.exit(130)`, set runner.failures to 130 (exit code for SIGINT)
+  // The amount of failures will be emitted as error code later
+  runner.failures = 130;
 });
 
 /**


### PR DESCRIPTION
- Exit with code 130 on SIGINT
- ~~Exit with code 1 if any error occurred~~
- Exit with an exit code of max 255 to avoid 8-bit overflow mistakingly reporting no errors

Closes #2438 
