### PR TITLE
Report non-match to STDERR and exit if no files are matched

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -358,8 +358,24 @@ if (!args.length) {
 }
 
 args.forEach(function(arg) {
-  files = files.concat(utils.lookupFiles(arg, extensions, program.recursive));
+  var newFiles;
+  try {
+    newFiles = utils.lookupFiles(arg, extensions, program.recursive);
+  } catch (err) {
+    if (err.message.indexOf('cannot resolve path') === 0) {
+      console.error('Warning: Could not find any test files matching pattern: ' + arg);
+      return;
+    } else {
+      throw err;
+    }
+  }
+
+  files = files.concat(newFiles);
 });
+
+if (files.length === 0) {
+  process.exit(1);
+}
 
 // resolve
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -365,15 +365,16 @@ args.forEach(function(arg) {
     if (err.message.indexOf('cannot resolve path') === 0) {
       console.error('Warning: Could not find any test files matching pattern: ' + arg);
       return;
-    } else {
-      throw err;
     }
+
+    throw err;
   }
 
   files = files.concat(newFiles);
 });
 
-if (files.length === 0) {
+if (!files.length) {
+  console.error('No test files found');
   process.exit(1);
 }
 

--- a/test/acceptance/glob/glob.sh
+++ b/test/acceptance/glob/glob.sh
@@ -22,8 +22,19 @@ cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"p
     exit 1
 }
 
-cat /tmp/mocha-glob.txt | grep -q -F 'cannot resolve path' || {
+cat /tmp/mocha-glob.txt | grep -q -F 'Could not find any test files matching pattern' || {
     echo Globbing './*-none.js' in `pwd` should match no files and run no tests.
+    exit 1
+}
+
+../../../bin/mocha -R json-stream  ./*.js ./*-none.js >& /tmp/mocha-glob.txt || {
+    echo Globbing ./*.js ./*-none.js in `pwd` failed.
+    exit 1
+}
+
+cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"pending":0,"failures":0,' &&
+cat /tmp/mocha-glob.txt | grep -q -F 'Could not find any test files matching pattern' || {
+    echo Globbing ./*.js ./*-none.js in `pwd` should match glob.js with one test inside and display one warning for the non-existing file.
     exit 1
 }
 
@@ -47,7 +58,7 @@ cat /tmp/mocha-glob.txt | grep -q -F '["end",{"suites":1,"tests":1,"passes":1,"p
     exit 1
 }
 
-cat /tmp/mocha-glob.txt | grep -q -F 'cannot resolve path' || {
+cat /tmp/mocha-glob.txt | grep -q -F 'Could not find any test files matching pattern' || {
     echo Globbing './*-none.js' in `pwd` should match no files and run no tests.
     exit 1
 }


### PR DESCRIPTION
This displays a warning on STDERR for each glob pattern that is passed in as a binary execution argument if the glob pattern results in no files matched.

If no files are matched across all the passed glob patterns it exits with error code 1

This allows for running tests for any glob pattern that correctly matches files, while still making the user aware of their other invalid glob patterns. Previously we would throw if any pattern did not match any files and the error message was not the best one to figure out the problem.

Fixes #2194