### PR TITLE
Allow relative path to custom reporter

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -210,19 +210,6 @@ if (program.reporterOptions !== undefined) {
 
 mocha.reporter(program.reporter, reporterOptions);
 
-// load reporter
-
-var Reporter = null;
-try {
-  Reporter = require('../lib/reporters/' + program.reporter);
-} catch (err) {
-  try {
-    Reporter = require(program.reporter);
-  } catch (err2) {
-    throw new Error('reporter "' + program.reporter + '" does not exist');
-  }
-}
-
 // --no-colors
 
 if (!program.colors) {

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -145,14 +145,24 @@ Mocha.prototype.reporter = function(reporter, reporterOptions) {
     if (reporters[reporter]) {
       _reporter = reporters[reporter];
     }
-    // Try to load reporters from process.cwd() and node_modules
+    // Try to load reporters from process.cwd()
+    if (!_reporter) {
+      try {
+        _reporter = require(path.resolve(reporter));
+      } catch (err) {
+        if (err.message.indexOf('Cannot find module') === -1) {
+          console.warn('"' + reporter + '" reporter blew up with error:\n' + err.stack);
+        }
+      }
+    }
+    // Try to load reporters from node_modules
     if (!_reporter) {
       try {
         _reporter = require(reporter);
       } catch (err) {
-        err.message.indexOf('Cannot find module') !== -1
-          ? console.warn('"' + reporter + '" reporter not found')
-          : console.warn('"' + reporter + '" reporter blew up with error:\n' + err.stack);
+        if (err.message.indexOf('Cannot find module') === -1) {
+          console.warn('"' + reporter + '" reporter blew up with error:\n' + err.stack);
+        }
       }
     }
     if (!_reporter && reporter === 'teamcity') {


### PR DESCRIPTION
Closes #2434

Previously, mocha --reporter=./path/to/custom-reporter.js would fail.

Also removes code from _mocha that has been unnecessary since 191b88c079d44f527dfeb022fbdb4079440c8428
