### PR TITLE
fix: Cant scroll test results in debug mode.

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -2,6 +2,8 @@
 
 body {
   margin:0;
+  max-height:100vh;
+  overflow:auto;
 }
 
 #mocha {


### PR DESCRIPTION
While running tests in the debug mode, this fix will let you scroll right now if you have a lot of tests so that it ends up taking more vertical space on screen than your browsers viewport height.

fixes #2463 