### PR TITLE
Dont count xunit failures as errors

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -90,7 +90,7 @@ function XUnit(runner, options) {
         {
           name: suiteName,
           tests: stats.tests,
-          failures: stats.failures,
+          failures: 0,
           errors: stats.failures,
           skipped: stats.tests - stats.failures - stats.passes,
           timestamp: new Date().toUTCString(),


### PR DESCRIPTION
Per http://reflex.gforge.inria.fr/xunit.html#xunitReport a failure and an error are different concepts and must be counted as such. Some parsers will fail if the number of expected tests do not add up.
