### PR TITLE
adds info about --inspect flag to options in --help

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -89,6 +89,7 @@ program
   .option('--preserve-symlinks', 'Instructs the module loader to preserve symbolic links when resolving and caching modules')
   .option('--icu-data-dir', 'include ICU data')
   .option('--inline-diffs', 'display actual/expected differences inline within each string')
+  .option('--inspect', 'activate devtools in chrome')
   .option('--interfaces', 'display available interfaces')
   .option('--no-deprecation', 'silence deprecation warnings')
   .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')


### PR DESCRIPTION
Simply adds information about `--inspect` support to options displayed when running `--help`
