### PR TITLE
lint the hell out of the javascript; closes #2525

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-lib/to-iso-string/
-test/**/*
-!test/runner.js
+lib/to-iso-string/**/*.js
+mocha.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  "extends": "semistandard"
-};

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,11 @@
+env:
+  node: true
+  browser: true
+parserOptions:
+  ecmaVersion: 5
+  sourceType: script
+extends: semistandard
+rules:
+  strict:
+    - error
+    - safe

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 lint:
 	@printf "==> [Test :: Lint]\n"
-	$(ESLINT) browser-entry.js index.js karma.conf.js bin/mocha bin/_mocha "lib/**/*.js" "scripts/**/*.js" test
+	$(ESLINT) .
 
 test-node: test-bdd test-tdd test-qunit test-exports test-unit test-integration test-jsapi test-compilers test-glob test-requires test-reporters test-only test-global-only
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /* eslint no-unused-vars: off */
 

--- a/bin/mocha
+++ b/bin/mocha
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 /**
  * This tiny wrapper file checks for known node flags and appends them
  * when found, before invoking the "real" _mocha(1) executable.

--- a/bin/options.js
+++ b/bin/options.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Dependencies.
  */
@@ -14,17 +16,17 @@ module.exports = getOptions;
  * Get options.
  */
 
-function getOptions() {
-  var optsPath = process.argv.indexOf('--opts') !== -1
-        ? process.argv[process.argv.indexOf('--opts') + 1]
-        : 'test/mocha.opts';
+function getOptions () {
+  var optsPath = process.argv.indexOf('--opts') === -1
+    ? 'test/mocha.opts'
+    : process.argv[process.argv.indexOf('--opts') + 1];
 
   try {
     var opts = fs.readFileSync(optsPath, 'utf8')
       .replace(/\\\s/g, '%20')
       .split(/\s/)
       .filter(Boolean)
-      .map(function(value) {
+      .map(function (value) {
         return value.replace(/%20/g, ' ');
       });
 

--- a/browser-entry.js
+++ b/browser-entry.js
@@ -1,4 +1,7 @@
+'use strict';
+
 /* eslint no-unused-vars: off */
+/* eslint-env commonjs */
 
 /**
  * Shim process.stdout.

--- a/lib/browser/.eslintrc.yaml
+++ b/lib/browser/.eslintrc.yaml
@@ -1,0 +1,4 @@
+env:
+  node: false
+  browser: false
+  commonjs: true

--- a/lib/browser/debug.js
+++ b/lib/browser/debug.js
@@ -1,4 +1,7 @@
-/* eslint-disable no-unused-vars */
-module.exports = function (type) {
-  return function () {};
+'use strict';
+
+function noop () {}
+
+module.exports = function () {
+  return noop;
 };

--- a/lib/browser/events.js
+++ b/lib/browser/events.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module exports.
  */

--- a/lib/browser/progress.js
+++ b/lib/browser/progress.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Expose `Progress`.
  */

--- a/lib/browser/tty.js
+++ b/lib/browser/tty.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.isatty = function isatty () {
   return true;
 };

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/interfaces/index.js
+++ b/lib/interfaces/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.bdd = require('./bdd');
 exports.tdd = require('./tdd');
 exports.qunit = require('./qunit');

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*!
  * mocha
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>

--- a/lib/ms.js
+++ b/lib/ms.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Helpers.
  */

--- a/lib/pending.js
+++ b/lib/pending.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Expose `Pending`.

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env browser */
 
 /**

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Alias exports to a their normalized format Mocha#reporter to prevent a need
 // for dynamic (try/catch) requires, which Browserify doesn't handle.
 exports.Base = exports.base = require('./base');

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env browser */
 
 /**

--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "supports-color": "3.1.2"
   },
   "devDependencies": {
+    "assert": "^1.4.1",
     "browserify": "^13.0.0",
     "coffee-script": "^1.10.0",
     "eslint": "^2.13.1",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,8 +1,0 @@
-module.exports = {
-  env: {
-    mocha: true
-  },
-  globals: {
-    expect: false
-  }
-};

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,7 @@
+env:
+  mocha: true
+globals:
+  expect: false
+  assert: false
+  # https://github.com/sindresorhus/globals/pull/102
+  run: false

--- a/test/acceptance/context.spec.js
+++ b/test/acceptance/context.spec.js
@@ -1,72 +1,73 @@
-describe('Context', function(){
-  beforeEach(function(){
+'use strict';
+
+describe('Context', function () {
+  beforeEach(function () {
     this.calls = ['before'];
-  })
+  });
 
-  describe('nested', function(){
-    beforeEach(function(){
+  describe('nested', function () {
+    beforeEach(function () {
       this.calls.push('before two');
-    })
+    });
 
-    it('should work', function(){
+    it('should work', function () {
       expect(this.calls).to.eql(['before', 'before two']);
       this.calls.push('test');
-    })
+    });
 
-    after(function(){
+    after(function () {
       expect(this.calls).to.eql(['before', 'before two', 'test']);
       this.calls.push('after two');
-    })
-  })
+    });
+  });
 
-  after(function(){
+  after(function () {
     expect(this.calls).to.eql(['before', 'before two', 'test', 'after two']);
-  })
-})
+  });
+});
 
-describe('Context Siblings', function(){
-  beforeEach(function(){
+describe('Context Siblings', function () {
+  beforeEach(function () {
     this.calls = ['before'];
-  })
+  });
 
-  describe('sequestered sibling', function(){
-    beforeEach(function(){
+  describe('sequestered sibling', function () {
+    beforeEach(function () {
       this.calls.push('before two');
       this.hiddenFromSibling = 'This should be hidden';
-    })
+    });
 
-    it('should work', function(){
-      expect(this.hiddenFromSibling).to.eql('This should be hidden')
-    })
-  })
+    it('should work', function () {
+      expect(this.hiddenFromSibling).to.eql('This should be hidden');
+    });
+  });
 
-  describe('sibling verifiction', function(){
-    beforeEach(function(){
+  describe('sibling verifiction', function () {
+    beforeEach(function () {
       this.calls.push('before sibling');
-    })
+    });
 
-    it('should not have value set within a sibling describe', function(){
+    it('should not have value set within a sibling describe', function () {
       expect('This should be hidden').not.to.eql(this.hiddenFromSibling);
       this.visibleFromTestSibling = 'Visible from test sibling';
-    })
+    });
 
-    it('should allow test siblings to modify shared context', function(){
+    it('should allow test siblings to modify shared context', function () {
       expect('Visible from test sibling').to.eql(this.visibleFromTestSibling);
-    })
+    });
 
-    it('should have reset this.calls before describe', function(){
+    it('should have reset this.calls before describe', function () {
       expect(this.calls).to.eql(['before', 'before sibling']);
-    })
-  })
+    });
+  });
 
-  after(function(){
+  after(function () {
     expect(this.calls).to.eql(['before', 'before sibling']);
-  })
+  });
+});
 
-})
-
-describe('timeout()', function(){
-  it('should return the timeout', function(){
+describe('timeout()', function () {
+  it('should return the timeout', function () {
     expect(this.timeout()).to.equal(200);
   });
 });

--- a/test/acceptance/duration.spec.js
+++ b/test/acceptance/duration.spec.js
@@ -1,25 +1,27 @@
-describe('durations', function(){
-  describe('when slow', function(){
-    it('should highlight in red', function(done){
-      setTimeout(function(){
+'use strict';
+
+describe('durations', function () {
+  describe('when slow', function () {
+    it('should highlight in red', function (done) {
+      setTimeout(function () {
         done();
       }, 100);
-    })
-  })
+    });
+  });
 
-  describe('when reasonable', function(){
-    it('should highlight in yellow', function(done){
-      setTimeout(function(){
+  describe('when reasonable', function () {
+    it('should highlight in yellow', function (done) {
+      setTimeout(function () {
         done();
       }, 50);
-    })
-  })
+    });
+  });
 
-  describe('when fast', function(){
-    it('should highlight in green', function(done){
-      setTimeout(function(){
+  describe('when fast', function () {
+    it('should highlight in green', function (done) {
+      setTimeout(function () {
         done();
       }, 10);
-    })
-  })
-})
+    });
+  });
+});

--- a/test/acceptance/fs.spec.js
+++ b/test/acceptance/fs.spec.js
@@ -1,20 +1,22 @@
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 var os = require('os');
 var tmpFile = path.join.bind(path, os.tmpdir());
 
-describe('fs.readFile()', function(){
-  describe('when the file exists', function(){
-    it('should succeed', function(done){
-      fs.writeFile(tmpFile('mocha'), 'wahoo', done)
-    })
-  })
+describe('fs.readFile()', function () {
+  describe('when the file exists', function () {
+    it('should succeed', function (done) {
+      fs.writeFile(tmpFile('mocha'), 'wahoo', done);
+    });
+  });
 
-  describe('when the file does not exist', function(){
-    it('should fail', function(done){
+  describe('when the file does not exist', function () {
+    it('should fail', function (done) {
       // uncomment
       // fs.readFile(tmpFile('does-not-exist'), done);
       done();
-    })
-  })
-})
+    });
+  });
+});

--- a/test/acceptance/glob/glob.spec.js
+++ b/test/acceptance/glob/glob.spec.js
@@ -1,5 +1,7 @@
-describe('globbing test', function(){
-  it('should find this test', function(){
+'use strict';
+
+describe('globbing test', function () {
+  it('should find this test', function () {
     // see glob.sh for details
-  })
+  });
 });

--- a/test/acceptance/globals.spec.js
+++ b/test/acceptance/globals.spec.js
@@ -1,40 +1,42 @@
-describe('global leaks', function(){
-  before(function(){
+'use strict';
+
+describe('global leaks', function () {
+  before(function () {
     // uncomment to test
     // foo = 'hey';
     // bar = 'hey';
-  })
+  });
 
-  beforeEach(function(){
+  beforeEach(function () {
     // uncomment to test
     // foo = 'bar'
   });
 
-  it('should cause tests to fail', function(){
+  it('should cause tests to fail', function () {
     // uncomment to test
     // foo = 'bar';
     // bar = 'baz';
     // baz = 'raz';
   });
 
-  it('should pass when accepted', function(){
+  it('should pass when accepted', function () {
     global.okGlobalA = 1;
     global.okGlobalB = 1;
     global.okGlobalC = 1;
-  })
+  });
 
-  it('should pass with wildcard', function(){
+  it('should pass with wildcard', function () {
     global.callback123 = 'foo';
     global.callback345 = 'bar';
   });
 
-  it('should pass when prefixed "mocha-"', function(){
+  it('should pass when prefixed "mocha-"', function () {
     // Opera and IE do this for HTML element IDs anyway
     // but to sure we can assert this in any browser, simulate it.
     global['mocha-example'] = { nodeType: 1 };
   });
 
-  afterEach(function(){
+  afterEach(function () {
     // uncomment to test
     // foo = 'bar'
   });

--- a/test/acceptance/http.spec.js
+++ b/test/acceptance/http.spec.js
@@ -1,16 +1,18 @@
+'use strict';
+
 var http = require('http');
 
-var server = http.createServer(function(req, res){
+var server = http.createServer(function (req, res) {
   res.end('Hello World\n');
-})
+});
 
 server.listen(8888);
 
-describe('http', function(){
-  it('should provide an example', function(done){
-    http.get({ path: '/', port: 8888 }, function(res){
+describe('http', function () {
+  it('should provide an example', function (done) {
+    http.get({ path: '/', port: 8888 }, function (res) {
       expect(res).to.have.property('statusCode', 200);
       done();
-    })
-  })
-})
+    });
+  });
+});

--- a/test/acceptance/interfaces/bdd.spec.js
+++ b/test/acceptance/interfaces/bdd.spec.js
@@ -1,32 +1,34 @@
-describe('integer primitives', function(){
-  describe('arithmetic', function(){
-    it('should add', function(){
+'use strict';
+
+describe('integer primitives', function () {
+  describe('arithmetic', function () {
+    it('should add', function () {
       expect(1 + 1).to.equal(2);
       expect(2 + 2).to.equal(4);
-    })
+    });
 
-    it('should subtract', function(){
+    it('should subtract', function () {
       expect(1 - 1).to.equal(0);
       expect(2 - 1).to.equal(1);
-    })
-  })
-})
+    });
+  });
+});
 
-describe('integer primitives', function(){
-  describe('arithmetic is not', function(){
-    it('should add', function(){
+describe('integer primitives', function () {
+  describe('arithmetic is not', function () {
+    it('should add', function () {
       expect(1 + 1).not.to.equal(3);
       expect(2 + 2).not.to.equal(5);
-    })
-  })
-})
+    });
+  });
+});
 
-context('test suite', function(){
-  beforeEach(function(){
+context('test suite', function () {
+  beforeEach(function () {
     this.number = 5;
-  })
+  });
 
-  specify('share a property', function(){
+  specify('share a property', function () {
     expect(this.number).to.equal(5);
-  })
-})
+  });
+});

--- a/test/acceptance/interfaces/exports.spec.js
+++ b/test/acceptance/interfaces/exports.spec.js
@@ -1,43 +1,48 @@
+'use strict';
+
 var calls = [];
 
 exports.Array = {
-  before: function(){
+  before: function () {
     calls.push('before');
   },
 
-  after: function(){
+  after: function () {
     calls.push('after');
-    expect(calls).to.eql([
-        'before'
-      , 'before each'
-      , 'one'
-      , 'after each'
-      , 'before each'
-      , 'two'
-      , 'after each'
-      , 'after']);
+    expect(calls)
+      .to
+      .eql([
+        'before',
+        'before each',
+        'one',
+        'after each',
+        'before each',
+        'two',
+        'after each',
+        'after'
+      ]);
   },
 
   '#indexOf()': {
-    beforeEach: function(){
+    beforeEach: function () {
       calls.push('before each');
     },
 
-    afterEach: function(){
+    afterEach: function () {
       calls.push('after each');
     },
 
-    'should return -1 when the value is not present': function(){
+    'should return -1 when the value is not present': function () {
       calls.push('one');
-      expect([1,2,3].indexOf(5)).to.equal(-1);
-      expect([1,2,3].indexOf(0)).to.equal(-1);
+      expect([1, 2, 3].indexOf(5)).to.equal(-1);
+      expect([1, 2, 3].indexOf(0)).to.equal(-1);
     },
 
-    'should return the correct index when the value is present': function(){
+    'should return the correct index when the value is present': function () {
       calls.push('two');
-      expect([1,2,3].indexOf(1)).to.equal(0);
-      expect([1,2,3].indexOf(2)).to.equal(1);
-      expect([1,2,3].indexOf(3)).to.equal(2);
+      expect([1, 2, 3].indexOf(1)).to.equal(0);
+      expect([1, 2, 3].indexOf(2)).to.equal(1);
+      expect([1, 2, 3].indexOf(3)).to.equal(2);
     }
   }
 };

--- a/test/acceptance/interfaces/qunit.spec.js
+++ b/test/acceptance/interfaces/qunit.spec.js
@@ -1,23 +1,25 @@
-function ok(expr, msg) {
+'use strict';
+
+function ok (expr, msg) {
   if (!expr) throw new Error(msg);
 }
 
 suite('integer primitives');
 
-test('should add', function(){
+test('should add', function () {
   var number = 2 + 2;
-  ok(number == 4);
+  ok(number === 4);
 });
 
-test('should decrement', function(){
+test('should decrement', function () {
   var number = 3;
-  ok(--number == 2);
-  ok(--number == 1);
-  ok(--number == 0);
+  ok(--number === 2);
+  ok(--number === 1);
+  ok(--number === 0);
 });
 
 suite('String');
 
-test('#length', function(){
-  ok('foo'.length == 3);
+test('#length', function () {
+  ok('foo'.length === 3);
 });

--- a/test/acceptance/interfaces/tdd.spec.js
+++ b/test/acceptance/interfaces/tdd.spec.js
@@ -1,38 +1,40 @@
-suite('integer primitives', function(){
-  suite('arithmetic', function(){
+'use strict';
+
+suite('integer primitives', function () {
+  suite('arithmetic', function () {
     var initialValue = 41;
 
-    suiteSetup(function(done){
+    suiteSetup(function (done) {
       expect(initialValue).to.eql(41);
       initialValue += 1;
       done();
     });
 
-    test('should add', function(){
+    test('should add', function () {
       expect(initialValue).to.eql(42);
       expect(1 + 1).to.equal(2);
       expect(2 + 2).to.equal(4);
     });
 
-    test('should subtract', function(){
+    test('should subtract', function () {
       expect(initialValue).to.eql(42);
       expect(1 - 1).to.equal(0);
       expect(2 - 1).to.equal(1);
     });
 
-    test.skip('should skip this test', function(){
+    test.skip('should skip this test', function () {
       var zero = 0;
       expect(zero).to.equal(1, 'this test should have been skipped');
     });
 
-    suite.skip('should skip this suite', function(){
-      test('should skip this test', function(){
+    suite.skip('should skip this suite', function () {
+      test('should skip this test', function () {
         var zero = 0;
         expect(zero).to.equal(1, 'this test should have been skipped');
       });
     });
 
-    suiteTeardown(function(done){
+    suiteTeardown(function (done) {
       expect(initialValue).to.eql(42);
       done();
     });

--- a/test/acceptance/lookup-files.spec.js
+++ b/test/acceptance/lookup-files.spec.js
@@ -7,13 +7,13 @@ var os = require('os');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 
-describe('lookupFiles', function() {
+describe('lookupFiles', function () {
   var tmpDir = path.join(os.tmpDir(), 'mocha-lookup-files');
   var existsSync = fs.existsSync;
   var tmpFile = path.join.bind(path, tmpDir);
   var symlinkSupported = false;
 
-  (function testSymlinkSupport() {
+  (function testSymlinkSupport () {
     makeTempDir();
 
     fs.writeFileSync(tmpFile('mocha-utils.js'), 'yippy skippy ying yang yow');
@@ -27,7 +27,7 @@ describe('lookupFiles', function() {
     }
   }());
 
-  beforeEach(function() {
+  beforeEach(function () {
     makeTempDir();
 
     fs.writeFileSync(tmpFile('mocha-utils.js'), 'yippy skippy ying yang yow');
@@ -36,7 +36,7 @@ describe('lookupFiles', function() {
     }
   });
 
-  (symlinkSupported ? it : it.skip)('should not choke on symlinks', function() {
+  (symlinkSupported ? it : it.skip)('should not choke on symlinks', function () {
     expect(utils.lookupFiles(tmpDir, ['js'], false))
       .to
       .contain(tmpFile('mocha-utils-link.js'))
@@ -57,7 +57,7 @@ describe('lookupFiles', function() {
       .eql([]);
   });
 
-  it('should accept a glob "path" value', function() {
+  it('should accept a glob "path" value', function () {
     var res = utils.lookupFiles(tmpFile('mocha-utils*'), ['js'], false)
       .map(path.normalize.bind(path));
 
@@ -80,11 +80,11 @@ describe('lookupFiles', function() {
 
   afterEach(removeTempDir);
 
-  function makeTempDir() {
+  function makeTempDir () {
     mkdirp.sync(tmpDir);
   }
 
-  function removeTempDir() {
+  function removeTempDir () {
     rimraf.sync(tmpDir);
   }
 });

--- a/test/acceptance/misc/exit.spec.js
+++ b/test/acceptance/misc/exit.spec.js
@@ -1,18 +1,20 @@
-describe('exit', function(){
-  //note --bail works nicely in that it still allows an 'early exit' in an error scenario
-  it('should not exit even in error scenario if called with --no-exit', function(done){
-    done(new Error('failure'));
-  })
+'use strict';
 
-  it('should take a long time to exit if called with --no-exit', function(done){
+describe('exit', function () {
+  // note --bail works nicely in that it still allows an 'early exit' in an error scenario
+  it('should not exit even in error scenario if called with --no-exit', function (done) {
+    done(new Error('failure'));
+  });
+
+  it('should take a long time to exit if called with --no-exit', function (done) {
     done();
-    setTimeout(function() {
+    setTimeout(function () {
       console.log('all done');
-    }, 2500)
-  })
+    }, 2500);
+  });
 
   it('should kill all processes when SIGINT received', function () {
     // uncomment to test
-    //while (true) {}
+    // while (true) {}
   });
-})
+});

--- a/test/acceptance/misc/many.spec.js
+++ b/test/acceptance/misc/many.spec.js
@@ -1,27 +1,28 @@
+'use strict';
+
 // Useful for testing SIGINT handler
 // use env.big_number to tune iterations so that you have time to ctrl+c
 
-describe('a load of tests', function(){
-  it('should fail the first test', function(){
+describe('a load of tests', function () {
+  it('should fail the first test', function () {
     throw new Error('this should appear in the summary');
-  })
+  });
 
   var iterations = (process.env.big_number || 1e7);
-  function work() {
+  function work () {
     var a = 0;
-    for(var i=0; i<iterations; ++i) {
+    for (var i = 0; i < iterations; ++i) {
       a += i;
     }
   }
 
-  function addTest() {
-    it('should pass test ' + i, function(){
+  function addTest () {
+    it('should pass test ' + i, function () {
       work();
-    })
+    });
   }
 
-  for(var i=0; i<500; ++i) {
+  for (var i = 0; i < 500; ++i) {
     addTest();
   }
-
-})
+});

--- a/test/acceptance/misc/nontty.spec.js
+++ b/test/acceptance/misc/nontty.spec.js
@@ -1,9 +1,11 @@
-describe('tests for non-tty', function(){
-  it('should pass', function(){
+'use strict';
 
-  })
+describe('tests for non-tty', function () {
+  it('should pass', function () {
 
-  it('should fail', function(){
-    throw new Error('oh noes')
-  })
-})
+  });
+
+  it('should fail', function () {
+    throw new Error('oh noes');
+  });
+});

--- a/test/acceptance/misc/only/bdd-require.spec.js
+++ b/test/acceptance/misc/only/bdd-require.spec.js
@@ -1,4 +1,6 @@
-/*jshint node: true */
+'use strict';
+
+/* jshint node: true */
 
 var mocha = require('../../../../lib/mocha');
 
@@ -6,12 +8,12 @@ var beforeEach = mocha.beforeEach;
 var it = mocha.it;
 var describe = mocha.describe;
 
-describe('it.only via require("mocha")', function() {
-  beforeEach(function() {
+describe('it.only via require("mocha")', function () {
+  beforeEach(function () {
     this.didRunBeforeEach = true;
   });
-  describe("nested within a describe/context", function() {
-    it.only('should run all enclosing beforeEach hooks', function() {
+  describe('nested within a describe/context', function () {
+    it.only('should run all enclosing beforeEach hooks', function () {
       require('assert').equal(this.didRunBeforeEach, true);
     });
   });

--- a/test/acceptance/misc/only/bdd.spec.js
+++ b/test/acceptance/misc/only/bdd.spec.js
@@ -1,75 +1,77 @@
-describe('should only run .only test in this bdd suite', function() {
-  it('should not run this test', function() {
+'use strict';
+
+describe('should only run .only test in this bdd suite', function () {
+  it('should not run this test', function () {
     (0).should.equal(1, 'this test should have been skipped');
   });
-  it.only('should run this test', function() {
+  it.only('should run this test', function () {
     (0).should.equal(0, 'this .only test should run');
   });
-  it('should run this test, not (includes the title of the .only test)', function() {
+  it('should run this test, not (includes the title of the .only test)', function () {
     (0).should.equal(1, 'this test should have been skipped');
   });
 });
 
-describe('should not run this suite', function() {
-  it('should not run this test', function() {
+describe('should not run this suite', function () {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  it('should not run this test', function() {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  it('should not run this test', function() {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
 });
 
-describe.only('should run all tests in this bdd suite', function() {
-  it('should run this test #1', function() {
+describe.only('should run all tests in this bdd suite', function () {
+  it('should run this test #1', function () {
     (true).should.equal(true);
   });
 
-  it('should run this test #2', function() {
+  it('should run this test #2', function () {
     (1).should.equal(1);
   });
 
-  it('should run this test #3', function() {
+  it('should run this test #3', function () {
     ('foo').should.equal('foo');
   });
 });
 
-describe('should run only suites that marked as `only`', function() {
-  describe.only('should run all this tdd suite', function() {
-    it('should run this test #1', function() {
+describe('should run only suites that marked as `only`', function () {
+  describe.only('should run all this tdd suite', function () {
+    it('should run this test #1', function () {
       (true).should.equal(true);
     });
 
-    it('should run this test #2', function() {
+    it('should run this test #2', function () {
       (true).should.equal(true);
     });
   });
 
-  describe('should not run this suite', function() {
-    it('should run this test', function() {
+  describe('should not run this suite', function () {
+    it('should run this test', function () {
       (true).should.equal(false);
     });
   });
 });
 
 // Nested situation
-describe('should not run parent tests', function() {
-  it('should not run this test', function() {
+describe('should not run parent tests', function () {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
-  describe('and not the child tests too', function() {
-    it('should not run this test', function() {
+  describe('and not the child tests too', function () {
+    it('should not run this test', function () {
       (true).should.equal(false);
     });
-    describe.only('but run all the tests in this suite', function() {
-      it('should run this test #1', function() {
+    describe.only('but run all the tests in this suite', function () {
+      it('should run this test #1', function () {
         (true).should.equal(true);
       });
-      it('should run this test #2', function() {
+      it('should run this test #2', function () {
         (true).should.equal(true);
       });
     });
@@ -77,49 +79,49 @@ describe('should not run parent tests', function() {
 });
 
 // mark test as `only` override the suite behavior
-describe.only('should run only tests that marked as `only`', function() {
-  it('should not run this test #1', function() {
+describe.only('should run only tests that marked as `only`', function () {
+  it('should not run this test #1', function () {
     (false).should.equal(true);
   });
 
-  it.only('should run this test #2', function() {
+  it.only('should run this test #2', function () {
     (true).should.equal(true);
   });
 
-  it('should not run this test #3', function() {
+  it('should not run this test #3', function () {
     (false).should.equal(true);
   });
 
-  it.only('should run this test #4', function() {
+  it.only('should run this test #4', function () {
     (true).should.equal(true);
   });
 });
 
-describe.only('Should run only test cases that mark as only', function() {
-  it.only('should runt his test', function() {
+describe.only('Should run only test cases that mark as only', function () {
+  it.only('should runt his test', function () {
     (true).should.equal(true);
   });
 
-  it('should not run this test', function() {
+  it('should not run this test', function () {
     (false).should.equal(true);
   });
 
-  describe('should not run this suite', function() {
-    it('should not run this test', function() {
+  describe('should not run this suite', function () {
+    it('should not run this test', function () {
       (false).should.equal(true);
     });
   });
 });
 
 // Root Suite
-it.only('#Root-Suite, should run this test-case #1', function() {
+it.only('#Root-Suite, should run this test-case #1', function () {
   (true).should.equal(true);
 });
 
-it.only('#Root-Suite, should run this test-case #2', function() {
+it.only('#Root-Suite, should run this test-case #2', function () {
   (true).should.equal(true);
 });
 
-it('#Root-Suite, should not run this test', function() {
+it('#Root-Suite, should not run this test', function () {
   (false).should.equal(true);
 });

--- a/test/acceptance/misc/only/global/bdd.spec.js
+++ b/test/acceptance/misc/only/global/bdd.spec.js
@@ -1,12 +1,14 @@
+'use strict';
+
 // Root-only test cases
-it.only('#Root-Suite, should run this bdd test-case #1', function() {
+it.only('#Root-Suite, should run this bdd test-case #1', function () {
   (true).should.equal(true);
 });
 
-it('#Root-Suite, should not run this bdd test-case #2', function() {
+it('#Root-Suite, should not run this bdd test-case #2', function () {
   (false).should.equal(true);
 });
 
-it('#Root-Suite, should not run this bdd test-case #3', function() {
+it('#Root-Suite, should not run this bdd test-case #3', function () {
   (false).should.equal(true);
 });

--- a/test/acceptance/misc/only/global/qunit.spec.js
+++ b/test/acceptance/misc/only/global/qunit.spec.js
@@ -1,12 +1,14 @@
+'use strict';
+
 // Root-only test cases
-test.only('#Root-Suite, should run this qunit test-case #1', function() {
+test.only('#Root-Suite, should run this qunit test-case #1', function () {
   (true).should.equal(true);
 });
 
-test('#Root-Suite, should not run this qunit test-case #2', function() {
+test('#Root-Suite, should not run this qunit test-case #2', function () {
   (false).should.equal(true);
 });
 
-test('#Root-Suite, should not run this qunit test-case #3', function() {
+test('#Root-Suite, should not run this qunit test-case #3', function () {
   (false).should.equal(true);
 });

--- a/test/acceptance/misc/only/global/tdd.spec.js
+++ b/test/acceptance/misc/only/global/tdd.spec.js
@@ -1,12 +1,14 @@
+'use strict';
+
 // Root-only test cases
-test.only('#Root-Suite, should run this tdd test-case #1', function() {
+test.only('#Root-Suite, should run this tdd test-case #1', function () {
   (true).should.equal(true);
 });
 
-test('#Root-Suite, should not run this tdd test-case #2', function() {
+test('#Root-Suite, should not run this tdd test-case #2', function () {
   (false).should.equal(true);
 });
 
-test('#Root-Suite, should not run this tdd test-case #3', function() {
+test('#Root-Suite, should not run this tdd test-case #3', function () {
   (false).should.equal(true);
 });

--- a/test/acceptance/misc/only/qunit.spec.js
+++ b/test/acceptance/misc/only/qunit.spec.js
@@ -1,73 +1,75 @@
+'use strict';
+
 // Root Suite
-test.only('#Root-Suite, should run this test-case #1', function() {
+test.only('#Root-Suite, should run this test-case #1', function () {
   (true).should.equal(true);
 });
 
-test.only('#Root-Suite, should run this test-case #2', function() {
+test.only('#Root-Suite, should run this test-case #2', function () {
   (true).should.equal(true);
 });
 
-test('#Root-Suite, should not run this test', function() {
+test('#Root-Suite, should not run this test', function () {
   (false).should.equal(true);
 });
 
 suite('should only run .only test in this qunit suite');
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (0).should.equal(1, 'this test should have been skipped');
 });
-test.only('should run this test', function() {
+test.only('should run this test', function () {
   (0).should.equal(0, 'this .only test should run');
 });
-test('should run this test, not (includes the title of the .only test)', function() {
+test('should run this test, not (includes the title of the .only test)', function () {
   (0).should.equal(1, 'this test should have been skipped');
 });
 
 // Mark suite
 suite.only('should run all tests in this suite');
 
-test('should run this test #1', function() {
+test('should run this test #1', function () {
   (true).should.equal(true);
 });
 
-test('should run this test #2', function() {
+test('should run this test #2', function () {
   (true).should.equal(true);
 });
 
-test('should run this test #3', function() {
+test('should run this test #3', function () {
   (true).should.equal(true);
 });
 
 // Unmark this suite
 suite('should not run any of this suite\'s tests');
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (false).should.equal(true);
 });
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (false).should.equal(true);
 });
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (false).should.equal(true);
 });
 
 // Mark test as `only` override the suite behavior
 suite.only('should run only tests that marked as `only`');
 
-test('should not run this test #1', function() {
+test('should not run this test #1', function () {
   (false).should.equal(true);
 });
 
-test.only('should not run this test #2', function() {
+test.only('should not run this test #2', function () {
   (true).should.equal(true);
 });
 
-test('should not run this test #3', function() {
+test('should not run this test #3', function () {
   (false).should.equal(true);
 });
 
-test.only('should not run this test #4', function() {
+test.only('should not run this test #4', function () {
   (true).should.equal(true);
 });

--- a/test/acceptance/misc/only/tdd.spec.js
+++ b/test/acceptance/misc/only/tdd.spec.js
@@ -1,75 +1,77 @@
-suite('should only run .only test in this tdd suite', function() {
-  test('should not run this test', function() {
+'use strict';
+
+suite('should only run .only test in this tdd suite', function () {
+  test('should not run this test', function () {
     (0).should.equal(1, 'this test should have been skipped');
   });
-  test.only('should run this test', function() {
+  test.only('should run this test', function () {
     (0).should.equal(0, 'this .only test should run');
   });
-  test('should run this test, not (includes the title of the .only test)', function() {
+  test('should run this test, not (includes the title of the .only test)', function () {
     (0).should.equal(1, 'this test should have been skipped');
   });
 });
 
-suite('should not run this suite', function() {
-  test('should not run this test', function() {
+suite('should not run this suite', function () {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  test('should not run this test', function() {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  test('should not run this test', function() {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
 });
 
-suite.only('should run all tests in this tdd suite', function() {
-  test('should run this test #1', function() {
+suite.only('should run all tests in this tdd suite', function () {
+  test('should run this test #1', function () {
     (true).should.equal(true);
   });
 
-  test('should run this test #2', function() {
+  test('should run this test #2', function () {
     (1).should.equal(1);
   });
 
-  test('should run this test #3', function() {
+  test('should run this test #3', function () {
     ('foo').should.equal('foo');
   });
 });
 
-suite('should run only suites that marked as `only`', function() {
-  suite.only('should run all this tdd suite', function() {
-    test('should run this test #1', function() {
+suite('should run only suites that marked as `only`', function () {
+  suite.only('should run all this tdd suite', function () {
+    test('should run this test #1', function () {
       (true).should.equal(true);
     });
 
-    test('should run this test #2', function() {
+    test('should run this test #2', function () {
       (true).should.equal(true);
     });
   });
 
-  suite('should not run this suite', function() {
-    test('should not run this test', function() {
+  suite('should not run this suite', function () {
+    test('should not run this test', function () {
       (true).should.equal(false);
     });
   });
 });
 
 // Nested situation
-suite('should not run parent tests', function() {
-  test('should not run this test', function() {
+suite('should not run parent tests', function () {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
-  suite('and not the child tests too', function() {
-    test('should not run this test', function() {
+  suite('and not the child tests too', function () {
+    test('should not run this test', function () {
       (true).should.equal(false);
     });
-    suite.only('but run all the tests in this suite', function() {
-      test('should run this test #1', function() {
+    suite.only('but run all the tests in this suite', function () {
+      test('should run this test #1', function () {
         (true).should.equal(true);
       });
-      test('should run this test #2', function() {
+      test('should run this test #2', function () {
         (true).should.equal(true);
       });
     });
@@ -77,49 +79,49 @@ suite('should not run parent tests', function() {
 });
 
 // mark test as `only` override the suite behavior
-suite.only('should run only tests that marked as `only`', function() {
-  test('should not run this test #1', function() {
+suite.only('should run only tests that marked as `only`', function () {
+  test('should not run this test #1', function () {
     (false).should.equal(true);
   });
 
-  test.only('should run this test #2', function() {
+  test.only('should run this test #2', function () {
     (true).should.equal(true);
   });
 
-  test('should not run this test #3', function() {
+  test('should not run this test #3', function () {
     (false).should.equal(true);
   });
 
-  test.only('should run this test #4', function() {
+  test.only('should run this test #4', function () {
     (true).should.equal(true);
   });
 });
 
-suite.only('Should run only test cases that mark as only', function() {
-  test.only('should runt his test', function() {
+suite.only('Should run only test cases that mark as only', function () {
+  test.only('should runt his test', function () {
     (true).should.equal(true);
   });
 
-  test('should not run this test', function() {
+  test('should not run this test', function () {
     (false).should.equal(true);
   });
 
-  suite('should not run this suite', function() {
-    test('should not run this test', function() {
+  suite('should not run this suite', function () {
+    test('should not run this test', function () {
       (false).should.equal(true);
     });
   });
 });
 
 // Root Suite
-test.only('#Root-Suite, should run this test-case #1', function() {
+test.only('#Root-Suite, should run this test-case #1', function () {
   (true).should.equal(true);
 });
 
-test.only('#Root-Suite, should run this test-case #2', function() {
+test.only('#Root-Suite, should run this test-case #2', function () {
   (true).should.equal(true);
 });
 
-test('#Root-Suite, should not run this test', function() {
+test('#Root-Suite, should not run this test', function () {
   (false).should.equal(true);
 });

--- a/test/acceptance/overspecified-async.spec.js
+++ b/test/acceptance/overspecified-async.spec.js
@@ -1,5 +1,7 @@
-describe('overspecified asynchronous resolution method', function() {
-  it('should fail when multiple methods are used', function(done) {
+'use strict';
+
+describe('overspecified asynchronous resolution method', function () {
+  it('should fail when multiple methods are used', function (done) {
     setTimeout(done, 0);
 
     // uncomment

--- a/test/acceptance/require/a.js
+++ b/test/acceptance/require/a.js
@@ -1,2 +1,4 @@
-global.required = (global.required || [])
-global.required.push('a.js')
+'use strict';
+
+global.required = (global.required || []);
+global.required.push('a.js');

--- a/test/acceptance/require/c.js
+++ b/test/acceptance/require/c.js
@@ -1,2 +1,4 @@
-global.required = (global.required || [])
-global.required.push('c.js')
+'use strict';
+
+global.required = (global.required || []);
+global.required.push('c.js');

--- a/test/acceptance/require/require.spec.js
+++ b/test/acceptance/require/require.spec.js
@@ -1,9 +1,11 @@
-describe('require test', function(){
-  it('should require args in order', function(){
+'use strict';
+
+describe('require test', function () {
+  it('should require args in order', function () {
     var req = global.required;
     expect(req.indexOf('a.js')).to.equal(0);
     expect(req.indexOf('b.coffee')).to.equal(1);
     expect(req.indexOf('c.js')).to.equal(2);
     expect(req.indexOf('d.coffee')).to.equal(3);
-  })
+  });
 });

--- a/test/acceptance/required-tokens.spec.js
+++ b/test/acceptance/required-tokens.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var assert = require('assert');
 var describe = require('../..').describe;
 var it = require('../..').it;
@@ -6,5 +8,5 @@ describe('using imported describe', function () {
   it('using imported it', function (done) {
     assert.ok(true);
     done();
-  })
-})
+  });
+});

--- a/test/acceptance/root.spec.js
+++ b/test/acceptance/root.spec.js
@@ -1,11 +1,13 @@
+'use strict';
+
 var calls = [];
 
-before(function(){
+before(function () {
   calls.push('before');
-})
+});
 
-describe('root', function(){
-  it('should be a valid suite', function(){
+describe('root', function () {
+  it('should be a valid suite', function () {
     expect(calls).to.eql(['before']);
-  })
-})
+  });
+});

--- a/test/acceptance/throw.spec.js
+++ b/test/acceptance/throw.spec.js
@@ -1,3 +1,7 @@
+'use strict';
+
+/* eslint no-throw-literal: off */
+
 var Suite = require('../../lib/suite');
 var Test = require('../../lib/test');
 var Runner = require('../../lib/runner');
@@ -5,34 +9,19 @@ var Runner = require('../../lib/runner');
 describe('a test that throws', function () {
   var suite, runner;
 
-  beforeEach(function(){
+  beforeEach(function () {
     suite = new Suite('Suite', 'root');
     runner = new Runner(suite);
-  })
-  
-  describe('undefined', function (){
-    it('should not pass if throwing sync and test is sync', function(done) {
-      var test = new Test('im sync and throw undefined sync', function(){
-        throw undefined;
-      });
-      suite.addTest(test);
-      runner = new Runner(suite);
-      runner.on('end', function(){
-        expect(runner.failures).to.equal(1);
-        expect(test.state).to.equal('failed');
-        done();
-      });
-      runner.run();
-    })
+  });
 
-    it('should not pass if throwing sync and test is async', function(done){
-      var test = new Test('im async and throw undefined sync', function(done2){
+  describe('undefined', function () {
+    it('should not pass if throwing sync and test is sync', function (done) {
+      var test = new Test('im sync and throw undefined sync', function () {
         throw undefined;
-        process.nexTick(done2);
       });
       suite.addTest(test);
       runner = new Runner(suite);
-      runner.on('end', function(){
+      runner.on('end', function () {
         expect(runner.failures).to.equal(1);
         expect(test.state).to.equal('failed');
         done();
@@ -40,47 +29,45 @@ describe('a test that throws', function () {
       runner.run();
     });
 
-    it('should not pass if throwing async and test is async', function(done){
-      var test = new Test('im async and throw undefined async', function(done2){
-        process.nexTick(function(){
+    it('should not pass if throwing sync and test is async', function (done) {
+      var test = new Test('im async and throw undefined sync', function (done2) {
+        throw undefined;
+      });
+      suite.addTest(test);
+      runner = new Runner(suite);
+      runner.on('end', function () {
+        expect(runner.failures).to.equal(1);
+        expect(test.state).to.equal('failed');
+        done();
+      });
+      runner.run();
+    });
+
+    it('should not pass if throwing async and test is async', function (done) {
+      var test = new Test('im async and throw undefined async', function (done2) {
+        process.nexTick(function () {
           throw undefined;
-          done2();
         });
       });
       suite.addTest(test);
       runner = new Runner(suite);
-      runner.on('end', function(){
+      runner.on('end', function () {
         expect(runner.failures).to.equal(1);
         expect(test.state).to.equal('failed');
         done();
       });
       runner.run();
-    })
-  })
+    });
+  });
 
-  describe('null', function (){
-    it('should not pass if throwing sync and test is sync', function(done) {
-      var test = new Test('im sync and throw null sync', function(){
+  describe('null', function () {
+    it('should not pass if throwing sync and test is sync', function (done) {
+      var test = new Test('im sync and throw null sync', function () {
         throw null;
       });
       suite.addTest(test);
       runner = new Runner(suite);
-      runner.on('end', function(){
-        expect(runner.failures).to.equal(1);
-        expect(test.state).to.equal('failed');
-        done();
-      });
-      runner.run();
-    })
-
-    it('should not pass if throwing sync and test is async', function(done){
-      var test = new Test('im async and throw null sync', function(done2){
-        throw null;
-        process.nexTick(done2);
-      });
-      suite.addTest(test);
-      runner = new Runner(suite);
-      runner.on('end', function(){
+      runner.on('end', function () {
         expect(runner.failures).to.equal(1);
         expect(test.state).to.equal('failed');
         done();
@@ -88,21 +75,34 @@ describe('a test that throws', function () {
       runner.run();
     });
 
-    it('should not pass if throwing async and test is async', function(done){
-      var test = new Test('im async and throw null async', function(done2){
-        process.nexTick(function(){
-          throw null;
-          done2();
-        });
+    it('should not pass if throwing sync and test is async', function (done) {
+      var test = new Test('im async and throw null sync', function (done2) {
+        throw null;
       });
       suite.addTest(test);
       runner = new Runner(suite);
-      runner.on('end', function(){
+      runner.on('end', function () {
         expect(runner.failures).to.equal(1);
         expect(test.state).to.equal('failed');
         done();
       });
       runner.run();
-    })
-  })
-})
+    });
+
+    it('should not pass if throwing async and test is async', function (done) {
+      var test = new Test('im async and throw null async', function (done2) {
+        process.nexTick(function () {
+          throw null;
+        });
+      });
+      suite.addTest(test);
+      runner = new Runner(suite);
+      runner.on('end', function () {
+        expect(runner.failures).to.equal(1);
+        expect(test.state).to.equal('failed');
+        done();
+      });
+      runner.run();
+    });
+  });
+});

--- a/test/acceptance/timeout.spec.js
+++ b/test/acceptance/timeout.spec.js
@@ -1,79 +1,79 @@
-describe('timeouts', function(){
-  beforeEach(function(done){
+'use strict';
+
+describe('timeouts', function () {
+  beforeEach(function (done) {
     // uncomment
     // setTimeout(done, 3000);
     done();
-  })
+  });
 
-  it('should error on timeout', function(done){
+  it('should error on timeout', function (done) {
     // uncomment
     // setTimeout(done, 3000);
     done();
-  })
+  });
 
-  it('should allow overriding per-test', function(done){
+  it('should allow overriding per-test', function (done) {
     this.timeout(1000);
-    setTimeout(function(){
+    setTimeout(function () {
       done();
     }, 300);
-  })
+  });
 
-  describe('disabling', function(){
-    it('should allow overriding per-test', function(done){
+  describe('disabling', function () {
+    it('should allow overriding per-test', function (done) {
       this.enableTimeouts(false);
       this.timeout(1);
       setTimeout(done, 2);
     });
 
-    it('should work with timeout(0)', function(done) {
+    it('should work with timeout(0)', function (done) {
       this.timeout(0);
       setTimeout(done, 1);
-    })
+    });
 
-    describe('using beforeEach', function() {
+    describe('using beforeEach', function () {
       beforeEach(function () {
         this.timeout(0);
-      })
+      });
 
-      it('should work with timeout(0)', function(done) {
+      it('should work with timeout(0)', function (done) {
         setTimeout(done, 1);
-      })
-    })
+      });
+    });
 
-    describe('using before', function() {
+    describe('using before', function () {
       before(function () {
         this.timeout(0);
-      })
+      });
 
-      it('should work with timeout(0)', function(done) {
+      it('should work with timeout(0)', function (done) {
         setTimeout(done, 1);
-      })
-    })
+      });
+    });
 
-    describe('using enableTimeouts(false)', function() {
+    describe('using enableTimeouts(false)', function () {
       this.timeout(4);
 
-      it('should suppress timeout(4)', function(done) {
+      it('should suppress timeout(4)', function (done) {
         // The test is in the before() call.
         this.enableTimeouts(false);
         setTimeout(done, 50);
-      })
-    })
+      });
+    });
 
-    describe('suite-level', function() {
+    describe('suite-level', function () {
       this.timeout(0);
 
-      it('should work with timeout(0)', function(done) {
+      it('should work with timeout(0)', function (done) {
         setTimeout(done, 1);
-      })
+      });
 
       describe('nested suite', function () {
-        it('should work with timeout(0)', function(done) {
+        it('should work with timeout(0)', function (done) {
           setTimeout(done, 1);
-        })
-
-      })
-    })
+        });
+      });
+    });
   });
-
-})
+});

--- a/test/acceptance/utils.spec.js
+++ b/test/acceptance/utils.spec.js
@@ -1,100 +1,103 @@
+'use strict';
+
 var utils = require('../../lib/utils');
 var toISOString = require('../../lib/to-iso-string');
 var JSON = require('json3');
 
 describe('lib/utils', function () {
   describe('clean', function () {
-    it("should format a single line test function", function () {
+    it('should format a single line test function', function () {
       var fn = [
-        "function () {"
-        , "  var a = 1;"
-        , "}"
-      ].join("\n");
-      expect(utils.clean(fn)).to.equal("var a = 1;");
+        'function () {',
+        '  var a = 1;',
+        '}'
+      ].join('\n');
+      expect(utils.clean(fn)).to.equal('var a = 1;');
     });
 
-    it("should format a multi line test indented with spaces", function () {
+    it('should format a multi line test indented with spaces', function () {
       // and no new lines after curly braces, shouldn't matter
       var fn = [
-        "function(){  var a = 1;"
-        , "    var b = 2;" // this one has more spaces
-        , "  var c = 3;  }"
-      ].join("\n");
-      expect(utils.clean(fn)).to.equal("var a = 1;\n  var b = 2;\nvar c = 3;");
+        'function(){  var a = 1;',
+        // this one has more spaces
+        '    var b = 2;',
+        '  var c = 3;  }'
+      ].join('\n');
+      expect(utils.clean(fn)).to.equal('var a = 1;\n  var b = 2;\nvar c = 3;');
     });
 
-    it("should format a multi line test indented with tabs", function () {
+    it('should format a multi line test indented with tabs', function () {
       var fn = [
-        "function (arg1, arg2)   {"
-        , "\tif (true) {"
-        , "\t\tvar a = 1;"
-        , "\t}"
-        , "}"
-      ].join("\n");
-      expect(utils.clean(fn)).to.equal("if (true) {\n\tvar a = 1;\n}");
+        'function (arg1, arg2)   {',
+        '\tif (true) {',
+        '\t\tvar a = 1;',
+        '\t}',
+        '}'
+      ].join('\n');
+      expect(utils.clean(fn)).to.equal('if (true) {\n\tvar a = 1;\n}');
     });
 
-    it("should format functions saved in windows style - spaces", function () {
+    it('should format functions saved in windows style - spaces', function () {
       var fn = [
-        "function (one) {"
-        , "   do {"
-        , '    "nothing";'
-        , "   } while (false);"
-        , ' }'
-      ].join("\r\n");
+        'function (one) {',
+        '   do {',
+        '    "nothing";',
+        '   } while (false);',
+        ' }'
+      ].join('\r\n');
       expect(utils.clean(fn)).to.equal('do {\n "nothing";\n} while (false);');
     });
 
-    it("should format functions saved in windows style - tabs", function () {
+    it('should format functions saved in windows style - tabs', function () {
       var fn = [
-        "function ( )   {"
-        , "\tif (false) {"
-        , "\t\tvar json = {"
-        , '\t\t\tone : 1'
-        , '\t\t};'
-        , "\t}"
-        , "}"
-      ].join("\r\n");
-      expect(utils.clean(fn)).to.equal("if (false) {\n\tvar json = {\n\t\tone : 1\n\t};\n}");
+        'function ( )   {',
+        '\tif (false) {',
+        '\t\tvar json = {',
+        '\t\t\tone : 1',
+        '\t\t};',
+        '\t}',
+        '}'
+      ].join('\r\n');
+      expect(utils.clean(fn)).to.equal('if (false) {\n\tvar json = {\n\t\tone : 1\n\t};\n}');
     });
 
-    it("should format es6 arrow functions", function () {
+    it('should format es6 arrow functions', function () {
       var fn = [
-        "() => {",
-        "  var a = 1;",
-        "}"
-      ].join("\n");
-      expect(utils.clean(fn)).to.equal("var a = 1;");
+        '() => {',
+        '  var a = 1;',
+        '}'
+      ].join('\n');
+      expect(utils.clean(fn)).to.equal('var a = 1;');
     });
 
-    it("should format es6 arrow functions with implicit return", function () {
-      var fn = "() => foo()";
-      expect(utils.clean(fn)).to.equal("foo()");
+    it('should format es6 arrow functions with implicit return', function () {
+      var fn = '() => foo()';
+      expect(utils.clean(fn)).to.equal('foo()');
     });
   });
 
-  describe('stringify', function(){
-
+  describe('stringify', function () {
     var stringify = utils.stringify;
 
-    it('should return an object representation of a string created with a String constructor', function() {
+    it('should return an object representation of a string created with a String constructor', function () {
+      /* eslint no-new-wrappers: off */
       expect(stringify(new String('foo'))).to.equal('{\n  "0": "f"\n  "1": "o"\n  "2": "o"\n}');
     });
 
-    it('should return Buffer with .toJSON representation', function() {
+    it('should return Buffer with .toJSON representation', function () {
       expect(stringify(new Buffer([0x01]))).to.equal('[\n  1\n]');
       expect(stringify(new Buffer([0x01, 0x02]))).to.equal('[\n  1\n  2\n]');
 
       expect(stringify(new Buffer('ABCD'))).to.equal('[\n  65\n  66\n  67\n  68\n]');
     });
 
-    it('should return Date object with .toISOString() + string prefix', function() {
+    it('should return Date object with .toISOString() + string prefix', function () {
       expect(stringify(new Date(0))).to.equal('[Date: ' + shimToISOString(new Date(0)) + ']');
 
       var date = new Date(); // now
       expect(stringify(date)).to.equal('[Date: ' + shimToISOString(date) + ']');
 
-      function shimToISOString(date) {
+      function shimToISOString (date) {
         if (date.toISOString) {
           return date.toISOString();
         } else {
@@ -103,32 +106,32 @@ describe('lib/utils', function () {
       }
     });
 
-    it('should return invalid Date object with .toString() + string prefix', function() {
+    it('should return invalid Date object with .toString() + string prefix', function () {
       expect(stringify(new Date(''))).to.equal('[Date: ' + new Date('').toString() + ']');
     });
 
-    describe('#Number', function() {
-      it('should show the handle -0 situations', function() {
+    describe('#Number', function () {
+      it('should show the handle -0 situations', function () {
         expect(stringify(-0)).to.eql('-0');
         expect(stringify(0)).to.eql('0');
         expect(stringify('-0')).to.eql('"-0"');
       });
 
-      it('should work well with `NaN` and `Infinity`', function() {
+      it('should work well with `NaN` and `Infinity`', function () {
         expect(stringify(NaN)).to.equal('NaN');
         expect(stringify(Infinity)).to.equal('Infinity');
         expect(stringify(-Infinity)).to.equal('-Infinity');
       });
 
-      it('floats and ints', function() {
+      it('floats and ints', function () {
         expect(stringify(1)).to.equal('1');
         expect(stringify(1.2)).to.equal('1.2');
         expect(stringify(1e9)).to.equal('1000000000');
       });
     });
 
-    describe('canonicalize example', function() {
-      it('should represent the actual full result', function() {
+    describe('canonicalize example', function () {
+      it('should represent the actual full result', function () {
         var expected = {
           str: 'string',
           int: 90,
@@ -138,148 +141,155 @@ describe('lib/utils', function () {
           undef: undefined,
           regex: /^[a-z|A-Z]/,
           date: new Date(0),
-          func: function() {},
+          func: function () {},
           infi: Infinity,
           nan: NaN,
           zero: -0,
           buffer: new Buffer([0x01, 0x02]),
-          array: [1,2,3],
+          array: [1, 2, 3],
           empArr: [],
-          matrix: [[1], [2,3,4] ],
+          matrix: [[1],
+            [
+              2,
+              3,
+              4
+            ]
+          ],
           object: { a: 1, b: 2 },
           canObj: { a: { b: 1, c: 2 }, b: {} },
           empObj: {}
         };
         expected.circular = expected; // Make `Circular` situation
-        var actual = ['{'
-          , '  "array": ['
-          , '    1'
-          , '    2'
-          , '    3'
-          , '  ]'
-          , '  "boolean": false'
-          , '  "buffer": [Buffer: ['
-          , '    1'
-          , '    2'
-          , '  ]]'
-          , '  "canObj": {'
-          , '    "a": {'
-          , '      "b": 1'
-          , '      "c": 2'
-          , '    }'
-          , '    "b": {}'
-          , '  }'
-          , '  "circular": [Circular]'
-          , '  "date": [Date: 1970-01-01T00:00:00.000Z]'
-          , '  "empArr": []'
-          , '  "empObj": {}'
-          , '  "float": 9.99'
-          , '  "func": [Function]'
-          , '  "infi": Infinity'
-          , '  "int": 90'
-          , '  "matrix": ['
-          , '    ['
-          , '      1'
-          , '    ]'
-          , '    ['
-          , '      2'
-          , '      3'
-          , '      4'
-          , '    ]'
-          , '  ]'
-          , '  "nan": NaN'
-          , '  "nil": [null]'
-          , '  "object": {'
-          , '    "a": 1'
-          , '    "b": 2'
-          , '  }'
-          , '  "regex": /^[a-z|A-Z]/'
-          , '  "str": "string"'
-          , '  "undef": [undefined]'
-          , '  "zero": -0'
-          , '}'].join('\n');
+        var actual = [
+          '{',
+          '  "array": [',
+          '    1',
+          '    2',
+          '    3',
+          '  ]',
+          '  "boolean": false',
+          '  "buffer": [Buffer: [',
+          '    1',
+          '    2',
+          '  ]]',
+          '  "canObj": {',
+          '    "a": {',
+          '      "b": 1',
+          '      "c": 2',
+          '    }',
+          '    "b": {}',
+          '  }',
+          '  "circular": [Circular]',
+          '  "date": [Date: 1970-01-01T00:00:00.000Z]',
+          '  "empArr": []',
+          '  "empObj": {}',
+          '  "float": 9.99',
+          '  "func": [Function]',
+          '  "infi": Infinity',
+          '  "int": 90',
+          '  "matrix": [',
+          '    [',
+          '      1',
+          '    ]',
+          '    [',
+          '      2',
+          '      3',
+          '      4',
+          '    ]',
+          '  ]',
+          '  "nan": NaN',
+          '  "nil": [null]',
+          '  "object": {',
+          '    "a": 1',
+          '    "b": 2',
+          '  }',
+          '  "regex": /^[a-z|A-Z]/',
+          '  "str": "string"',
+          '  "undef": [undefined]',
+          '  "zero": -0',
+          '}'
+        ].join('\n');
         expect(stringify(expected)).to.equal(actual);
       });
     });
 
-    it('should canonicalize the object', function(){
+    it('should canonicalize the object', function () {
       var travis = { name: 'travis', age: 24 };
       var travis2 = { age: 24, name: 'travis' };
 
       expect(stringify(travis)).to.equal(stringify(travis2));
     });
 
-    it('should handle circular structures in objects', function(){
+    it('should handle circular structures in objects', function () {
       var travis = { name: 'travis' };
       travis.whoami = travis;
 
       expect(stringify(travis)).to.equal('{\n  "name": "travis"\n  "whoami": [Circular]\n}');
     });
 
-    it('should handle circular structures in arrays', function(){
+    it('should handle circular structures in arrays', function () {
       var travis = ['travis'];
       travis.push(travis);
 
       expect(stringify(travis)).to.equal('[\n  "travis"\n  [Circular]\n]');
     });
 
-    it('should handle circular structures in functions', function(){
+    it('should handle circular structures in functions', function () {
       var travis = function () {};
       travis.fn = travis;
 
       expect(stringify(travis)).to.equal('{\n  "fn": [Circular]\n}');
     });
 
-
     it('should handle various non-undefined, non-null, non-object, non-array, non-date, and non-function values', function () {
-      var regexp = new RegExp("(?:)"),
-        regExpObj = { regexp: regexp },
-        regexpString = '/(?:)/';
+      var regexp = new RegExp('(?:)');
+      var regExpObj = {regexp: regexp};
+      var regexpString = '/(?:)/';
 
       expect(stringify(regExpObj)).to.equal('{\n  "regexp": ' + regexpString + '\n}');
       expect(stringify(regexp)).to.equal(regexpString);
 
-      var number = 1,
-        numberObj = { number: number },
-        numberString = '1';
+      var number = 1;
+      var numberObj = {number: number};
+      var numberString = '1';
 
       expect(stringify(numberObj)).to.equal('{\n  "number": ' + number + '\n}');
       expect(stringify(number)).to.equal(numberString);
 
-      var boolean = false,
-        booleanObj = { boolean: boolean },
-        booleanString = 'false';
+      var boolean = false;
+      var booleanObj = {boolean: boolean};
+      var booleanString = 'false';
 
       expect(stringify(booleanObj)).to.equal('{\n  "boolean": ' + boolean + '\n}');
       expect(stringify(boolean)).to.equal(booleanString);
 
-      var string = 'sneepy',
-        stringObj = { string: string };
+      var string = 'sneepy';
+      var stringObj = {string: string};
 
       expect(stringify(stringObj)).to.equal('{\n  "string": "' + string + '"\n}');
       expect(stringify(string)).to.equal(JSON.stringify(string));
 
-      var nullValue = null,
-        nullObj = { 'null': null },
-        nullString = '[null]';
+      var nullValue = null;
+      var nullObj = {'null': null};
+      var nullString = '[null]';
 
       expect(stringify(nullObj)).to.equal('{\n  "null": [null]\n}');
       expect(stringify(nullValue)).to.equal(nullString);
     });
 
     it('should handle arrays', function () {
-      var array = ['dave', 'dave', 'dave', 'dave'],
-        arrayObj = {array: array},
-        arrayString = '    "dave"\n    "dave"\n    "dave"\n    "dave"'
+      var array = ['dave', 'dave', 'dave', 'dave'];
+      var arrayObj = {array: array};
+      var arrayString = '    "dave"\n    "dave"\n    "dave"\n    "dave"';
 
       expect(stringify(arrayObj)).to.equal('{\n  "array": [\n' + arrayString + '\n  ]\n}');
       expect(stringify(array)).to.equal('[' + arrayString.replace(/\s+/g, '\n  ') + '\n]');
     });
 
     it('should handle functions', function () {
-      var fn = function() {},
-        fnObj = {fn: fn},
-        fnString = '[Function]';
+      var fn = function () {};
+      var fnObj = {fn: fn};
+      var fnString = '[Function]';
 
       expect(stringify(fnObj)).to.equal('{\n  "fn": ' + fnString + '\n}');
       expect(stringify(fn)).to.equal('[Function]');
@@ -296,17 +306,17 @@ describe('lib/utils', function () {
     });
 
     it('should handle non-empty arrays', function () {
-      expect(stringify(['a', 'b', 'c'])).to.equal('[\n  "a"\n  "b"\n  "c"\n]')
+      expect(stringify(['a', 'b', 'c'])).to.equal('[\n  "a"\n  "b"\n  "c"\n]');
     });
 
     it('should handle empty functions (with no properties)', function () {
-      expect(stringify(function(){})).to.equal('[Function]');
-      expect(stringify({foo: function() {}})).to.equal('{\n  "foo": [Function]\n}');
-      expect(stringify({foo: function() {}, bar: 'baz'})).to.equal('{\n  "bar": "baz"\n  "foo": [Function]\n}');
+      expect(stringify(function () {})).to.equal('[Function]');
+      expect(stringify({foo: function () {}})).to.equal('{\n  "foo": [Function]\n}');
+      expect(stringify({foo: function () {}, bar: 'baz'})).to.equal('{\n  "bar": "baz"\n  "foo": [Function]\n}');
     });
 
     it('should handle functions w/ properties', function () {
-      var fn = function(){};
+      var fn = function () {};
       fn.bar = 'baz';
       expect(stringify(fn)).to.equal('{\n  "bar": "baz"\n}');
       expect(stringify({foo: fn})).to.equal('{\n  "foo": {\n    "bar": "baz"\n  }\n}');
@@ -354,23 +364,25 @@ describe('lib/utils', function () {
       it('should handle Symbol', function () {
         var symbol = Symbol('value');
         expect(stringify(symbol)).to.equal('Symbol(value)');
-        expect(stringify({symbol: symbol})).to.equal('{\n  "symbol": Symbol(value)\n}')
+        expect(stringify({symbol: symbol})).to.equal('{\n  "symbol": Symbol(value)\n}');
       });
     }
 
     it('should handle length properties that cannot be coerced to a number', function () {
       expect(stringify({length: {nonBuiltinProperty: 0}})).to.equal('{\n  "length": {\n    "nonBuiltinProperty": 0\n  }\n}');
-      expect(stringify({length: "a string where length should be"})).to.equal('{\n  "length": "a string where length should be"\n}');
+      expect(stringify({length: 'a string where length should be'})).to.equal('{\n  "length": "a string where length should be"\n}');
     });
   });
 
   describe('type', function () {
+    /* eslint no-extend-native: off */
+
     var type = utils.type;
     var toString = Object.prototype.toString;
 
-    beforeEach(function() {
+    beforeEach(function () {
       // some JS engines such as PhantomJS 1.x exhibit this behavior
-      Object.prototype.toString = function() {
+      Object.prototype.toString = function () {
         if (this === global) {
           return '[object DOMWindow]';
         }

--- a/test/browser-fixtures/bdd.fixture.js
+++ b/test/browser-fixtures/bdd.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env browser */
 
 window.mocha.timeout(200)

--- a/test/browser-fixtures/exports.fixture.js
+++ b/test/browser-fixtures/exports.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env browser */
 
 window.mocha.timeout(200)

--- a/test/browser-fixtures/qunit.fixture.js
+++ b/test/browser-fixtures/qunit.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env browser */
 
 window.mocha.timeout(200)

--- a/test/browser-fixtures/tdd.fixture.js
+++ b/test/browser-fixtures/tdd.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env browser */
 
 window.mocha.timeout(200)

--- a/test/browser/array.spec.js
+++ b/test/browser/array.spec.js
@@ -1,38 +1,39 @@
-describe('Array', function(){
-  describe('#push()', function(){
-    it('should append a value', function(){
-      foo = 'asdf'
+'use strict';
+
+describe('Array', function () {
+  describe('#push()', function () {
+    it('should append a value', function () {
       var arr = [];
       arr.push('foo');
       arr.push('bar');
       arr.push('baz');
-        assert('foo' == arr[0]); // to test indentation
-        assert('bar' == arr[1]);
-      assert('baz' == arr[2]);
-    })
+      assert(arr[0] === 'foo'); // to test indentation
+      assert(arr[1] === 'bar');
+      assert(arr[2] === 'baz');
+    });
 
-    it('should return the length', function(){
+    it('should return the length', function () {
       var arr = [];
-      assert(1 == arr.push('foo'));
-      assert(2 == arr.push('bar'));
-      assert(3 == arr.push('baz'));
-    })
-  })
-})
+      assert(arr.push('foo') === 1);
+      assert(arr.push('bar') === 2);
+      assert(arr.push('baz') === 3);
+    });
+  });
+});
 
-describe('Array', function(){
-  describe('#pop()', function(){
-    it('should remove and return the last value', function(){
-      var arr = [1,2,3];
-      assert(arr.pop() == 3);
-      assert(arr.pop() == 2);
-      assert(arr.pop() == -1);
-    })
+describe('Array', function () {
+  describe('#pop()', function () {
+    it('should remove and return the last value', function () {
+      var arr = [1, 2, 3];
+      assert(arr.pop() === 3);
+      assert(arr.pop() === 2);
+      assert(arr.pop() === -1);
+    });
 
-    it('should adjust .length', function(){
-      var arr = [1,2,3];
+    it('should adjust .length', function () {
+      var arr = [1, 2, 3];
       arr.pop();
-      assert(arr.length == 2);
-    })
-  })
-})
+      assert(arr.length === 2);
+    });
+  });
+});

--- a/test/browser/grep.spec.js
+++ b/test/browser/grep.spec.js
@@ -1,108 +1,110 @@
+'use strict';
+
 // numbers
-describe('21', function() {
-  it('1', function() {
+describe('21', function () {
+  it('1', function () {
     assert(true);
   });
-  it('2', function() {
+  it('2', function () {
     assert(true);
   });
 });
 // symbols
-describe('@Array', function() {
-  it('.pop()', function() {
+describe('@Array', function () {
+  it('.pop()', function () {
     assert(true);
   });
-  it('.push()', function() {
+  it('.push()', function () {
     assert(true);
   });
-  it('.length', function() {
-    assert(true);
-  });
-});
-
-describe('@Function', function() {
-  it('.call()', function() {
-    assert(true);
-  });
-  it('.apply()', function() {
-    assert(true);
-  });
-  it('.length', function() {
-    assert(true);
-  });
-  it('.name', function() {
-    assert(true);
-  });
-  it('.prototype', function() {
+  it('.length', function () {
     assert(true);
   });
 });
 
-//url with hashtags
-describe('#Services',function() {
-  describe('#http', function() {
-    it('.createClient()', function() {
+describe('@Function', function () {
+  it('.call()', function () {
+    assert(true);
+  });
+  it('.apply()', function () {
+    assert(true);
+  });
+  it('.length', function () {
+    assert(true);
+  });
+  it('.name', function () {
+    assert(true);
+  });
+  it('.prototype', function () {
+    assert(true);
+  });
+});
+
+// url with hashtags
+describe('#Services', function () {
+  describe('#http', function () {
+    it('.createClient()', function () {
       assert(true);
     });
-    it('.Server()', function() {
+    it('.Server()', function () {
       assert(true);
     });
   });
-  describe('#crypto', function() {
-    it('.randomBytes()', function() {
+  describe('#crypto', function () {
+    it('.randomBytes()', function () {
       assert(true);
     });
-    it('.Hmac()', function() {
+    it('.Hmac()', function () {
       assert(true);
     });
   });
 });
 
 // Uppercase
-describe('CONSTANTS', function() {
-  it('.STATUS_CODES', function() {
+describe('CONSTANTS', function () {
+  it('.STATUS_CODES', function () {
     assert(true);
   });
 });
 
 // Dates
-describe('Date:', function() {
-  it('01/02/2015', function() {
+describe('Date:', function () {
+  it('01/02/2015', function () {
     assert(true);
   });
-  it('01/03/2015', function() {
+  it('01/03/2015', function () {
     assert(true);
   });
-  it('01/06/2015', function() {
+  it('01/06/2015', function () {
     assert(true);
   });
 });
 
 // etc..
-describe('booking/summary', function() {
-  it('should be run last', function() {
+describe('booking/summary', function () {
+  it('should be run last', function () {
     assert(true);
   });
 });
 
-describe('component/booking/summary', function() {
-  it('should be run second', function() {
+describe('component/booking/summary', function () {
+  it('should be run second', function () {
     assert(true);
   });
 });
 
-describe('component/booking/intro', function() {
-  it('should be run first', function() {
+describe('component/booking/intro', function () {
+  it('should be run first', function () {
     assert(true);
   });
 });
 
-describe('contains numbers', function() {
-  it('should run if the number 92 matching', function() {
+describe('contains numbers', function () {
+  it('should run if the number 92 matching', function () {
     assert(true);
   });
 
-  it('should run if the number 8 matching', function() {
+  it('should run if the number 8 matching', function () {
     assert(true);
   });
 });

--- a/test/browser/large.spec.js
+++ b/test/browser/large.spec.js
@@ -1,37 +1,38 @@
+'use strict';
+
 var n = 30;
 while (n--) {
-  describe('Array ' + n, function(){
+  describe('Array ' + n, function () {
     var arr;
 
-    beforeEach(function(){
-      arr = [1,2,3];
-    })
+    beforeEach(function () {
+      arr = [1, 2, 3];
+    });
 
-    describe('#indexOf()', function(){
-      it('should return -1 when the value is not present', function(){
-        assert(-1 == arr.indexOf(5));
-      })
+    describe('#indexOf()', function () {
+      it('should return -1 when the value is not present', function () {
+        assert(arr.indexOf(5) === -1);
+      });
 
-      it('should return the correct index when the value is present', function(done){
-        assert(0 == arr.indexOf(1));
-        assert(1 == arr.indexOf(2));
+      it('should return the correct index when the value is present', function (done) {
+        assert(arr.indexOf(1) === 0);
+        assert(arr.indexOf(2) === 1);
         done();
-      })
-    })
-  })
+      });
+    });
+  });
 }
 
-describe('something', function(){
-  it('should provide a useful error', function(done){
-    setTimeout(function(){
+describe('something', function () {
+  it('should provide a useful error', function (done) {
+    setTimeout(function () {
       throw new Error('boom');
-      done();
     }, 1);
-  })
+  });
 
-  it('should provide an even better error on phantomjs', function(done){
-    setTimeout(function(){
-      var AssertionError = function(message, actual, expected) {
+  it('should provide an even better error on phantomjs', function (done) {
+    setTimeout(function () {
+      var AssertionError = function (message, actual, expected) {
         this.message = message;
         this.actual = actual;
         this.expected = expected;
@@ -44,5 +45,5 @@ describe('something', function(){
       mocha.throwError(new AssertionError('kabooom', 'text with a typo', 'text without a typo'));
       done();
     }, 1);
-  })
-})
+  });
+});

--- a/test/browser/multiple-done.spec.js
+++ b/test/browser/multiple-done.spec.js
@@ -1,16 +1,18 @@
-describe('Multiple Done calls', function(){
-  it('should report an error if done was called more than once', function(done){
+'use strict';
+
+describe('Multiple Done calls', function () {
+  it('should report an error if done was called more than once', function (done) {
     done();
     done();
-  })
+  });
 
   it('should report an error if an exception happened async after done was called', function (done) {
     done();
     setTimeout(done, 50);
-  })
+  });
 
-  it('should report an error if an exception happened after done was called', function(done){
+  it('should report an error if an exception happened after done was called', function (done) {
     done();
-    throw new Error("thrown error");
-  })
-})
+    throw new Error('thrown error');
+  });
+});

--- a/test/browser/opts.spec.js
+++ b/test/browser/opts.spec.js
@@ -1,5 +1,7 @@
-describe('Options', function() {
-  it('should set timeout value', function() {
+'use strict';
+
+describe('Options', function () {
+  it('should set timeout value', function () {
     assert(this.test._timeout === 1500);
   });
-})
+});

--- a/test/browser/stack-trace.spec.js
+++ b/test/browser/stack-trace.spec.js
@@ -1,20 +1,22 @@
 'use strict';
-describe('Stack trace', function() {
-  it('should prettify the stack-trace', function() {
+describe('Stack trace', function () {
+  it('should prettify the stack-trace', function () {
     var err = new Error();
     // We do this fake stack-trace because we under development,
     // and our root isn't `node_modules`, `bower` or `components`
-    err.stack = ['Error: failed'
-      , 'at assert (stack-trace.html:11:30)'
-      , 'at Context.<anonymous> (stack-trace.js:5:5)'
-      , 'at callFn (http://localhost:63342/node_modules/mocha.js:4546:21)'
-      , 'at Test.require.register.Runnable.run (http://localhost:63342/node_modules/mocha.js:4539:7)'
-      , 'at Runner.require.register.Runner.runTest (http://localhost:63342/node_modules/mocha.js:4958:10)'
-      , 'at http://localhost:63342/bower_components/mocha.js:5041:12'
-      , 'at next (http://localhost:63342/bower_components/mocha.js:4883:14)'
-      , 'at http://localhost:63342/bower_components/mocha.js:4893:7'
-      , 'at next (http://localhost:63342/bower_components/mocha.js:4828:23)'
-      , 'at http://localhost:63342/bower_components/mocha.js:4860:5'].join('\n');
+    err.stack = [
+      'Error: failed',
+      'at assert (stack-trace.html:11:30)',
+      'at Context.<anonymous> (stack-trace.js:5:5)',
+      'at callFn (http://localhost:63342/node_modules/mocha.js:4546:21)',
+      'at Test.require.register.Runnable.run (http://localhost:63342/node_modules/mocha.js:4539:7)',
+      'at Runner.require.register.Runner.runTest (http://localhost:63342/node_modules/mocha.js:4958:10)',
+      'at http://localhost:63342/bower_components/mocha.js:5041:12',
+      'at next (http://localhost:63342/bower_components/mocha.js:4883:14)',
+      'at http://localhost:63342/bower_components/mocha.js:4893:7',
+      'at next (http://localhost:63342/bower_components/mocha.js:4828:23)',
+      'at http://localhost:63342/bower_components/mocha.js:4860:5'
+    ].join('\n');
     assert(false, err);
   });
 });

--- a/test/browser/ui.spec.js
+++ b/test/browser/ui.spec.js
@@ -1,10 +1,12 @@
+'use strict';
+
 // test titles containing regex-conflicting characters
 
 // leading $
-describe('$.jQuery', function() {
+describe('$.jQuery', function () {
   // parens
   describe('.on()', function () {
-    it('should set an event', function() {
+    it('should set an event', function () {
       assert(true);
     });
   });
@@ -18,14 +20,14 @@ describe('$.jQuery', function() {
 
 // another generic describe block to verify it is absent
 // when greeping on $.jQuery
-describe('@Array', function() {
-  it('.pop()', function() {
+describe('@Array', function () {
+  it('.pop()', function () {
     assert(true);
   });
-  it('.push()', function() {
+  it('.push()', function () {
     assert(true);
   });
-  it('.length', function() {
+  it('.length', function () {
     assert(true);
   });
 });

--- a/test/color.spec.js
+++ b/test/color.spec.js
@@ -1,13 +1,15 @@
+'use strict';
+
 var assert = require('assert');
-var child_process = require('child_process');
+var childProcess = require('child_process');
 var path = require('path');
 
-describe('Mocha', function() {
+describe('Mocha', function () {
   this.timeout(2000);
 
-  it('should not output colors to pipe', function(cb) {
+  it('should not output colors to pipe', function (cb) {
     var command = [path.join('bin', 'mocha'), '--grep', 'missing-test'];
-    child_process.execFile(process.execPath, command, function(err, stdout, stderr) {
+    childProcess.execFile(process.execPath, command, function (err, stdout, stderr) {
       if (err) return cb(err);
 
       assert(stdout.indexOf('[90m') === -1);

--- a/test/compiler/foo.js
+++ b/test/compiler/foo.js
@@ -1,8 +1,10 @@
+'use strict';
+
 var fs = require('fs');
-require.extensions['.foo'] = function(module, filename) {
+require.extensions['.foo'] = function (module, filename) {
   var content;
   content = fs.readFileSync(filename, 'utf8');
-  var test = 'describe("custom compiler",function(){ it("should work",function() { '
-    + content + '.should.eql(1); }); });';
+  var test = 'describe("custom compiler",function(){ it("should work",function() { ' +
+    content + '.should.eql(1); }); });';
   return module._compile(test, filename);
 };

--- a/test/fixture-expect.js
+++ b/test/fixture-expect.js
@@ -1,1 +1,0 @@
-global.expect = require("expect.js")

--- a/test/grep.spec.js
+++ b/test/grep.spec.js
@@ -1,48 +1,50 @@
+'use strict';
+
 var Mocha = require('../');
 
-describe('Mocha', function(){
-  describe('"grep" option', function(){
-    it('should add a RegExp to the mocha.options object', function(){
+describe('Mocha', function () {
+  describe('"grep" option', function () {
+    it('should add a RegExp to the mocha.options object', function () {
       var mocha = new Mocha({ grep: /foo.*/ });
       mocha.options.grep.toString().should.equal('/foo.*/');
     });
 
-    it('should convert string to a RegExp', function(){
+    it('should convert string to a RegExp', function () {
       var mocha = new Mocha({ grep: 'foo.*' });
       mocha.options.grep.toString().should.equal('/foo.*/');
     });
   });
 
-  describe('"fgrep" option', function(){
-    it('should escape and convert string to a RegExp', function(){
+  describe('"fgrep" option', function () {
+    it('should escape and convert string to a RegExp', function () {
       var mocha = new Mocha({ fgrep: 'foo.*' });
       mocha.options.grep.toString().should.equal('/foo\\.\\*/');
     });
   });
 
-  describe('.grep()', function() {
+  describe('.grep()', function () {
     // Test helper
-    function testGrep(mocha) {
-      return function testGrep(grep, expected) {
+    function testGrep (mocha) {
+      return function testGrep (grep, expected) {
         mocha.grep(grep);
         mocha.options.grep.toString().should.equal(expected);
-      }
+      };
     }
 
-    it('should add a RegExp to the mocha.options object', function() {
-      var test = testGrep(new Mocha);
+    it('should add a RegExp to the mocha.options object', function () {
+      var test = testGrep(new Mocha());
       test(/foo/, '/foo/');
     });
 
-    it('should convert grep string to a RegExp', function() {
-      var test = testGrep(new Mocha);
+    it('should convert grep string to a RegExp', function () {
+      var test = testGrep(new Mocha());
       test('foo', '/foo/');
       test('^foo.*bar$', '/^foo.*bar$/');
       test('^@.*(?=\\(\\)$)', '/^@.*(?=\\(\\)$)/');
     });
 
-    it('should covert grep regex-like string to a RegExp', function() {
-      var test = testGrep(new Mocha);
+    it('should covert grep regex-like string to a RegExp', function () {
+      var test = testGrep(new Mocha());
       test('/foo/', '/foo/');
       // Keep the flags
       test('/baz/i', '/baz/i');
@@ -50,14 +52,14 @@ describe('Mocha', function(){
       test('/^foo(.*)bar/g', '/^foo(.*)bar/g');
     });
 
-    it('should return it\'s parent Mocha object for chainability', function(){
-      var mocha = new Mocha;
+    it('should return it\'s parent Mocha object for chainability', function () {
+      var mocha = new Mocha();
       mocha.grep().should.equal(mocha);
     });
   });
 
-  describe('"invert" option', function(){
-    it('should add a Boolean to the mocha.options object', function(){
+  describe('"invert" option', function () {
+    it('should add a Boolean to the mocha.options object', function () {
       var mocha = new Mocha({ invert: true });
       mocha.options.invert.should.be.ok;
     });

--- a/test/hook-async.spec.js
+++ b/test/hook-async.spec.js
@@ -1,129 +1,135 @@
-describe('async', function(){
+'use strict';
+
+describe('async', function () {
   var calls = [];
 
-  before(function(){
+  before(function () {
     calls.push('root before all');
-  })
+  });
 
-  after(function(){
+  after(function () {
     calls.push('root after all');
     calls.should.eql([
-        'root before all'
-      , 'before all'
-      , 'parent before'
-      , 'before'
-      , 'before test one'
-      , 'one'
-      , 'after'
-      , 'after test one passed'
-      , 'parent after'
-      , 'parent before'
-      , 'before'
-      , 'before test two'
-      , 'two'
-      , 'after'
-      , 'after test two passed'
-      , 'parent after'
-      , 'parent before'
-      , 'before'
-      , 'before test three'
-      , 'three'
-      , 'after'
-      , 'after test three passed'
-      , 'parent after'
-      , 'after all'
-      , 'root after all']);
-  })
+      'root before all',
+      'before all',
+      'parent before',
+      'before',
+      'before test one',
+      'one',
+      'after',
+      'after test one passed',
+      'parent after',
+      'parent before',
+      'before',
+      'before test two',
+      'two',
+      'after',
+      'after test two passed',
+      'parent after',
+      'parent before',
+      'before',
+      'before test three',
+      'three',
+      'after',
+      'after test three passed',
+      'parent after',
+      'after all',
+      'root after all'
+    ]);
+  });
 
-  beforeEach(function(){
+  beforeEach(function () {
     calls.push('parent before');
-  })
+  });
 
-  afterEach(function(){
-    calls.push('parent after' );
-  })
+  afterEach(function () {
+    calls.push('parent after');
+  });
 
-  describe('hooks', function(){
-    before(function(){
+  describe('hooks', function () {
+    before(function () {
       calls.push('before all');
     });
 
-    after(function(){
+    after(function () {
       calls.push('after all');
     });
 
-    beforeEach(function(done){
+    beforeEach(function (done) {
       var ctx = this;
-      process.nextTick(function(){
+      process.nextTick(function () {
         calls.push('before');
         if (ctx.currentTest) {
           calls.push('before test ' + ctx.currentTest.title);
         }
         done();
-      })
-    })
+      });
+    });
 
-    it('one', function(done){
+    it('one', function (done) {
       calls.should.eql([
-          'root before all'
-        , 'before all'
-        , 'parent before'
-        , 'before'
-        , 'before test one']);
+        'root before all',
+        'before all',
+        'parent before',
+        'before',
+        'before test one'
+      ]);
       calls.push('one');
       process.nextTick(done);
-    })
+    });
 
-    it('two', function(){
+    it('two', function () {
       calls.should.eql([
-          'root before all'
-        , 'before all'
-        , 'parent before'
-        , 'before'
-        , 'before test one'
-        , 'one'
-        , 'after'
-        , 'after test one passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test two']);
+        'root before all',
+        'before all',
+        'parent before',
+        'before',
+        'before test one',
+        'one',
+        'after',
+        'after test one passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test two'
+      ]);
       calls.push('two');
-    })
+    });
 
-    it('three', function(){
+    it('three', function () {
       calls.should.eql([
-          'root before all'
-        , 'before all'
-        , 'parent before'
-        , 'before'
-        , 'before test one'
-        , 'one'
-        , 'after'
-        , 'after test one passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test two'
-        , 'two'
-        , 'after'
-        , 'after test two passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test three']);
+        'root before all',
+        'before all',
+        'parent before',
+        'before',
+        'before test one',
+        'one',
+        'after',
+        'after test one passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test two',
+        'two',
+        'after',
+        'after test two passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test three'
+      ]);
       calls.push('three');
-    })
+    });
 
-    afterEach(function(done){
+    afterEach(function (done) {
       var ctx = this;
-      process.nextTick(function(){
+      process.nextTick(function () {
         calls.push('after');
         if (ctx.currentTest) {
           calls.push('after test ' + ctx.currentTest.title + ' ' + ctx.currentTest.state);
         }
         done();
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});

--- a/test/hook-sync-nested.spec.js
+++ b/test/hook-sync-nested.spec.js
@@ -1,98 +1,104 @@
-describe('serial', function(){
-  describe('nested', function(){
+'use strict';
+
+describe('serial', function () {
+  describe('nested', function () {
     var calls = [];
 
-    beforeEach(function(){
+    beforeEach(function () {
       calls.push('parent before');
       if (this.currentTest) {
         calls.push('parent before test ' + this.currentTest.title);
       }
-    })
+    });
 
-    afterEach(function(){
+    afterEach(function () {
       calls.push('parent after');
       if (this.currentTest) {
         calls.push('parent after test ' + this.currentTest.title + ' ' + this.currentTest.state);
       }
     });
 
-    it('foo', function(){
+    it('foo', function () {
       calls.should.eql([
-          'parent before'
-        , 'parent before test foo']);
+        'parent before',
+        'parent before test foo'
+      ]);
       calls.push('foo');
-    })
+    });
 
-    it('bar', function(){
+    it('bar', function () {
       calls.should.eql([
-          'parent before'
-        , 'parent before test foo'
-        , 'foo'
-        , 'parent after'
-        , 'parent after test foo passed'
-        , 'parent before'
-        , 'parent before test bar']);
-    })
+        'parent before',
+        'parent before test foo',
+        'foo',
+        'parent after',
+        'parent after test foo passed',
+        'parent before',
+        'parent before test bar'
+      ]);
+    });
 
-    describe('hooks', function(){
-      beforeEach(function(){
+    describe('hooks', function () {
+      beforeEach(function () {
         calls.push('before');
         if (this.currentTest) {
           calls.push('before test ' + this.currentTest.title);
         }
-      })
+      });
 
-      it('one', function(){
+      it('one', function () {
         calls.should.eql([
-            'parent before'
-          , 'parent before test foo'
-          , 'foo'
-          , 'parent after'
-          , 'parent after test foo passed'
-          , 'parent before'
-          , 'parent before test bar'
-          , 'parent after'
-          , 'parent after test bar passed'
-          , 'parent before'
-          , 'parent before test one'
-          , 'before'
-          , 'before test one']);
+          'parent before',
+          'parent before test foo',
+          'foo',
+          'parent after',
+          'parent after test foo passed',
+          'parent before',
+          'parent before test bar',
+          'parent after',
+          'parent after test bar passed',
+          'parent before',
+          'parent before test one',
+          'before',
+          'before test one'
+        ]);
         calls.push('one');
-      })
+      });
 
-      it('two', function(){
+      it('two', function () {
         calls.should.eql([
-            'parent before'
-          , 'parent before test foo'
-          , 'foo'
-          , 'parent after'
-          , 'parent after test foo passed'
-          , 'parent before'
-          , 'parent before test bar'
-          , 'parent after'
-          , 'parent after test bar passed'
-          , 'parent before'
-          , 'parent before test one'
-          , 'before'
-          , 'before test one'
-          , 'one'
-          , 'after'
-          , 'after test one passed'
-          , 'parent after'
-          , 'parent after test one passed'
-          , 'parent before'
-          , 'parent before test two'
-          , 'before'
-          , 'before test two']);
+          'parent before',
+          'parent before test foo',
+          'foo',
+          'parent after',
+          'parent after test foo passed',
+          'parent before',
+          'parent before test bar',
+          'parent after',
+          'parent after test bar passed',
+          'parent before',
+          'parent before test one',
+          'before',
+          'before test one',
+          'one',
+          'after',
+          'after test one passed',
+          'parent after',
+          'parent after test one passed',
+          'parent before',
+          'parent before test two',
+          'before',
+          'before test two'
+        ]);
         calls.push('two');
       });
 
-      afterEach(function(){
+      afterEach(function () {
         calls.push('after');
         if (this.currentTest) {
           calls.push('after test ' + this.currentTest.title + ' ' + this.currentTest.state);
         }
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});

--- a/test/hook-sync.spec.js
+++ b/test/hook-sync.spec.js
@@ -1,97 +1,103 @@
-describe('serial', function(){
+'use strict';
+
+describe('serial', function () {
   var calls = [];
 
-  beforeEach(function(){
+  beforeEach(function () {
     calls.push('parent before');
-  })
+  });
 
-  afterEach(function(){
+  afterEach(function () {
     calls.push('parent after');
-  })
+  });
 
-  describe('hooks', function(){
-    beforeEach(function(){
+  describe('hooks', function () {
+    beforeEach(function () {
       calls.push('before');
       if (this.currentTest) {
         calls.push('before test ' + this.currentTest.title);
       }
-    })
+    });
 
-    it('one', function(){
+    it('one', function () {
       calls.should.eql([
-          'parent before'
-        , 'before'
-        , 'before test one']);
+        'parent before',
+        'before',
+        'before test one'
+      ]);
       calls.push('one');
-    })
+    });
 
-    it('two', function(){
+    it('two', function () {
       calls.should.eql([
-          'parent before'
-        , 'before'
-        , 'before test one'
-        , 'one'
-        , 'after'
-        , 'after test one passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test two']);
+        'parent before',
+        'before',
+        'before test one',
+        'one',
+        'after',
+        'after test one passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test two'
+      ]);
       calls.push('two');
-    })
+    });
 
-    it('three', function(){
+    it('three', function () {
       calls.should.eql([
-          'parent before'
-        , 'before'
-        , 'before test one'
-        , 'one'
-        , 'after'
-        , 'after test one passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test two'
-        , 'two'
-        , 'after'
-        , 'after test two passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test three']);
+        'parent before',
+        'before',
+        'before test one',
+        'one',
+        'after',
+        'after test one passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test two',
+        'two',
+        'after',
+        'after test two passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test three'
+      ]);
       calls.push('three');
-    })
+    });
 
-    afterEach(function(){
+    afterEach(function () {
       calls.push('after');
       if (this.currentTest) {
         calls.push('after test ' + this.currentTest.title + ' ' + this.currentTest.state);
       }
-    })
+    });
 
-    after(function(){
+    after(function () {
       calls.should.eql([
-          'parent before'
-        , 'before'
-        , 'before test one'
-        , 'one'
-        , 'after'
-        , 'after test one passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test two'
-        , 'two'
-        , 'after'
-        , 'after test two passed'
-        , 'parent after'
-        , 'parent before'
-        , 'before'
-        , 'before test three'
-        , 'three'
-        , 'after'
-        , 'after test three passed'
-        , 'parent after']);
-    })
-  })
-})
+        'parent before',
+        'before',
+        'before test one',
+        'one',
+        'after',
+        'after test one passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test two',
+        'two',
+        'after',
+        'after test two passed',
+        'parent after',
+        'parent before',
+        'before',
+        'before test three',
+        'three',
+        'after',
+        'after test three passed',
+        'parent after'
+      ]);
+    });
+  });
+});

--- a/test/hook-timeout.spec.js
+++ b/test/hook-timeout.spec.js
@@ -1,8 +1,10 @@
-before(function(done){
+'use strict';
+
+before(function (done) {
   this.timeout(100);
   setTimeout(done, 50);
-})
+});
 
-it('should work', function(done) {
+it('should work', function (done) {
   done();
 });

--- a/test/http-meta-2.spec.js
+++ b/test/http-meta-2.spec.js
@@ -1,10 +1,12 @@
+'use strict';
+
 var http = require('http');
 
 var PORT = 8899;
 
-var server = http.createServer(function(req, res){
-  var accept = req.headers.accept || ''
-    , json = ~accept.indexOf('json');
+var server = http.createServer(function (req, res) {
+  var accept = req.headers.accept || '';
+  var json = ~accept.indexOf('json');
 
   switch (req.url) {
     case '/':
@@ -18,43 +20,43 @@ var server = http.createServer(function(req, res){
       }
       break;
   }
-})
+});
 
-function get(url) {
-  var fields
-    , expected
-    , header = {};
+function get (url) {
+  var fields;
+  var expected;
+  var header = {};
 
-  function request(done) {
-    http.get({ path: url, port: PORT, headers: header }, function(res){
+  function request (done) {
+    http.get({ path: url, port: PORT, headers: header }, function (res) {
       var buf = '';
       res.should.have.property('statusCode', 200);
       res.setEncoding('utf8');
-      res.on('data', function(chunk){ buf += chunk });
-      res.on('end', function(){
+      res.on('data', function (chunk) { buf += chunk; });
+      res.on('end', function () {
         buf.should.equal(expected);
         done();
       });
-    })
+    });
   }
 
   return {
-    set: function(field, val){
+    set: function (field, val) {
       header[field] = val;
       return this;
     },
 
     should: {
-      respond: function(body){
-        fields = Object.keys(header).map(function(field){
+      respond: function (body) {
+        fields = Object.keys(header).map(function (field) {
           return field + ': ' + header[field];
         }).join(', ');
 
         expected = body;
-        describe('GET ' + url, function(){
+        describe('GET ' + url, function () {
           this.timeout(500);
           if (fields) {
-            describe('when given ' + fields, function(){
+            describe('when given ' + fields, function () {
               it('should respond with "' + body + '"', request);
             });
           } else {
@@ -66,26 +68,25 @@ function get(url) {
   };
 }
 
-describe('http server', function(){
-
-  before(function(done) {
+describe('http server', function () {
+  before(function (done) {
     server.listen(PORT, done);
   });
 
-  after(function() {
+  after(function () {
     server.close();
   });
 
   get('/')
     .should
-    .respond('hello')
+    .respond('hello');
 
   get('/users')
     .should
-    .respond('tobi, loki, jane')
+    .respond('tobi, loki, jane');
 
   get('/users')
     .set('Accept', 'application/json')
     .should
-    .respond('["tobi","loki","jane"]')
-})
+    .respond('["tobi","loki","jane"]');
+});

--- a/test/http-meta.spec.js
+++ b/test/http-meta.spec.js
@@ -1,10 +1,12 @@
+'use strict';
+
 var http = require('http');
 
 var PORT = 8889;
 
-var server = http.createServer(function(req, res){
-  var accept = req.headers.accept || ''
-    , json = ~accept.indexOf('json');
+var server = http.createServer(function (req, res) {
+  var accept = req.headers.accept || '';
+  var json = ~accept.indexOf('json');
 
   switch (req.url) {
     case '/':
@@ -20,42 +22,44 @@ var server = http.createServer(function(req, res){
   }
 });
 
-
-function get(url, body, header) {
-  return function(done){
-    http.get({ path: url, port: PORT, headers: header || {}}, function(res){
+function get (url, body, header) {
+  return function (done) {
+    http.get({
+      path: url,
+      port: PORT,
+      headers: header || {}
+    }, function (res) {
       var buf = '';
       res.should.have.property('statusCode', 200);
       res.setEncoding('utf8');
-      res.on('data', function(chunk){ buf += chunk });
-      res.on('end', function(){
+      res.on('data', function (chunk) { buf += chunk; });
+      res.on('end', function () {
         buf.should.equal(body);
         done();
       });
-    })
-  }
+    });
+  };
 }
 
 describe('http requests', function () {
-
-  before(function(done) {
+  before(function (done) {
     server.listen(PORT, done);
   });
 
-  after(function() {
+  after(function () {
     server.close();
   });
 
   describe('GET /', function () {
     it('should respond with hello',
-      get('/', 'hello'))
-  })
+      get('/', 'hello'));
+  });
 
-  describe('GET /users', function(){
+  describe('GET /users', function () {
     it('should respond with users',
-      get('/users', 'tobi, loki, jane'))
+      get('/users', 'tobi, loki, jane'));
 
     it('should respond with users',
-      get('/users', '["tobi","loki","jane"]', { Accept: 'application/json' }))
-  })
-})
+      get('/users', '["tobi","loki","jane"]', { Accept: 'application/json' }));
+  });
+});

--- a/test/integration/diffs.spec.js
+++ b/test/integration/diffs.spec.js
@@ -1,23 +1,25 @@
-var assert   = require('assert');
-var helpers  = require('./helpers');
-var run      = helpers.runMocha;
-var fs       = require('fs');
+'use strict';
+
+var assert = require('assert');
+var helpers = require('./helpers');
+var run = helpers.runMocha;
+var fs = require('fs');
 var getDiffs = helpers.getDiffs;
 
-function getExpectedOutput() {
+function getExpectedOutput () {
   var output = fs.readFileSync('test/integration/fixtures/diffs/output', 'UTF8');
 
   // Diffs are delimited in file by "// DIFF"
-  return output.split(/\s*\/\/ DIFF/).slice(1).map(function(diff) {
+  return output.split(/\s*\/\/ DIFF/).slice(1).map(function (diff) {
     return diff.split('\n').filter(Boolean).join('\n');
   });
 }
 
-describe('diffs', function() {
+describe('diffs', function () {
   var diffs, expected;
 
-  before(function(done) {
-    run('diffs/diffs.fixture.js', ['-C'], function(err, res) {
+  before(function (done) {
+    run('diffs/diffs.fixture.js', ['-C'], function (err, res) {
       expected = getExpectedOutput();
       diffs = getDiffs(res.output);
       done(err);
@@ -36,8 +38,8 @@ describe('diffs', function() {
     'should work with objects',
     'should show value diffs and not be affected by commas',
     'should display diff by data and not like an objects'
-  ].forEach(function(title, i) {
-    it(title, function() {
+  ].forEach(function (title, i) {
+    it(title, function () {
       assert.equal(diffs[i], expected[i]);
     });
   });

--- a/test/integration/fixtures/cascade.fixture.js
+++ b/test/integration/fixtures/cascade.fixture.js
@@ -1,55 +1,57 @@
-describe('one', function() {
-  before(function() {
+'use strict';
+
+describe('one', function () {
+  before(function () {
     console.log('before one');
   });
 
-  after(function() {
+  after(function () {
     console.log('after one');
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     console.log('  before each one');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     console.log('  after each one');
   });
 
-  describe('two', function() {
-    before(function() {
+  describe('two', function () {
+    before(function () {
       console.log('  before two');
     });
 
-    after(function() {
+    after(function () {
       console.log('  after two');
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       console.log('    before each two');
     });
 
-    afterEach(function() {
+    afterEach(function () {
       console.log('    after each two');
     });
 
-    describe('three', function() {
-      before(function() {
+    describe('three', function () {
+      before(function () {
         console.log('    before three');
       });
 
-      after(function() {
+      after(function () {
         console.log('    after three');
       });
 
-      beforeEach(function() {
+      beforeEach(function () {
         console.log('    before each three');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         console.log('    after each three');
       });
 
-      it('should three', function() {
+      it('should three', function () {
         console.log('      TEST three');
       });
     });

--- a/test/integration/fixtures/diffs/diffs.fixture.js
+++ b/test/integration/fixtures/diffs/diffs.fixture.js
@@ -1,58 +1,87 @@
-var fs     = require('fs');
-var assert = require('assert');
-var cssin  = fs.readFileSync('test/integration/fixtures/diffs/diffs.css.in', 'ascii');
+'use strict';
+
+var fs = require('fs');
+var cssin = fs.readFileSync('test/integration/fixtures/diffs/diffs.css.in', 'ascii');
 var cssout = fs.readFileSync('test/integration/fixtures/diffs/diffs.css.out', 'ascii');
 
-describe('diffs', function() {
+describe('diffs', function () {
   var actual, expected;
 
-  it('should display a diff for small strings', function() {
+  it('should display a diff for small strings', function () {
     actual = 'foo rar baz';
     expected = 'foo bar baz';
     actual.should.equal(expected);
   });
 
-  it('should display a diff of canonicalized objects', function() {
+  it('should display a diff of canonicalized objects', function () {
     actual = { name: 'travis j', age: 23 };
     expected = { age: 23, name: 'travis' };
     actual.should.equal(expected);
   });
 
-  it('should display a diff for medium strings', function() {
+  it('should display a diff for medium strings', function () {
     actual = 'foo bar baz\nfoo rar baz\nfoo bar raz';
     expected = 'foo bar baz\nfoo bar baz\nfoo bar baz';
     actual.should.equal(expected);
   });
 
-  it('should display a diff for entire object dumps', function() {
-    actual   = { name: 'joel', age: 30, address: {city: 'new york', country: 'usa' }};
-    expected = { name: 'joe',  age: 30, address: {city: 'new york', country: 'us'  }};
+  it('should display a diff for entire object dumps', function () {
+    actual = {
+      name: 'joel',
+      age: 30,
+      address: {
+        city: 'new york',
+        country: 'usa'
+      }
+    };
+    expected = {
+      name: 'joe',
+      age: 30,
+      address: {
+        city: 'new york',
+        country: 'us'
+      }
+    };
     actual.should.equal(expected);
   });
 
-  it('should display a diff for multi-line strings', function() {
-    actual   = 'one two three\nfour zzzz six\nseven eight nine';
+  it('should display a diff for multi-line strings', function () {
+    actual = 'one two three\nfour zzzz six\nseven eight nine';
     expected = 'one two three\nfour five six\nseven eight nine';
     actual.should.equal(expected);
   });
 
-  it('should display a diff for entire object dumps', function() {
-    actual   = { name: 'joel', age: 30, address: {city: 'new york', country: 'usa' }};
-    expected = { name: 'joe',  age: 30, address: {city: 'new york', country: 'us'  }}
+  it('should display a diff for entire object dumps', function () {
+    actual = {
+      name: 'joel',
+      age: 30,
+      address: {
+        city: 'new york',
+        country: 'usa'
+      }
+    };
+    expected = {
+      name: 'joe',
+      age: 30,
+      address: {
+        city: 'new york',
+        country: 'us'
+      }
+    };
     actual.should.equal(expected);
   });
 
-  it('should display a full-comparison with escaped special characters', function() {
-    actual   = 'one\ttab\ntwo\t\t\ttabs';
+  it('should display a full-comparison with escaped special characters', function () {
+    actual = 'one\ttab\ntwo\t\t\ttabs';
     expected = 'one\ttab\ntwo\t\ttabs';
     actual.should.equal(expected);
   });
 
-  it('should display a word diff for large strings', function() {
+  it('should display a word diff for large strings', function () {
     cssin.should.equal(cssout);
   });
 
-  it('should work with objects', function() {
+  it('should work with objects', function () {
     actual = {
       name: 'tobi',
       species: 'ferret',
@@ -70,13 +99,13 @@ describe('diffs', function() {
     actual.should.eql(expected);
   });
 
-  it('should show value diffs and not be affected by commas', function() {
+  it('should show value diffs and not be affected by commas', function () {
     actual = { a: 123 };
     expected = { a: 123, b: 456 };
     actual.should.equal(expected);
   });
 
-  it('should display diff by data and not like an objects', function() {
+  it('should display diff by data and not like an objects', function () {
     actual = new Buffer([0x01]);
     expected = new Buffer([0x02]);
     actual.should.equal(expected);

--- a/test/integration/fixtures/hooks/after-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-hook-async-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   after(function (done) {
     console.log('after');

--- a/test/integration/fixtures/hooks/after-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-hook-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   after(function () {
     console.log('after');

--- a/test/integration/fixtures/hooks/afterEach-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/afterEach-hook-async-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   afterEach(function (done) {
     console.log('after');

--- a/test/integration/fixtures/hooks/afterEach-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/afterEach-hook-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   afterEach(function () {
     console.log('after');

--- a/test/integration/fixtures/hooks/before-hook-async-error-tip.fixture.js
+++ b/test/integration/fixtures/hooks/before-hook-async-error-tip.fixture.js
@@ -1,8 +1,10 @@
-describe('spec 1', function() {
-  it('should not blame me', function() { });
+'use strict';
+
+describe('spec 1', function () {
+  it('should not blame me', function () { });
 });
-describe('spec 2', function() {
-  before(function(done) {
+describe('spec 2', function () {
+  before(function (done) {
     process.nextTick(function () {
       throw new Error('before hook error');
     });

--- a/test/integration/fixtures/hooks/before-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/before-hook-async-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   before(function (done) {
     console.log('before');

--- a/test/integration/fixtures/hooks/before-hook-error-tip.fixture.js
+++ b/test/integration/fixtures/hooks/before-hook-error-tip.fixture.js
@@ -1,8 +1,10 @@
-describe('spec 1', function() {
-  it('should not blame me', function() { });
+'use strict';
+
+describe('spec 1', function () {
+  it('should not blame me', function () { });
 });
-describe('spec 2', function() {
-  before(function() {
+describe('spec 2', function () {
+  before(function () {
     throw new Error('before hook error');
   });
   it('skipped');

--- a/test/integration/fixtures/hooks/before-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/before-hook-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   before(function () {
     console.log('before');

--- a/test/integration/fixtures/hooks/beforeEach-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/beforeEach-hook-async-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   beforeEach(function (done) {
     console.log('before');

--- a/test/integration/fixtures/hooks/beforeEach-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/beforeEach-hook-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('spec 1', function () {
   beforeEach(function () {
     console.log('before');

--- a/test/integration/fixtures/hooks/multiple-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/multiple-hook-async-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 before(function () {
   console.log('root before');
 });

--- a/test/integration/fixtures/hooks/multiple-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/multiple-hook-error.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 before(function () {
   console.log('root before');
 });

--- a/test/integration/fixtures/multiple-done-before.fixture.js
+++ b/test/integration/fixtures/multiple-done-before.fixture.js
@@ -1,10 +1,12 @@
-describe('suite', function() {
-  before(function(done) {
+'use strict';
+
+describe('suite', function () {
+  before(function (done) {
     setTimeout(done, 10);
     setTimeout(done, 30);
   });
 
-  it('test1', function(done) {
+  it('test1', function (done) {
     setTimeout(done, 50);
   });
 });

--- a/test/integration/fixtures/multiple-done-beforeEach.fixture.js
+++ b/test/integration/fixtures/multiple-done-beforeEach.fixture.js
@@ -1,14 +1,16 @@
-describe('suite', function() {
-  beforeEach(function(done) {
+'use strict';
+
+describe('suite', function () {
+  beforeEach(function (done) {
     setTimeout(done, 10);
     setTimeout(done, 20);
   });
 
-  it('test1', function(done) {
+  it('test1', function (done) {
     setTimeout(done, 50);
   });
 
-  it('test2', function(done) {
+  it('test2', function (done) {
     setTimeout(done, 50);
   });
 });

--- a/test/integration/fixtures/multiple-done-specs.fixture.js
+++ b/test/integration/fixtures/multiple-done-specs.fixture.js
@@ -1,10 +1,12 @@
-describe('suite', function() {
-  it('test1', function(done) {
+'use strict';
+
+describe('suite', function () {
+  it('test1', function (done) {
     done();
     setTimeout(done, 10);
   });
 
-  it('test2', function(done) {
+  it('test2', function (done) {
     setTimeout(done, 20);
   });
 });

--- a/test/integration/fixtures/multiple-done.fixture.js
+++ b/test/integration/fixtures/multiple-done.fixture.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // The suite below should result in an additional error, but does
 // not. Uncomment once this bug is resolved.
 
@@ -10,8 +12,8 @@
 //   it('test', function() {});
 // });
 
-it('should fail in a test-case', function(done) {
-  process.nextTick(function(){
+it('should fail in a test-case', function (done) {
+  process.nextTick(function () {
     done();
     done();
   });

--- a/test/integration/fixtures/options/async-only-async.fixture.js
+++ b/test/integration/fixtures/options/async-only-async.fixture.js
@@ -1,3 +1,5 @@
-it('should pass', function(done){
+'use strict';
+
+it('should pass', function (done) {
   done();
 });

--- a/test/integration/fixtures/options/async-only-sync.fixture.js
+++ b/test/integration/fixtures/options/async-only-sync.fixture.js
@@ -1,1 +1,3 @@
-it('throws an error', function() {});
+'use strict';
+
+it('throws an error', function () {});

--- a/test/integration/fixtures/options/bail.fixture.js
+++ b/test/integration/fixtures/options/bail.fixture.js
@@ -1,21 +1,23 @@
-describe('suite1', function() {
-  it('should display this spec', function() {});
+'use strict';
 
-  it('should only display this error', function(done) {
+describe('suite1', function () {
+  it('should display this spec', function () {});
+
+  it('should only display this error', function (done) {
     throw new Error('this should be displayed');
   });
 
-  it('should not display this error', function(done) {
+  it('should not display this error', function (done) {
     throw new Error('this should not be displayed');
   });
 });
 
-describe('suite2', function() {
-  before(function(done) {
+describe('suite2', function () {
+  before(function (done) {
     throw new Error('this hook should not be displayed');
   });
 
-  it('should not display this error', function(done) {
+  it('should not display this error', function (done) {
     throw new Error('this should not be displayed');
   });
 });

--- a/test/integration/fixtures/options/delay-fail.fixture.js
+++ b/test/integration/fixtures/options/delay-fail.fixture.js
@@ -1,5 +1,8 @@
-setTimeout(function() {
+'use strict';
+
+setTimeout(function () {
   throw new Error('oops');
-  it('test', function() {});
+  /* eslint no-unreachable: off */
+  it('test', function () {});
   run();
 }, 100);

--- a/test/integration/fixtures/options/delay.fixture.js
+++ b/test/integration/fixtures/options/delay.fixture.js
@@ -1,9 +1,11 @@
-var assert = require('assert');
-var delay  = 500;
+'use strict';
 
-setTimeout(function() {
-  describe('delayed execution', function() {
-    it('should have no effect if attempted twice in the same suite', function() {
+var assert = require('assert');
+var delay = 500;
+
+setTimeout(function () {
+  describe('delayed execution', function () {
+    it('should have no effect if attempted twice in the same suite', function () {
       assert(true);
       run();
       assert(true);

--- a/test/integration/fixtures/options/grep.fixture.js
+++ b/test/integration/fixtures/options/grep.fixture.js
@@ -1,16 +1,18 @@
-describe('grep', function() {
-  describe('Match', function() {
-    it('should run', function(){});
-    it('should also run', function() {});
+'use strict';
+
+describe('grep', function () {
+  describe('Match', function () {
+    it('should run', function () {});
+    it('should also run', function () {});
   });
 
-  describe('match', function() {
-    it('should run', function(){});
-    it('should also run', function() {});
+  describe('match', function () {
+    it('should run', function () {});
+    it('should also run', function () {});
   });
 
-  describe('fail', function() {
-    it('should not be ran', function() {
+  describe('fail', function () {
+    it('should not be ran', function () {
       throw new Error('Spec should not run');
     });
   });

--- a/test/integration/fixtures/options/only/bdd.fixture.js
+++ b/test/integration/fixtures/options/only/bdd.fixture.js
@@ -1,70 +1,71 @@
-describe.only('should run this suite', function() {
-  it('should run this test', function() {});
+'use strict';
 
-  it('should run this test', function() {});
+describe.only('should run this suite', function () {
+  it('should run this test', function () {});
 
-  it('should run this test', function() {});
+  it('should run this test', function () {});
+
+  it('should run this test', function () {});
 });
 
-describe('should not run this suite', function() {
-  it('should not run this test', function() {
+describe('should not run this suite', function () {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  it('should not run this test', function() {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  it('should not run this test', function() {
+  it('should not run this test', function () {
     (true).should.equal(false);
   });
 });
 
-describe.only('should run this suite too', function() {
+describe.only('should run this suite too', function () {
   describe('should run this nested suite', function () {
-    it('should run this test', function() {});
+    it('should run this test', function () {});
 
-    it('should run this test', function() {});
+    it('should run this test', function () {});
 
-    it('should run this test', function() {});
+    it('should run this test', function () {});
   });
 });
 
-describe.only('should run this suite, even', function() {
+describe.only('should run this suite, even', function () {
   describe('should run this nested suite, even', function () {
     describe('should run this doubly-nested suite!', function () {
-      it('should run this test', function() {});
+      it('should run this test', function () {});
 
-      it('should run this test', function() {});
+      it('should run this test', function () {});
 
-      it('should run this test', function() {});
+      it('should run this test', function () {});
     });
   });
 });
 
-
-describe('should run this suite with an exclusive test', function() {
+describe('should run this suite with an exclusive test', function () {
   it.only('should run this test', function () {});
 
   describe('should not run this nested suite', function () {
     describe.only('should not run this doubly-nested suite', function () {
-      it('should not run this test', function() {});
+      it('should not run this test', function () {});
 
-      it('should not run this test', function() {});
+      it('should not run this test', function () {});
 
-      it('should not run this test', function() {});
+      it('should not run this test', function () {});
     });
   });
 });
 
-describe('should run this suite with an exclusive test (reverse order)', function() {
+describe('should run this suite with an exclusive test (reverse order)', function () {
   describe('should not run this nested suite', function () {
     describe.only('should not run this doubly-nested suite', function () {
-      it('should not run this test', function() {});
+      it('should not run this test', function () {});
 
-      it('should not run this test', function() {});
+      it('should not run this test', function () {});
 
-      it('should not run this test', function() {});
+      it('should not run this test', function () {});
     });
   });
   it.only('should run this test', function () {});

--- a/test/integration/fixtures/options/only/qunit.fixture.js
+++ b/test/integration/fixtures/options/only/qunit.fixture.js
@@ -1,26 +1,27 @@
+'use strict';
+
 suite.only('should run all tests in this suite');
 
-test('should run this test #1', function() {});
+test('should run this test #1', function () {});
 
-test('should run this test #2', function() {});
+test('should run this test #2', function () {});
 
-test('should run this test #3', function() {});
+test('should run this test #3', function () {});
 
-test('should run this test #4', function() {});
+test('should run this test #4', function () {});
 
-test('should run this test #5', function() {});
-
+test('should run this test #5', function () {});
 
 suite('should not run any of this suite\'s tests');
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (false).should.equal(true);
 });
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (false).should.equal(true);
 });
 
-test('should not run this test', function() {
+test('should not run this test', function () {
   (false).should.equal(true);
 });

--- a/test/integration/fixtures/options/only/tdd.fixture.js
+++ b/test/integration/fixtures/options/only/tdd.fixture.js
@@ -1,35 +1,37 @@
-suite.only('should run all tests in this tdd suite', function() {
-  test('should run this test #1', function() {});
+'use strict';
 
-  test('should run this test #2', function() {});
+suite.only('should run all tests in this tdd suite', function () {
+  test('should run this test #1', function () {});
 
-  test('should run this test #3', function() {});
+  test('should run this test #2', function () {});
 
-  test('should run this test #4', function() {});
+  test('should run this test #3', function () {});
+
+  test('should run this test #4', function () {});
 });
 
-suite('should not run this suite', function() {
-  test('should not run this test', function() {
+suite('should not run this suite', function () {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  test('should not run this test', function() {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
 
-  test('should not run this test', function() {
+  test('should not run this test', function () {
     (true).should.equal(false);
   });
 });
 
-suite.only('should run this suite too', function() {
+suite.only('should run this suite too', function () {
   suite('should run this nested suite', function () {
-    test('should run this test', function() {});
+    test('should run this test', function () {});
 
-    test('should run this test', function() {});
+    test('should run this test', function () {});
 
-    test('should run this test', function() {});
+    test('should run this test', function () {});
 
-    test('should run this test', function() {});
+    test('should run this test', function () {});
   });
 });

--- a/test/integration/fixtures/options/retries.fixture.js
+++ b/test/integration/fixtures/options/retries.fixture.js
@@ -1,4 +1,6 @@
-describe('retries', function() {
+'use strict';
+
+describe('retries', function () {
   it('should fail', function () {
     throw new Error('retry failure');
   });

--- a/test/integration/fixtures/options/sort-alpha.fixture.js
+++ b/test/integration/fixtures/options/sort-alpha.fixture.js
@@ -1,5 +1,7 @@
-describe('alpha', function(){
-  it('should be executed first', function(){
+'use strict';
+
+describe('alpha', function () {
+  it('should be executed first', function () {
     if (global.beta) {
       throw new Error('alpha was not executed first');
     }

--- a/test/integration/fixtures/options/sort-beta.fixture.js
+++ b/test/integration/fixtures/options/sort-beta.fixture.js
@@ -1,5 +1,7 @@
-describe('beta', function(){
-  it('should be executed second', function(){
+'use strict';
+
+describe('beta', function () {
+  it('should be executed second', function () {
     global.beta = 1;
   });
 });

--- a/test/integration/fixtures/passing.fixture.js
+++ b/test/integration/fixtures/passing.fixture.js
@@ -1,11 +1,13 @@
+'use strict';
+
 var assert = require('assert');
 
-describe('suite', function() {
-  it('test1', function() {
+describe('suite', function () {
+  it('test1', function () {
     assert(true);
   });
 
-  it('test2', function() {
+  it('test2', function () {
     assert(true);
   });
 });

--- a/test/integration/fixtures/pending/skip-async-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before.fixture.js
@@ -1,16 +1,18 @@
-describe('skip in before', function() {
-  before(function(done) {
+'use strict';
+
+describe('skip in before', function () {
+  before(function (done) {
     var self = this;
-    setTimeout(function() {
+    setTimeout(function () {
       self.skip();
     }, 50);
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 });

--- a/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
@@ -1,16 +1,18 @@
-describe('skip in beforeEach', function() {
-  beforeEach(function(done) {
+'use strict';
+
+describe('skip in beforeEach', function () {
+  beforeEach(function (done) {
     var self = this;
-    setTimeout(function() {
+    setTimeout(function () {
       self.skip();
     }, 50);
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 });

--- a/test/integration/fixtures/pending/skip-async-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-spec.fixture.js
@@ -1,12 +1,14 @@
-describe('skip in test', function() {
-  it('should skip async', function(done) {
+'use strict';
+
+describe('skip in test', function () {
+  it('should skip async', function (done) {
     var self = this;
-    setTimeout(function() {
+    setTimeout(function () {
       self.skip();
     }, 50);
   });
 
-  it('should run other tests in the suite', function() {
+  it('should run other tests in the suite', function () {
     // Do nothing
   });
 });

--- a/test/integration/fixtures/pending/skip-sync-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before.fixture.js
@@ -1,13 +1,15 @@
-describe('skip in before', function() {
-  before(function() {
+'use strict';
+
+describe('skip in before', function () {
+  before(function () {
     this.skip();
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 });

--- a/test/integration/fixtures/pending/skip-sync-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-beforeEach.fixture.js
@@ -1,13 +1,15 @@
-describe('skip in beforeEach', function() {
-  beforeEach(function() {
+'use strict';
+
+describe('skip in beforeEach', function () {
+  beforeEach(function () {
     this.skip();
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 
-  it('should never run this test', function() {
+  it('should never run this test', function () {
     throw new Error('never thrown');
   });
 });

--- a/test/integration/fixtures/pending/skip-sync-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-spec.fixture.js
@@ -1,10 +1,12 @@
-describe('skip in test', function() {
-  it('should skip immediately', function() {
+'use strict';
+
+describe('skip in test', function () {
+  it('should skip immediately', function () {
     this.skip();
     throw new Error('never thrown');
   });
 
-  it('should run other tests in the suite', function() {
+  it('should run other tests in the suite', function () {
     // Do nothing
   });
 });

--- a/test/integration/fixtures/pending/spec.fixture.js
+++ b/test/integration/fixtures/pending/spec.fixture.js
@@ -1,3 +1,5 @@
-describe('suite', function() {
+'use strict';
+
+describe('suite', function () {
   it('pending spec');
 });

--- a/test/integration/fixtures/regression/1794/issue-1794.fixture.js
+++ b/test/integration/fixtures/regression/1794/issue-1794.fixture.js
@@ -1,3 +1,5 @@
-test('pass', function() {
+'use strict';
+
+test('pass', function () {
   // pass
 });

--- a/test/integration/fixtures/regression/1794/simple-ui.js
+++ b/test/integration/fixtures/regression/1794/simple-ui.js
@@ -1,13 +1,14 @@
-var path  = '../../../../../lib/',
-    Mocha = require(path + 'mocha');
-    Suite = require(path + 'suite'),
-    Test  = require(path + 'test');
+'use strict';
+
+var path = '../../../../../lib/';
+var Mocha = require(path + 'mocha');
+var Test = require(path + 'test');
 
 /**
  * A simple UI that only exposes a single function: test
  */
-module.exports = Mocha.interfaces['simple-ui'] = function(suite) {
-  suite.on('pre-require', function(context, file, mocha) {
+module.exports = Mocha.interfaces['simple-ui'] = function (suite) {
+  suite.on('pre-require', function (context, file, mocha) {
     var common = require(path + 'interfaces/common')([suite], context);
 
     context.run = mocha.options.delay && common.runWithSuite(suite);
@@ -16,7 +17,7 @@ module.exports = Mocha.interfaces['simple-ui'] = function(suite) {
      * Describes a specification or test-case with the given `title`
      * and callback `fn` acting as a thunk.
      */
-    context.test = function(title, fn) {
+    context.test = function (title, fn) {
       var test = new Test(title, fn);
       test.file = file;
       suite.addTest(test);

--- a/test/integration/fixtures/regression/issue-1327.fixture.js
+++ b/test/integration/fixtures/regression/issue-1327.fixture.js
@@ -1,15 +1,17 @@
-it('test 1', function() {
+'use strict';
+
+it('test 1', function () {
   console.log('testbody1');
-  process.nextTick(function() {
-    throw 'Too bad';
+  process.nextTick(function () {
+    throw new Error('Too bad');
   });
 });
 
-it('test 2', function() {
+it('test 2', function () {
   console.log('testbody2');
 });
 
-it('test 3', function() {
+it('test 3', function () {
   console.log('testbody3');
   throw new Error('OUCH');
 });

--- a/test/integration/fixtures/regression/issue-1417.js
+++ b/test/integration/fixtures/regression/issue-1417.js
@@ -5,16 +5,16 @@
  * It should not report misleading 'multiple calls to done()'.
  */
 
-it('fails exactly once when a global error is thrown synchronously and done errors', function(done) {
-  setTimeout(function() {
+it('fails exactly once when a global error is thrown synchronously and done errors', function (done) {
+  setTimeout(function () {
     done(new Error('test error'));
   }, 1); // Not 0 - it will 'succeed', but won't test the breaking condition
 
   throw new Error('sync error');
 });
 
-it('fails exactly once when a global error is thrown synchronously and done completes', function(done) {
-  setTimeout(function() {
+it('fails exactly once when a global error is thrown synchronously and done completes', function (done) {
+  setTimeout(function () {
     done();
   }, 1); // Not 0 - it will 'succeed', but won't test the breaking condition
 

--- a/test/integration/fixtures/regression/issue-1991.fixture.js
+++ b/test/integration/fixtures/regression/issue-1991.fixture.js
@@ -1,7 +1,11 @@
-function MemoryLeak() {
+'use strict';
+
+/* eslint no-unused-vars: off */
+
+function MemoryLeak () {
   this.myArr = [];
   for (var i = 0; i < 1000000; i++) {
-    this.myArr.push(i)
+    this.myArr.push(i);
   }
 }
 
@@ -13,7 +17,6 @@ for (var i = 0; i < numOfTests; i += 1) {
    * if all the deferred functions references have not been cleared
    */
   describe('Memory Leak Suite #' + i, function () {
-
     // The <closureVar> variable will be accessed by the test below.
     // As long as those test's functions are
     // referenced in memory, the closure variable may not be garbage collected
@@ -22,19 +25,19 @@ for (var i = 0; i < numOfTests; i += 1) {
     var closureVar;
 
     before(function () {
-      var x = closureVar ? 1 : 2
+      var x = closureVar ? 1 : 2;
     });
 
     after(function () {
-      var x = closureVar[0]
+      var x = closureVar[0];
     });
 
     beforeEach(function () {
-      var x = closureVar ? 1 : 2
+      var x = closureVar ? 1 : 2;
     });
 
     afterEach(function () {
-      var x = closureVar[0]
+      var x = closureVar[0];
     });
 
     it('access a variable via a closure', function () {
@@ -42,6 +45,5 @@ for (var i = 0; i < numOfTests; i += 1) {
       this.timeout(1000);
       closureVar = new MemoryLeak();
     });
-
   });
 }

--- a/test/integration/fixtures/regression/issue-2315.js
+++ b/test/integration/fixtures/regression/issue-2315.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('issue-2315: cannot read property currentRetry of undefined', function () {
   before(function () {
     process.nextTick(function () {

--- a/test/integration/fixtures/regression/issue-2406.fixture.js
+++ b/test/integration/fixtures/regression/issue-2406.fixture.js
@@ -1,15 +1,17 @@
-describe('outer describe', function() {
-  it('should not run this test', function() {});
-  describe('this suite should not run', function() {
-    it('should not run this test', function() {});
+'use strict';
+
+describe('outer describe', function () {
+  it('should not run this test', function () {});
+  describe('this suite should not run', function () {
+    it('should not run this test', function () {});
   });
-  describe.only('this .only suite should run', function() {
-    describe('this suite should run', function() {
-      it('should run this test in a nested suite', function() {});
+  describe.only('this .only suite should run', function () {
+    describe('this suite should run', function () {
+      it('should run this test in a nested suite', function () {});
     });
-    it('should run this test', function() {});
+    it('should run this test', function () {});
   });
-  describe('this suite should not run', function() {
-    it('should not run this test', function() {});
+  describe('this suite should not run', function () {
+    it('should not run this test', function () {});
   });
 });

--- a/test/integration/fixtures/regression/issue-2417.fixture.js
+++ b/test/integration/fixtures/regression/issue-2417.fixture.js
@@ -1,6 +1,8 @@
-describe('outer describe', function() {
-  describe.only('outer describe.only', function() {
-    it.only('inner it.only', function() {
+'use strict';
+
+describe('outer describe', function () {
+  describe.only('outer describe.only', function () {
+    it.only('inner it.only', function () {
       // should run and exit without error
     });
   });

--- a/test/integration/fixtures/retries/async.fixture.js
+++ b/test/integration/fixtures/retries/async.fixture.js
@@ -1,4 +1,6 @@
-describe('retries', function() {
+'use strict';
+
+describe('retries', function () {
   var times = 0;
   before(function () {
     console.log('before');
@@ -8,7 +10,7 @@ describe('retries', function() {
     console.log('after');
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     console.log('before each', times);
   });
 

--- a/test/integration/fixtures/retries/early-pass.fixture.js
+++ b/test/integration/fixtures/retries/early-pass.fixture.js
@@ -1,8 +1,10 @@
-describe('retries', function() {
+'use strict';
+
+describe('retries', function () {
   this.retries(1);
   var times = 0;
 
-  it('should pass after 1 retry', function() {
+  it('should pass after 1 retry', function () {
     times++;
     if (times !== 2) {
       throw new Error('retry error ' + times);

--- a/test/integration/fixtures/retries/hooks.fixture.js
+++ b/test/integration/fixtures/retries/hooks.fixture.js
@@ -1,4 +1,6 @@
-describe('retries', function() {
+'use strict';
+
+describe('retries', function () {
   var times = 0;
   before(function () {
     console.log('before');
@@ -8,7 +10,7 @@ describe('retries', function() {
     console.log('after');
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     console.log('before each', times);
   });
 
@@ -16,7 +18,7 @@ describe('retries', function() {
     console.log('after each', times);
   });
 
-  it('should allow override and run appropriate hooks', function(){
+  it('should allow override and run appropriate hooks', function () {
     this.retries(4);
     console.log('TEST', times);
     times++;

--- a/test/integration/fixtures/retries/nested.fixture.js
+++ b/test/integration/fixtures/retries/nested.fixture.js
@@ -1,7 +1,9 @@
-describe('retries', function() {
+'use strict';
+
+describe('retries', function () {
   this.retries(3);
   describe('nested', function () {
-    it('should fail after only 1 retry', function(){
+    it('should fail after only 1 retry', function () {
       this.retries(1);
       throw new Error('retry error');
     });

--- a/test/integration/fixtures/suite/suite-no-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-no-callback.fixture.js
@@ -1,1 +1,3 @@
+'use strict';
+
 describe('a suite without a callback');

--- a/test/integration/fixtures/suite/suite-skipped-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-skipped-callback.fixture.js
@@ -1,1 +1,3 @@
+'use strict';
+
 xdescribe('a pending suite with a callback', function () {});

--- a/test/integration/fixtures/suite/suite-skipped-no-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-skipped-no-callback.fixture.js
@@ -1,1 +1,3 @@
+'use strict';
+
 xdescribe('a pending suite without a callback');

--- a/test/integration/fixtures/timeout.fixture.js
+++ b/test/integration/fixtures/timeout.fixture.js
@@ -1,16 +1,18 @@
-describe('timeout', function(){
+'use strict';
+
+describe('timeout', function () {
   this.timeout(1);
 
-  it('should be honored with sync suites', function() {
+  it('should be honored with sync suites', function () {
     sleep(2);
   });
 
-  it('should be honored with async suites', function(done) {
+  it('should be honored with async suites', function (done) {
     sleep(2);
     done();
   });
 
-  function sleep(ms) {
+  function sleep (ms) {
     var start = Date.now();
     while (start + ms > Date.now());
   }

--- a/test/integration/fixtures/uncaught-hook.fixture.js
+++ b/test/integration/fixtures/uncaught-hook.fixture.js
@@ -1,15 +1,15 @@
-describe('uncaught', function() {
-  beforeEach(function(done) {
-    process.nextTick(function() {
+'use strict';
+
+describe('uncaught', function () {
+  beforeEach(function (done) {
+    process.nextTick(function () {
       throw new Error('oh noes');
-      done();
     });
   });
 
-  it('test', function(done) {
-    process.nextTick(function() {
+  it('test', function (done) {
+    process.nextTick(function () {
       throw new Error("I'm uncaught!");
-      done();
     });
   });
 });

--- a/test/integration/fixtures/uncaught.fixture.js
+++ b/test/integration/fixtures/uncaught.fixture.js
@@ -5,22 +5,18 @@
  * Mocha is capable of detecting two distinct exceptions during test execution.
  */
 
-it('fails exactly once when a global error is thrown first', function(done) {
-  setTimeout(function() {
+it('fails exactly once when a global error is thrown first', function (done) {
+  setTimeout(function () {
     throw new Error('global error');
-
-    setTimeout(function() {
-      done(new Error('test error'));
-    }, 0);
   }, 0);
 });
 
-it('fails exactly once when a global error is thrown second', function(done) {
-  setTimeout(function() {
+it('fails exactly once when a global error is thrown second', function (done) {
+  setTimeout(function () {
     done(new Error('test error'));
   }, 0);
 
-  setTimeout(function() {
+  setTimeout(function () {
     throw new Error('global error');
   }, 0);
 });

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,5 +1,7 @@
+'use strict';
+
 var spawn = require('child_process').spawn;
-var path  = require('path');
+var path = require('path');
 var fs = require('fs');
 var baseReporter = require('../../lib/reporters/base');
 
@@ -24,13 +26,13 @@ module.exports = {
    * @param {array}    args
    * @param {function} fn
    */
-  runMocha: function(fixturePath, args, fn) {
+  runMocha: function (fixturePath, args, fn) {
     var path;
 
     path = resolveFixturePath(fixturePath);
     args = args || [];
 
-    invokeMocha(args.concat(['-C', path]), function(err, res) {
+    invokeMocha(args.concat(['-C', path]), function (err, res) {
       if (err) return fn(err);
 
       fn(null, getSummary(res));
@@ -57,19 +59,19 @@ module.exports = {
    * @param {array}    args
    * @param {function} fn
    */
-  runMochaFunction: function(fixture, args, fn) {
+  runMochaFunction: function (fixture, args, fn) {
     var path = resolveFixturePath(fixture.name + '.js' || 'tempfile.js');
     args = args || [];
 
     var fixtureContent = 'var fn = ' + fixture.toString() + '; fn()';
     fs.writeFileSync(path, fixtureContent, 'utf8');
 
-    function cleanup() {
+    function cleanup () {
       fs.unlink(path);
       fn.apply(this, arguments);
     }
 
-    invokeMocha(args.concat(['-C', path]), function(err, res) {
+    invokeMocha(args.concat(['-C', path]), function (err, res) {
       if (err) {
         return cleanup(err);
       }
@@ -86,13 +88,13 @@ module.exports = {
    * @param {array}    args
    * @param {function} fn
    */
-  runMochaJSON: function(fixturePath, args, fn) {
+  runMochaJSON: function (fixturePath, args, fn) {
     var path;
 
     path = resolveFixturePath(fixturePath);
     args = args || [];
 
-    invokeMocha(args.concat(['--reporter', 'json', path]), function(err, res) {
+    invokeMocha(args.concat(['--reporter', 'json', path]), function (err, res) {
       if (err) return fn(err);
 
       try {
@@ -113,12 +115,12 @@ module.exports = {
    * @param  {string}   output
    * returns {string[]}
    */
-  getDiffs: function(output) {
+  getDiffs: function (output) {
     var diffs, i, inDiff, inStackTrace;
 
     diffs = [];
-    output.split('\n').forEach(function(line) {
-      if (line.match(/^  \d+\)/)) {
+    output.split('\n').forEach(function (line) {
+      if (line.match(/^\s{2}\d+\)/)) {
         // New spec, e.g. "1) spec title"
         diffs.push([]);
         i = diffs.length - 1;
@@ -140,7 +142,7 @@ module.exports = {
     });
 
     // Ignore empty lines before/after diff
-    return diffs.map(function(diff) {
+    return diffs.map(function (diff) {
       return diff.slice(1, -3).join('\n');
     });
   },
@@ -151,14 +153,14 @@ module.exports = {
   splitRegExp: new RegExp('[\\n' + baseReporter.symbols.dot + ']+')
 };
 
-function invokeMocha(args, fn) {
+function invokeMocha (args, fn) {
   var output, mocha, listener;
 
   output = '';
   args = [path.join('bin', 'mocha')].concat(args);
   mocha = spawn(process.execPath, args);
 
-  listener = function(data) {
+  listener = function (data) {
     output += data;
   };
 
@@ -166,7 +168,7 @@ function invokeMocha(args, fn) {
   mocha.stderr.on('data', listener);
   mocha.on('error', fn);
 
-  mocha.on('close', function(code) {
+  mocha.on('close', function (code) {
     fn(null, {
       output: output.split('\n').join('\n'),
       code: code
@@ -174,12 +176,12 @@ function invokeMocha(args, fn) {
   });
 }
 
-function resolveFixturePath(fixture) {
+function resolveFixturePath (fixture) {
   return path.join('./test/integration/fixtures', fixture);
 }
 
-function getSummary(res) {
-  return ['passing', 'pending', 'failing'].reduce(function(summary, type) {
+function getSummary (res) {
+  return ['passing', 'pending', 'failing'].reduce(function (summary, type) {
     var pattern, match;
 
     pattern = new RegExp('  (\\d+) ' + type + '\\s');

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -1,14 +1,16 @@
+'use strict';
+
 var assert = require('assert');
 var runMocha = require('./helpers').runMocha;
 var splitRegExp = require('./helpers').splitRegExp;
 var bang = require('../../lib/reporters/base').symbols.bang;
 
-describe('hook error handling', function() {
+describe('hook error handling', function () {
   var lines;
 
-  describe('before hook error', function() {
+  describe('before hook error', function () {
     before(run('hooks/before-hook-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['before', bang + 'test 3']
@@ -16,9 +18,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('before hook error tip', function() {
+  describe('before hook error tip', function () {
     before(run('hooks/before-hook-error-tip.fixture.js', onlyErrorTitle));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['1) spec 2 "before all" hook:']
@@ -26,9 +28,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('before each hook error', function() {
+  describe('before each hook error', function () {
     before(run('hooks/beforeEach-hook-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['before', bang + 'test 3']
@@ -36,9 +38,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('after hook error', function() {
+  describe('after hook error', function () {
     before(run('hooks/after-hook-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['test 1', 'test 2', 'after', bang + 'test 3']
@@ -46,9 +48,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('after each hook error', function() {
+  describe('after each hook error', function () {
     before(run('hooks/afterEach-hook-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['test 1', 'after', bang + 'test 3']
@@ -56,9 +58,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('multiple hook errors', function() {
+  describe('multiple hook errors', function () {
     before(run('hooks/multiple-hook-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         [
@@ -94,9 +96,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('async - before hook error', function() {
+  describe('async - before hook error', function () {
     before(run('hooks/before-hook-async-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['before', bang + 'test 3']
@@ -104,9 +106,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('async - before hook error tip', function() {
+  describe('async - before hook error tip', function () {
     before(run('hooks/before-hook-async-error-tip.fixture.js', onlyErrorTitle));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['1) spec 2 "before all" hook:']
@@ -114,9 +116,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('async - before each hook error', function() {
+  describe('async - before each hook error', function () {
     before(run('hooks/beforeEach-hook-async-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['before', bang + 'test 3']
@@ -124,9 +126,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('async - after hook error', function() {
+  describe('async - after hook error', function () {
     before(run('hooks/after-hook-async-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['test 1', 'test 2', 'after', bang + 'test 3']
@@ -134,9 +136,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('async - after each hook error', function() {
+  describe('async - after each hook error', function () {
     before(run('hooks/afterEach-hook-async-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['test 1', 'after', bang + 'test 3']
@@ -144,9 +146,9 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('async - multiple hook errors', function() {
+  describe('async - multiple hook errors', function () {
     before(run('hooks/multiple-hook-async-error.fixture.js'));
-    it('should verify results', function() {
+    it('should verify results', function () {
       assert.deepEqual(
         lines,
         [
@@ -182,14 +184,14 @@ describe('hook error handling', function() {
     });
   });
 
-  function run(fnPath, outputFilter) {
-    return function(done) {
-      runMocha(fnPath, [], function(err, res) {
+  function run (fnPath, outputFilter) {
+    return function (done) {
+      runMocha(fnPath, [], function (err, res) {
         assert.ifError(err);
 
         lines = res.output
           .split(splitRegExp)
-          .map(function(line) {
+          .map(function (line) {
             return line.trim();
           })
           .filter(outputFilter || onlyConsoleOutput());
@@ -200,9 +202,9 @@ describe('hook error handling', function() {
   }
 });
 
-function onlyConsoleOutput() {
+function onlyConsoleOutput () {
   var foundSummary = false;
-  return function(line) {
+  return function (line) {
     if (!foundSummary) {
       foundSummary = !!(/\(\d+ms\)/).exec(line);
     }
@@ -210,6 +212,6 @@ function onlyConsoleOutput() {
   };
 }
 
-function onlyErrorTitle(line) {
+function onlyErrorTitle (line) {
   return !!(/^1\)/).exec(line);
 }

--- a/test/integration/hooks.spec.js
+++ b/test/integration/hooks.spec.js
@@ -1,18 +1,20 @@
-var assert = require('assert');
-var run    = require('./helpers').runMocha;
-var splitRegExp = require('./helpers').splitRegExp;
-var args   = [];
+'use strict';
 
-describe('hooks', function() {
-  it('are ran in correct order', function(done) {
-    run('cascade.fixture.js', args, function(err, res) {
+var assert = require('assert');
+var run = require('./helpers').runMocha;
+var splitRegExp = require('./helpers').splitRegExp;
+var args = [];
+
+describe('hooks', function () {
+  it('are ran in correct order', function (done) {
+    run('cascade.fixture.js', args, function (err, res) {
       var lines, expected;
 
       assert(!err);
 
-      lines = res.output.split(splitRegExp).map(function(line) {
+      lines = res.output.split(splitRegExp).map(function (line) {
         return line.trim();
-      }).filter(function(line) {
+      }).filter(function (line) {
         return line.length;
       }).slice(0, -1);
 
@@ -32,7 +34,7 @@ describe('hooks', function() {
         'after one'
       ];
 
-      expected.forEach(function(line, i) {
+      expected.forEach(function (line, i) {
         assert.equal(lines[i], line);
       });
 

--- a/test/integration/multiple-done.spec.js
+++ b/test/integration/multiple-done.spec.js
@@ -1,92 +1,94 @@
-var assert = require('assert');
-var run    = require('./helpers').runMochaJSON;
-var args   = [];
+'use strict';
 
-describe('multiple calls to done()', function() {
+var assert = require('assert');
+var run = require('./helpers').runMochaJSON;
+var args = [];
+
+describe('multiple calls to done()', function () {
   var res;
-  describe('from a spec', function() {
-    before(function(done) {
-      run('multiple-done.fixture.js', args, function(err, result) {
+  describe('from a spec', function () {
+    before(function (done) {
+      run('multiple-done.fixture.js', args, function (err, result) {
         res = result;
         done(err);
       });
     });
 
-    it('results in failures', function() {
+    it('results in failures', function () {
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 1);
       assert.equal(res.stats.failures, 1);
       assert.equal(res.code, 1);
     });
 
-    it('throws a descriptive error', function() {
+    it('throws a descriptive error', function () {
       assert.equal(res.failures[0].err.message,
         'done() called multiple times');
     });
   });
 
-  describe('with multiple specs', function() {
-    before(function(done) {
-      run('multiple-done-specs.fixture.js', args, function(err, result) {
+  describe('with multiple specs', function () {
+    before(function (done) {
+      run('multiple-done-specs.fixture.js', args, function (err, result) {
         res = result;
         done(err);
       });
     });
 
-    it('results in a failure', function() {
+    it('results in a failure', function () {
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 2);
       assert.equal(res.stats.failures, 1);
       assert.equal(res.code, 1);
     });
 
-    it('correctly attributes the error', function() {
+    it('correctly attributes the error', function () {
       assert.equal(res.failures[0].fullTitle, 'suite test1');
       assert.equal(res.failures[0].err.message,
         'done() called multiple times');
     });
   });
 
-  describe('from a before hook', function() {
-    before(function(done) {
-      run('multiple-done-before.fixture.js', args, function(err, result) {
+  describe('from a before hook', function () {
+    before(function (done) {
+      run('multiple-done-before.fixture.js', args, function (err, result) {
         res = result;
         done(err);
       });
     });
 
-    it('results in a failure', function() {
+    it('results in a failure', function () {
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 1);
       assert.equal(res.stats.failures, 1);
       assert.equal(res.code, 1);
     });
 
-    it('correctly attributes the error', function() {
+    it('correctly attributes the error', function () {
       assert.equal(res.failures[0].fullTitle, 'suite "before all" hook');
       assert.equal(res.failures[0].err.message,
         'done() called multiple times');
     });
   });
 
-  describe('from a beforeEach hook', function() {
-    before(function(done) {
-      run('multiple-done-beforeEach.fixture.js', args, function(err, result) {
+  describe('from a beforeEach hook', function () {
+    before(function (done) {
+      run('multiple-done-beforeEach.fixture.js', args, function (err, result) {
         res = result;
         done(err);
       });
     });
 
-    it('results in a failure', function() {
+    it('results in a failure', function () {
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 2);
       assert.equal(res.stats.failures, 2);
       assert.equal(res.code, 2);
     });
 
-    it('correctly attributes the errors', function() {
+    it('correctly attributes the errors', function () {
       assert.equal(res.failures.length, 2);
-      res.failures.forEach(function(failure) {
+      res.failures.forEach(function (failure) {
         assert.equal(failure.fullTitle, 'suite "before each" hook');
         assert.equal(failure.err.message,
           'done() called multiple times');

--- a/test/integration/only.spec.js
+++ b/test/integration/only.spec.js
@@ -1,10 +1,12 @@
+'use strict';
+
 var run = require('./helpers').runMochaJSON;
 var assert = require('assert');
 
-describe('.only()', function() {
-  describe('bdd', function() {
-    it('should run only tests that marked as `only`', function(done) {
-      run('options/only/bdd.fixture.js', ['--ui', 'bdd'], function(err, res) {
+describe('.only()', function () {
+  describe('bdd', function () {
+    it('should run only tests that marked as `only`', function (done) {
+      run('options/only/bdd.fixture.js', ['--ui', 'bdd'], function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 11);
@@ -15,9 +17,9 @@ describe('.only()', function() {
     });
   });
 
-  describe('tdd', function() {
-    it('should run only tests that marked as `only`', function(done) {
-      run('options/only/tdd.fixture.js', ['--ui', 'tdd'], function(err, res) {
+  describe('tdd', function () {
+    it('should run only tests that marked as `only`', function (done) {
+      run('options/only/tdd.fixture.js', ['--ui', 'tdd'], function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 8);
@@ -28,9 +30,9 @@ describe('.only()', function() {
     });
   });
 
-  describe('qunit', function() {
-    it('should run only tests that marked as `only`', function(done) {
-      run('options/only/qunit.fixture.js', ['--ui', 'qunit'], function(err, res) {
+  describe('qunit', function () {
+    it('should run only tests that marked as `only`', function (done) {
+      run('options/only/qunit.fixture.js', ['--ui', 'qunit'], function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 5);

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -1,16 +1,17 @@
+'use strict';
+
 var assert = require('assert');
-var run    = require('./helpers').runMochaJSON;
-var args   = [];
+var run = require('./helpers').runMochaJSON;
+var args = [];
 
-describe('options', function() {
-  describe('--async-only', function() {
-
-    before(function() {
+describe('options', function () {
+  describe('--async-only', function () {
+    before(function () {
       args = ['--async-only'];
     });
 
-    it('should fail synchronous specs', function(done) {
-      run('options/async-only-sync.fixture.js', args, function(err, res) {
+    it('should fail synchronous specs', function (done) {
+      run('options/async-only-sync.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 0);
@@ -22,8 +23,8 @@ describe('options', function() {
       });
     });
 
-    it('should allow asynchronous specs', function(done) {
-      run('options/async-only-async.fixture.js', args, function(err, res) {
+    it('should allow asynchronous specs', function (done) {
+      run('options/async-only-async.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 1);
@@ -36,13 +37,13 @@ describe('options', function() {
     });
   });
 
-  describe('--bail', function() {
-    before(function() {
+  describe('--bail', function () {
+    before(function () {
       args = ['--bail'];
     });
 
-    it('should stop after the first error', function(done) {
-      run('options/bail.fixture.js', args, function(err, res) {
+    it('should stop after the first error', function (done) {
+      run('options/bail.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 1);
@@ -56,13 +57,13 @@ describe('options', function() {
     });
   });
 
-  describe('--sort', function() {
-    before(function() {
+  describe('--sort', function () {
+    before(function () {
       args = ['--sort'];
     });
 
-    it('should sort tests in alphabetical order', function(done) {
-      run('options/sort*', args, function(err, res) {
+    it('should sort tests in alphabetical order', function (done) {
+      run('options/sort*', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 2);
@@ -76,13 +77,13 @@ describe('options', function() {
     });
   });
 
-  describe('--delay', function() {
-    before(function() {
+  describe('--delay', function () {
+    before(function () {
       args = ['--delay'];
     });
 
-    it('should run the generated test suite', function(done) {
-      run('options/delay.fixture.js', args, function(err, res) {
+    it('should run the generated test suite', function (done) {
+      run('options/delay.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 1);
@@ -95,8 +96,8 @@ describe('options', function() {
       });
     });
 
-    it('should throw an error if the test suite failed to run', function(done) {
-      run('options/delay-fail.fixture.js', args, function(err, res) {
+    it('should throw an error if the test suite failed to run', function (done) {
+      run('options/delay-fail.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 0);
@@ -110,10 +111,10 @@ describe('options', function() {
     });
   });
 
-  describe('--grep', function() {
-    it('runs specs matching a string', function(done) {
+  describe('--grep', function () {
+    it('runs specs matching a string', function (done) {
       args = ['--grep', 'match'];
-      run('options/grep.fixture.js', args, function(err, res) {
+      run('options/grep.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 2);
@@ -123,10 +124,10 @@ describe('options', function() {
       });
     });
 
-    describe('runs specs matching a RegExp', function() {
-      it('with RegExp like strings(pattern follow by flag)', function(done) {
+    describe('runs specs matching a RegExp', function () {
+      it('with RegExp like strings(pattern follow by flag)', function (done) {
         args = ['--grep', '/match/i'];
-        run('options/grep.fixture.js', args, function(err, res) {
+        run('options/grep.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 0);
           assert.equal(res.stats.passes, 4);
@@ -136,9 +137,9 @@ describe('options', function() {
         });
       });
 
-      it('string as pattern', function(done) {
+      it('string as pattern', function (done) {
         args = ['--grep', '.*'];
-        run('options/grep.fixture.js', args, function(err, res) {
+        run('options/grep.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 0);
           assert.equal(res.stats.passes, 4);
@@ -149,10 +150,10 @@ describe('options', function() {
       });
     });
 
-    describe('with --invert', function() {
-      it('runs specs that do not match the pattern', function(done) {
+    describe('with --invert', function () {
+      it('runs specs that do not match the pattern', function (done) {
         args = ['--grep', 'fail', '--invert'];
-        run('options/grep.fixture.js', args, function(err, res) {
+        run('options/grep.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 0);
           assert.equal(res.stats.passes, 4);
@@ -164,10 +165,10 @@ describe('options', function() {
     });
   });
 
-  describe('--retries', function() {
+  describe('--retries', function () {
     it('retries after a certain threshold', function (done) {
       args = ['--retries', '3'];
-      run('options/retries.fixture.js', args, function(err, res) {
+      run('options/retries.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 0);
@@ -177,6 +178,6 @@ describe('options', function() {
         assert.equal(res.code, 1);
         done();
       });
-    })
+    });
   });
 });

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -1,11 +1,13 @@
-var assert = require('assert');
-var run    = require('./helpers').runMochaJSON;
-var args   = [];
+'use strict';
 
-describe('pending', function() {
-  describe('pending specs', function() {
-    it('should be created by omitting a function', function(done) {
-      run('pending/spec.fixture.js', args, function(err, res) {
+var assert = require('assert');
+var run = require('./helpers').runMochaJSON;
+var args = [];
+
+describe('pending', function () {
+  describe('pending specs', function () {
+    it('should be created by omitting a function', function (done) {
+      run('pending/spec.fixture.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 1);
         assert.equal(res.stats.passes, 0);
@@ -16,10 +18,10 @@ describe('pending', function() {
     });
   });
 
-  describe('synchronous skip()', function() {
-    describe('in spec', function() {
-      it('should immediately skip the spec and run all others', function(done) {
-        run('pending/skip-sync-spec.fixture.js', args, function(err, res) {
+  describe('synchronous skip()', function () {
+    describe('in spec', function () {
+      it('should immediately skip the spec and run all others', function (done) {
+        run('pending/skip-sync-spec.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 1);
           assert.equal(res.stats.passes, 1);
@@ -30,9 +32,9 @@ describe('pending', function() {
       });
     });
 
-    describe('in before', function() {
-      it('should skip all suite specs', function(done) {
-        run('pending/skip-sync-before.fixture.js', args, function(err, res) {
+    describe('in before', function () {
+      it('should skip all suite specs', function (done) {
+        run('pending/skip-sync-before.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
@@ -43,9 +45,9 @@ describe('pending', function() {
       });
     });
 
-    describe('in beforeEach', function() {
-      it('should skip all suite specs', function(done) {
-        run('pending/skip-sync-beforeEach.fixture.js', args, function(err, res) {
+    describe('in beforeEach', function () {
+      it('should skip all suite specs', function (done) {
+        run('pending/skip-sync-beforeEach.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
@@ -57,10 +59,10 @@ describe('pending', function() {
     });
   });
 
-  describe('asynchronous skip()', function() {
-    describe('in spec', function() {
-      it('should immediately skip the spec and run all others', function(done) {
-        run('pending/skip-async-spec.fixture.js', args, function(err, res) {
+  describe('asynchronous skip()', function () {
+    describe('in spec', function () {
+      it('should immediately skip the spec and run all others', function (done) {
+        run('pending/skip-async-spec.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 1);
           assert.equal(res.stats.passes, 1);
@@ -71,9 +73,9 @@ describe('pending', function() {
       });
     });
 
-    describe('in before', function() {
-      it('should skip all suite specs', function(done) {
-        run('pending/skip-async-before.fixture.js', args, function(err, res) {
+    describe('in before', function () {
+      it('should skip all suite specs', function (done) {
+        run('pending/skip-async-before.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
@@ -84,9 +86,9 @@ describe('pending', function() {
       });
     });
 
-    describe('in beforeEach', function() {
-      it('should skip all suite specs', function(done) {
-        run('pending/skip-sync-beforeEach.fixture.js', args, function(err, res) {
+    describe('in beforeEach', function () {
+      it('should skip all suite specs', function (done) {
+        run('pending/skip-sync-beforeEach.fixture.js', args, function (err, res) {
           assert(!err);
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -1,14 +1,16 @@
-var assert  = require('assert');
-var fs      = require('fs');
-var path    = require('path');
-var run     = require('./helpers').runMocha;
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var run = require('./helpers').runMocha;
 var runJSON = require('./helpers').runMochaJSON;
 
-describe('regressions', function() {
-  it('issue-1327: should run all 3 specs exactly once', function(done) {
+describe('regressions', function () {
+  it('issue-1327: should run all 3 specs exactly once', function (done) {
     var args = [];
-    run('regression/issue-1327.fixture.js', args, function(err, res) {
-      var occurences = function(str) {
+    run('regression/issue-1327.fixture.js', args, function (err, res) {
+      var occurences = function (str) {
         var pattern = new RegExp(str, 'g');
         return (res.output.match(pattern) || []).length;
       };
@@ -23,32 +25,34 @@ describe('regressions', function() {
     });
   });
 
-  it('should not duplicate mocha.opts args in process.argv', function() {
+  it('should not duplicate mocha.opts args in process.argv', function () {
     var processArgv = process.argv.join('');
     var mochaOpts = fs.readFileSync(path.join(__dirname, '..', 'mocha.opts'), 'utf-8').split(/[\s]+/).join('');
     assert.notEqual(processArgv.indexOf(mochaOpts), -1, 'process.argv missing mocha.opts');
     assert.equal(processArgv.indexOf(mochaOpts), processArgv.lastIndexOf(mochaOpts), 'process.argv contains duplicated mocha.opts');
   });
 
-  it('issue-1794: Can\'t --require custom UI and use it', function(done) {
+  it('issue-1794: Can\'t --require custom UI and use it', function (done) {
     var simpleUiPath = path.join(__dirname, 'fixtures', 'regression', '1794', 'simple-ui.js');
     var args = ['--require', simpleUiPath, '--ui', 'simple-ui'];
-    run('regression/1794/issue-1794.fixture.js', args, function(err, res) {
+    run('regression/1794/issue-1794.fixture.js', args, function (err, res) {
+      assert(!err);
       assert.equal(res.code, 0, 'Custom UI should be loaded');
       done();
     });
   });
 
-  it('issue-1991: Declarations do not get cleaned up unless you set them to `null` - Memory Leak', function(done) {
+  it('issue-1991: Declarations do not get cleaned up unless you set them to `null` - Memory Leak', function (done) {
     // on a modern MBP takes ±5 seconds on node 4.0, but on older laptops with node 0.12 ±40 seconds.
     // Could easily take longer on even weaker machines (Travis-CI containers for example).
     this.timeout(120000);
-    run('regression/issue-1991.fixture.js', [], function(err, res) {
+    run('regression/issue-1991.fixture.js', [], function (err, res) {
+      assert(!err);
       assert.equal(/process out of memory/.test(res.output), false, 'fixture\'s process out of memory!');
       assert.equal(res.code, 0, 'Runnable fn (it/before[Each]/after[Each]) references should be deleted to avoid memory leaks');
       done();
     });
-  })
+  });
 
   describe('issue-2286: after doesn\'t execute if test was skipped in beforeEach', function () {
     var afterWasRun = false;
@@ -56,14 +60,14 @@ describe('regressions', function() {
       beforeEach(function () { this.skip(); });
       after(function () { afterWasRun = true; });
       it('should be pending', function () {});
-    })
+    });
     after('meta test', function () {
       afterWasRun.should.be.ok();
     });
   });
 
   it('issue-2315: cannot read property currentRetry of undefined', function (done) {
-    runJSON('regression/issue-2315.js', [], function(err, res) {
+    runJSON('regression/issue-2315.js', [], function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
@@ -73,9 +77,9 @@ describe('regressions', function() {
     });
   });
 
-  it('issue-2406: should run nested describe.only suites', function(done) {
+  it('issue-2406: should run nested describe.only suites', function (done) {
     this.timeout(2000);
-    runJSON('regression/issue-2406.fixture.js', [], function(err, res) {
+    runJSON('regression/issue-2406.fixture.js', [], function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 2);
@@ -85,8 +89,8 @@ describe('regressions', function() {
     });
   });
 
-  it('issue-2417: should not recurse infinitely with .only suites nested within each other', function() {
-    runJSON('regression/issue-2417.fixture.js', [], function(err, res) {
+  it('issue-2417: should not recurse infinitely with .only suites nested within each other', function () {
+    runJSON('regression/issue-2417.fixture.js', [], function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 1);
@@ -95,8 +99,8 @@ describe('regressions', function() {
     });
   });
 
-  it('issue-1417 uncaught exceptions from async specs', function(done) {
-    runJSON('regression/issue-1417.js', [], function(err, res) {
+  it('issue-1417 uncaught exceptions from async specs', function (done) {
+    runJSON('regression/issue-1417.js', [], function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -1,26 +1,28 @@
-var assert = require('assert');
-var os     = require('os');
-var fs     = require('fs');
-var crypto = require('crypto');
-var path   = require('path');
-var run    = require('./helpers').runMocha;
+'use strict';
 
-describe('reporters', function() {
-  describe('markdown', function() {
+var assert = require('assert');
+var os = require('os');
+var fs = require('fs');
+var crypto = require('crypto');
+var path = require('path');
+var run = require('./helpers').runMocha;
+
+describe('reporters', function () {
+  describe('markdown', function () {
     var res;
 
-    before(function(done) {
-      run('passing.fixture.js', ['--reporter', 'markdown'], function(err, result) {
+    before(function (done) {
+      run('passing.fixture.js', ['--reporter', 'markdown'], function (err, result) {
         res = result;
         done(err);
       });
     });
 
-    it('does not exceed maximum callstack (issue: 1875)', function() {
+    it('does not exceed maximum callstack (issue: 1875)', function () {
       assert(res.output.indexOf('RangeError') === -1, 'Threw RangeError');
     });
 
-    it('contains spec src', function() {
+    it('contains spec src', function () {
       var src = [
         '```js',
         'assert(true);',
@@ -31,8 +33,8 @@ describe('reporters', function() {
     });
   });
 
-  describe('xunit', function() {
-    it('prints test cases with --reporter-options output (issue: 1864)', function(done) {
+  describe('xunit', function () {
+    it('prints test cases with --reporter-options output (issue: 1864)', function (done) {
       var randomStr = crypto.randomBytes(8).toString('hex');
       var tmpDir = os.tmpDir().replace(new RegExp(path.sep + '$'), '');
       var tmpFile = tmpDir + path.sep + 'test-issue-1864-' + randomStr + '.xml';
@@ -44,13 +46,13 @@ describe('reporters', function() {
         '</testsuite>'
       ];
 
-      run('passing.fixture.js', args, function(err, result) {
+      run('passing.fixture.js', args, function (err, result) {
         if (err) return done(err);
 
         var xml = fs.readFileSync(tmpFile, 'utf8');
         fs.unlinkSync(tmpFile);
 
-        expectedOutput.forEach(function(line) {
+        expectedOutput.forEach(function (line) {
           assert(xml.indexOf(line) !== -1, 'XML did not contain ' + line);
         });
 

--- a/test/integration/retries.spec.js
+++ b/test/integration/retries.spec.js
@@ -1,18 +1,20 @@
+'use strict';
+
 var assert = require('assert');
 var helpers = require('./helpers');
-var args   = [];
+var args = [];
 var bang = require('../../lib/reporters/base').symbols.bang;
 
-describe('retries', function() {
-  it('are ran in correct order', function(done) {
-    helpers.runMocha('retries/hooks.fixture.js', args, function(err, res) {
+describe('retries', function () {
+  it('are ran in correct order', function (done) {
+    helpers.runMocha('retries/hooks.fixture.js', args, function (err, res) {
       var lines, expected;
 
       assert(!err);
 
-      lines = res.output.split(helpers.splitRegExp).map(function(line) {
+      lines = res.output.split(helpers.splitRegExp).map(function (line) {
         return line.trim();
-      }).filter(function(line) {
+      }).filter(function (line) {
         return line.length;
       }).slice(0, -1);
 
@@ -36,7 +38,7 @@ describe('retries', function() {
         'after'
       ];
 
-      expected.forEach(function(line, i) {
+      expected.forEach(function (line, i) {
         assert.equal(lines[i], line);
       });
 
@@ -46,7 +48,7 @@ describe('retries', function() {
   });
 
   it('should exit early if test passes', function (done) {
-    helpers.runMochaJSON('retries/early-pass.fixture.js', args, function(err, res) {
+    helpers.runMochaJSON('retries/early-pass.fixture.js', args, function (err, res) {
       assert(!err);
       assert.equal(res.stats.passes, 1);
       assert.equal(res.stats.failures, 0);
@@ -58,7 +60,7 @@ describe('retries', function() {
   });
 
   it('should let test override', function (done) {
-    helpers.runMochaJSON('retries/nested.fixture.js', args, function(err, res) {
+    helpers.runMochaJSON('retries/nested.fixture.js', args, function (err, res) {
       assert(!err);
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 1);
@@ -70,14 +72,14 @@ describe('retries', function() {
   });
 
   it('should not hang w/ async test', function (done) {
-    helpers.runMocha('retries/async.fixture.js', args, function(err, res) {
+    helpers.runMocha('retries/async.fixture.js', args, function (err, res) {
       var lines, expected;
 
       assert(!err);
 
-      lines = res.output.split(helpers.splitRegExp).map(function(line) {
+      lines = res.output.split(helpers.splitRegExp).map(function (line) {
         return line.trim();
-      }).filter(function(line) {
+      }).filter(function (line) {
         return line.length;
       }).slice(0, -1);
 
@@ -95,7 +97,7 @@ describe('retries', function() {
         'after'
       ];
 
-      expected.forEach(function(line, i) {
+      expected.forEach(function (line, i) {
         assert.equal(lines[i], line);
       });
 

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -1,11 +1,13 @@
+'use strict';
+
 var assert = require('assert');
 var run = require('./helpers').runMocha;
 var args = [];
 
-describe('suite w/no callback', function() {
+describe('suite w/no callback', function () {
   this.timeout(1000);
-  it('should throw a helpful error message when a callback for suite is not supplied', function(done) {
-    run('suite/suite-no-callback.fixture.js', args, function(err, res) {
+  it('should throw a helpful error message when a callback for suite is not supplied', function (done) {
+    run('suite/suite-no-callback.fixture.js', args, function (err, res) {
       assert(!err);
       var result = res.output.match(/no callback was supplied/) || [];
       assert.equal(result.length, 1);
@@ -14,12 +16,12 @@ describe('suite w/no callback', function() {
   });
 });
 
-describe('skipped suite w/no callback', function() {
+describe('skipped suite w/no callback', function () {
   this.timeout(1000);
-  it('should not throw an error when a callback for skipped suite is not supplied', function(done) {
-    run('suite/suite-skipped-no-callback.fixture.js', args, function(err, res) {
+  it('should not throw an error when a callback for skipped suite is not supplied', function (done) {
+    run('suite/suite-skipped-no-callback.fixture.js', args, function (err, res) {
       assert(!err);
-      pattern = new RegExp("Error", 'g');
+      var pattern = new RegExp('Error', 'g');
       var result = res.output.match(pattern) || [];
       assert.equal(result.length, 0);
       done();
@@ -27,13 +29,12 @@ describe('skipped suite w/no callback', function() {
   });
 });
 
-
-describe('skipped suite w/ callback', function() {
+describe('skipped suite w/ callback', function () {
   this.timeout(1000);
-  it('should not throw an error when a callback for skipped suite is supplied', function(done) {
-    run('suite/suite-skipped-callback.fixture.js', args, function(err, res) {
+  it('should not throw an error when a callback for skipped suite is supplied', function (done) {
+    run('suite/suite-skipped-callback.fixture.js', args, function (err, res) {
       assert(!err);
-      pattern = new RegExp("Error", 'g');
+      var pattern = new RegExp('Error', 'g');
       var result = res.output.match(pattern) || [];
       assert.equal(result.length, 0);
       done();

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -1,10 +1,12 @@
-var assert = require('assert');
-var run    = require('./helpers').runMochaJSON;
-var args   = [];
+'use strict';
 
-describe('this.timeout()', function() {
-  it('is respected by sync and async suites', function(done) {
-    run('timeout.fixture.js', args, function(err, res) {
+var assert = require('assert');
+var run = require('./helpers').runMochaJSON;
+var args = [];
+
+describe('this.timeout()', function () {
+  it('is respected by sync and async suites', function (done) {
+    run('timeout.fixture.js', args, function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -1,10 +1,12 @@
-var assert = require('assert');
-var run    = require('./helpers').runMochaJSON;
-var args   = [];
+'use strict';
 
-describe('uncaught exceptions', function() {
-  it('handles uncaught exceptions from hooks', function(done) {
-    run('uncaught-hook.fixture.js', args, function(err, res) {
+var assert = require('assert');
+var run = require('./helpers').runMochaJSON;
+var args = [];
+
+describe('uncaught exceptions', function () {
+  it('handles uncaught exceptions from hooks', function (done) {
+    run('uncaught-hook.fixture.js', args, function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
@@ -17,8 +19,8 @@ describe('uncaught exceptions', function() {
     });
   });
 
-  it('handles uncaught exceptions from async specs', function(done) {
-    run('uncaught.fixture.js', args, function(err, res) {
+  it('handles uncaught exceptions from async specs', function (done) {
+    run('uncaught.fixture.js', args, function (err, res) {
       assert(!err);
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);

--- a/test/jsapi/index.js
+++ b/test/jsapi/index.js
@@ -1,5 +1,6 @@
-var Mocha = require('../../')
-  , path = require('path');
+'use strict';
+
+var Mocha = require('../../');
 
 var mocha = new Mocha({
   ui: 'bdd',
@@ -22,8 +23,8 @@ mocha.addFile('test/acceptance/fs.spec.js');
 mocha.addFile('test/acceptance/globals.spec.js');
 mocha.addFile('test/acceptance/timeout.spec.js');
 
-mocha.run(function(){
+mocha.run(function () {
   console.log('done');
-}).on('pass', function(test){
+}).on('pass', function (test) {
   // console.log('... %s', test.title);
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --require should
---require ./test/fixture-expect.js
+--require ./test/setup
 --reporter dot
 --ui bdd
 --globals okGlobalA,okGlobalB

--- a/test/mocha.spec.js
+++ b/test/mocha.spec.js
@@ -1,33 +1,35 @@
+'use strict';
+
 var Mocha = require('../');
 var Test = Mocha.Test;
 
-describe('Mocha', function(){
-  var blankOpts = { reporter: function(){} }; // no output
+describe('Mocha', function () {
+  var blankOpts = { reporter: function () {} }; // no output
 
-  describe('.run(fn)', function(){
-    it('should not raise errors if callback was not provided', function(){
+  describe('.run(fn)', function () {
+    it('should not raise errors if callback was not provided', function () {
       var mocha = new Mocha(blankOpts);
       mocha.run();
-    })
+    });
 
-    it('should execute the callback when complete', function(done) {
+    it('should execute the callback when complete', function (done) {
       var mocha = new Mocha(blankOpts);
-      mocha.run(function(){
+      mocha.run(function () {
         done();
-      })
-    })
+      });
+    });
 
-    it('should execute the callback with the number of failures '+
-      'as parameter', function(done) {
+    it('should execute the callback with the number of failures ' +
+      'as parameter', function (done) {
       var mocha = new Mocha(blankOpts);
-      var failingTest = new Test('failing test', function(){
+      var failingTest = new Test('failing test', function () {
         throw new Error('such fail');
       });
       mocha.suite.addTest(failingTest);
-      mocha.run(function(failures) {
+      mocha.run(function (failures) {
         failures.should.equal(1);
         done();
       });
-    })
-  })
-})
+    });
+  });
+});

--- a/test/ms.spec.js
+++ b/test/ms.spec.js
@@ -1,71 +1,71 @@
 'use strict';
 var ms = require('../lib/ms');
 
-describe('.ms()', function() {
+describe('.ms()', function () {
   // Helpers
   var time = {
-    minutes: function(n) { return n * 60 * 1000; },
+    minutes: function (n) { return n * 60 * 1000; },
     hours: function (n) { return n * this.minutes(60); },
-    days: function(n) { return n * this.hours(24); },
-    years: function(n) { return n * this.days(365.25); }
+    days: function (n) { return n * this.hours(24); },
+    years: function (n) { return n * this.days(365.25); }
   };
-  describe('get a value that less than 1 second', function() {
-    it('should return milliseconds representation', function() {
+  describe('get a value that less than 1 second', function () {
+    it('should return milliseconds representation', function () {
       ms(200).should.equal('200ms');
       ms(30).should.equal('30ms');
       ms(2000).should.not.equal('2000ms');
     });
   });
 
-  describe('seconds representation', function() {
-    it('should return short format', function() {
+  describe('seconds representation', function () {
+    it('should return short format', function () {
       ms(2000).should.equal('2s');
     });
 
-    it('should return long format', function() {
+    it('should return long format', function () {
       ms(2000, { long: true }).should.equal('2 seconds');
       ms(1000, { long: true }).should.equal('1 second');
       ms(1010, { long: true }).should.equal('1 second');
     });
   });
 
-  describe('minutess representation', function() {
-    it('should return short format', function() {
+  describe('minutess representation', function () {
+    it('should return short format', function () {
       ms(time.minutes(1)).should.equal('1m');
     });
 
-    it('should return long format', function() {
+    it('should return long format', function () {
       ms(time.minutes(1), { long: true }).should.equal('1 minute');
       ms(time.minutes(3), { long: true }).should.equal('3 minutes');
     });
   });
 
-  describe('hours representation', function() {
-    it('should return short format', function() {
+  describe('hours representation', function () {
+    it('should return short format', function () {
       ms(time.hours(1)).should.equal('1h');
     });
 
-    it('should return long format', function() {
+    it('should return long format', function () {
       ms(time.hours(1), { long: true }).should.equal('1 hour');
       ms(time.hours(3), { long: true }).should.equal('3 hours');
     });
   });
 
-  describe('days representation', function() {
-    it('should return short format', function() {
+  describe('days representation', function () {
+    it('should return short format', function () {
       ms(time.days(1)).should.equal('1d');
     });
 
-    it('should return long format', function() {
+    it('should return long format', function () {
       ms(time.days(1), { long: true }).should.equal('1 day');
       ms(time.days(3), { long: true }).should.equal('3 days');
     });
   });
 
-  describe('Getting string value', function() {
-    it('should return the milliseconds representation(Number)', function() {
+  describe('Getting string value', function () {
+    it('should return the milliseconds representation(Number)', function () {
       ms('1 second').should.equal(1000);
-      
+
       ms('1 minute').should.equal(time.minutes(1));
       ms('6 minutes').should.equal(time.minutes(6));
 

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -1,9 +1,11 @@
+'use strict';
+
 var assert = require('assert');
 
-var Base   = require('../../lib/reporters/base')
-  , Assert = require('assert').AssertionError;
+var Base = require('../../lib/reporters/base');
+var Assert = require('assert').AssertionError;
 
-function makeTest(err) {
+function makeTest (err) {
   return {
     err: err,
     fullTitle: function () {
@@ -13,9 +15,9 @@ function makeTest(err) {
 }
 
 describe('Base reporter', function () {
-  var stdout
-    , stdoutWrite
-    , useColors;
+  var stdout;
+  var stdoutWrite;
+  var useColors;
 
   beforeEach(function () {
     stdout = [];
@@ -32,10 +34,10 @@ describe('Base reporter', function () {
     Base.useColors = useColors;
   });
 
-  describe('showDiff', function() {
+  describe('showDiff', function () {
     it('should show diffs by default', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' })
-        , errOut;
+      var err = new Assert({ actual: 'foo', expected: 'bar' });
+      var errOut;
 
       var test = makeTest(err);
 
@@ -47,12 +49,11 @@ describe('Base reporter', function () {
     });
 
     it('should show diffs if property set to `true`', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' })
-        , errOut;
+      var err = new Assert({ actual: 'foo', expected: 'bar' });
+      var errOut;
 
       err.showDiff = true;
       var test = makeTest(err);
-
 
       Base.list([test]);
 
@@ -62,8 +63,8 @@ describe('Base reporter', function () {
     });
 
     it('should not show diffs when showDiff property set to `false`', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' })
-        , errOut;
+      var err = new Assert({ actual: 'foo', expected: 'bar' });
+      var errOut;
 
       err.showDiff = false;
       var test = makeTest(err);
@@ -76,8 +77,8 @@ describe('Base reporter', function () {
     });
 
     it('should not show diffs when expected is not defined', function () {
-      var err = new Error('ouch')
-        , errOut;
+      var err = new Error('ouch');
+      var errOut;
 
       var test = makeTest(err);
 
@@ -87,14 +88,13 @@ describe('Base reporter', function () {
       errOut.should.not.match(/\- actual/);
       errOut.should.not.match(/\+ expected/);
     });
-
   });
 
-  describe('Getting two strings', function() {
+  describe('Getting two strings', function () {
     // Fix regression V1.2.1(see: issue #1241)
     it('should show strings diff as is', function () {
-      var err = new Error('test'),
-        errOut;
+      var err = new Error('test');
+      var errOut;
 
       err.actual = 'foo\nbar';
       err.expected = 'foo\nbaz';
@@ -114,11 +114,11 @@ describe('Base reporter', function () {
   });
 
   it('should stringify objects', function () {
-    var err = new Error('test'),
-      errOut;
+    var err = new Error('test');
+    var errOut;
 
-    err.actual = {key:"a1"};
-    err.expected = {key:"e1"};
+    err.actual = {key: 'a1'};
+    err.expected = {key: 'e1'};
     err.showDiff = true;
     var test = makeTest(err);
 
@@ -132,8 +132,8 @@ describe('Base reporter', function () {
   });
 
   it('should stringify Object.create(null)', function () {
-    var err = new Error('test'),
-      errOut;
+    var err = new Error('test');
+    var errOut;
 
     err.actual = Object.create(null);
     err.actual.hasOwnProperty = 1;
@@ -189,7 +189,7 @@ describe('Base reporter', function () {
   it('should use the inspect() property if `message` is not set', function () {
     var err = {
       showDiff: false,
-      inspect: function() { return 'an error happened'; },
+      inspect: function () { return 'an error happened'; }
     };
     var test = makeTest(err);
     Base.list([test]);
@@ -210,5 +210,4 @@ describe('Base reporter', function () {
     var errOut = stdout.join('\n').trim();
     errOut.should.equal('1) test title:\n     Error\n  foo\n  bar');
   });
-
 });

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -1,61 +1,63 @@
-var Mocha = require('../../')
-  , Suite = Mocha.Suite
-  , Runner = Mocha.Runner
-  , Test = Mocha.Test;
+'use strict';
 
-describe('json reporter', function(){
+var Mocha = require('../../');
+var Suite = Mocha.Suite;
+var Runner = Mocha.Runner;
+var Test = Mocha.Test;
+
+describe('json reporter', function () {
   var suite, runner;
 
-  beforeEach(function(){
+  beforeEach(function () {
     var mocha = new Mocha({
       reporter: 'json'
     });
     suite = new Suite('JSON suite', 'root');
     runner = new Runner(suite);
+    /* eslint no-unused-vars: off */
     var mochaReporter = new mocha._reporter(runner);
   });
 
-   it('should have 1 test failure', function(done){
-     var testTitle = 'json test 1';
-     var error = { message: 'oh shit' };
+  it('should have 1 test failure', function (done) {
+    var testTitle = 'json test 1';
+    var error = { message: 'oh shit' };
 
-     suite.addTest(new Test(testTitle, function (done) {
-       done(new Error(error.message));
-     }));
+    suite.addTest(new Test(testTitle, function (done) {
+      done(new Error(error.message));
+    }));
 
-     runner.run(function(failureCount) {
-       failureCount.should.be.exactly(1);
-       runner.should.have.property('testResults');
-       runner.testResults.should.have.property('failures');
-       runner.testResults.failures.should.be.an.instanceOf(Array);
-       runner.testResults.failures.should.have.a.lengthOf(1);
+    runner.run(function (failureCount) {
+      failureCount.should.be.exactly(1);
+      runner.should.have.property('testResults');
+      runner.testResults.should.have.property('failures');
+      runner.testResults.failures.should.be.an.instanceOf(Array);
+      runner.testResults.failures.should.have.a.lengthOf(1);
 
-       var failure = runner.testResults.failures[0];
-       failure.should.have.property('title', testTitle);
-       failure.err.message.should.equal(error.message);
-       failure.should.have.properties('err');
+      var failure = runner.testResults.failures[0];
+      failure.should.have.property('title', testTitle);
+      failure.err.message.should.equal(error.message);
+      failure.should.have.properties('err');
 
-       done();
-     });
+      done();
+    });
   });
 
-  it('should have 1 test pending', function(done) {
+  it('should have 1 test pending', function (done) {
     var testTitle = 'json test 1';
 
-     suite.addTest(new Test(testTitle));
+    suite.addTest(new Test(testTitle));
 
-     runner.run(function(failureCount) {
-       failureCount.should.be.exactly(0);
-       runner.should.have.property('testResults');
-       runner.testResults.should.have.property('pending');
-       runner.testResults.pending.should.be.an.instanceOf(Array);
-       runner.testResults.pending.should.have.a.lengthOf(1);
+    runner.run(function (failureCount) {
+      failureCount.should.be.exactly(0);
+      runner.should.have.property('testResults');
+      runner.testResults.should.have.property('pending');
+      runner.testResults.pending.should.be.an.instanceOf(Array);
+      runner.testResults.pending.should.have.a.lengthOf(1);
 
-       var pending = runner.testResults.pending[0];
-       pending.should.have.property('title', testTitle);
+      var pending = runner.testResults.pending[0];
+      pending.should.have.property('title', testTitle);
 
-       done();
-     });
-  })
-
+      done();
+    });
+  });
 });

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -1,30 +1,31 @@
-var reporters = require('../../').reporters
-   , NyanCat = reporters.Nyan;
+'use strict';
 
+var reporters = require('../../').reporters;
+var NyanCat = reporters.Nyan;
 
 describe('nyan face', function () {
   it('nyan face:(x .x) when "failures" at least one', function () {
-    var nyanCat = new NyanCat({on: function(){}});
+    var nyanCat = new NyanCat({on: function () {}});
     nyanCat.stats = { passes: 2, pending: 1, failures: 1 };
-    nyanCat.face.call(nyanCat).should.equal('( x .x)');
+    nyanCat.face().should.equal('( x .x)');
   });
 
   it('expected nyan face:(x .x) when "pending" at least one and no failing', function () {
-    var nyanCat = new NyanCat({on: function(){}});
+    var nyanCat = new NyanCat({on: function () {}});
     nyanCat.stats = { passes: 2, pending: 1, failures: 0 };
-    nyanCat.face.call(nyanCat).should.equal('( o .o)');
+    nyanCat.face().should.equal('( o .o)');
   });
 
   it('expected nyan face:(^ .^) when "passing" only', function () {
-    var nyanCat = new NyanCat({on: function(){}});
+    var nyanCat = new NyanCat({on: function () {}});
     nyanCat.stats = { passes: 1, pending: 0, failures: 0 };
-    nyanCat.face.call(nyanCat).should.equal('( ^ .^)');
+    nyanCat.face().should.equal('( ^ .^)');
   });
 
   it('nyan face:(- .-) when otherwise', function (done) {
-    var nyanCat = new NyanCat({on: function(){}});
+    var nyanCat = new NyanCat({on: function () {}});
     nyanCat.stats = { passes: 0, pending: 0, failures: 0 };
-    nyanCat.face.call(nyanCat).should.equal('( - .-)');
+    nyanCat.face().should.equal('( - .-)');
     done();
   });
 });

--- a/test/runnable.spec.js
+++ b/test/runnable.spec.js
@@ -1,187 +1,188 @@
-var mocha = require('../')
-  , utils = mocha.utils
-  , Runnable = mocha.Runnable
-  , EventEmitter = require('events').EventEmitter;
+'use strict';
 
-describe('Runnable(title, fn)', function(){
+var mocha = require('../');
+var utils = mocha.utils;
+var Runnable = mocha.Runnable;
+
+describe('Runnable(title, fn)', function () {
   // For every test we poison the global time-related methods.
   // runnable.js etc. should keep its own local copy, in order to fix GH-237.
   // NB: we can't poison global.Date because the normal implementation of
   // global.setTimeout uses it [1] so if the runnable.js keeps a copy of
   // global.setTimeout (like it's supposed to), that will blow up.
   // [1]: https://github.com/joyent/node/blob/7fc835afe362ebd30a0dbec81d3360bd24525222/lib/timers.js#L74
-  var setTimeout = global.setTimeout
-    , setInterval = global.setInterval
-    , clearTimeout = global.clearTimeout
-    , clearInterval = global.clearInterval;
+  var setTimeout = global.setTimeout;
+  var setInterval = global.setInterval;
+  var clearTimeout = global.clearTimeout;
+  var clearInterval = global.clearInterval;
 
-  function poisonPill() {
+  function poisonPill () {
     throw new Error("Don't use global time-related stuff.");
   }
 
-  beforeEach(function(){
+  beforeEach(function () {
     global.setTimeout =
     global.setInterval =
     global.clearTimeout =
     global.clearInterval = poisonPill;
-  })
+  });
 
-  afterEach(function(){
+  afterEach(function () {
     global.setTimeout = setTimeout;
     global.setInterval = setInterval;
     global.clearTimeout = clearTimeout;
     global.clearInterval = clearInterval;
-  })
+  });
 
-  describe('#timeout(ms)', function(){
-    it('should set the timeout', function(){
-      var run = new Runnable;
-      run.timeout(1000)
+  describe('#timeout(ms)', function () {
+    it('should set the timeout', function () {
+      var run = new Runnable();
+      run.timeout(1000);
       run.timeout().should.equal(1000);
-    })
-  })
+    });
+  });
 
-  describe('#timeout(ms) when ms>2^31', function() {
-    it('should set disabled', function() {
+  describe('#timeout(ms) when ms>2^31', function () {
+    it('should set disabled', function () {
       var run = new Runnable();
       run.timeout(1e10);
       run.enableTimeouts().should.be.false;
     });
   });
 
-  describe('#enableTimeouts(enabled)', function(){
-    it('should set enabled', function(){
-      var run = new Runnable;
+  describe('#enableTimeouts(enabled)', function () {
+    it('should set enabled', function () {
+      var run = new Runnable();
       run.enableTimeouts(false);
       run.enableTimeouts().should.equal(false);
     });
   });
 
-  describe('#slow(ms)', function() {
+  describe('#slow(ms)', function () {
     var run;
 
-    beforeEach(function() {
+    beforeEach(function () {
       run = new Runnable();
     });
 
-    it('should set the slow threshold', function() {
+    it('should set the slow threshold', function () {
       run.slow(100);
       run.slow().should.equal(100);
     });
 
-    it('should not set the slow threshold if the parameter is not passed', function() {
+    it('should not set the slow threshold if the parameter is not passed', function () {
       run.slow();
       run.slow().should.equal(75);
     });
 
-    it('should not set the slow threshold if the parameter is undefined', function() {
+    it('should not set the slow threshold if the parameter is undefined', function () {
       run.slow(undefined);
       run.slow().should.equal(75);
     });
-  })
+  });
 
-  describe('.title', function(){
-    it('should be present', function(){
+  describe('.title', function () {
+    it('should be present', function () {
       new Runnable('foo').title.should.equal('foo');
-    })
-  })
+    });
+  });
 
-  describe('when arity >= 1', function(){
-    it('should be .async', function(){
-      var run = new Runnable('foo', function(done){});
+  describe('when arity >= 1', function () {
+    it('should be .async', function () {
+      var run = new Runnable('foo', function (done) {});
       run.async.should.equal(1);
       run.sync.should.be.false();
-    })
-  })
+    });
+  });
 
-  describe('when arity == 0', function(){
-    it('should be .sync', function(){
-      var run = new Runnable('foo', function(){});
+  describe('when arity == 0', function () {
+    it('should be .sync', function () {
+      var run = new Runnable('foo', function () {});
       run.async.should.be.equal(0);
       run.sync.should.be.true();
-    })
-  })
+    });
+  });
 
-  describe('#globals', function(){
-    it('should allow for whitelisting globals', function(done){
-      var test = new Runnable('foo', function(){});
+  describe('#globals', function () {
+    it('should allow for whitelisting globals', function (done) {
+      var test = new Runnable('foo', function () {});
       test.async.should.be.equal(0);
       test.sync.should.be.true();
       test.globals(['foobar']);
       test.run(done);
-    })
-  })
+    });
+  });
 
-  describe('#retries(n)', function(){
-    it('should set the number of retries', function(){
-      var run = new Runnable;
+  describe('#retries(n)', function () {
+    it('should set the number of retries', function () {
+      var run = new Runnable();
       run.retries(1);
       run.retries().should.equal(1);
-    })
-  })
+    });
+  });
 
-  describe('.run(fn)', function(){
-    describe('when .pending', function(){
-      it('should not invoke the callback', function(done){
-        var test = new Runnable('foo', function(){
+  describe('.run(fn)', function () {
+    describe('when .pending', function () {
+      it('should not invoke the callback', function (done) {
+        var test = new Runnable('foo', function () {
           throw new Error('should not be called');
         });
 
         test.pending = true;
         test.run(done);
-      })
-    })
+      });
+    });
 
-    describe('when sync', function(){
-      describe('without error', function(){
-        it('should invoke the callback', function(done){
+    describe('when sync', function () {
+      describe('without error', function () {
+        it('should invoke the callback', function (done) {
           var calls = 0;
-          var test = new Runnable('foo', function(){
+          var test = new Runnable('foo', function () {
             ++calls;
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             calls.should.equal(1);
             test.duration.should.be.type('number');
             done(err);
-          })
-        })
-      })
+          });
+        });
+      });
 
-      describe('when an exception is thrown', function(){
-        it('should invoke the callback', function(done){
+      describe('when an exception is thrown', function () {
+        it('should invoke the callback', function (done) {
           var calls = 0;
-          var test = new Runnable('foo', function(){
+          var test = new Runnable('foo', function () {
             ++calls;
             throw new Error('fail');
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             calls.should.equal(1);
             err.message.should.equal('fail');
             done();
-          })
-        })
-      })
+          });
+        });
+      });
 
-      describe('when an exception is thrown and is allowed to remain uncaught', function(){
-        it('throws an error when it is allowed', function(done) {
-          var test = new Runnable('foo', function(){
+      describe('when an exception is thrown and is allowed to remain uncaught', function () {
+        it('throws an error when it is allowed', function (done) {
+          var test = new Runnable('foo', function () {
             throw new Error('fail');
           });
           test.allowUncaught = true;
-          function fail() {
-            test.run(function(err) {});
+          function fail () {
+            test.run(function () {});
           }
           fail.should.throw('fail');
           done();
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('when timeouts are disabled', function() {
-      it('should not error with timeout', function(done) {
-        var test = new Runnable('foo', function(done){
+    describe('when timeouts are disabled', function () {
+      it('should not error with timeout', function (done) {
+        var test = new Runnable('foo', function (done) {
           setTimeout(process.nextTick.bind(undefined, done), 2);
         });
         test.timeout(1);
@@ -190,32 +191,31 @@ describe('Runnable(title, fn)', function(){
       });
     });
 
-    describe('when async', function(){
-      describe('without error', function(){
-        it('should invoke the callback', function(done){
-          var calls = 0;
-          var test = new Runnable('foo', function(done){
+    describe('when async', function () {
+      describe('without error', function () {
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function (done) {
             process.nextTick(done);
           });
 
           test.run(done);
-        })
-      })
+        });
+      });
 
-      describe('when the callback is invoked several times', function(){
-        describe('without an error', function(){
-          it('should emit a single "error" event', function(done){
+      describe('when the callback is invoked several times', function () {
+        describe('without an error', function () {
+          it('should emit a single "error" event', function (done) {
             var calls = 0;
             var errCalls = 0;
 
-            var test = new Runnable('foo', function(done){
+            var test = new Runnable('foo', function (done) {
               process.nextTick(done);
               process.nextTick(done);
               process.nextTick(done);
               process.nextTick(done);
             });
 
-            test.on('error', function(err){
+            test.on('error', function (err) {
               ++errCalls;
               err.message.should.equal('done() called multiple times');
               calls.should.equal(1);
@@ -223,18 +223,18 @@ describe('Runnable(title, fn)', function(){
               done();
             });
 
-            test.run(function(){
+            test.run(function () {
               ++calls;
             });
-          })
-        })
+          });
+        });
 
-        describe('with an error', function(){
-          it('should emit a single "error" event', function(done){
+        describe('with an error', function () {
+          it('should emit a single "error" event', function (done) {
             var calls = 0;
             var errCalls = 0;
 
-            var test = new Runnable('foo', function(done){
+            var test = new Runnable('foo', function (done) {
               done(new Error('fail'));
               process.nextTick(done);
               done(new Error('fail'));
@@ -242,7 +242,7 @@ describe('Runnable(title, fn)', function(){
               process.nextTick(done);
             });
 
-            test.on('error', function(err){
+            test.on('error', function (err) {
               ++errCalls;
               err.message.should.equal('fail');
               calls.should.equal(1);
@@ -250,133 +250,129 @@ describe('Runnable(title, fn)', function(){
               done();
             });
 
-            test.run(function(){
+            test.run(function () {
               ++calls;
             });
-          })
-        })
-      })
+          });
+        });
+      });
 
-      describe('when an exception is thrown', function(){
-        it('should invoke the callback', function(done){
-          var calls = 0;
-          var test = new Runnable('foo', function(done){
+      describe('when an exception is thrown', function () {
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function (done) {
             throw new Error('fail');
-            process.nextTick(done);
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             err.message.should.equal('fail');
             done();
           });
-        })
+        });
 
         it('should not throw its own exception if passed a non-object', function (done) {
-          var test = new Runnable('foo', function(done) {
+          var test = new Runnable('foo', function (done) {
+            /* eslint no-throw-literal: off */
             throw null;
-            process.nextTick(done);
           });
 
-          test.run(function(err) {
+          test.run(function (err) {
             err.message.should.equal(utils.undefinedError().message);
             done();
-          })
+          });
         });
-      })
+      });
 
-      describe('when an exception is thrown and is allowed to remain uncaught', function(){
-        it('throws an error when it is allowed', function(done) {
-          var test = new Runnable('foo', function(done){
+      describe('when an exception is thrown and is allowed to remain uncaught', function () {
+        it('throws an error when it is allowed', function (done) {
+          var test = new Runnable('foo', function (done) {
             throw new Error('fail');
-            process.nextTick(done);
           });
           test.allowUncaught = true;
-          function fail() {
-            test.run(function(err) {});
+          function fail () {
+            test.run(function () {});
           }
           fail.should.throw('fail');
           done();
-        })
-      })
+        });
+      });
 
-      describe('when an error is passed', function(){
-        it('should invoke the callback', function(done){
-          var calls = 0;
-          var test = new Runnable('foo', function(done){
+      describe('when an error is passed', function () {
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function (done) {
             done(new Error('fail'));
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             err.message.should.equal('fail');
             done();
           });
-        })
-      })
+        });
+      });
 
-      describe('when done() is invoked with a non-Error object', function(){
-        it('should invoke the callback', function(done){
-          var test = new Runnable('foo', function(done){
+      describe('when done() is invoked with a non-Error object', function () {
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function (done) {
             done({ error: 'Test error' });
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             err.message.should.equal('done() invoked with non-Error: {"error":"Test error"}');
             done();
           });
-        })
-      })
+        });
+      });
 
-      describe('when done() is invoked with a string', function(){
-        it('should invoke the callback', function(done){
-          var test = new Runnable('foo', function(done){
+      describe('when done() is invoked with a string', function () {
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function (done) {
             done('Test error');
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             err.message.should.equal('done() invoked with non-Error: Test error');
             done();
           });
-        })
-      })
+        });
+      });
 
-      it('should allow updating the timeout', function(done){
+      it('should allow updating the timeout', function (done) {
         var callCount = 0;
-        var increment = function() {
+        var increment = function () {
           callCount++;
         };
-        var test = new Runnable('foo', function(done){
+        var test = new Runnable('foo', function (done) {
           setTimeout(increment, 1);
           setTimeout(increment, 100);
         });
         test.timeout(10);
-        test.run(function(err){
+        test.run(function (err) {
           err.should.be.ok();
           callCount.should.equal(1);
           done();
         });
-      })
+      });
 
-      it('should allow a timeout of 0')
-    })
+      it('should allow a timeout of 0');
+    });
 
-    describe('when fn returns a promise', function(){
-      describe('when the promise is fulfilled with no value', function(){
+    describe('when fn returns a promise', function () {
+      describe('when the promise is fulfilled with no value', function () {
         var fulfilledPromise = {
           then: function (fulfilled, rejected) {
             process.nextTick(fulfilled);
           }
         };
 
-        it('should invoke the callback', function(done){
-          var test = new Runnable('foo', function(){
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function () {
             return fulfilledPromise;
           });
 
           test.run(done);
-        })
-      })
+        });
+      });
 
-      describe('when the promise is fulfilled with a value', function(){
+      describe('when the promise is fulfilled with a value', function () {
         var fulfilledPromise = {
           then: function (fulfilled, rejected) {
             process.nextTick(function () {
@@ -385,16 +381,16 @@ describe('Runnable(title, fn)', function(){
           }
         };
 
-        it('should invoke the callback', function(done){
-          var test = new Runnable('foo', function(){
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function () {
             return fulfilledPromise;
           });
 
           test.run(done);
-        })
-      })
+        });
+      });
 
-      describe('when the promise is rejected', function(){
+      describe('when the promise is rejected', function () {
         var expectedErr = new Error('fail');
         var rejectedPromise = {
           then: function (fulfilled, rejected) {
@@ -404,19 +400,19 @@ describe('Runnable(title, fn)', function(){
           }
         };
 
-        it('should invoke the callback', function(done){
-          var test = new Runnable('foo', function(){
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function () {
             return rejectedPromise;
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             err.should.equal(expectedErr);
             done();
           });
-        })
-      })
+        });
+      });
 
-      describe('when the promise is rejected without a reason', function(){
+      describe('when the promise is rejected without a reason', function () {
         var expectedErr = new Error('Promise rejected with no or falsy reason');
         var rejectedPromise = {
           then: function (fulfilled, rejected) {
@@ -426,45 +422,45 @@ describe('Runnable(title, fn)', function(){
           }
         };
 
-        it('should invoke the callback', function(done){
-          var test = new Runnable('foo', function(){
+        it('should invoke the callback', function (done) {
+          var test = new Runnable('foo', function () {
             return rejectedPromise;
           });
 
-          test.run(function(err){
+          test.run(function (err) {
             err.should.eql(expectedErr);
             done();
           });
-        })
-      })
+        });
+      });
 
-      describe('when the promise takes too long to settle', function(){
+      describe('when the promise takes too long to settle', function () {
         var foreverPendingPromise = {
           then: function () { }
         };
 
-        it('should give the timeout error', function(done){
-          var test = new Runnable('foo', function(){
+        it('should give the timeout error', function (done) {
+          var test = new Runnable('foo', function () {
             return foreverPendingPromise;
           });
 
           test.timeout(10);
-          test.run(function(err){
+          test.run(function (err) {
             err.should.be.ok();
             done();
           });
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('when fn returns a non-promise', function(){
-      it('should invoke the callback', function(done){
-        var test = new Runnable('foo', function(){
-          return { then: "i ran my tests" };
+    describe('when fn returns a non-promise', function () {
+      it('should invoke the callback', function (done) {
+        var test = new Runnable('foo', function () {
+          return { then: 'i ran my tests' };
         });
 
         test.run(done);
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var mocha = require('../');
 var Suite = mocha.Suite;
 var Runner = mocha.Runner;
@@ -5,19 +7,19 @@ var Test = mocha.Test;
 var Hook = mocha.Hook;
 var path = require('path');
 
-function noop() {}
+function noop () {}
 
-describe('Runner', function() {
+describe('Runner', function () {
   var suite;
   var runner;
 
-  beforeEach(function() {
+  beforeEach(function () {
     suite = new Suite('Suite', 'root');
     runner = new Runner(suite);
   });
 
-  describe('.grep()', function() {
-    it('should update the runner.total with number of matched tests', function() {
+  describe('.grep()', function () {
+    it('should update the runner.total with number of matched tests', function () {
       suite.addTest(new Test('im a test about lions', noop));
       suite.addTest(new Test('im another test about lions', noop));
       suite.addTest(new Test('im a test about bears', noop));
@@ -26,7 +28,7 @@ describe('Runner', function() {
       newRunner.total.should.equal(2);
     });
 
-    it('should update the runner.total with number of matched tests when inverted', function() {
+    it('should update the runner.total with number of matched tests when inverted', function () {
       suite.addTest(new Test('im a test about lions', noop));
       suite.addTest(new Test('im another test about lions', noop));
       suite.addTest(new Test('im a test about bears', noop));
@@ -36,8 +38,8 @@ describe('Runner', function() {
     });
   });
 
-  describe('.grepTotal()', function() {
-    it('should return the total number of matched tests', function() {
+  describe('.grepTotal()', function () {
+    it('should return the total number of matched tests', function () {
       suite.addTest(new Test('im a test about lions', noop));
       suite.addTest(new Test('im another test about lions', noop));
       suite.addTest(new Test('im a test about bears', noop));
@@ -45,7 +47,7 @@ describe('Runner', function() {
       runner.grepTotal(suite).should.equal(2);
     });
 
-    it('should return the total number of matched tests when inverted', function() {
+    it('should return the total number of matched tests when inverted', function () {
       suite.addTest(new Test('im a test about lions', noop));
       suite.addTest(new Test('im another test about lions', noop));
       suite.addTest(new Test('im a test about bears', noop));
@@ -54,8 +56,8 @@ describe('Runner', function() {
     });
   });
 
-  describe('.globalProps()', function() {
-    it('should include common non enumerable globals', function() {
+  describe('.globalProps()', function () {
+    it('should include common non enumerable globals', function () {
       var props = runner.globalProps();
       props.should.containEql('setTimeout');
       props.should.containEql('clearTimeout');
@@ -66,20 +68,20 @@ describe('Runner', function() {
     });
   });
 
-  describe('.globals()', function() {
-    it('should default to the known globals', function() {
+  describe('.globals()', function () {
+    it('should default to the known globals', function () {
       runner.globals().length.should.be.above(16);
     });
 
-    it('should white-list globals', function() {
+    it('should white-list globals', function () {
       runner.globals(['foo', 'bar']);
       runner.globals().should.containEql('foo');
       runner.globals().should.containEql('bar');
     });
   });
 
-  describe('.checkGlobals(test)', function() {
-    it('should allow variables that match a wildcard', function(done) {
+  describe('.checkGlobals(test)', function () {
+    it('should allow variables that match a wildcard', function (done) {
       runner.globals(['foo*', 'giz*']);
       global.foo = 'baz';
       global.gizmo = 'quux';
@@ -89,11 +91,11 @@ describe('Runner', function() {
       done();
     });
 
-    it('should emit "fail" when a new global is introduced', function(done) {
+    it('should emit "fail" when a new global is introduced', function (done) {
       var test = new Test('im a test', noop);
       runner.checkGlobals();
       global.foo = 'bar';
-      runner.on('fail', function(_test, err) {
+      runner.on('fail', function (_test, err) {
         _test.should.equal(test);
         err.message.should.equal('global leak detected: foo');
         delete global.foo;
@@ -102,11 +104,11 @@ describe('Runner', function() {
       runner.checkGlobals(test);
     });
 
-    it('should emit "fail" when a single new disallowed global is introduced after a single extra global is allowed', function(done) {
+    it('should emit "fail" when a single new disallowed global is introduced after a single extra global is allowed', function (done) {
       var doneCalled = false;
       runner.globals('good');
       global.bad = 1;
-      runner.on('fail', function() {
+      runner.on('fail', function () {
         delete global.bad;
         done();
         doneCalled = true;
@@ -117,7 +119,7 @@ describe('Runner', function() {
       }
     });
 
-    it('should not fail when a new common global is introduced', function() {
+    it('should not fail when a new common global is introduced', function () {
       // verify that the prop isn't enumerable
       delete global.XMLHttpRequest;
       global.propertyIsEnumerable('XMLHttpRequest').should.not.be.ok();
@@ -128,7 +130,7 @@ describe('Runner', function() {
       var newRunner = new Runner(suite);
 
       // make the prop enumerable again.
-      global.XMLHttpRequest = function() {};
+      global.XMLHttpRequest = function () {};
       global.propertyIsEnumerable('XMLHttpRequest').should.be.ok();
 
       // verify the test hasn't failed.
@@ -139,12 +141,12 @@ describe('Runner', function() {
       delete global.XMLHttpRequest;
     });
 
-    it('should pluralize the error message when several are introduced', function(done) {
+    it('should pluralize the error message when several are introduced', function (done) {
       var test = new Test('im a test', noop);
       runner.checkGlobals();
       global.foo = 'bar';
       global.bar = 'baz';
-      runner.on('fail', function(_test, err) {
+      runner.on('fail', function (_test, err) {
         _test.should.equal(test);
         err.message.should.equal('global leaks detected: foo, bar');
         delete global.foo;
@@ -154,7 +156,7 @@ describe('Runner', function() {
       runner.checkGlobals(test);
     });
 
-    it('should respect per test whitelisted globals', function() {
+    it('should respect per test whitelisted globals', function () {
       var test = new Test('im a test about lions', noop);
       test.globals(['foo']);
 
@@ -170,7 +172,7 @@ describe('Runner', function() {
       delete global.foo;
     });
 
-    it('should respect per test whitelisted globals but still detect other leaks', function(done) {
+    it('should respect per test whitelisted globals but still detect other leaks', function (done) {
       var test = new Test('im a test about lions', noop);
       test.globals(['foo']);
 
@@ -178,7 +180,7 @@ describe('Runner', function() {
 
       global.foo = 'bar';
       global.bar = 'baz';
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         test.title.should.equal('im a test about lions');
         err.message.should.equal('global leak detected: bar');
         delete global.foo;
@@ -187,32 +189,32 @@ describe('Runner', function() {
       runner.checkGlobals(test);
     });
 
-    it('should emit "fail" when a global beginning with d is introduced', function(done) {
+    it('should emit "fail" when a global beginning with d is introduced', function (done) {
       global.derp = 'bar';
-      runner.on('fail', function() {
+      runner.on('fail', function () {
         delete global.derp;
         done();
       });
-      runner.checkGlobals(new Test('herp', function() {}));
+      runner.checkGlobals(new Test('herp', function () {}));
     });
   });
 
-  describe('.hook(name, fn)', function() {
-    it('should execute hooks after failed test if suite bail is true', function(done) {
+  describe('.hook(name, fn)', function () {
+    it('should execute hooks after failed test if suite bail is true', function (done) {
       runner.fail(new Test('failed test', noop));
       suite.bail(true);
-      suite.afterEach(function() {
-        suite.afterAll(function() {
+      suite.afterEach(function () {
+        suite.afterAll(function () {
           done();
         });
       });
-      runner.hook('afterEach', function() {});
-      runner.hook('afterAll', function() {});
+      runner.hook('afterEach', function () {});
+      runner.hook('afterAll', function () {});
     });
   });
 
-  describe('.fail(test, err)', function() {
-    it('should increment .failures', function() {
+  describe('.fail(test, err)', function () {
+    it('should increment .failures', function () {
       runner.failures.should.equal(0);
       runner.fail(new Test('one', noop), {});
       runner.failures.should.equal(1);
@@ -220,16 +222,16 @@ describe('Runner', function() {
       runner.failures.should.equal(2);
     });
 
-    it('should set test.state to "failed"', function() {
+    it('should set test.state to "failed"', function () {
       var test = new Test('some test', noop);
       runner.fail(test, 'some error');
       test.state.should.equal('failed');
     });
 
-    it('should emit "fail"', function(done) {
+    it('should emit "fail"', function (done) {
       var test = new Test('some other test', noop);
       var err = {};
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         test.should.equal(test);
         err.should.equal(err);
         done();
@@ -237,53 +239,53 @@ describe('Runner', function() {
       runner.fail(test, err);
     });
 
-    it('should emit a helpful message when failed with a string', function(done) {
+    it('should emit a helpful message when failed with a string', function (done) {
       var test = new Test('helpful test', noop);
       var err = 'string';
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         err.message.should.equal('the string "string" was thrown, throw an Error :)');
         done();
       });
       runner.fail(test, err);
     });
 
-    it('should emit a the error when failed with an Error instance', function(done) {
+    it('should emit a the error when failed with an Error instance', function (done) {
       var test = new Test('a test', noop);
       var err = new Error('an error message');
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         err.message.should.equal('an error message');
         done();
       });
       runner.fail(test, err);
     });
 
-    it('should emit the error when failed with an Error-like object', function(done) {
+    it('should emit the error when failed with an Error-like object', function (done) {
       var test = new Test('a test', noop);
       var err = { message: 'an error message' };
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         err.message.should.equal('an error message');
         done();
       });
       runner.fail(test, err);
     });
 
-    it('should emit a helpful message when failed with an Object', function(done) {
+    it('should emit a helpful message when failed with an Object', function (done) {
       var test = new Test('a test', noop);
       var err = { x: 1 };
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         err.message.should.equal('the object {\n  "x": 1\n} was thrown, throw an Error :)');
         done();
       });
       runner.fail(test, err);
     });
 
-    it('should emit a helpful message when failed with an Array', function(done) {
+    it('should emit a helpful message when failed with an Array', function (done) {
       var test = new Test('a test', noop);
       var err = [
         1,
         2
       ];
-      runner.on('fail', function(test, err) {
+      runner.on('fail', function (test, err) {
         err.message.should.equal('the array [\n  1\n  2\n] was thrown, throw an Error :)');
         done();
       });
@@ -291,8 +293,8 @@ describe('Runner', function() {
     });
   });
 
-  describe('.failHook(hook, err)', function() {
-    it('should increment .failures', function() {
+  describe('.failHook(hook, err)', function () {
+    it('should increment .failures', function () {
       runner.failures.should.equal(0);
       runner.failHook(new Test('fail hook 1', noop), {});
       runner.failures.should.equal(1);
@@ -300,7 +302,7 @@ describe('Runner', function() {
       runner.failures.should.equal(2);
     });
 
-    it('should augment hook title with current test title', function() {
+    it('should augment hook title with current test title', function () {
       var hook = new Hook('"before each" hook');
       hook.ctx = { currentTest: new Test('should behave', noop) };
 
@@ -312,10 +314,10 @@ describe('Runner', function() {
       hook.title.should.equal('"before each" hook for "should obey"');
     });
 
-    it('should emit "fail"', function(done) {
+    it('should emit "fail"', function (done) {
       var hook = new Hook();
       var err = {};
-      runner.on('fail', function(hook, err) {
+      runner.on('fail', function (hook, err) {
         hook.should.equal(hook);
         err.should.equal(err);
         done();
@@ -323,7 +325,7 @@ describe('Runner', function() {
       runner.failHook(hook, err);
     });
 
-    it('should emit "end" if suite bail is true', function(done) {
+    it('should emit "end" if suite bail is true', function (done) {
       var hook = new Hook();
       var err = {};
       suite.bail(true);
@@ -331,11 +333,11 @@ describe('Runner', function() {
       runner.failHook(hook, err);
     });
 
-    it('should not emit "end" if suite bail is not true', function(done) {
+    it('should not emit "end" if suite bail is not true', function (done) {
       var hook = new Hook();
       var err = {};
       suite.bail(false);
-      runner.on('end', function() {
+      runner.on('end', function () {
         throw new Error('"end" was emit, but the bail is false');
       });
       runner.failHook(hook, err);
@@ -343,14 +345,14 @@ describe('Runner', function() {
     });
   });
 
-  describe('allowUncaught', function() {
-    it('should allow unhandled errors to propagate through', function(done) {
+  describe('allowUncaught', function () {
+    it('should allow unhandled errors to propagate through', function (done) {
       var newRunner = new Runner(suite);
       newRunner.allowUncaught = true;
-      newRunner.test = new Test('failing test', function() {
+      newRunner.test = new Test('failing test', function () {
         throw new Error('allow unhandled errors');
       });
-      function fail() {
+      function fail () {
         newRunner.runTest();
       }
       fail.should.throw('allow unhandled errors');
@@ -358,7 +360,7 @@ describe('Runner', function() {
     });
   });
 
-  describe('stackTrace', function() {
+  describe('stackTrace', function () {
     var stack = [
       'AssertionError: foo bar',
       'at EventEmitter.<anonymous> (/usr/local/dev/test.js:16:12)',
@@ -373,20 +375,20 @@ describe('Runner', function() {
       'at processImmediate [as _immediateCallback] (timers.js:321:17)'
     ];
 
-    describe('shortStackTrace', function() {
-      beforeEach(function() {
+    describe('shortStackTrace', function () {
+      beforeEach(function () {
         if (path.sep !== '/') {
           this.skip();
         }
       });
 
-      it('should prettify the stack-trace', function(done) {
+      it('should prettify the stack-trace', function (done) {
         var hook = new Hook();
         var err = new Error();
         // Fake stack-trace
         err.stack = stack.join('\n');
 
-        runner.on('fail', function(hook, err) {
+        runner.on('fail', function (hook, err) {
           err.stack.should.equal(stack.slice(0, 3).join('\n'));
           done();
         });
@@ -394,14 +396,14 @@ describe('Runner', function() {
       });
     });
 
-    describe('longStackTrace', function() {
-      beforeEach(function() {
+    describe('longStackTrace', function () {
+      beforeEach(function () {
         if (path.sep !== '/') {
           this.skip();
         }
       });
 
-      it('should display the full stack-trace', function(done) {
+      it('should display the full stack-trace', function (done) {
         var hook = new Hook();
         var err = new Error();
         // Fake stack-trace
@@ -409,7 +411,7 @@ describe('Runner', function() {
         // Add --stack-trace option
         runner.fullStackTrace = true;
 
-        runner.on('fail', function(hook, err) {
+        runner.on('fail', function (hook, err) {
           err.stack.should.equal(stack.join('\n'));
           done();
         });

--- a/test/sanity/sanity.spec.js
+++ b/test/sanity/sanity.spec.js
@@ -2,8 +2,8 @@
 
 var assert = require('assert');
 
-describe('a production installation of Mocha', function() {
-  it('should be able to execute a test', function() {
+describe('a production installation of Mocha', function () {
+  it('should be able to execute a test', function () {
     assert.ok(true);
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,4 @@
+'use strict';
+
+global.expect = require('expect.js');
+global.assert = require('assert');

--- a/test/suite.spec.js
+++ b/test/suite.spec.js
@@ -1,11 +1,12 @@
-var mocha = require('../')
-  , Context = mocha.Context
-  , Suite = mocha.Suite
-  , Test = mocha.Test;
+'use strict';
 
-describe('Suite', function(){
-  describe('.clone()', function(){
-    beforeEach(function(){
+var mocha = require('../');
+var Suite = mocha.Suite;
+var Test = mocha.Test;
+
+describe('Suite', function () {
+  describe('.clone()', function () {
+    beforeEach(function () {
       this.suite = new Suite('To be cloned');
       this.suite._timeout = 3043;
       this.suite._slow = 101;
@@ -18,120 +19,120 @@ describe('Suite', function(){
       this.suite._afterAll.push(5);
     });
 
-    it('should copy the title', function(){
+    it('should copy the title', function () {
       this.suite.clone().title.should.equal('To be cloned');
     });
 
-    it('should copy the timeout value', function(){
+    it('should copy the timeout value', function () {
       this.suite.clone().timeout().should.equal(3043);
     });
 
-    it('should copy the slow value', function(){
+    it('should copy the slow value', function () {
       this.suite.clone().slow().should.equal(101);
     });
 
-    it('should copy the bail value', function(){
+    it('should copy the bail value', function () {
       this.suite.clone().bail().should.be.true();
     });
 
-    it('should not copy the values from the suites array', function(){
+    it('should not copy the values from the suites array', function () {
       this.suite.clone().suites.should.be.empty();
     });
 
-    it('should not copy the values from the tests array', function(){
+    it('should not copy the values from the tests array', function () {
       this.suite.clone().tests.should.be.empty();
     });
 
-    it('should not copy the values from the _beforeEach array', function(){
+    it('should not copy the values from the _beforeEach array', function () {
       this.suite.clone()._beforeEach.should.be.empty();
     });
 
-    it('should not copy the values from the _beforeAll array', function(){
+    it('should not copy the values from the _beforeAll array', function () {
       this.suite.clone()._beforeAll.should.be.empty();
     });
 
-    it('should not copy the values from the _afterEach array', function(){
+    it('should not copy the values from the _afterEach array', function () {
       this.suite.clone()._afterEach.should.be.empty();
     });
 
-    it('should not copy the values from the _afterAll array', function(){
+    it('should not copy the values from the _afterAll array', function () {
       this.suite.clone()._afterAll.should.be.empty();
     });
   });
 
-  describe('.timeout()', function(){
-    beforeEach(function(){
+  describe('.timeout()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('when no argument is passed', function(){
-      it('should return the timeout value', function(){
+    describe('when no argument is passed', function () {
+      it('should return the timeout value', function () {
         this.suite.timeout().should.equal(2000);
       });
     });
 
-    describe('when argument is passed', function(){
-      it('should return the Suite object', function(){
+    describe('when argument is passed', function () {
+      it('should return the Suite object', function () {
         var newSuite = this.suite.timeout(5000);
         newSuite.timeout().should.equal(5000);
       });
     });
   });
 
-  describe('.slow()', function(){
-    beforeEach(function(){
+  describe('.slow()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('when given a string', function(){
-      it('should parse it', function(){
+    describe('when given a string', function () {
+      it('should parse it', function () {
         this.suite.slow('5 seconds');
         this.suite.slow().should.equal(5000);
-      })
-    })
+      });
+    });
 
-    describe('when no argument is passed', function(){
-      it('should return the slow value', function(){
+    describe('when no argument is passed', function () {
+      it('should return the slow value', function () {
         this.suite.slow().should.equal(75);
       });
     });
 
-    describe('when argument is passed', function(){
-      it('should return the Suite object', function(){
+    describe('when argument is passed', function () {
+      it('should return the Suite object', function () {
         var newSuite = this.suite.slow(5000);
         newSuite.slow().should.equal(5000);
       });
     });
   });
 
-  describe('.bail()', function(){
-    beforeEach(function(){
+  describe('.bail()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
-      this.suite._bail = true
+      this.suite._bail = true;
     });
 
-    describe('when no argument is passed', function(){
-      it('should return the bail value', function(){
+    describe('when no argument is passed', function () {
+      it('should return the bail value', function () {
         this.suite.bail().should.be.true();
       });
     });
 
-    describe('when argument is passed', function(){
-      it('should return the Suite object', function(){
+    describe('when argument is passed', function () {
+      it('should return the Suite object', function () {
         var newSuite = this.suite.bail(false);
         newSuite.bail().should.be.false();
       });
     });
   });
 
-  describe('.beforeAll()', function(){
-    beforeEach(function(){
+  describe('.beforeAll()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('wraps the passed in function in a Hook', function(){
-      it('adds it to _beforeAll', function(){
-        var fn = function(){};
+    describe('wraps the passed in function in a Hook', function () {
+      it('adds it to _beforeAll', function () {
+        var fn = function () {};
         this.suite.beforeAll(fn);
 
         this.suite._beforeAll.should.have.length(1);
@@ -140,8 +141,8 @@ describe('Suite', function(){
         beforeAllItem.fn.should.equal(fn);
       });
 
-      it('appends title to hook', function(){
-        var fn = function(){};
+      it('appends title to hook', function () {
+        var fn = function () {};
         this.suite.beforeAll('test', fn);
 
         this.suite._beforeAll.should.have.length(1);
@@ -149,7 +150,7 @@ describe('Suite', function(){
         beforeAllItem.title.should.equal('"before all" hook: test');
         beforeAllItem.fn.should.equal(fn);
 
-        function namedFn(){}
+        function namedFn () {}
         this.suite.beforeAll(namedFn);
         this.suite._beforeAll.should.have.length(2);
         beforeAllItem = this.suite._beforeAll[1];
@@ -159,14 +160,14 @@ describe('Suite', function(){
     });
   });
 
-  describe('.afterAll()', function(){
-    beforeEach(function(){
+  describe('.afterAll()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('wraps the passed in function in a Hook', function(){
-      it('adds it to _afterAll', function(){
-        var fn = function(){};
+    describe('wraps the passed in function in a Hook', function () {
+      it('adds it to _afterAll', function () {
+        var fn = function () {};
         this.suite.afterAll(fn);
 
         this.suite._afterAll.should.have.length(1);
@@ -174,8 +175,8 @@ describe('Suite', function(){
         afterAllItem.title.should.match(/^"after all" hook/);
         afterAllItem.fn.should.equal(fn);
       });
-      it('appends title to hook', function(){
-        var fn = function(){};
+      it('appends title to hook', function () {
+        var fn = function () {};
         this.suite.afterAll('test', fn);
 
         this.suite._afterAll.should.have.length(1);
@@ -183,7 +184,7 @@ describe('Suite', function(){
         beforeAllItem.title.should.equal('"after all" hook: test');
         beforeAllItem.fn.should.equal(fn);
 
-        function namedFn(){}
+        function namedFn () {}
         this.suite.afterAll(namedFn);
         this.suite._afterAll.should.have.length(2);
         beforeAllItem = this.suite._afterAll[1];
@@ -193,14 +194,14 @@ describe('Suite', function(){
     });
   });
 
-  describe('.beforeEach()', function(){
-    beforeEach(function(){
+  describe('.beforeEach()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('wraps the passed in function in a Hook', function(){
-      it('adds it to _beforeEach', function(){
-        var fn = function(){};
+    describe('wraps the passed in function in a Hook', function () {
+      it('adds it to _beforeEach', function () {
+        var fn = function () {};
         this.suite.beforeEach(fn);
 
         this.suite._beforeEach.should.have.length(1);
@@ -209,8 +210,8 @@ describe('Suite', function(){
         beforeEachItem.fn.should.equal(fn);
       });
 
-      it('appends title to hook', function(){
-        var fn = function(){};
+      it('appends title to hook', function () {
+        var fn = function () {};
         this.suite.beforeEach('test', fn);
 
         this.suite._beforeEach.should.have.length(1);
@@ -218,7 +219,7 @@ describe('Suite', function(){
         beforeAllItem.title.should.equal('"before each" hook: test');
         beforeAllItem.fn.should.equal(fn);
 
-        function namedFn(){}
+        function namedFn () {}
         this.suite.beforeEach(namedFn);
         this.suite._beforeEach.should.have.length(2);
         beforeAllItem = this.suite._beforeEach[1];
@@ -228,14 +229,14 @@ describe('Suite', function(){
     });
   });
 
-  describe('.afterEach()', function(){
-    beforeEach(function(){
+  describe('.afterEach()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('wraps the passed in function in a Hook', function(){
-      it('adds it to _afterEach', function(){
-        var fn = function(){};
+    describe('wraps the passed in function in a Hook', function () {
+      it('adds it to _afterEach', function () {
+        var fn = function () {};
         this.suite.afterEach(fn);
 
         this.suite._afterEach.should.have.length(1);
@@ -244,8 +245,8 @@ describe('Suite', function(){
         afterEachItem.fn.should.equal(fn);
       });
 
-      it('appends title to hook', function(){
-        var fn = function(){};
+      it('appends title to hook', function () {
+        var fn = function () {};
         this.suite.afterEach('test', fn);
 
         this.suite._afterEach.should.have.length(1);
@@ -253,7 +254,7 @@ describe('Suite', function(){
         beforeAllItem.title.should.equal('"after each" hook: test');
         beforeAllItem.fn.should.equal(fn);
 
-        function namedFn(){}
+        function namedFn () {}
         this.suite.afterEach(namedFn);
         this.suite._afterEach.should.have.length(2);
         beforeAllItem = this.suite._afterEach[1];
@@ -263,8 +264,8 @@ describe('Suite', function(){
     });
   });
 
-  describe('.addSuite()', function(){
-    beforeEach(function(){
+  describe('.addSuite()', function () {
+    beforeEach(function () {
       this.first = new Suite('First suite');
       this.first.timeout(4002);
       this.first.slow(200);
@@ -272,26 +273,26 @@ describe('Suite', function(){
       this.first.addSuite(this.second);
     });
 
-    it('sets the parent on the added Suite', function(){
+    it('sets the parent on the added Suite', function () {
       this.second.parent.should.equal(this.first);
     });
 
-    it('copies the timeout value', function(){
+    it('copies the timeout value', function () {
       this.second.timeout().should.equal(4002);
     });
 
-    it('copies the slow value', function(){
+    it('copies the slow value', function () {
       this.second.slow().should.equal(200);
     });
 
-    it('adds the suite to the suites collection', function(){
+    it('adds the suite to the suites collection', function () {
       this.first.suites.should.have.length(1);
       this.first.suites[0].should.equal(this.second);
     });
 
-    it('treats suite as pending if its parent is pending', function(){
-      this.first.pending = true
-      this.second.isPending.should.be.true
+    it('treats suite as pending if its parent is pending', function () {
+      this.first.pending = true;
+      this.second.isPending.should.be.true;
     });
   });
 
@@ -317,19 +318,19 @@ describe('Suite', function(){
   //   });
   // });
 
-  describe('.fullTitle()', function(){
-    beforeEach(function(){
+  describe('.fullTitle()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('when there is no parent', function(){
-      it('returns the suite title', function(){
+    describe('when there is no parent', function () {
+      it('returns the suite title', function () {
         this.suite.fullTitle().should.equal('A Suite');
       });
     });
 
-    describe('when there is a parent', function(){
-      it('returns the combination of parent\'s and suite\'s title', function(){
+    describe('when there is a parent', function () {
+      it('returns the combination of parent\'s and suite\'s title', function () {
         var parentSuite = new Suite('I am a parent');
         parentSuite.addSuite(this.suite);
         this.suite.fullTitle().should.equal('I am a parent A Suite');
@@ -337,19 +338,19 @@ describe('Suite', function(){
     });
   });
 
-  describe('.total()', function(){
-    beforeEach(function(){
+  describe('.total()', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('when there are no nested suites or tests', function(){
-      it('should return 0', function(){
+    describe('when there are no nested suites or tests', function () {
+      it('should return 0', function () {
         this.suite.total().should.equal(0);
       });
     });
 
-    describe('when there are several tests in the suite', function(){
-      it('should return the number', function(){
+    describe('when there are several tests in the suite', function () {
+      it('should return the number', function () {
         this.suite.addTest(new Test('a child test'));
         this.suite.addTest(new Test('another child test'));
         this.suite.total().should.equal(2);
@@ -357,82 +358,82 @@ describe('Suite', function(){
     });
   });
 
-  describe('.eachTest(fn)', function(){
-    beforeEach(function(){
+  describe('.eachTest(fn)', function () {
+    beforeEach(function () {
       this.suite = new Suite('A Suite');
     });
 
-    describe('when there are no nested suites or tests', function(){
-      it('should return 0', function(){
+    describe('when there are no nested suites or tests', function () {
+      it('should return 0', function () {
         var n = 0;
-        function fn(){ n++; }
+        function fn () { n++; }
         this.suite.eachTest(fn);
         n.should.equal(0);
       });
     });
 
-    describe('when there are several tests in the suite', function(){
-      it('should return the number', function(){
+    describe('when there are several tests in the suite', function () {
+      it('should return the number', function () {
         this.suite.addTest(new Test('a child test'));
         this.suite.addTest(new Test('another child test'));
 
         var n = 0;
-        function fn(){ n++; }
+        function fn () { n++; }
         this.suite.eachTest(fn);
         n.should.equal(2);
       });
     });
 
-    describe('when there are several levels of nested suites', function(){
-      it('should return the number', function(){
+    describe('when there are several levels of nested suites', function () {
+      it('should return the number', function () {
         this.suite.addTest(new Test('a child test'));
         var suite = new Suite('a child suite');
         suite.addTest(new Test('a test in a child suite'));
         this.suite.addSuite(suite);
 
         var n = 0;
-        function fn(){ n++; }
+        function fn () { n++; }
         this.suite.eachTest(fn);
         n.should.equal(2);
       });
     });
-
   });
 
-  describe('initialization', function() {
-    it('should throw an error if the title isn\'t a string', function() {
-      (function() {
+  describe('initialization', function () {
+    /* eslint no-new: off */
+    it('should throw an error if the title isn\'t a string', function () {
+      (function () {
         new Suite(undefined, 'root');
       }).should.throw();
 
-      (function() {
-        new Suite(function(){}, 'root');
+      (function () {
+        new Suite(function () {}, 'root');
       }).should.throw();
     });
 
-    it('should not throw if the title is a string', function() {
-      (function() {
+    it('should not throw if the title is a string', function () {
+      (function () {
         new Suite('Bdd suite', 'root');
       }).should.not.throw();
     });
   });
 });
 
-describe('Test', function() {
-  describe('initialization', function() {
-    it('should throw an error if the title isn\'t a string', function() {
-      (function() {
-        new Test(function(){});
+describe('Test', function () {
+  describe('initialization', function () {
+    it('should throw an error if the title isn\'t a string', function () {
+      (function () {
+        new Test(function () {});
       }).should.throw();
 
-      (function() {
-        new Test(undefined, function(){});
+      (function () {
+        new Test(undefined, function () {});
       }).should.throw();
     });
 
-    it('should not throw if the title is a string', function() {
-      (function() {
-        new Test('test-case',  function(){});
+    it('should not throw if the title is a string', function () {
+      (function () {
+        new Test('test-case', function () {});
       }).should.not.throw();
     });
   });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,11 +1,12 @@
-var mocha = require('../')
-  , should = require('should')
-  , Context = mocha.Context
-  , Test = mocha.Test;
+'use strict';
 
-describe('Test', function(){
-  describe('.clone()', function(){
-    beforeEach(function(){
+var mocha = require('../');
+var should = require('should');
+var Test = mocha.Test;
+
+describe('Test', function () {
+  describe('.clone()', function () {
+    beforeEach(function () {
       this._test = new Test('To be cloned', function () {});
       this._test._timeout = 3043;
       this._test._slow = 101;
@@ -17,59 +18,59 @@ describe('Test', function(){
       this._test.file = 'bar';
     });
 
-    it('should copy the title', function(){
+    it('should copy the title', function () {
       this._test.clone().title.should.equal('To be cloned');
     });
 
-    it('should copy the timeout value', function(){
+    it('should copy the timeout value', function () {
       this._test.clone().timeout().should.equal(3043);
     });
 
-    it('should copy the slow value', function(){
+    it('should copy the slow value', function () {
       this._test.clone().slow().should.equal(101);
     });
 
-    it('should copy the enableTimeouts value', function(){
+    it('should copy the enableTimeouts value', function () {
       this._test.clone().enableTimeouts().should.be.true();
     });
 
-    it('should copy the retries value', function(){
+    it('should copy the retries value', function () {
       this._test.clone().retries().should.equal(3);
     });
 
-    it('should copy the currentRetry value', function(){
+    it('should copy the currentRetry value', function () {
       this._test.clone().currentRetry().should.equal(1);
     });
 
-    it('should copy the globals value', function(){
+    it('should copy the globals value', function () {
       this._test.clone().globals().should.not.be.empty();
     });
 
-    it('should copy the parent value', function(){
+    it('should copy the parent value', function () {
       this._test.clone().parent.should.equal('foo');
     });
 
-    it('should copy the file value', function(){
+    it('should copy the file value', function () {
       this._test.clone().file.should.equal('bar');
     });
   });
 
-  describe('.isPending()', function(){
-    beforeEach(function(){
+  describe('.isPending()', function () {
+    beforeEach(function () {
       this._test = new Test('Is it skipped', function () {});
     });
 
-    it('should not be pending by default', function(){
+    it('should not be pending by default', function () {
       should(this._test.isPending()).not.be.ok();
     });
 
-    it('should be pending when marked as such', function(){
+    it('should be pending when marked as such', function () {
       this._test.pending = true;
       should(this._test.isPending()).be.ok();
     });
 
-    it('should be pending when its parent is pending', function(){
-      this._test.parent = { isPending: function(){ return true } };
+    it('should be pending when its parent is pending', function () {
+      this._test.parent = { isPending: function () { return true; } };
       should(this._test.isPending()).be.ok();
     });
   });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,86 +1,88 @@
+'use strict';
+
 var mocha = require('..');
 var utils = mocha.utils;
 var path = require('path');
 var JSON = require('json3');
 
-describe('utils', function() {
-  describe('.clean()', function() {
+describe('utils', function () {
+  describe('.clean()', function () {
     var clean = utils.clean;
-    it('should remove the wrapping function declaration', function() {
+    it('should remove the wrapping function declaration', function () {
       clean('function  (one, two, three)  {\n//code\n}').should.equal('//code');
     });
 
-    it('should handle newlines in the function declaration', function() {
+    it('should handle newlines in the function declaration', function () {
       clean('function  (one, two, three)\n  {\n//code\n}').should.equal('//code');
     });
 
-    it('should remove space character indentation from the function body', function() {
+    it('should remove space character indentation from the function body', function () {
       clean('  //line1\n    //line2').should.equal('//line1\n  //line2');
     });
 
-    it('should remove tab character indentation from the function body', function() {
+    it('should remove tab character indentation from the function body', function () {
       clean('\t//line1\n\t\t//line2').should.equal('//line1\n\t//line2');
     });
 
-    it('should handle functions with tabs in their declarations', function() {
+    it('should handle functions with tabs in their declarations', function () {
       clean('function\t(\t)\t{\n//code\n}').should.equal('//code');
     });
 
-    it('should handle named functions without space after name', function() {
+    it('should handle named functions without space after name', function () {
       clean('function withName() {\n//code\n}').should.equal('//code');
     });
 
-    it('should handle named functions with space after name', function() {
+    it('should handle named functions with space after name', function () {
       clean('function withName () {\n//code\n}').should.equal('//code');
     });
 
-    it('should handle functions with no space between the end and the closing brace', function() {
+    it('should handle functions with no space between the end and the closing brace', function () {
       clean('function() {/*code*/}').should.equal('/*code*/');
     });
 
-    it('should handle functions with parentheses in the same line', function() {
+    it('should handle functions with parentheses in the same line', function () {
       clean('function() { if (true) { /* code */ } }').should.equal('if (true) { /* code */ }');
     });
 
-    it('should handle empty functions', function() {
+    it('should handle empty functions', function () {
       clean('function() {}').should.equal('');
     });
   });
 
-  describe('.isBuffer()', function() {
+  describe('.isBuffer()', function () {
     var isBuffer = utils.isBuffer;
-    it('should test if object is a Buffer', function() {
+    it('should test if object is a Buffer', function () {
       isBuffer(new Buffer([0x01])).should.equal(true);
       isBuffer({}).should.equal(false);
-    })
+    });
   });
 
-  describe('.map()', function() {
+  describe('.map()', function () {
     var map = utils.map;
-    it('should behave same as Array.prototype.map', function() {
+    it('should behave same as Array.prototype.map', function () {
       var arr = [1, 2, 3];
       map(arr, JSON.stringify).should.eql(arr.map(JSON.stringify));
     });
 
-    it('should call the callback with 3 arguments[currentValue, index, array]', function() {
+    it('should call the callback with 3 arguments[currentValue, index, array]', function () {
       var index = 0;
-      map([1, 2, 3], function(e, i, arr) {
+      map([1, 2, 3], function (e, i, arr) {
         e.should.equal(arr[index]);
         i.should.equal(index++);
-      })
+      });
     });
 
-    it('should apply with the given scope', function() {
+    it('should apply with the given scope', function () {
       var scope = {};
-      map(['a', 'b', 'c'], function() {
+      map(['a', 'b', 'c'], function () {
         this.should.equal(scope);
       }, scope);
     });
   });
 
-  describe('.parseQuery()', function() {
+  describe('.parseQuery()', function () {
     var parseQuery = utils.parseQuery;
-    it('should get queryString and return key-value object', function() {
+    it('should get queryString and return key-value object', function () {
       parseQuery('?foo=1&bar=2&baz=3').should.eql({
         foo: '1',
         bar: '2',
@@ -92,11 +94,11 @@ describe('utils', function() {
         r2: 'm{2}',
         r3: '^co.*'
       });
-    })
+    });
   });
 
-  describe('.stackTraceFilter()', function() {
-    describe('on node', function() {
+  describe('.stackTraceFilter()', function () {
+    describe('on node', function () {
       var filter = utils.stackTraceFilter();
 
       describe('on POSIX OS', function () {
@@ -187,7 +189,7 @@ describe('utils', function() {
         });
       });
 
-      describe('on Windows', function() {
+      describe('on Windows', function () {
         before(function () {
           if (path.sep === '/') {
             this.skip();
@@ -215,44 +217,46 @@ describe('utils', function() {
       });
     });
 
-    describe('on browser', function() {
+    describe('on browser', function () {
       var filter;
-      before(function() {
+      before(function () {
         global.document = true;
         global.location = { href: 'localhost:3000/foo/bar/index.html' };
         filter = utils.stackTraceFilter();
       });
-      it('does not strip out other bower_components', function() {
-        var stack = ['Error: failed'
-          , 'at assert (index.html:11:26)'
-          , 'at Context.<anonymous> (test.js:17:18)'
-          , 'at bower_components/should/should.js:4827:7'
-          , 'at next (bower_components/should/should.js:4766:23)'
-          , 'at components/should/5.0.0/should.js:4827:7'
-          , 'at next (components/should/5.0.0/should.js:4766:23)'
-          , 'at Runner.require.register.Runner.runTest (node_modules/mocha.js:4892:10)'
-          , 'at localhost:3000/foo/bar/node_modules/mocha.js:4970:12'
-          , 'at next (node_modules/mocha.js:4817:14)'];
-        filter(stack.join('\n')).should.equal(stack.slice(0,7).join('\n'));
+      it('does not strip out other bower_components', function () {
+        var stack = [
+          'Error: failed',
+          'at assert (index.html:11:26)',
+          'at Context.<anonymous> (test.js:17:18)',
+          'at bower_components/should/should.js:4827:7',
+          'at next (bower_components/should/should.js:4766:23)',
+          'at components/should/5.0.0/should.js:4827:7',
+          'at next (components/should/5.0.0/should.js:4766:23)',
+          'at Runner.require.register.Runner.runTest (node_modules/mocha.js:4892:10)',
+          'at localhost:3000/foo/bar/node_modules/mocha.js:4970:12',
+          'at next (node_modules/mocha.js:4817:14)'
+        ];
+        filter(stack.join('\n')).should.equal(stack.slice(0, 7).join('\n'));
       });
 
-      after(function() {
+      after(function () {
         delete global.document;
         delete global.location;
       });
     });
   });
 
-  describe('.isPromise', function() {
-    it('should return true if the value is Promise-ish', function() {
-      utils.isPromise({then: function() {}}).should.be.true;
+  describe('.isPromise', function () {
+    it('should return true if the value is Promise-ish', function () {
+      utils.isPromise({then: function () {}}).should.be.true;
     });
 
-    it('should return false if the value is not an object', function() {
+    it('should return false if the value is not an object', function () {
       utils.isPromise(1).should.be.false;
     });
 
-    it('should return false if the value is an object w/o a "then" function', function() {
+    it('should return false if the value is an object w/o a "then" function', function () {
       utils.isPromise({}).should.be.false;
     });
   });


### PR DESCRIPTION
- mostly whitespace changes
- add `'use strict';` everywhere
- fix problems with unused variables, bad variable names, multiple declarations, unreachable code, yoda expressions, error handling, instantiation, etc.
- add a few eslint directives to avoid rules when needed
- switch to YAML eslint configs
- remove `test/` from `.eslintignore`
- add `mocha.js` to `.eslintignore`
- add userland `assert` as dev dependency (as is recommended)
- rename `test/fixture-expect.js` to `test/setup.js`; add global `assert` here
- add `assert` and `run` globals to `test/`'s eslint config
- update `test/mocha.opts` as appropriate
- update `lint` target in `Makefile`
- update eslint environments as appropriate