### PR TITLE
recover gracefully if stack is not writable; closes #2528

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -233,9 +233,13 @@ Runner.prototype.fail = function (test, err) {
     err = new Error('the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)');
   }
 
-  err.stack = (this.fullStackTrace || !err.stack)
-    ? err.stack
-    : stackFilter(err.stack);
+  try {
+    err.stack = (this.fullStackTrace || !err.stack)
+      ? err.stack
+      : stackFilter(err.stack);
+  } catch (ignored) {
+    // some environments do not take kindly to monkeying with the stack
+  }
 
   this.emit('fail', test, err);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -794,3 +794,9 @@ exports.stackTraceFilter = function () {
 exports.isPromise = function isPromise (value) {
   return typeof value === 'object' && typeof value.then === 'function';
 };
+
+/**
+ * It's a noop.
+ * @api
+ */
+exports.noop = function () {};

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -6,8 +6,7 @@ var Runner = mocha.Runner;
 var Test = mocha.Test;
 var Hook = mocha.Hook;
 var path = require('path');
-
-function noop () {}
+var noop = mocha.utils.noop;
 
 describe('Runner', function () {
   var suite;
@@ -289,6 +288,21 @@ describe('Runner', function () {
         err.message.should.equal('the array [\n  1\n  2\n] was thrown, throw an Error :)');
         done();
       });
+      runner.fail(test, err);
+    });
+
+    it('should recover if the error stack is not writable', function (done) {
+      var err = new Error('not evil');
+      Object.defineProperty(err, 'stack', {
+        value: err.stack
+      });
+      var test = new Test('a test', noop);
+
+      runner.on('fail', function (test, err) {
+        err.message.should.equal('not evil');
+        done();
+      });
+
       runner.fail(test, err);
     });
   });


### PR DESCRIPTION
I have no idea what's causing the error to have a non-writable `stack` property. ¯\_(ツ)_/¯