### PR TITLE
Added link to License text for easy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ Does your company use Mocha?  Ask your manager or marketing team if your company
 
 ## License
 
-MIT
+[MIT](https://raw.githubusercontent.com/mochajs/mocha/master/LICENSE)


### PR DESCRIPTION
There might be people who are looking for the exact license text.  Added a link to the license text (Raw form at https://raw.githubusercontent.com/mochajs/mocha/master/LICENSE) for easy access.