### PR TITLE
fix circular objects in json reporter. Closes #2433

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -54,18 +54,7 @@ function JSONReporter (runner) {
 
     runner.testResults = obj;
 
-    var cache = [];
-    process.stdout.write(JSON.stringify(obj, function (key, value) {
-      if (typeof value === 'object' && value !== null) {
-        if (cache.indexOf(value) !== -1) {
-          // Instead of going in a circle, we'll print [object Object]
-          return '' + value;
-        }
-        cache.push(value);
-      }
-
-      return value;
-    }, 2));
+    process.stdout.write(JSON.stringify(obj, null, 2));
   });
 }
 
@@ -78,17 +67,43 @@ function JSONReporter (runner) {
  * @return {Object}
  */
 function clean (test) {
+  var err = test.err || {};
+  if (err instanceof Error) {
+    err = errorJSON(err);
+  }
+
   return {
     title: test.title,
     fullTitle: test.fullTitle(),
     duration: test.duration,
     currentRetry: test.currentRetry(),
-    err: errorJSON(test.err || {})
+    err: cleanCycles(err)
   };
+}
+/**
+ * Replaces any circular references inside `obj` with '[object Object]'
+ *
+ * @api private
+ * @param {Object} obj
+ * @return {Object}
+ */
+function cleanCycles (obj) {
+  var cache = [];
+  return JSON.parse(JSON.stringify(obj, function (key, value) {
+    if (typeof value === 'object' && value !== null) {
+      if (cache.indexOf(value) !== -1) {
+        // Instead of going in a circle, we'll print [object Object]
+        return '' + value;
+      }
+      cache.push(value);
+    }
+
+    return value;
+  }));
 }
 
 /**
- * Transform `error` into a JSON object.
+ * Transform an Error object into a JSON object.
  *
  * @api private
  * @param {Error} err

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -54,7 +54,18 @@ function JSONReporter (runner) {
 
     runner.testResults = obj;
 
-    process.stdout.write(JSON.stringify(obj, null, 2));
+    var cache = [];
+    process.stdout.write(JSON.stringify(obj, function (key, value) {
+      if (typeof value === 'object' && value !== null) {
+        if (cache.indexOf(value) !== -1) {
+          // Instead of going in a circle, we'll print [object Object]
+          return '' + value;
+        }
+        cache.push(value);
+      }
+
+      return value;
+    }, 2));
   });
 }
 

--- a/mocha.js
+++ b/mocha.js
@@ -3061,7 +3061,18 @@ function JSONReporter (runner) {
 
     runner.testResults = obj;
 
-    process.stdout.write(JSON.stringify(obj, null, 2));
+    var cache = [];
+    process.stdout.write(JSON.stringify(obj, function (key, value) {
+      if (typeof value === 'object' && value !== null) {
+        if (cache.indexOf(value) !== -1) {
+          // Instead of going in a circle, we'll print [object Object]
+          return '' + value;
+        }
+        cache.push(value);
+      }
+
+      return value;
+    }, 2));
   });
 }
 

--- a/mocha.js
+++ b/mocha.js
@@ -3061,18 +3061,7 @@ function JSONReporter (runner) {
 
     runner.testResults = obj;
 
-    var cache = [];
-    process.stdout.write(JSON.stringify(obj, function (key, value) {
-      if (typeof value === 'object' && value !== null) {
-        if (cache.indexOf(value) !== -1) {
-          // Instead of going in a circle, we'll print [object Object]
-          return '' + value;
-        }
-        cache.push(value);
-      }
-
-      return value;
-    }, 2));
+    process.stdout.write(JSON.stringify(obj, null, 2));
   });
 }
 
@@ -3085,17 +3074,43 @@ function JSONReporter (runner) {
  * @return {Object}
  */
 function clean (test) {
+  var err = test.err || {};
+  if (err instanceof Error) {
+    err = errorJSON(err);
+  }
+
   return {
     title: test.title,
     fullTitle: test.fullTitle(),
     duration: test.duration,
     currentRetry: test.currentRetry(),
-    err: errorJSON(test.err || {})
+    err: cleanCycles(err)
   };
+}
+/**
+ * Replaces any circular references inside `obj` with '[object Object]'
+ *
+ * @api private
+ * @param {Object} obj
+ * @return {Object}
+ */
+function cleanCycles (obj) {
+  var cache = [];
+  return JSON.parse(JSON.stringify(obj, function (key, value) {
+    if (typeof value === 'object' && value !== null) {
+      if (cache.indexOf(value) !== -1) {
+        // Instead of going in a circle, we'll print [object Object]
+        return '' + value;
+      }
+      cache.push(value);
+    }
+
+    return value;
+  }));
 }
 
 /**
- * Transform `error` into a JSON object.
+ * Transform an Error object into a JSON object.
  *
  * @api private
  * @param {Error} err

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -60,4 +60,31 @@ describe('json reporter', function () {
       done();
     });
   });
+
+  it('should handle circular objects in errors', function (done) {
+    var testTitle = 'json test 1';
+    function CircleError () {
+      this.message = 'oh shit';
+      this.circular = this;
+    }
+    var error = new CircleError();
+
+    suite.addTest(new Test(testTitle, function (done) {
+      throw error;
+    }));
+
+    runner.run(function (failureCount) {
+      failureCount.should.be.exactly(1);
+      runner.should.have.property('testResults');
+      runner.testResults.should.have.property('failures');
+      runner.testResults.failures.should.be.an.instanceOf(Array);
+      runner.testResults.failures.should.have.a.lengthOf(1);
+
+      var failure = runner.testResults.failures[0];
+      failure.should.have.property('title', testTitle);
+      failure.should.have.properties('err');
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
In #2433, @boneskull recommended using `jsonStringify()` from `./lib/utils`, but that function isn't exported by the utils module, and more importantly it isn't actually circular-reference safe.

Instead, I took the custom replacer from [this StackOverflow post](http://stackoverflow.com/questions/11616630/json-stringify-avoid-typeerror-converting-circular-structure-to-json) and added it to the reporter's invocation of `JSON.stringify`.

The test for this issue is mostly a copy of the 1st json reporter test. It has fewer asserts because there's no way to test for the change to the object that is made by the replacer, but the test _does_ fail without the additional code.
