### PR TITLE
Add # at the beginning of errors in tap reporter. Closes #1257

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -47,7 +47,7 @@ function TAP (runner) {
     failures++;
     console.log('not ok %d %s', n, title(test));
     if (err.stack) {
-      console.log(err.stack.replace(/^/gm, '  '));
+      console.log(err.stack.replace(/^/gm, '#  '));
     }
   });
 

--- a/mocha.js
+++ b/mocha.js
@@ -3904,7 +3904,7 @@ function TAP (runner) {
     failures++;
     console.log('not ok %d %s', n, title(test));
     if (err.stack) {
-      console.log(err.stack.replace(/^/gm, '  '));
+      console.log(err.stack.replace(/^/gm, '#  '));
     }
   });
 


### PR DESCRIPTION
This was the solution to the problem in #1257 identified by @jreichenberg, but there was never a PR.
