### PR TITLE
wip Runnables should be functions

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,12 +1,6 @@
 'use strict';
 
 /**
- * Module dependencies.
- */
-
-var Test = require('../test');
-
-/**
  * BDD-style interface:
  *
  *      describe('Array', function() {
@@ -79,14 +73,12 @@ module.exports = function (suite) {
      */
 
     context.it = context.specify = function (title, fn) {
-      var suite = suites[0];
-      if (suite.isPending()) {
-        fn = null;
-      }
-      var test = new Test(title, fn);
-      test.file = file;
-      suite.addTest(test);
-      return test;
+      return common.test.create({
+        title: title,
+        file: file,
+        fn: fn,
+        suite: suites[0]
+      });
     };
 
     /**

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -114,8 +114,8 @@ module.exports = function (suites, context, mocha) {
         if (typeof opts.fn === 'function') {
           opts.fn.call(suite);
           suites.shift();
-        } else if (typeof opts.fn === 'undefined' && !suite.pending) {
-          throw new Error('Suite "' + suite.fullTitle() + '" was defined but no callback was supplied. Supply a callback or explicitly skip the suite.');
+        } else if (!suite.pending) {
+          throw new TypeError('Suite "' + suite.fullTitle() + '" was defined but no callback was supplied (got `' + utils.canonicalize(opts.fn) + '` instead). Supply a callback or explicitly skip the suite.');
         }
 
         return suite;

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -2,6 +2,7 @@
 
 var Suite = require('../suite');
 var Test = require('../test');
+var utils = require('../utils');
 
 /**
  * Functions common to more than one interface.

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Suite = require('../suite');
+var Test = require('../test');
 
 /**
  * Functions common to more than one interface.
@@ -152,6 +153,26 @@ module.exports = function (suites, context, mocha) {
        */
       retries: function (n) {
         context.retries(n);
+      },
+
+      /**
+       * Creates a test.
+       * @param {Object} opts Options
+       * @param {string} opts.title Title of Test
+       * @param {Function} [opts.fn] Test Function
+       * @param {string} [opts.file] Filepath where this Test resides
+       * @returns {Test}
+       */
+      create: function create (opts) {
+        var suite = opts.suite;
+        if (suite.isPending()) {
+          opts.fn = null;
+        }
+
+        var test = new Test(opts.title, opts.fn);
+        test.file = opts.file;
+        suite.addTest(test);
+        return test;
       }
     }
   };

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -201,10 +201,10 @@ Suite.prototype.beforeAll = function (title, fn) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
+
+  var definition = utils.handleTitleAndFn('beforeAll hook', title, fn);
+  title = definition[0];
+  fn = definition[1];
   title = '"before all" hook' + (title ? ': ' + title : '');
 
   var hook = new Hook(title, fn);
@@ -231,10 +231,10 @@ Suite.prototype.afterAll = function (title, fn) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
+
+  var definition = utils.handleTitleAndFn('afterAll hook', title, fn);
+  title = definition[0];
+  fn = definition[1];
   title = '"after all" hook' + (title ? ': ' + title : '');
 
   var hook = new Hook(title, fn);
@@ -261,10 +261,10 @@ Suite.prototype.beforeEach = function (title, fn) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
+
+  var definition = utils.handleTitleAndFn('beforeEach hook', title, fn);
+  title = definition[0];
+  fn = definition[1];
   title = '"before each" hook' + (title ? ': ' + title : '');
 
   var hook = new Hook(title, fn);
@@ -291,10 +291,10 @@ Suite.prototype.afterEach = function (title, fn) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
+
+  var definition = utils.handleTitleAndFn('afterEach hook', title, fn);
+  title = definition[0];
+  fn = definition[1];
   title = '"after each" hook' + (title ? ': ' + title : '');
 
   var hook = new Hook(title, fn);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -800,3 +800,21 @@ exports.isPromise = function isPromise (value) {
  * @api
  */
 exports.noop = function () {};
+
+/**
+ * Handle Suite/Test definition.
+ * Typecheck (title, runnable) pair.
+ * @returns {[String, Function]}
+ */
+exports.handleTitleAndFn = function handleTitleAndFn (thing, title, fn) {
+  if (typeof fn !== 'function') {
+    if (typeof title === 'function') {
+      fn = title;
+      title = fn.name;
+    } else {
+      throw new TypeError(thing + ' definition expected a `function` as its second argument. Got ' + exports.canonicalize(fn) + ' instead.');
+    }
+  }
+
+  return [title, fn];
+};


### PR DESCRIPTION
Feedback on the Error messages? What's your opinion on this?

## Describe's second argument is not a function

```js
describe('MyClass', new Promise(() => {}))
```

Before:
```sh
➜  temp mocha silly-tests.js


  0 passing (2ms)
```

After:
```sh
➜  temp mocha silly-tests.js
/Users/dasilvacontin/github/mochajs/mocha/lib/interfaces/common.js:119
          throw new TypeError('Suite "' + suite.fullTitle() + '" was defined but no callback was supplied (got `' + utils.canonicalize(opts.fn) + '` instead). Supply a callback or explicitly skip the suite.');
          ^

TypeError: Suite "MyClass" was defined but no callback was supplied (got `[object Promise]` instead). Supply a callback or explicitly skip the suite.
    at Object.create (/Users/dasilvacontin/github/mochajs/mocha/lib/interfaces/common.js:119:17)
    at context.describe.context.context (/Users/dasilvacontin/github/mochajs/mocha/lib/interfaces/bdd.js:38:27)
    at Object.<anonymous> (/Users/dasilvacontin/temp/silly-tests.js:8:1)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at /Users/dasilvacontin/github/mochajs/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/dasilvacontin/github/mochajs/mocha/lib/mocha.js:219:14)
    at Mocha.run (/Users/dasilvacontin/github/mochajs/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/Users/dasilvacontin/github/mochajs/mocha/bin/_mocha:458:18)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.runMain (module.js:607:10)
    at run (bootstrap_node.js:382:7)
    at startup (bootstrap_node.js:137:9)
    at bootstrap_node.js:497:3
```

## Hooks with no callback or with a wrong type

```js
function setup () {}
beforeEach(setup())
```

Before:
```sh
➜  temp mocha silly-tests.js


  0 passing (2ms)
```

After:
```sh
➜  temp mocha silly-tests.js
/Users/dasilvacontin/github/mochajs/mocha/lib/utils.js:815
      throw new TypeError(thing + ' definition expected a `function` as its second argument. Got ' + exports.canonicalize(fn) + ' instead.');
      ^

TypeError: beforeEach hook definition expected a `function` as its second argument. Got undefined instead.
    at Object.handleTitleAndFn (/Users/dasilvacontin/github/mochajs/mocha/lib/utils.js:815:13)
    at Suite.beforeEach (/Users/dasilvacontin/github/mochajs/mocha/lib/suite.js:265:26)
    at beforeEach (/Users/dasilvacontin/github/mochajs/mocha/lib/interfaces/common.js:57:17)
    at Object.<anonymous> (/Users/dasilvacontin/temp/silly-tests.js:1:63)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at /Users/dasilvacontin/github/mochajs/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/dasilvacontin/github/mochajs/mocha/lib/mocha.js:219:14)
    at Mocha.run (/Users/dasilvacontin/github/mochajs/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/Users/dasilvacontin/github/mochajs/mocha/bin/_mocha:458:18)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.runMain (module.js:607:10)
    at run (bootstrap_node.js:382:7)
    at startup (bootstrap_node.js:137:9)
    at bootstrap_node.js:497:3
```