### PR TITLE
change "pending" behavior ("this.skip()"); closes #2286 [DO NOT MERGE]

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -313,15 +313,10 @@ Runner.prototype.hook = function (name, fn) {
       }
       if (err) {
         if (err instanceof Pending) {
-          if (name === 'beforeEach' || name === 'afterEach') {
-            self.test.pending = true;
-          } else {
-            utils.forEach(suite.tests, function (test) {
-              test.pending = true;
-            });
-            // a pending hook won't be executed twice.
-            hook.pending = true;
-          }
+          utils.forEach(suite.tests, function (test) {
+            test.pending = true;
+          });
+          hook.pending = true;
         } else {
           self.failHook(hook, err);
 
@@ -541,7 +536,7 @@ Runner.prototype.runTests = function (suite, fn) {
       if (test.isPending()) {
         self.emit('pending', test);
         self.emit('test end', test);
-        return next();
+        return self.hookUp('afterEach', next);
       }
       if (err) {
         return hookErr(err, errSuite, false);
@@ -566,10 +561,6 @@ Runner.prototype.runTests = function (suite, fn) {
             self.fail(test, err);
           }
           self.emit('test end', test);
-
-          if (err instanceof Pending) {
-            return next();
-          }
 
           return self.hookUp('afterEach', next);
         }


### PR DESCRIPTION
This is a proposal for how `this.skip()` should work.  Related: #2286 and #2148.

When `this.skip()` is called in a:

- **"before all" hook**: Skip *all* tests and *all* "each" hooks.  Continue to run "after all" hooks.
- **"before each" hook**: Skip *subsequent* tests.  Continue to run all remaining hooks.
- **test**:  Skip *just this test*.  Continue to run all remaining hooks.
- **"after each" hook**: Skip *subsequent* tests.  Continue to run all remaining hooks.
- **"after all" hook**: Skip *this just hook*.  Continue to run all remaining hooks.

I feel like the *intent* of `this.skip()` is more of a "permanent" directive; if you need to temporarily disable things, you can use `it.skip()`, `describe.skip()`, etc.  This is why we should *tear down* if we've *set up*.  It becomes the user's responsibility to be explicit about which hooks should be skipped, if there are multiple of the same type.

My tests here are a bit crude (assertions in an "after all" hook?!), and possibly should live elsewhere.  Also, we need assertions against "nested" suites, but I was about at my limit for abstracting these tests.