### PR TITLE
Revert test pass symbol in List reporter

### DIFF
--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -42,7 +42,7 @@ function List (runner) {
   });
 
   runner.on('pass', function (test) {
-    var fmt = color('checkmark', '  ' + Base.symbols.dot) +
+    var fmt = color('checkmark', '  ' + Base.symbols.ok) +
       color('pass', ' %s: ') +
       color(test.speed, '%dms');
     cursor.CR();


### PR DESCRIPTION
Hello,

The List reporter's output regressed during a [past refactoring](https://github.com/mochajs/mocha/commit/bec7a6e1686cf1f4c26ef6c2ba25eda36ccdd6c5#diff-855bef20eedfd15010e9e05ba5ddf02f). This pull request reverts the output to the [old correct output](https://mochajs.org/#list) but it still retains the benefit of the refactoring.

All tests passing.