### PR TITLE
refactors .only() behaviour, closes #2429 and #2606

### DIFF
--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -3,8 +3,8 @@
 var Suite = require('../suite');
 
 function setOnlies (suite) {
-  if ((suite.hasOnly || suite.isOnly) && suite.parent) {
-    suite.parent.hasOnly = true;
+  if ((suite._hasOnly || suite._isOnly) && suite.parent) {
+    suite.parent._hasOnly = true;
     setOnlies(suite.parent);
   }
 }
@@ -113,7 +113,7 @@ module.exports = function (suites, context, mocha) {
         suite.file = opts.file;
         suites.unshift(suite);
         if (opts.isOnly) {
-          suite.isOnly = true;
+          suite._isOnly = true;
         }
         setOnlies(suite);
         if (typeof opts.fn === 'function') {
@@ -137,7 +137,7 @@ module.exports = function (suites, context, mocha) {
        * @returns {*}
        */
       only: function (mocha, test) {
-        test.isOnly = true;
+        test._isOnly = true;
         setOnlies(test);
         return test;
       },

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -2,13 +2,6 @@
 
 var Suite = require('../suite');
 
-function setOnlies (suite) {
-  if ((suite._hasOnly || suite._isOnly) && suite.parent) {
-    suite.parent._hasOnly = true;
-    setOnlies(suite.parent);
-  }
-}
-
 /**
  * Functions common to more than one interface.
  *
@@ -115,7 +108,6 @@ module.exports = function (suites, context, mocha) {
         if (opts.isOnly) {
           suite._isOnly = true;
         }
-        setOnlies(suite);
         if (typeof opts.fn === 'function') {
           opts.fn.call(suite);
           suites.shift();
@@ -138,7 +130,6 @@ module.exports = function (suites, context, mocha) {
        */
       only: function (mocha, test) {
         test._isOnly = true;
-        setOnlies(test);
         return test;
       },
 

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -2,6 +2,13 @@
 
 var Suite = require('../suite');
 
+function setOnlies (suite) {
+  if ((suite.hasOnly || suite.isOnly) && suite.parent) {
+    suite.parent.hasOnly = true;
+    setOnlies(suite.parent);
+  }
+}
+
 /**
  * Functions common to more than one interface.
  *
@@ -74,7 +81,6 @@ module.exports = function (suites, context, mocha) {
        * @returns {Suite}
        */
       only: function only (opts) {
-        mocha.options.hasOnly = true;
         opts.isOnly = true;
         return this.create(opts);
       },
@@ -107,9 +113,9 @@ module.exports = function (suites, context, mocha) {
         suite.file = opts.file;
         suites.unshift(suite);
         if (opts.isOnly) {
-          suite.parent._onlySuites = suite.parent._onlySuites.concat(suite);
-          mocha.options.hasOnly = true;
+          suite.isOnly = true;
         }
+        setOnlies(suite);
         if (typeof opts.fn === 'function') {
           opts.fn.call(suite);
           suites.shift();
@@ -131,8 +137,8 @@ module.exports = function (suites, context, mocha) {
        * @returns {*}
        */
       only: function (mocha, test) {
-        test.parent._onlyTests = test.parent._onlyTests.concat(test);
-        mocha.options.hasOnly = true;
+        test.isOnly = true;
+        setOnlies(test);
         return test;
       },
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -493,7 +493,6 @@ Mocha.prototype.run = function (fn) {
   var reporter = new this._reporter(runner, options);
   runner.ignoreLeaks = options.ignoreLeaks !== false;
   runner.fullStackTrace = options.fullStackTrace;
-  runner.hasOnly = options.hasOnly;
   runner.asyncOnly = options.asyncOnly;
   runner.allowUncaught = options.allowUncaught;
   if (options.grep) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -792,8 +792,7 @@ function cleanSuiteReferences (suite) {
 Runner.prototype.run = function (fn) {
   var self = this;
   var rootSuite = this.suite;
-
-  rootSuite = filterOnly(rootSuite);
+  rootSuite.filterOnly();
   fn = fn || function () {};
 
   function uncaught (err) {
@@ -848,26 +847,6 @@ Runner.prototype.abort = function () {
 
   return this;
 };
-
-/**
- * Filter suites based on `isOnly` logic.
- *
- * @param {Array} suite
- * @returns {Boolean}
- * @api private
- */
-function filterOnly (suite) {
-  if (suite.hasOnly()) {
-    suite.suites = suite.suites.filter(function (childSuite) {
-      return childSuite._isOnly || childSuite.hasOnly();
-    });
-    suite.suites = suite.suites.map(filterOnly);
-    suite.tests = suite.tests.filter(function (test) {
-      return test._isOnly;
-    });
-  }
-  return suite;
-}
 
 /**
  * Filter leaks with the given globals flagged as `ok`.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,7 +12,6 @@ var debug = require('debug')('mocha:runner');
 var Runnable = require('./runnable');
 var filter = utils.filter;
 var indexOf = utils.indexOf;
-var some = utils.some;
 var keys = utils.keys;
 var stackFilter = utils.stackTraceFilter();
 var stringify = utils.stringify;
@@ -795,10 +794,9 @@ Runner.prototype.run = function (fn) {
   var rootSuite = this.suite;
 
   // If there is an `only` filter
-  if (this.hasOnly) {
-    filterOnly(rootSuite);
+  if (rootSuite.hasOnly) {
+    rootSuite = filterOnly(rootSuite);
   }
-
   fn = fn || function () {};
 
   function uncaught (err) {
@@ -862,38 +860,16 @@ Runner.prototype.abort = function () {
  * @api private
  */
 function filterOnly (suite) {
-  if (suite._onlyTests.length) {
-    // If the suite contains `only` tests, run those and ignore any nested suites.
-    suite.tests = suite._onlyTests;
-    suite.suites = [];
-  } else {
-    // Otherwise, do not run any of the tests in this suite.
-    suite.tests = [];
-    utils.forEach(suite._onlySuites, function (onlySuite) {
-      // If there are other `only` tests/suites nested in the current `only` suite, then filter that `only` suite.
-      // Otherwise, all of the tests on this `only` suite should be run, so don't filter it.
-      if (hasOnly(onlySuite)) {
-        filterOnly(onlySuite);
-      }
+  if (suite.hasOnly) {
+    suite.suites = suite.suites.filter(function (childSuite) {
+      return childSuite.hasOnly || childSuite.isOnly;
     });
-    // Run the `only` suites, as well as any other suites that have `only` tests/suites as descendants.
-    suite.suites = filter(suite.suites, function (childSuite) {
-      return indexOf(suite._onlySuites, childSuite) !== -1 || filterOnly(childSuite);
+    suite.suites = suite.suites.map(filterOnly);
+    suite.tests = suite.tests.filter(function (test) {
+      return test.isOnly;
     });
   }
-  // Keep the suite only if there is something to run
-  return suite.tests.length || suite.suites.length;
-}
-
-/**
- * Determines whether a suite has an `only` test or suite as a descendant.
- *
- * @param {Array} suite
- * @returns {Boolean}
- * @api private
- */
-function hasOnly (suite) {
-  return suite._onlyTests.length || suite._onlySuites.length || some(suite.suites, hasOnly);
+  return suite;
 }
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -793,10 +793,7 @@ Runner.prototype.run = function (fn) {
   var self = this;
   var rootSuite = this.suite;
 
-  // If there is an `only` filter
-  if (rootSuite._hasOnly) {
-    rootSuite = filterOnly(rootSuite);
-  }
+  rootSuite = filterOnly(rootSuite);
   fn = fn || function () {};
 
   function uncaught (err) {
@@ -860,9 +857,9 @@ Runner.prototype.abort = function () {
  * @api private
  */
 function filterOnly (suite) {
-  if (suite._hasOnly) {
+  if (suite.hasOnly()) {
     suite.suites = suite.suites.filter(function (childSuite) {
-      return childSuite._hasOnly || childSuite._isOnly;
+      return childSuite._isOnly || childSuite.hasOnly();
     });
     suite.suites = suite.suites.map(filterOnly);
     suite.tests = suite.tests.filter(function (test) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -794,7 +794,7 @@ Runner.prototype.run = function (fn) {
   var rootSuite = this.suite;
 
   // If there is an `only` filter
-  if (rootSuite.hasOnly) {
+  if (rootSuite._hasOnly) {
     rootSuite = filterOnly(rootSuite);
   }
   fn = fn || function () {};
@@ -860,13 +860,13 @@ Runner.prototype.abort = function () {
  * @api private
  */
 function filterOnly (suite) {
-  if (suite.hasOnly) {
+  if (suite._hasOnly) {
     suite.suites = suite.suites.filter(function (childSuite) {
-      return childSuite.hasOnly || childSuite.isOnly;
+      return childSuite._hasOnly || childSuite._isOnly;
     });
     suite.suites = suite.suites.map(filterOnly);
     suite.tests = suite.tests.filter(function (test) {
-      return test.isOnly;
+      return test._isOnly;
     });
   }
   return suite;

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -188,6 +188,22 @@ Suite.prototype.hasOnly = function () {
   });
 };
 
+Suite.prototype.filterOnly = function () {
+  if (this.hasOnly()) {
+    this.suites = this.suites.filter(function (childSuite) {
+      return childSuite._isOnly || childSuite.hasOnly();
+    });
+
+    this.tests = this.tests.filter(function (test) {
+      return test._isOnly;
+    });
+
+    this.suites.forEach(function (suite) {
+      suite.filterOnly();
+    });
+  }
+};
+
 /**
  * Check if this suite or its parent suite is marked as pending.
  *

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -63,8 +63,6 @@ function Suite (title, parentContext) {
   this._slow = 75;
   this._bail = false;
   this._retries = -1;
-  this._onlyTests = [];
-  this._onlySuites = [];
   this.delayed = false;
 }
 

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -178,26 +178,22 @@ Suite.prototype.bail = function (bail) {
   return this;
 };
 
-Suite.prototype.hasOnly = function () {
-  var hasOnlyTests = this.tests.some(function (test) {
-    return test._isOnly;
-  });
+function onlySuite (suite) {
+  return suite._isOnly || suite.hasOnly();
+}
 
-  return hasOnlyTests || this.suites.some(function (suite) {
-    return suite._isOnly || suite.hasOnly();
-  });
+function onlyTest (test) {
+  return test._isOnly;
+}
+
+Suite.prototype.hasOnly = function () {
+  return this.tests.some(onlyTest) || this.suites.some(onlySuite);
 };
 
 Suite.prototype.filterOnly = function () {
   if (this.hasOnly()) {
-    this.suites = this.suites.filter(function (childSuite) {
-      return childSuite._isOnly || childSuite.hasOnly();
-    });
-
-    this.tests = this.tests.filter(function (test) {
-      return test._isOnly;
-    });
-
+    this.suites = this.suites.filter(onlySuite);
+    this.tests = this.tests.filter(onlyTest);
     this.suites.forEach(function (suite) {
       suite.filterOnly();
     });

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -178,6 +178,16 @@ Suite.prototype.bail = function (bail) {
   return this;
 };
 
+Suite.prototype.hasOnly = function () {
+  var hasOnlyTests = this.tests.some(function (test) {
+    return test._isOnly;
+  });
+
+  return hasOnlyTests || this.suites.some(function (suite) {
+    return suite._isOnly || suite.hasOnly();
+  });
+};
+
 /**
  * Check if this suite or its parent suite is marked as pending.
  *

--- a/test/acceptance/misc/only/tdd.spec.js
+++ b/test/acceptance/misc/only/tdd.spec.js
@@ -98,7 +98,7 @@ suite.only('should run only tests that marked as `only`', function () {
 });
 
 suite.only('Should run only test cases that mark as only', function () {
-  test.only('should runt his test', function () {
+  test.only('should run this test', function () {
     (true).should.equal(true);
   });
 

--- a/test/integration/fixtures/options/only/bdd.fixture.js
+++ b/test/integration/fixtures/options/only/bdd.fixture.js
@@ -47,26 +47,43 @@ describe.only('should run this suite, even', function () {
 describe('should run this suite with an exclusive test', function () {
   it.only('should run this test', function () {});
 
-  describe('should not run this nested suite', function () {
-    describe.only('should not run this doubly-nested suite', function () {
-      it('should not run this test', function () {});
+  it('should not run this test', function () {
+    (true).should.equal(false);
+  });
 
-      it('should not run this test', function () {});
+  describe('should run this nested suite', function () {
+    it('should not run this test', function () {
+      (true).should.equal(false);
+    });
 
-      it('should not run this test', function () {});
+    describe.only('should run this doubly-nested suite', function () {
+      it('should run this test', function () {});
+
+      it('should run this test', function () {});
+
+      it('should run this test', function () {});
     });
   });
 });
 
 describe('should run this suite with an exclusive test (reverse order)', function () {
-  describe('should not run this nested suite', function () {
-    describe.only('should not run this doubly-nested suite', function () {
-      it('should not run this test', function () {});
+  describe('should run this nested suite with an exclusive suite', function () {
+    describe.only('should run this doubly-nested suite', function () {
+      it('should run this test', function () {});
 
-      it('should not run this test', function () {});
+      it('should run this test', function () {});
 
-      it('should not run this test', function () {});
+      it('should run this test', function () {});
+    });
+
+    it('should not run this test', function () {
+      (true).should.equal(false);
     });
   });
+
   it.only('should run this test', function () {});
+
+  it('should not run this test', function () {
+    (true).should.equal(false);
+  });
 });

--- a/test/integration/fixtures/options/only/bdd.fixture.js
+++ b/test/integration/fixtures/options/only/bdd.fixture.js
@@ -2,32 +2,20 @@
 
 describe.only('should run this suite', function () {
   it('should run this test', function () {});
-
   it('should run this test', function () {});
-
   it('should run this test', function () {});
 });
 
 describe('should not run this suite', function () {
-  it('should not run this test', function () {
-    (true).should.equal(false);
-  });
-
-  it('should not run this test', function () {
-    (true).should.equal(false);
-  });
-
-  it('should not run this test', function () {
-    (true).should.equal(false);
-  });
+  it('should not run this test', function () {});
+  it('should not run this test', function () {});
+  it('should not run this test', function () {});
 });
 
 describe.only('should run this suite too', function () {
   describe('should run this nested suite', function () {
     it('should run this test', function () {});
-
     it('should run this test', function () {});
-
     it('should run this test', function () {});
   });
 });
@@ -36,9 +24,7 @@ describe.only('should run this suite, even', function () {
   describe('should run this nested suite, even', function () {
     describe('should run this doubly-nested suite!', function () {
       it('should run this test', function () {});
-
       it('should run this test', function () {});
-
       it('should run this test', function () {});
     });
   });
@@ -46,21 +32,14 @@ describe.only('should run this suite, even', function () {
 
 describe('should run this suite with an exclusive test', function () {
   it.only('should run this test', function () {});
-
-  it('should not run this test', function () {
-    (true).should.equal(false);
-  });
+  it('should not run this test', function () {});
 
   describe('should run this nested suite', function () {
-    it('should not run this test', function () {
-      (true).should.equal(false);
-    });
+    it('should not run this test', function () {});
 
     describe.only('should run this doubly-nested suite', function () {
       it('should run this test', function () {});
-
       it('should run this test', function () {});
-
       it('should run this test', function () {});
     });
   });
@@ -70,20 +49,12 @@ describe('should run this suite with an exclusive test (reverse order)', functio
   describe('should run this nested suite with an exclusive suite', function () {
     describe.only('should run this doubly-nested suite', function () {
       it('should run this test', function () {});
-
       it('should run this test', function () {});
-
       it('should run this test', function () {});
     });
 
-    it('should not run this test', function () {
-      (true).should.equal(false);
-    });
+    it('should not run this test', function () {});
   });
-
   it.only('should run this test', function () {});
-
-  it('should not run this test', function () {
-    (true).should.equal(false);
-  });
+  it('should not run this test', function () {});
 });

--- a/test/integration/only.spec.js
+++ b/test/integration/only.spec.js
@@ -9,7 +9,7 @@ describe('.only()', function () {
       run('options/only/bdd.fixture.js', ['--ui', 'bdd'], function (err, res) {
         assert(!err);
         assert.equal(res.stats.pending, 0);
-        assert.equal(res.stats.passes, 11);
+        assert.equal(res.stats.passes, 17);
         assert.equal(res.stats.failures, 0);
         assert.equal(res.code, 0);
         done();


### PR DESCRIPTION
This pr moves hasOnly logic into suites and tests instead of global state and filter tests and suites based on suites' and tests' hasOnly and isOnly flags. Also removes need to duplicate suite arrays which means less state to maintain.

fixes #2429 and #2606

Unfortunately i was not able easily to write tests for #2429 even though this pr solves it. eg. regression tests does not have option to run same instance of mocha continuously which makes validating the fix more difficult. If you have any hints for writing tests for this, feel free to suggest :)