### PR TITLE
options.reporterOptions are used for progress reporter

### DIFF
--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -39,11 +39,13 @@ function Progress (runner, options) {
 
   // default chars
   options = options || {};
-  options.open = options.open || '[';
-  options.complete = options.complete || '▬';
-  options.incomplete = options.incomplete || Base.symbols.dot;
-  options.close = options.close || ']';
-  options.verbose = false;
+  var reporterOptions = options.reporterOptions || {};
+
+  options.open = reporterOptions.open || '[';
+  options.complete = reporterOptions.complete || '▬';
+  options.incomplete = reporterOptions.incomplete || Base.symbols.dot;
+  options.close = reporterOptions.close || ']';
+  options.verbose = reporterOptions.verbose || false;
 
   // tests started
   runner.on('start', function () {


### PR DESCRIPTION
Progress reporter had multiple options for configuring the reporter,
but it needed the optional fields under `options` object, while
those fields are provided under `options.reporterOptions`.
This commit enables usage of optional fields from `reporterOptions`.