### PR TITLE
+ json ouput controls: output-file, output-object

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -17,8 +17,13 @@ exports = module.exports = JSONReporter;
  *
  * @api public
  * @param {Runner} runner
+ * @param {options} mocha invocation options. Invoking
+ *   `mocha -R --reporter-options output-file=asdf` yields options like:
+ *   { ... reporterOptions: { "output-file": "asdf" } ... }
  */
-function JSONReporter (runner) {
+function JSONReporter (runner, options) {
+  options = options || {};
+  var reptOptions = options.reporterOptions || {};
   Base.call(this, runner);
 
   var self = this;
@@ -53,8 +58,22 @@ function JSONReporter (runner) {
     };
 
     runner.testResults = obj;
-
-    process.stdout.write(JSON.stringify(obj, null, 2));
+    if ('output-object' in reptOptions) {
+      // Pass to reporter with: reporter("json", {"output-object": myObject})
+      Object.assign(reptOptions['output-object'], obj);
+    } else {
+      var text = JSON.stringify(obj, null, 2);
+      if ('output-file' in reptOptions) {
+        // Direct output with `mocha -R --reporter-options output-file=rpt.json`
+        try {
+          require('fs').writeFileSync(reptOptions['output-file'], text);
+        } catch (e) {
+          console.warn('error writing to ' + reptOptions.output + ':', e);
+        }
+      } else {
+        process.stdout.write(text);
+      }
+    }
   });
 }
 


### PR DESCRIPTION
It's practical to use the json reporter's output with in scripts. This patch provides to controls:

**output-object**: pass an object to the reporter so an invoking script can use the results:

```
var Mocha = require('mocha');

var ob = {};

new Mocha().
  addFile("test/toyTest").
  reporter("json", {"output-object": ob}).
  run(function (failures) {
    process.on('exit', function () {
      var s = ob.stats;
      console.log("percentage: " + s.passes/(s.passes+s.failures));
      process.exit(failures > 0 ? 1 : 0);
    });
  });
```

**output-file**: invoke mocha with a reporter option:
`mocha -R json --reporter-options output-file=rpt.json`