### PR TITLE
Double timeouts on integration tests

### DIFF
--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -5,7 +5,7 @@ var run = require('./helpers').runMocha;
 var args = [];
 
 describe('suite w/no callback', function () {
-  this.timeout(1000);
+  this.timeout(2000);
   it('should throw a helpful error message when a callback for suite is not supplied', function (done) {
     run('suite/suite-no-callback.fixture.js', args, function (err, res) {
       assert(!err);
@@ -17,7 +17,7 @@ describe('suite w/no callback', function () {
 });
 
 describe('skipped suite w/no callback', function () {
-  this.timeout(1000);
+  this.timeout(2000);
   it('should not throw an error when a callback for skipped suite is not supplied', function (done) {
     run('suite/suite-skipped-no-callback.fixture.js', args, function (err, res) {
       assert(!err);
@@ -30,7 +30,7 @@ describe('skipped suite w/no callback', function () {
 });
 
 describe('skipped suite w/ callback', function () {
-  this.timeout(1000);
+  this.timeout(2000);
   it('should not throw an error when a callback for skipped suite is supplied', function (done) {
     run('suite/suite-skipped-callback.fixture.js', args, function (err, res) {
       assert(!err);


### PR DESCRIPTION
The current timeout of 1000ms gives us a lot of false negatives on different node tests on Travis. The problem might be related to running lots of tests in parallel. Since this is hard to confirm on a local machine I have no scientific grounds for setting 2000ms specifically