### PR TITLE
Use temporary test-only build of mocha.js for browsers tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage/
 lib/to-iso-string/**/*.js
 mocha.js
+BUILDTMP

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log*
 *.orig
 .nyc_output/
 coverage/
+BUILDTMP/

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ TESTS = $(shell find test -name "*.js" -type f | sort)
 
 all: mocha.js
 
-mocha.js: $(SRC) browser-entry.js
+mocha.js BUILDTMP/mocha.js: $(SRC) browser-entry.js
 	@printf "==> [Browser :: build]\n"
+	mkdir -p ${@D}
 	$(BROWSERIFY) ./browser-entry \
 		--plugin ./scripts/dedefine \
 		--ignore 'fs' \
@@ -29,7 +30,7 @@ mocha.js: $(SRC) browser-entry.js
 
 clean:
 	@printf "==> [Clean]\n"
-	rm -f mocha.js
+	rm -rf BUILDTMP
 
 lint:
 	@printf "==> [Test :: Lint]\n"
@@ -37,13 +38,13 @@ lint:
 
 test-node: test-bdd test-tdd test-qunit test-exports test-unit test-integration test-jsapi test-compilers test-glob test-requires test-reporters test-only test-global-only
 
-test-browser: clean mocha.js test-browser-unit test-browser-bdd test-browser-qunit test-browser-tdd test-browser-exports
+test-browser: clean BUILDTMP/mocha.js test-browser-unit test-browser-bdd test-browser-qunit test-browser-tdd test-browser-exports
 
 test: lint test-node test-browser
 
 test-browser-unit:
 	@printf "==> [Test :: Browser]\n"
-	NODE_PATH=. $(KARMA) start --single-run
+	NODE_PATH=BUILDTMP $(KARMA) start --single-run
 
 test-browser-bdd:
 	@printf "==> [Test :: Browser :: BDD]\n"

--- a/package.json
+++ b/package.json
@@ -299,10 +299,11 @@
     "npm": ">= 1.4.x"
   },
   "scripts": {
-    "test": "make test",
+    "test": "make test && make clean",
     "precoverage": "rm -rf coverage",
     "coverage": "COVERAGE=true npm run test",
-    "postcoverage": "istanbul-combine -d coverage -r lcov -r html coverage/reports/*/*.json"
+    "postcoverage": "istanbul-combine -d coverage -r lcov -r html coverage/reports/*/*.json",
+    "preversion": "make test && make mocha.js && git add mocha.js"
   },
   "dependencies": {
     "browser-stdout": "1.3.0",


### PR DESCRIPTION
This PR does the following things:

- Creates a new `BUILDTMP/mocha.js` temporary file during test run, used by karma test only
- Deletes `BUILDTMP` after successful run
- Changed all make test run targets to depend on the new temporary file instead of an updated dist file
- Added `BUILDTMP` to all relevant ignore lists
- Added npm `preversion hook` to run tests and create the mocha.js distribution build artefact, plus stage it, so the build artifacts become a part of the release created by `npm version`

The overall goal of this PR is to only ever have the `mocha.js` browser build artefact generated when creating a new release. We want to avoid that contributors accidentally generate the build artefact during a normal test run and then accidentally check in the updated artefact.