### PR TITLE
limit browser concurrency on sauce; closes #2478 and #2667

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -174,6 +174,8 @@ function addSauceTests (cfg) {
     startConnect: true
   };
 
+  cfg.concurrency = 5;
+
   // for slow browser booting, ostensibly
   cfg.captureTimeout = 120000;
   cfg.browserNoActivityTimeout = 20000;

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "2.0.1",
     "expect.js": "^0.3.1",
-    "karma": "^1.1.0",
+    "karma": "1.3.0",
     "karma-browserify": "^5.0.5",
     "karma-chrome-launcher": "^2.0.0",
     "karma-expect": "^1.1.2",


### PR DESCRIPTION
We need to pin Karma to v1.3.0 for whatever reason, and also pin the # of concurrent Karma sessions to 5.  This seems to imrpove the situation, though I can't guarantee it's "fixed".