### PR TITLE
in favor of 'istanbul report' over wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "test": "make test && make clean",
     "precoverage": "rm -rf coverage",
     "coverage": "COVERAGE=true npm run test",
-    "postcoverage": "istanbul-combine -d coverage -r lcov -r html coverage/reports/*/*.json",
+    "postcoverage": "istanbul report --root coverage/ text-summary",
     "preversion": "make test && make mocha.js && git add mocha.js"
   },
   "dependencies": {
@@ -329,7 +329,7 @@
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "2.0.1",
     "expect.js": "^0.3.1",
-    "istanbul-combine": "^0.3.0",
+    "istanbul": "^0.4.4",
     "karma": "1.3.0",
     "karma-browserify": "^5.0.5",
     "karma-chrome-launcher": "^2.0.0",


### PR DESCRIPTION
Is there any specific reason for keeping `istanbul-combine`? For what I can see the results are the same.