### PR TITLE
chore(Saucelabs): test on IE9, IE10 and IE11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,42 @@ matrix:
       env: TARGET=test-node
     - node_js: '7'
       env: TARGET=lint
+    # phantomjs
     - node_js: '7'
-      env: TARGET=test-browser S3=1
+      env: TARGET=test-browser
+    # chrome
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="chrome@latest" PLATFORM="Windows 8"
+    # edge
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="MicrosoftEdge@latest" PLATFORM="Windows 10"
+    # ie11
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="internet explorer@11.0" PLATFORM="Windows 8.1"
+    # ie10
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="internet explorer@10.0" PLATFORM="Windows 8"
+    # ie9
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="internet explorer@9.0" PLATFORM="Windows 7"
+    # ie8
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="internet explorer@8.0" PLATFORM="Windows 7"
+    # ie7
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="internet explorer@7.0" PLATFORM="Windows XP"
+    # firefox
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="firefox@latest" PLATFORM="Windows 8.1"
+    # safari
+    - node_js: '7'
+      env: TARGET=test-browser BROWSER="safari@latest" PLATFORM="OS X 10.11"
 
 before_install: scripts/travis-before-install.sh
+
+install:
+ - npm install
+ - cd node_modules && ln -nsf @coderbyheart/karma-sauce-launcher karma-sauce-launcher && cd ../
 
 before_script: scripts/travis-before-script.sh
 

--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
     "karma-expect": "^1.1.2",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.2",
-    "karma-sauce-launcher": "^1.0.0",
+    "karma-sauce-launcher": "coderbyheart/karma-sauce-launcher",
     "karma-spec-reporter": "0.0.26",
     "nyc": "^10.0.0",
     "os-name": "^2.0.1",


### PR DESCRIPTION
Fixes #2344.
    
This moves the selection of the browsers to test to the travis build
script. The number of concurrent travis jobs should be limited to 5
(Saucelabs limit).
This also removes the S3 env variable which does nothing
    
This uses a fork of karma-sauce-launcher, which contains upated
dependencies, in order to support retries:
https://github.com/karma-runner/karma-sauce-launcher/pull/114