### PR TITLE
Remove unused code from base reporter

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -185,7 +185,6 @@ exports.list = function (failures) {
     var index = message ? stack.indexOf(message) : -1;
     var actual = err.actual;
     var expected = err.expected;
-    var escape = true;
 
     if (index === -1) {
       msg = message;
@@ -202,7 +201,6 @@ exports.list = function (failures) {
     }
     // explicitly show diff
     if (err.showDiff !== false && sameType(actual, expected) && expected !== undefined) {
-      escape = false;
       if (!(utils.isString(actual) && utils.isString(expected))) {
         err.actual = actual = utils.stringify(actual);
         err.expected = expected = utils.stringify(expected);
@@ -213,9 +211,9 @@ exports.list = function (failures) {
       msg = '\n      ' + color('error message', match ? match[1] : msg);
 
       if (exports.inlineDiffs) {
-        msg += inlineDiff(err, escape);
+        msg += inlineDiff(err);
       } else {
-        msg += unifiedDiff(err, escape);
+        msg += unifiedDiff(err);
       }
     }
 
@@ -354,11 +352,10 @@ function pad (str, len) {
  *
  * @api private
  * @param {Error} err with actual/expected
- * @param {boolean} escape
  * @return {string} Diff
  */
-function inlineDiff (err, escape) {
-  var msg = errorDiff(err, 'WordsWithSpace', escape);
+function inlineDiff (err) {
+  var msg = errorDiff(err);
 
   // linenos
   var lines = msg.split('\n');
@@ -388,15 +385,11 @@ function inlineDiff (err, escape) {
  *
  * @api private
  * @param {Error} err with actual/expected
- * @param {boolean} escape
  * @return {string} The diff.
  */
-function unifiedDiff (err, escape) {
+function unifiedDiff (err) {
   var indent = '      ';
   function cleanUp (line) {
-    if (escape) {
-      line = escapeInvisibles(line);
-    }
     if (line[0] === '+') {
       return indent + colorLines('diff added', line);
     }
@@ -428,14 +421,10 @@ function unifiedDiff (err, escape) {
  *
  * @api private
  * @param {Error} err
- * @param {string} type
- * @param {boolean} escape
  * @return {string}
  */
-function errorDiff (err, type, escape) {
-  var actual = escape ? escapeInvisibles(err.actual) : err.actual;
-  var expected = escape ? escapeInvisibles(err.expected) : err.expected;
-  return diff['diff' + type](actual, expected).map(function (str) {
+function errorDiff (err) {
+  return diff['diffWordsWithSpace'](err.actual, err.expected).map(function (str) {
     if (str.added) {
       return colorLines('diff added', str.value);
     }
@@ -444,19 +433,6 @@ function errorDiff (err, type, escape) {
     }
     return str.value;
   }).join('');
-}
-
-/**
- * Returns a string with all invisible characters in plain text
- *
- * @api private
- * @param {string} line
- * @return {string}
- */
-function escapeInvisibles (line) {
-  return line.replace(/\t/g, '<tab>')
-    .replace(/\r/g, '<CR>')
-    .replace(/\n/g, '<LF>\n');
 }
 
 /**


### PR DESCRIPTION
I am doing some clean up. There is no use case for `escape=true` so I have removed everything that is related to that case.