### PR TITLE
Increase tests coverage for spec + dot reporters

### DIFF
--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -9,6 +9,7 @@ describe('Dot reporter', function () {
   var stdoutWrite;
   var runner;
   var useColors;
+  var windowWidth;
 
   beforeEach(function () {
     stdout = [];
@@ -18,11 +19,14 @@ describe('Dot reporter', function () {
       stdout.push(string);
     };
     useColors = Base.useColors;
+    windowWidth = Base.window.width;
     Base.useColors = false;
+    Base.window.width = 0;
   });
 
   afterEach(function () {
     Base.useColors = useColors;
+    Base.window.width = windowWidth;
   });
 
   describe('on start', function () {
@@ -41,82 +45,152 @@ describe('Dot reporter', function () {
     });
   });
   describe('on pending', function () {
-    it('should return a new line and a coma', function () {
-      runner.on = function (event, callback) {
-        if (event === 'pending') {
-          callback();
-        }
-      };
-      Dot.call({epilogue: function () {}}, runner);
-      process.stdout.write = stdoutWrite;
-      var expectedArray = [
-        '\n  ',
-        Base.symbols.comma
-      ];
-      stdout.should.deepEqual(expectedArray);
-    });
-  });
-  describe('on pass', function () {
-    describe('if test speed is fast', function () {
-      it('should return a new line and a dot', function () {
-        var test = {
-          duration: 1,
-          slow: function () { return 2; }
-        };
+    describe('if window width is greater than 1', function () {
+      beforeEach(function () {
+        Base.window.width = 2;
+      });
+      it('should return a new line and then a coma', function () {
         runner.on = function (event, callback) {
-          if (event === 'pass') {
-            callback(test);
+          if (event === 'pending') {
+            callback();
           }
         };
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
           '\n  ',
-          Base.symbols.dot
+          Base.symbols.comma
         ];
         stdout.should.deepEqual(expectedArray);
       });
     });
-    describe('if test speed is slow', function () {
-      it('should return a new line and a dot', function () {
-        var test = {
-          duration: 2,
-          slow: function () { return 1; }
-        };
+    describe('if window width is equal to or less than 1', function () {
+      it('should return a coma', function () {
         runner.on = function (event, callback) {
-          if (event === 'pass') {
-            callback(test);
+          if (event === 'pending') {
+            callback();
           }
         };
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
-          '\n  ',
-          Base.symbols.dot
+          Base.symbols.comma
         ];
         stdout.should.deepEqual(expectedArray);
+      });
+    });
+  });
+  describe('on pass', function () {
+    describe('if window width is greater than 1', function () {
+      beforeEach(function () {
+        Base.window.width = 2;
+      });
+      describe('if test speed is fast', function () {
+        it('should return a new line and then a dot', function () {
+          var test = {
+            duration: 1,
+            slow: function () { return 2; }
+          };
+          runner.on = function (event, callback) {
+            if (event === 'pass') {
+              callback(test);
+            }
+          };
+          Dot.call({epilogue: function () {}}, runner);
+          process.stdout.write = stdoutWrite;
+          var expectedArray = [
+            '\n  ',
+            Base.symbols.dot
+          ];
+          stdout.should.deepEqual(expectedArray);
+        });
+      });
+    });
+    describe('if window width is equal to or less than 1', function () {
+      describe('if test speed is fast', function () {
+        it('should return a dot', function () {
+          var test = {
+            duration: 1,
+            slow: function () { return 2; }
+          };
+          runner.on = function (event, callback) {
+            if (event === 'pass') {
+              callback(test);
+            }
+          };
+          Dot.call({epilogue: function () {}}, runner);
+          process.stdout.write = stdoutWrite;
+          var expectedArray = [
+            Base.symbols.dot
+          ];
+          stdout.should.deepEqual(expectedArray);
+        });
+      });
+      describe('if test speed is slow', function () {
+        it('should return a dot', function () {
+          var test = {
+            duration: 2,
+            slow: function () { return 1; }
+          };
+          runner.on = function (event, callback) {
+            if (event === 'pass') {
+              callback(test);
+            }
+          };
+          Dot.call({epilogue: function () {}}, runner);
+          process.stdout.write = stdoutWrite;
+          var expectedArray = [
+            Base.symbols.dot
+          ];
+          stdout.should.deepEqual(expectedArray);
+        });
       });
     });
   });
   describe('on fail', function () {
-    it('should return a new line and a exclamation mark', function () {
-      var test = {
-        test: {
-          err: 'some error'
-        }
-      };
-      runner.on = function (event, callback) {
-        if (event === 'fail') {
-          callback(test);
-        }
-      };
-      Dot.call({epilogue: function () {}}, runner);
-      process.stdout.write = stdoutWrite;
-      var expectedArray = [
-        '\n  ',
-        Base.symbols.bang
-      ];
-      stdout.should.deepEqual(expectedArray);
+    describe('if window width is greater than 1', function () {
+      beforeEach(function () {
+        Base.window.width = 2;
+      });
+      it('should return a new line and then an exclamation mark', function () {
+        var test = {
+          test: {
+            err: 'some error'
+          }
+        };
+        runner.on = function (event, callback) {
+          if (event === 'fail') {
+            callback(test);
+          }
+        };
+        Dot.call({epilogue: function () {}}, runner);
+        process.stdout.write = stdoutWrite;
+        var expectedArray = [
+          '\n  ',
+          Base.symbols.bang
+        ];
+        stdout.should.deepEqual(expectedArray);
+      });
+    });
+    describe('if window width is equal to or less than 1', function () {
+      it('should return an exclamation mark', function () {
+        var test = {
+          test: {
+            err: 'some error'
+          }
+        };
+        runner.on = function (event, callback) {
+          if (event === 'fail') {
+            callback(test);
+          }
+        };
+        Dot.call({epilogue: function () {}}, runner);
+        process.stdout.write = stdoutWrite;
+        var expectedArray = [
+          Base.symbols.bang
+        ];
+        stdout.should.deepEqual(expectedArray);
+      });
     });
   });
   describe('on end', function () {

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -2,16 +2,13 @@
 
 var reporters = require('../../').reporters;
 var Dot = reporters.Dot;
+var Base = reporters.Base;
 
 describe('Dot reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;
-  var ansiColorCodeReset = '\u001b[0m';
-  var ansiColorCodeCyan = '\u001b[36m';
-  var ansiColorCodeGrey = '\u001b[90m';
-  var ansiColorCodeBrightYellow = '\u001b[93m';
-  var ansiColorCodeRed = '\u001b[31m';
+  var useColors;
 
   beforeEach(function () {
     stdout = [];
@@ -20,6 +17,12 @@ describe('Dot reporter', function () {
     process.stdout.write = function (string) {
       stdout.push(string);
     };
+    useColors = Base.useColors;
+    Base.useColors = false;
+  });
+
+  afterEach(function () {
+    Base.useColors = useColors;
   });
 
   describe('on start', function () {
@@ -38,7 +41,7 @@ describe('Dot reporter', function () {
     });
   });
   describe('on pending', function () {
-    it('should return a new line and a coma in the color cyan', function () {
+    it('should return a new line and a coma', function () {
       runner.on = function (event, callback) {
         if (event === 'pending') {
           callback();
@@ -48,14 +51,14 @@ describe('Dot reporter', function () {
       process.stdout.write = stdoutWrite;
       var expectedArray = [
         '\n  ',
-        ansiColorCodeCyan + ',' + ansiColorCodeReset
+        Base.symbols.comma
       ];
       stdout.should.deepEqual(expectedArray);
     });
   });
   describe('on pass', function () {
     describe('if test speed is fast', function () {
-      it('should return a new line and a dot in the color grey', function () {
+      it('should return a new line and a dot', function () {
         var test = {
           duration: 1,
           slow: function () { return 2; }
@@ -69,13 +72,13 @@ describe('Dot reporter', function () {
         process.stdout.write = stdoutWrite;
         var expectedArray = [
           '\n  ',
-          ansiColorCodeGrey + '․' + ansiColorCodeReset
+          Base.symbols.dot
         ];
         stdout.should.deepEqual(expectedArray);
       });
     });
     describe('if test speed is slow', function () {
-      it('should return a new line and a dot in the color bright yellow', function () {
+      it('should return a new line and a dot', function () {
         var test = {
           duration: 2,
           slow: function () { return 1; }
@@ -89,14 +92,14 @@ describe('Dot reporter', function () {
         process.stdout.write = stdoutWrite;
         var expectedArray = [
           '\n  ',
-          ansiColorCodeBrightYellow + '․' + ansiColorCodeReset
+          Base.symbols.dot
         ];
         stdout.should.deepEqual(expectedArray);
       });
     });
   });
   describe('on fail', function () {
-    it('should return a new line and a exclamation mark in the color red', function () {
+    it('should return a new line and a exclamation mark', function () {
       var test = {
         test: {
           err: 'some error'
@@ -111,7 +114,7 @@ describe('Dot reporter', function () {
       process.stdout.write = stdoutWrite;
       var expectedArray = [
         '\n  ',
-        ansiColorCodeRed + '!' + ansiColorCodeReset
+        Base.symbols.bang
       ];
       stdout.should.deepEqual(expectedArray);
     });

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -1,0 +1,135 @@
+'use strict';
+
+var reporters = require('../../').reporters;
+var Dot = reporters.Dot;
+
+describe('Dot reporter', function () {
+  var stdout;
+  var stdoutWrite;
+  var runner;
+  var ansiColorCodeReset = '\u001b[0m';
+  var ansiColorCodeCyan = '\u001b[36m';
+  var ansiColorCodeGrey = '\u001b[90m';
+  var ansiColorCodeBrightYellow = '\u001b[93m';
+  var ansiColorCodeRed = '\u001b[31m';
+
+  beforeEach(function () {
+    stdout = [];
+    runner = {};
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+  });
+
+  describe('on start', function () {
+    it('should return a new line', function () {
+      runner.on = function (event, callback) {
+        if (event === 'start') {
+          callback();
+        }
+      };
+      Dot.call({epilogue: function () {}}, runner);
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        '\n'
+      ];
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+  describe('on pending', function () {
+    it('should return a new line and a coma in the color cyan', function () {
+      runner.on = function (event, callback) {
+        if (event === 'pending') {
+          callback();
+        }
+      };
+      Dot.call({epilogue: function () {}}, runner);
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        '\n  ',
+        ansiColorCodeCyan + ',' + ansiColorCodeReset
+      ];
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+  describe('on pass', function () {
+    describe('if test speed is fast', function () {
+      it('should return a new line and a dot in the color grey', function () {
+        var test = {
+          duration: 1,
+          slow: function () { return 2; }
+        };
+        runner.on = function (event, callback) {
+          if (event === 'pass') {
+            callback(test);
+          }
+        };
+        Dot.call({epilogue: function () {}}, runner);
+        process.stdout.write = stdoutWrite;
+        var expectedArray = [
+          '\n  ',
+          ansiColorCodeGrey + '․' + ansiColorCodeReset
+        ];
+        stdout.should.deepEqual(expectedArray);
+      });
+    });
+    describe('if test speed is slow', function () {
+      it('should return a new line and a dot in the color bright yellow', function () {
+        var test = {
+          duration: 2,
+          slow: function () { return 1; }
+        };
+        runner.on = function (event, callback) {
+          if (event === 'pass') {
+            callback(test);
+          }
+        };
+        Dot.call({epilogue: function () {}}, runner);
+        process.stdout.write = stdoutWrite;
+        var expectedArray = [
+          '\n  ',
+          ansiColorCodeBrightYellow + '․' + ansiColorCodeReset
+        ];
+        stdout.should.deepEqual(expectedArray);
+      });
+    });
+  });
+  describe('on fail', function () {
+    it('should return a new line and a exclamation mark in the color red', function () {
+      var test = {
+        test: {
+          err: 'some error'
+        }
+      };
+      runner.on = function (event, callback) {
+        if (event === 'fail') {
+          callback(test);
+        }
+      };
+      Dot.call({epilogue: function () {}}, runner);
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        '\n  ',
+        ansiColorCodeRed + '!' + ansiColorCodeReset
+      ];
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+  describe('on end', function () {
+    it('should call the epilogue', function () {
+      runner.on = function (event, callback) {
+        if (event === 'end') {
+          callback();
+        }
+      };
+      var epilogueCalled = false;
+      var epilogue = function () {
+        epilogueCalled = true;
+      };
+      Dot.call({epilogue: epilogue}, runner);
+      process.stdout.write = stdoutWrite;
+      epilogueCalled.should.be.true();
+    });
+  });
+});

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -2,16 +2,13 @@
 
 var reporters = require('../../').reporters;
 var Spec = reporters.Spec;
+var Base = reporters.Base;
 
 describe('Spec reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;
-  var ansiColorCodeReset = '\u001b[0m';
-  var ansiColorCodeCyan = '\u001b[36m';
-  var ansiColorCodeRed = '\u001b[31m';
-  var ansiColorCodeGreen = '\u001b[32m';
-  var ansiColorCodeGrey = '\u001b[90m';
+  var useColors;
 
   beforeEach(function () {
     stdout = [];
@@ -20,10 +17,16 @@ describe('Spec reporter', function () {
     process.stdout.write = function (string) {
       stdout.push(string);
     };
+    useColors = Base.useColors;
+    Base.useColors = false;
+  });
+
+  afterEach(function () {
+    Base.useColors = useColors;
   });
 
   describe('on suite', function () {
-    it('should log title indented in color', function () {
+    it('should return title', function () {
       var expectedTitle = 'expectedTitle';
       var suite = {
         title: expectedTitle
@@ -36,13 +39,13 @@ describe('Spec reporter', function () {
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
-        ansiColorCodeReset + expectedTitle + ansiColorCodeReset + '\n'
+        expectedTitle + '\n'
       ];
       stdout.should.deepEqual(expectedArray);
     });
   });
   describe('on pending', function () {
-    it('should log title indented in the color cyan', function () {
+    it('should return title', function () {
       var expectedTitle = 'expectedTitle';
       var suite = {
         title: expectedTitle
@@ -55,14 +58,14 @@ describe('Spec reporter', function () {
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
-        ansiColorCodeCyan + '  - ' + expectedTitle + ansiColorCodeReset + '\n'
+        '  - ' + expectedTitle + '\n'
       ];
       stdout.should.deepEqual(expectedArray);
     });
   });
   describe('on pass', function () {
     describe('if test speed is slow', function () {
-      it('should return expected green tick, grey title and with duration colored in red', function () {
+      it('should return expected tick, title and duration', function () {
         var expectedTitle = 'expectedTitle';
         var expectedDuration = 2;
         var test = {
@@ -77,12 +80,12 @@ describe('Spec reporter', function () {
         };
         Spec.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
-        var expectedString = ansiColorCodeGreen + '  ✓' + ansiColorCodeReset + ansiColorCodeGrey + ' ' + expectedTitle + ansiColorCodeReset + ansiColorCodeRed + ' (' + expectedDuration + 'ms)' + ansiColorCodeReset + '\n';
+        var expectedString = '  ' + Base.symbols.ok + ' ' + expectedTitle + ' (' + expectedDuration + 'ms)' + '\n';
         stdout[0].should.equal(expectedString);
       });
     });
     describe('if test speed is fast', function () {
-      it('should return expected green tick, grey title and without a duration', function () {
+      it('should return expected tick, title and without a duration', function () {
         var expectedTitle = 'expectedTitle';
         var expectedDuration = 1;
         var test = {
@@ -97,14 +100,15 @@ describe('Spec reporter', function () {
         };
         Spec.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
-        var expectedString = ansiColorCodeGreen + '  ✓' + ansiColorCodeReset + ansiColorCodeGrey + ' ' + expectedTitle + ansiColorCodeReset + '\n';
+        var expectedString = '  ' + Base.symbols.ok + ' ' + expectedTitle + '\n';
         stdout[0].should.equal(expectedString);
       });
     });
   });
   describe('on fail', function () {
-    it('should log title indented in the color red', function () {
+    it('should return title and function count', function () {
       var expectedTitle = 'expectedTitle';
+      var functionCount = 1;
       var test = {
         title: expectedTitle
       };
@@ -116,7 +120,7 @@ describe('Spec reporter', function () {
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
-        ansiColorCodeRed + '  1) ' + expectedTitle + ansiColorCodeReset + '\n'
+        '  ' + functionCount + ') ' + expectedTitle + '\n'
       ];
       stdout.should.deepEqual(expectedArray);
     });

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var reporters = require('../../').reporters;
+var Spec = reporters.Spec;
+
+describe('Spec reporter', function () {
+  var stdout;
+  var stdoutWrite;
+  var runner;
+  var ansiColorCodeReset = '\u001b[0m';
+  var ansiColorCodeCyan = '\u001b[36m';
+  var ansiColorCodeRed = '\u001b[31m';
+  var ansiColorCodeGreen = '\u001b[32m';
+  var ansiColorCodeGrey = '\u001b[90m';
+
+  beforeEach(function () {
+    stdout = [];
+    runner = {};
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+  });
+
+  describe('on suite', function () {
+    it('should log title indented in color', function () {
+      var expectedTitle = 'expectedTitle';
+      var suite = {
+        title: expectedTitle
+      };
+      runner.on = function (event, callback) {
+        if (event === 'suite') {
+          callback(suite);
+        }
+      };
+      Spec.call({epilogue: function () {}}, runner);
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        ansiColorCodeReset + expectedTitle + ansiColorCodeReset + '\n'
+      ];
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+  describe('on pending', function () {
+    it('should log title indented in the color cyan', function () {
+      var expectedTitle = 'expectedTitle';
+      var suite = {
+        title: expectedTitle
+      };
+      runner.on = function (event, callback) {
+        if (event === 'pending') {
+          callback(suite);
+        }
+      };
+      Spec.call({epilogue: function () {}}, runner);
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        ansiColorCodeCyan + '  - ' + expectedTitle + ansiColorCodeReset + '\n'
+      ];
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+  describe('on pass', function () {
+    describe('if test speed is slow', function () {
+      it('should return expected green tick, grey title and with duration colored in red', function () {
+        var expectedTitle = 'expectedTitle';
+        var expectedDuration = 2;
+        var test = {
+          title: expectedTitle,
+          duration: expectedDuration,
+          slow: function () { return 1; }
+        };
+        runner.on = function (event, callback) {
+          if (event === 'pass') {
+            callback(test);
+          }
+        };
+        Spec.call({epilogue: function () {}}, runner);
+        process.stdout.write = stdoutWrite;
+        var expectedString = ansiColorCodeGreen + '  ✓' + ansiColorCodeReset + ansiColorCodeGrey + ' ' + expectedTitle + ansiColorCodeReset + ansiColorCodeRed + ' (' + expectedDuration + 'ms)' + ansiColorCodeReset + '\n';
+        stdout[0].should.equal(expectedString);
+      });
+    });
+    describe('if test speed is fast', function () {
+      it('should return expected green tick, grey title and without a duration', function () {
+        var expectedTitle = 'expectedTitle';
+        var expectedDuration = 1;
+        var test = {
+          title: expectedTitle,
+          duration: expectedDuration,
+          slow: function () { return 2; }
+        };
+        runner.on = function (event, callback) {
+          if (event === 'pass') {
+            callback(test);
+          }
+        };
+        Spec.call({epilogue: function () {}}, runner);
+        process.stdout.write = stdoutWrite;
+        var expectedString = ansiColorCodeGreen + '  ✓' + ansiColorCodeReset + ansiColorCodeGrey + ' ' + expectedTitle + ansiColorCodeReset + '\n';
+        stdout[0].should.equal(expectedString);
+      });
+    });
+  });
+  describe('on fail', function () {
+    it('should log title indented in the color red', function () {
+      var expectedTitle = 'expectedTitle';
+      var test = {
+        title: expectedTitle
+      };
+      runner.on = function (event, callback) {
+        if (event === 'fail') {
+          callback(test);
+        }
+      };
+      Spec.call({epilogue: function () {}}, runner);
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        ansiColorCodeRed + '  1) ' + expectedTitle + ansiColorCodeReset + '\n'
+      ];
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+});


### PR DESCRIPTION
I am adding 9 new test scenarios for the dot reporter and 5 for the spec reporter. They should be fully covered now.
I have had to disable colors for these tests due appveyor seeming to have no ANSI color code support.

Dot Coverage diff:
<img width="1186" alt="screen shot 2017-01-28 at 18 50 23" src="https://cloud.githubusercontent.com/assets/3532787/22399012/0ca972f6-e58b-11e6-865f-ea72f11a1436.png">
<img width="1183" alt="screen shot 2017-01-29 at 12 02 05" src="https://cloud.githubusercontent.com/assets/3532787/22403821/c823187c-e61a-11e6-9c0f-a122a81e9198.png">


Spec Coverage diff:
<img width="1191" alt="screen shot 2017-01-28 at 18 47 29" src="https://cloud.githubusercontent.com/assets/3532787/22399013/0cae76ca-e58b-11e6-843e-f94f5d31fd37.png">
<img width="1186" alt="screen shot 2017-01-28 at 18 47 23" src="https://cloud.githubusercontent.com/assets/3532787/22399014/0cb24f84-e58b-11e6-983c-f0b33d818e3d.png">

Hope it helps