### PR TITLE
Node support for --allow-uncaught

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -107,7 +107,8 @@ program
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--use_strict', 'enforce strict mode')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
-  .option('--delay', 'wait for async suite definition');
+  .option('--delay', 'wait for async suite definition')
+  .option('--allow-uncaught', 'enable uncaught errors to propagate');
 
 program._name = 'mocha';
 
@@ -311,6 +312,12 @@ if (program.asyncOnly) {
 
 if (program.delay) {
   mocha.delay();
+}
+
+// --allow-uncaught
+
+if (program.allowUncaught) {
+  mocha.allowUncaught();
 }
 
 // --globals

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -324,8 +324,11 @@ Runnable.prototype.run = function (fn) {
   }
 
   if (this.allowUncaught) {
-    callFn(this.fn);
-    done();
+    if (this.isPending()) {
+      done();
+    } else {
+      callFn(this.fn);
+    }
     return;
   }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -432,15 +432,14 @@ Runner.prototype.runTest = function (fn) {
   if (this.asyncOnly) {
     test.asyncOnly = true;
   }
-
+  test.on('error', function (err) {
+    self.fail(test, err);
+  });
   if (this.allowUncaught) {
     test.allowUncaught = true;
     return test.run(fn);
   }
   try {
-    test.on('error', function (err) {
-      self.fail(test, err);
-    });
     test.run(fn);
   } catch (err) {
     fn(err);


### PR DESCRIPTION
It's super handy to be able to drop into a debugger on test failure. See #1985.