### PR TITLE
Increase tests coverage for json-stream, markdown and progress reporters

### DIFF
--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -1,0 +1,138 @@
+var reporters = require('../../').reporters;
+var JSONStream = reporters.JSONStream;
+
+describe('Json Stream reporter', function () {
+  var runner;
+  var stdout;
+  var stdoutWrite;
+
+  beforeEach(function () {
+    stdout = [];
+    runner = {};
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+  });
+
+  describe('on start', function () {
+    it('should write stringified start with expected total', function () {
+      runner.on = function (event, callback) {
+        if (event === 'start') {
+          callback();
+        }
+      };
+      var expectedTotal = 12;
+      runner.total = expectedTotal;
+      JSONStream.call({}, runner);
+
+      process.stdout.write = stdoutWrite;
+
+      stdout[0].should.deepEqual('[\"start\",{\"total\":' + expectedTotal + '}]\n');
+    });
+  });
+
+  describe('on pass', function () {
+    it('should write stringified test data', function () {
+      var expectedTitle = 'some title';
+      var expectedFullTitle = 'full title';
+      var expectedDuration = 1000;
+      var currentRetry = 1;
+      var expectedTest = {
+        title: expectedTitle,
+        fullTitle: function () { return expectedFullTitle; },
+        duration: expectedDuration,
+        currentRetry: function () { return currentRetry; },
+        slow: function () {}
+      };
+      runner.on = function (event, callback) {
+        if (event === 'pass') {
+          callback(expectedTest);
+        }
+      };
+      JSONStream.call({}, runner);
+
+      process.stdout.write = stdoutWrite;
+
+      stdout[0].should.deepEqual('["pass",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + '}]\n');
+    });
+  });
+
+  describe('on fail', function () {
+    describe('if error stack exists', function () {
+      it('should write stringified test data with error data', function () {
+        var expectedTitle = 'some title';
+        var expectedFullTitle = 'full title';
+        var expectedDuration = 1000;
+        var currentRetry = 1;
+        var expectedTest = {
+          title: expectedTitle,
+          fullTitle: function () { return expectedFullTitle; },
+          duration: expectedDuration,
+          currentRetry: function () { return currentRetry; },
+          slow: function () {}
+        };
+        var expectedErrorMessage = 'error message';
+        var expectedErrorStack = 'error stack';
+        var expectedError = {
+          message: expectedErrorMessage,
+          stack: expectedErrorStack
+        }
+        runner.on = function (event, callback) {
+          if (event === 'fail') {
+            callback(expectedTest, expectedError);
+          }
+        };
+        JSONStream.call({}, runner);
+
+        process.stdout.write = stdoutWrite;
+
+        stdout[0].should.deepEqual('["fail",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + ',"err":"' + expectedErrorMessage + '","stack":"' + expectedErrorStack + '"}]\n');
+      });
+    });
+    describe('if error stack does not exist', function () {
+      it('should write stringified test data with error data', function () {
+        var expectedTitle = 'some title';
+        var expectedFullTitle = 'full title';
+        var expectedDuration = 1000;
+        var currentRetry = 1;
+        var expectedTest = {
+          title: expectedTitle,
+          fullTitle: function () { return expectedFullTitle; },
+          duration: expectedDuration,
+          currentRetry: function () { return currentRetry; },
+          slow: function () {}
+        };
+        var expectedErrorMessage = 'error message';
+        var expectedError = {
+          message: expectedErrorMessage
+        }
+        runner.on = function (event, callback) {
+          if (event === 'fail') {
+            callback(expectedTest, expectedError);
+          }
+        };
+        JSONStream.call({}, runner);
+
+        process.stdout.write = stdoutWrite;
+
+        stdout[0].should.deepEqual('["fail",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + ',"err":"' + expectedErrorMessage + '","stack":null}]\n');
+      });
+    });
+  });
+
+  describe('on end', function () {
+    it('should write end details', function () {
+      runner.on = function (event, callback) {
+        if (event === 'end') {
+          callback();
+        }
+      };
+      JSONStream.call({}, runner);
+
+      process.stdout.write = stdoutWrite;
+
+      stdout[0].should.match(/end/);
+    });
+  });
+});

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -28,7 +28,7 @@ describe('Json Stream reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.deepEqual('[\"start\",{\"total\":' + expectedTotal + '}]\n');
+      stdout[0].should.deepEqual('["start",{"total":' + expectedTotal + '}]\n');
     });
   });
 
@@ -77,7 +77,7 @@ describe('Json Stream reporter', function () {
         var expectedError = {
           message: expectedErrorMessage,
           stack: expectedErrorStack
-        }
+        };
         runner.on = function (event, callback) {
           if (event === 'fail') {
             callback(expectedTest, expectedError);
@@ -106,7 +106,7 @@ describe('Json Stream reporter', function () {
         var expectedErrorMessage = 'error message';
         var expectedError = {
           message: expectedErrorMessage
-        }
+        };
         runner.on = function (event, callback) {
           if (event === 'fail') {
             callback(expectedTest, expectedError);

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var reporters = require('../../').reporters;
 var JSONStream = reporters.JSONStream;
 

--- a/test/reporters/markdown.spec.js
+++ b/test/reporters/markdown.spec.js
@@ -1,0 +1,100 @@
+'use strict';
+
+var reporters = require('../../').reporters;
+var Markdown = reporters.Markdown;
+
+describe('Markdown reporter', function () {
+  var stdout;
+  var stdoutWrite;
+  var runner;
+
+  beforeEach(function () {
+    stdout = [];
+    runner = {};
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+  });
+
+  describe('on \'suite\'', function () {
+    it('should write expected slugged titles on \'end\' event', function () {
+      var expectedTitle = 'expected title';
+      var expectedFullTitle = 'full title';
+      var sluggedFullTitle = 'full-title';
+      var expectedSuite = {
+        title: expectedTitle,
+        fullTitle: function () { return expectedFullTitle; },
+        suites: [{
+          title: expectedTitle,
+          fullTitle: function () { return expectedFullTitle; },
+          suites: []
+        }]
+      };
+      runner.on = function (event, callback) {
+        if (event === 'suite') {
+          callback(expectedSuite);
+        }
+        if (event === 'suite end') {
+          callback();
+        }
+        if (event === 'end') {
+          callback();
+        }
+      };
+      runner.suite = expectedSuite;
+      Markdown.call({}, runner);
+      process.stdout.write = stdoutWrite;
+
+      var expectedArray = [
+        '# TOC\n',
+        ' - [' + expectedTitle + '](#' + sluggedFullTitle + ')\n   - [' + expectedTitle + '](#' + sluggedFullTitle + ')\n',
+        '<a name="' + sluggedFullTitle + '"></a>\n ' + expectedTitle + '\n'
+      ];
+
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+  describe('on \'pass\'', function () {
+    it('should write test code inside js code block, on \'end\' event', function () {
+      var expectedTitle = 'expected title';
+      var expectedFullTitle = 'full title';
+      var sluggedFullTitle = 'full-title';
+      var expectedSuite = {
+        title: expectedTitle,
+        fullTitle: function () { return expectedFullTitle; },
+        suites: []
+      };
+      var expectedDuration = 1000;
+      var currentRetry = 1;
+      var expectedBody = 'some body';
+      var expectedTest = {
+        title: expectedTitle,
+        fullTitle: function () { return expectedFullTitle; },
+        duration: expectedDuration,
+        currentRetry: function () { return currentRetry; },
+        slow: function () {},
+        body: expectedBody
+      };
+      runner.on = function (event, callback) {
+        if (event === 'pass') {
+          callback(expectedTest);
+        }
+        if (event === 'end') {
+          callback();
+        }
+      };
+      runner.suite = expectedSuite;
+      Markdown.call({}, runner);
+      process.stdout.write = stdoutWrite;
+
+      var expectedArray = [
+        '# TOC\n',
+        ' - [' + expectedTitle + '](#' + sluggedFullTitle + ')\n',
+        expectedTitle + '.\n\n```js\n' + expectedBody + '\n```\n\n'
+      ];
+
+      stdout.should.deepEqual(expectedArray);
+    });
+  });
+});

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -40,7 +40,7 @@ describe('Progress reporter', function () {
   });
 
   describe('on test end', function () {
-    describe('if line has not changed', () => {
+    describe('if line has not changed', function () {
       it('should return and not write anything', function () {
         var cachedCursor = Base.cursor;
         var useColors = Base.useColors;
@@ -68,7 +68,7 @@ describe('Progress reporter', function () {
         Base.window.width = windowWidth;
       });
     });
-    describe('if line has changed', () => {
+    describe('if line has changed', function () {
       it('should write expected progress of open and close options', function () {
         var calledCursorCR = false;
         var cachedCursor = Base.cursor;

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -1,0 +1,114 @@
+'use strict';
+
+var reporters = require('../../').reporters;
+var Progress = reporters.Progress;
+var Base = reporters.Base;
+
+describe('Progrss reporter', function () {
+  var stdout;
+  var stdoutWrite;
+  var runner;
+
+  beforeEach(function () {
+    stdout = [];
+    runner = {};
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = function (string) {
+      stdout.push(string);
+    };
+  });
+
+  describe('on start', function () {
+    it('should call cursor hide', function () {
+      var cachedCursor = Base.cursor;
+      var calledCursorHide = false;
+      Base.cursor.hide = function () {
+        calledCursorHide = true;
+      };
+      runner.on = function (event, callback) {
+        if (event === 'start') {
+          callback();
+        }
+      };
+      Progress.call({}, runner);
+
+      process.stdout.write = stdoutWrite;
+      calledCursorHide.should.be.true();
+
+      Base.cursor = cachedCursor;
+    });
+  });
+
+  describe('on test end', function () {
+    it('should write expected progress of open and close options', function () {
+      var calledCursorCR = false;
+      var cachedCursor = Base.cursor;
+      var useColors = Base.useColors;
+      Base.useColors = false;
+      Base.cursor.CR = function () {
+        calledCursorCR = true;
+      };
+      var windowWidth = Base.window.width;
+      Base.window.width = 0;
+
+      var expectedTotal = 12;
+      var expectedOpen = 'OpEn';
+      var expectedClose = 'cLoSe';
+      var expectedOptions = {
+        open: expectedOpen,
+        complete: 'cOmPlEtE',
+        incomplete: 'iNcOmPlEtE',
+        close: expectedClose
+      };
+      runner.total = expectedTotal;
+      runner.on = function (event, callback) {
+        if (event === 'test end') {
+          callback();
+        }
+      };
+      Progress.call({}, runner, expectedOptions);
+
+      process.stdout.write = stdoutWrite;
+      var expectedArray = [
+        '\u001b[J',
+        '  ' + expectedOpen,
+        '',
+        '',
+        expectedClose
+      ];
+      calledCursorCR.should.be.true();
+      stdout.should.deepEqual(expectedArray);
+
+      Base.cursor = cachedCursor;
+      Base.useColors = useColors;
+      Base.window.width = windowWidth;
+    });
+  });
+
+  describe('on end', function () {
+    it('should call cursor show and epilogue', function () {
+      var cachedCursor = Base.cursor;
+      var calledCursorShow = false;
+      Base.cursor.show = function () {
+        calledCursorShow = true;
+      };
+      runner.on = function (event, callback) {
+        if (event === 'end') {
+          callback();
+        }
+      };
+      var calledEpilogue = false;
+      Progress.call({
+        epilogue: function () {
+          calledEpilogue = true;
+        }
+      }, runner);
+
+      process.stdout.write = stdoutWrite;
+      calledEpilogue.should.be.true();
+      calledCursorShow.should.be.true();
+
+      Base.cursor = cachedCursor;
+    });
+  });
+});

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -40,48 +40,79 @@ describe('Progrss reporter', function () {
   });
 
   describe('on test end', function () {
-    it('should write expected progress of open and close options', function () {
-      var calledCursorCR = false;
-      var cachedCursor = Base.cursor;
-      var useColors = Base.useColors;
-      Base.useColors = false;
-      Base.cursor.CR = function () {
-        calledCursorCR = true;
-      };
-      var windowWidth = Base.window.width;
-      Base.window.width = 0;
+    describe('if line has not changed', () => {
+      it('should return and not write anything', function () {
+        var cachedCursor = Base.cursor;
+        var useColors = Base.useColors;
+        Base.useColors = false;
+        Base.cursor.CR = function () {};
+        var windowWidth = Base.window.width;
+        Base.window.width = -3;
 
-      var expectedTotal = 12;
-      var expectedOpen = 'OpEn';
-      var expectedClose = 'cLoSe';
-      var expectedOptions = {
-        open: expectedOpen,
-        complete: 'cOmPlEtE',
-        incomplete: 'iNcOmPlEtE',
-        close: expectedClose
-      };
-      runner.total = expectedTotal;
-      runner.on = function (event, callback) {
-        if (event === 'test end') {
-          callback();
-        }
-      };
-      Progress.call({}, runner, expectedOptions);
+        var expectedTotal = 1;
+        var expectedOptions = {};
+        runner.total = expectedTotal;
+        runner.on = function (event, callback) {
+          if (event === 'test end') {
+            callback();
+          }
+        };
+        Progress.call({}, runner, expectedOptions);
 
-      process.stdout.write = stdoutWrite;
-      var expectedArray = [
-        '\u001b[J',
-        '  ' + expectedOpen,
-        '',
-        '',
-        expectedClose
-      ];
-      calledCursorCR.should.be.true();
-      stdout.should.deepEqual(expectedArray);
+        process.stdout.write = stdoutWrite;
 
-      Base.cursor = cachedCursor;
-      Base.useColors = useColors;
-      Base.window.width = windowWidth;
+        stdout.should.deepEqual([]);
+
+        Base.cursor = cachedCursor;
+        Base.useColors = useColors;
+        Base.window.width = windowWidth;
+      });
+    });
+    describe('if line has changed', () => {
+      it('should write expected progress of open and close options', function () {
+        var calledCursorCR = false;
+        var cachedCursor = Base.cursor;
+        var useColors = Base.useColors;
+        Base.useColors = false;
+        Base.cursor.CR = function () {
+          calledCursorCR = true;
+        };
+        var windowWidth = Base.window.width;
+        Base.window.width = 5;
+
+        var expectedTotal = 12;
+        var expectedOpen = 'OpEn';
+        var expectedClose = 'cLoSe';
+        var expectedIncomplete = 'iNcOmPlEtE';
+        var expectedOptions = {
+          open: expectedOpen,
+          complete: 'cOmPlEtE',
+          incomplete: expectedIncomplete,
+          close: expectedClose
+        };
+        runner.total = expectedTotal;
+        runner.on = function (event, callback) {
+          if (event === 'test end') {
+            callback();
+          }
+        };
+        Progress.call({}, runner, expectedOptions);
+
+        process.stdout.write = stdoutWrite;
+        var expectedArray = [
+          '\u001b[J',
+          '  ' + expectedOpen,
+          '',
+          expectedIncomplete,
+          expectedClose
+        ];
+        calledCursorCR.should.be.true();
+        stdout.should.deepEqual(expectedArray);
+
+        Base.cursor = cachedCursor;
+        Base.useColors = useColors;
+        Base.window.width = windowWidth;
+      });
     });
   });
 

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var Progress = reporters.Progress;
 var Base = reporters.Base;
 
-describe('Progrss reporter', function () {
+describe('Progress reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;


### PR DESCRIPTION
Json Stream coverage diff:
<img width="1183" alt="screen shot 2017-02-03 at 14 14 10" src="https://cloud.githubusercontent.com/assets/3532787/22594707/0d09695a-ea1c-11e6-86e0-ee12d0162998.png">
<img width="1184" alt="screen shot 2017-02-03 at 14 14 21" src="https://cloud.githubusercontent.com/assets/3532787/22594711/1353f488-ea1c-11e6-8428-602154165d10.png">

Markdown coverage diff:
<img width="1185" alt="screen shot 2017-02-03 at 14 13 18" src="https://cloud.githubusercontent.com/assets/3532787/22594670/f7b7ef0e-ea1b-11e6-990f-7a3987b18ba2.png">
<img width="1187" alt="screen shot 2017-02-03 at 14 16 07" src="https://cloud.githubusercontent.com/assets/3532787/22594684/fcfa6faa-ea1b-11e6-8019-690b9b97decb.png">

Progress coverage diff:
<img width="1180" alt="screen shot 2017-02-03 at 14 46 53" src="https://cloud.githubusercontent.com/assets/3532787/22595600/16037114-ea20-11e6-97eb-6e859d36aca8.png">
<img width="1182" alt="screen shot 2017-02-03 at 15 05 21" src="https://cloud.githubusercontent.com/assets/3532787/22596120/3704b4d4-ea22-11e6-8da2-4f23d51dd281.png">
(missing statement as unable to set verbose option to `true`)

Overall coverage +2% (not sure why coveralls hasnt recognised it).

Hope it helps
