### PR TITLE
Allow prepending hooks beforeAll/afterAll/beforeEach/afterEach

### DIFF
--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -31,8 +31,8 @@ module.exports = function (suites, context, mocha) {
      * @param {string} name
      * @param {Function} fn
      */
-    before: function (name, fn) {
-      suites[0].beforeAll(name, fn);
+    before: function (name, fn, prepend) {
+      suites[0].beforeAll(name, fn, prepend);
     },
 
     /**
@@ -41,8 +41,8 @@ module.exports = function (suites, context, mocha) {
      * @param {string} name
      * @param {Function} fn
      */
-    after: function (name, fn) {
-      suites[0].afterAll(name, fn);
+    after: function (name, fn, prepend) {
+      suites[0].afterAll(name, fn, prepend);
     },
 
     /**
@@ -51,8 +51,8 @@ module.exports = function (suites, context, mocha) {
      * @param {string} name
      * @param {Function} fn
      */
-    beforeEach: function (name, fn) {
-      suites[0].beforeEach(name, fn);
+    beforeEach: function (name, fn, prepend) {
+      suites[0].beforeEach(name, fn, prepend);
     },
 
     /**
@@ -61,8 +61,8 @@ module.exports = function (suites, context, mocha) {
      * @param {string} name
      * @param {Function} fn
      */
-    afterEach: function (name, fn) {
-      suites[0].afterEach(name, fn);
+    afterEach: function (name, fn, prepend) {
+      suites[0].afterEach(name, fn, prepend);
     },
 
     suite: {

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -190,22 +190,16 @@ Suite.prototype.isPending = function () {
 };
 
 /**
- * Run `fn(test[, done])` before running tests.
+ *
  *
  * @api private
- * @param {string} title
- * @param {Function} fn
- * @return {Suite} for chaining
  */
-Suite.prototype.beforeAll = function (title, fn) {
-  if (this.isPending()) {
-    return this;
-  }
+Suite.prototype._createHook = function (type, title, fn) {
   if (typeof title === 'function') {
     fn = title;
     title = fn.name;
   }
-  title = '"before all" hook' + (title ? ': ' + title : '');
+  title = '"' + type + '" hook' + (title ? ': ' + title : '');
 
   var hook = new Hook(title, fn);
   hook.parent = this;
@@ -214,7 +208,28 @@ Suite.prototype.beforeAll = function (title, fn) {
   hook.enableTimeouts(this.enableTimeouts());
   hook.slow(this.slow());
   hook.ctx = this.ctx;
-  this._beforeAll.push(hook);
+  return hook;
+};
+
+/**
+ * Run `fn(test[, done])` before running tests.
+ *
+ * @api private
+ * @param {string} title
+ * @param {Function} fn
+ * @return {Suite} for chaining
+ */
+Suite.prototype.beforeAll = function (title, fn, prepend) {
+  if (this.isPending()) {
+    return this;
+  }
+
+  var hook = this._createHook('before all', title, fn);
+  if (prepend) {
+    this._beforeAll.unshift(hook);
+  } else {
+    this._beforeAll.push(hook);
+  }
   this.emit('beforeAll', hook);
   return this;
 };
@@ -227,24 +242,17 @@ Suite.prototype.beforeAll = function (title, fn) {
  * @param {Function} fn
  * @return {Suite} for chaining
  */
-Suite.prototype.afterAll = function (title, fn) {
+Suite.prototype.afterAll = function (title, fn, prepend) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
-  title = '"after all" hook' + (title ? ': ' + title : '');
 
-  var hook = new Hook(title, fn);
-  hook.parent = this;
-  hook.timeout(this.timeout());
-  hook.retries(this.retries());
-  hook.enableTimeouts(this.enableTimeouts());
-  hook.slow(this.slow());
-  hook.ctx = this.ctx;
-  this._afterAll.push(hook);
+  var hook = this._createHook('after all', title, fn);
+  if (prepend) {
+    this._afterAll.unshift(hook);
+  } else {
+    this._afterAll.push(hook);
+  }
   this.emit('afterAll', hook);
   return this;
 };
@@ -257,24 +265,17 @@ Suite.prototype.afterAll = function (title, fn) {
  * @param {Function} fn
  * @return {Suite} for chaining
  */
-Suite.prototype.beforeEach = function (title, fn) {
+Suite.prototype.beforeEach = function (title, fn, prepend) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
-  title = '"before each" hook' + (title ? ': ' + title : '');
 
-  var hook = new Hook(title, fn);
-  hook.parent = this;
-  hook.timeout(this.timeout());
-  hook.retries(this.retries());
-  hook.enableTimeouts(this.enableTimeouts());
-  hook.slow(this.slow());
-  hook.ctx = this.ctx;
-  this._beforeEach.push(hook);
+  var hook = this._createHook('before each', title, fn);
+  if (prepend) {
+    this._beforeEach.unshift(hook);
+  } else {
+    this._beforeEach.push(hook);
+  }
   this.emit('beforeEach', hook);
   return this;
 };
@@ -287,24 +288,17 @@ Suite.prototype.beforeEach = function (title, fn) {
  * @param {Function} fn
  * @return {Suite} for chaining
  */
-Suite.prototype.afterEach = function (title, fn) {
+Suite.prototype.afterEach = function (title, fn, prepend) {
   if (this.isPending()) {
     return this;
   }
-  if (typeof title === 'function') {
-    fn = title;
-    title = fn.name;
-  }
-  title = '"after each" hook' + (title ? ': ' + title : '');
 
-  var hook = new Hook(title, fn);
-  hook.parent = this;
-  hook.timeout(this.timeout());
-  hook.retries(this.retries());
-  hook.enableTimeouts(this.enableTimeouts());
-  hook.slow(this.slow());
-  hook.ctx = this.ctx;
-  this._afterEach.push(hook);
+  var hook = this._createHook('after each', title, fn);
+  if (prepend) {
+    this._afterEach.unshift(hook);
+  } else {
+    this._afterEach.push(hook);
+  }
   this.emit('afterEach', hook);
   return this;
 };

--- a/test/suite.spec.js
+++ b/test/suite.spec.js
@@ -141,6 +141,17 @@ describe('Suite', function () {
         beforeAllItem.fn.should.equal(fn);
       });
 
+      it('prepends it to _beforeAll', function () {
+        var fn = function () {};
+        this.suite.beforeAll(fn);
+        this.suite.beforeAll('prepend', fn, true);
+
+        this.suite._beforeAll.should.have.length(2);
+        var beforeAllItem = this.suite._beforeAll[0];
+        beforeAllItem.title.should.match(/^"before all" hook/);
+        beforeAllItem.fn.should.equal(fn);
+      });
+
       it('appends title to hook', function () {
         var fn = function () {};
         this.suite.beforeAll('test', fn);
@@ -175,6 +186,18 @@ describe('Suite', function () {
         afterAllItem.title.should.match(/^"after all" hook/);
         afterAllItem.fn.should.equal(fn);
       });
+
+      it('prepends it to _afterAll', function () {
+        var fn = function () {};
+        this.suite.afterAll(fn);
+        this.suite.afterAll('prepend', fn, true);
+
+        this.suite._afterAll.should.have.length(2);
+        var afterAllItem = this.suite._afterAll[0];
+        afterAllItem.title.should.match(/^"after all" hook/);
+        afterAllItem.fn.should.equal(fn);
+      });
+
       it('appends title to hook', function () {
         var fn = function () {};
         this.suite.afterAll('test', fn);
@@ -210,6 +233,17 @@ describe('Suite', function () {
         beforeEachItem.fn.should.equal(fn);
       });
 
+      it('prepends it to _beforeEach', function () {
+        var fn = function () {};
+        this.suite.beforeEach(fn);
+        this.suite.beforeEach('prepend', fn, true);
+
+        this.suite._beforeEach.should.have.length(2);
+        var beforeEachItem = this.suite._beforeEach[0];
+        beforeEachItem.title.should.match(/^"before each" hook/);
+        beforeEachItem.fn.should.equal(fn);
+      });
+
       it('appends title to hook', function () {
         var fn = function () {};
         this.suite.beforeEach('test', fn);
@@ -240,6 +274,17 @@ describe('Suite', function () {
         this.suite.afterEach(fn);
 
         this.suite._afterEach.should.have.length(1);
+        var afterEachItem = this.suite._afterEach[0];
+        afterEachItem.title.should.match(/^"after each" hook/);
+        afterEachItem.fn.should.equal(fn);
+      });
+
+      it('prepends it to _afterEach', function () {
+        var fn = function () {};
+        this.suite.afterEach(fn);
+        this.suite.afterEach('prepend', fn, true);
+
+        this.suite._afterEach.should.have.length(2);
         var afterEachItem = this.suite._afterEach[0];
         afterEachItem.title.should.match(/^"after each" hook/);
         afterEachItem.fn.should.equal(fn);


### PR DESCRIPTION
A `prepend` argument allows for a hook to placed in front of the list.

Thoughts?  Let me know.