### PR TITLE
Fix for issue #2713

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -466,12 +466,19 @@ function exitLater (code) {
 }
 
 function exit (code) {
+  var clampedCode = Math.min(code, 255);
+
+  // Eagerly set the process's exit code in case stream.write doesn't
+  // execute its callback before the process terminates.
+  process.exitCode = clampedCode;
+
   // flush output for Node.js Windows pipe bug
   // https://github.com/joyent/node/issues/6247 is just one bug example
   // https://github.com/visionmedia/mocha/issues/333 has a good discussion
   function done () {
-    if (!(draining--)) {
-      process.exit(Math.min(code, 255));
+    draining--;
+    if (draining <= 0) {
+      process.exit(clampedCode);
     }
   }
 
@@ -483,8 +490,6 @@ function exit (code) {
     draining += 1;
     stream.write('', done);
   });
-
-  done();
 }
 
 process.on('SIGINT', function () {


### PR DESCRIPTION
* Eagerly set the process exitcode in case the write callback isn't executed before the process terminates.
* Remove the extraneous call to `done()` at the bottom of the function.
* Cleanup the `draining` reduction and value check in `done` into separate lines for easier reading.