### PR TITLE
add gdb support to mocha

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -107,7 +107,8 @@ program
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--use_strict', 'enforce strict mode')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
-  .option('--delay', 'wait for async suite definition');
+  .option('--delay', 'wait for async suite definition')
+  .option('--gdb', 'start with gdb attached');
 
 program._name = 'mocha';
 

--- a/bin/mocha
+++ b/bin/mocha
@@ -11,6 +11,7 @@ var spawn = require('child_process').spawn;
 var path = require('path');
 var getOptions = require('./options');
 var args = [path.join(__dirname, '_mocha')];
+var gdb = false;
 
 // Load mocha.opts into process.argv
 // Must be loaded here to handle node-specific options
@@ -47,6 +48,9 @@ process.argv.slice(2).forEach(function (arg) {
     case '--perf-basic-prof':
       args.unshift(arg);
       break;
+    case '--gdb':
+        gdb = true;
+        break;
     default:
       if (arg.indexOf('--harmony') === 0) {
         args.unshift(arg);
@@ -65,7 +69,14 @@ process.argv.slice(2).forEach(function (arg) {
   }
 });
 
-var proc = spawn(process.execPath, args, { stdio: 'inherit' });
+var binary = process.execPath;
+if(gdb){
+  args.unshift(binary);
+  args.unshift('--args');
+  binary = '/usr/bin/gdb'
+}
+
+var proc = spawn(binary, args, { stdio: 'inherit' });
 proc.on('exit', function (code, signal) {
   process.on('exit', function () {
     if (signal) {

--- a/bin/mocha
+++ b/bin/mocha
@@ -49,8 +49,8 @@ process.argv.slice(2).forEach(function (arg) {
       args.unshift(arg);
       break;
     case '--gdb':
-        gdb = true;
-        break;
+      gdb = true;
+      break;
     default:
       if (arg.indexOf('--harmony') === 0) {
         args.unshift(arg);
@@ -70,10 +70,10 @@ process.argv.slice(2).forEach(function (arg) {
 });
 
 var binary = process.execPath;
-if(gdb){
+if (gdb) {
   args.unshift(binary);
   args.unshift('--args');
-  binary = '/usr/bin/gdb'
+  binary = '/usr/bin/gdb';
 }
 
 var proc = spawn(binary, args, { stdio: 'inherit' });


### PR DESCRIPTION
Hi,

I am developing a c++ and nodejs driver (using Nan) for a database. There was a segmentation fault in my bindings and nodejs crashed without a proper trace or other useful information. Our js guru was not able to isolate the error (I personally guess he was too lazy to switch the tests off one by one). So it seemed useful to me to have the option to start node with an attached debugger (even over core files). The js guy had less work and I was able to find the bug in the native code in about 5 seconds.