### PR TITLE
Add observable support with `symbol-observable`

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -6,6 +6,7 @@
 
 var EventEmitter = require('events').EventEmitter;
 var JSON = require('json3');
+var $$observable = require('symbol-observable').default;
 var Pending = require('./pending');
 var debug = require('debug')('mocha:runnable');
 var milliseconds = require('./ms');
@@ -355,6 +356,19 @@ Runnable.prototype.run = function (fn) {
         function (reason) {
           done(reason || new Error('Promise rejected with no or falsy reason'));
         });
+    } else if (result && typeof result[$$observable] === 'function') {
+      self.resetTimeout();
+      var observable = result[$$observable]();
+
+      observable.subscribe({
+        error: function (reason) {
+          done(reason || new Error('Observable errored with no or falsy reason'));
+        },
+
+        complete: function () {
+          done();
+        }
+      });
     } else {
       if (self.asyncOnly) {
         return done(new Error('--async-only option in use without declaring `done()` or returning a promise'));

--- a/package.json
+++ b/package.json
@@ -316,7 +316,8 @@
     "json3": "3.3.2",
     "lodash.create": "3.1.1",
     "mkdirp": "0.5.1",
-    "supports-color": "3.1.2"
+    "supports-color": "3.1.2",
+    "symbol-observable": "^1.0.4"
   },
   "devDependencies": {
     "assert": "^1.4.1",


### PR DESCRIPTION
Handles returned observables the same way we handle returned promises.
Use the shared `symbol-observable` library for interop and consume the
stream until it ends. If an error is emitted, call callback with error object
from stream.

Fixes #1898.