### PR TITLE
Add `--no-warnings` and `--trace-warnings` flags

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -95,6 +95,7 @@ program
   .option('--no-deprecation', 'silence deprecation warnings')
   .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
   .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
+  .option('--no-warnings', 'silence all node process warnings')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
   .option('--perf-basic-prof', 'enable perf linux profiler (basic support)')
   .option('--prof', 'log statistical profiling information')

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -106,6 +106,7 @@ program
   .option('--throw-deprecation', 'throw an exception anytime a deprecated function is used')
   .option('--trace', 'trace function calls')
   .option('--trace-deprecation', 'show stack traces on deprecations')
+  .option('--trace-warnings', 'show stack traces on node process warnings')
   .option('--use_strict', 'enforce strict mode')
   .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch', list, [])
   .option('--delay', 'wait for async suite definition');

--- a/bin/mocha
+++ b/bin/mocha
@@ -38,6 +38,7 @@ process.argv.slice(2).forEach(function (arg) {
     case '--gc-global':
     case '--es_staging':
     case '--no-deprecation':
+    case '--no-warnings':
     case '--prof':
     case '--log-timer-events':
     case '--throw-deprecation':

--- a/bin/mocha
+++ b/bin/mocha
@@ -43,6 +43,7 @@ process.argv.slice(2).forEach(function (arg) {
     case '--log-timer-events':
     case '--throw-deprecation':
     case '--trace-deprecation':
+    case '--trace-warnings':
     case '--use_strict':
     case '--allow-natives-syntax':
     case '--perf-basic-prof':


### PR DESCRIPTION
Adds support for Node.js’s [`--no-warnings`](https://nodejs.org/dist/latest-v6.x/docs/api/cli.html#cli_no_warnings) and [`--trace-warnings`](https://nodejs.org/dist/latest-v6.x/docs/api/cli.html#cli_trace_warnings) flags.

See also https://github.com/mochajs/mocha/pull/2495.