### PR TITLE
Support `--inspect-brk` on command-line

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -91,6 +91,7 @@ program
   .option('--icu-data-dir', 'include ICU data')
   .option('--inline-diffs', 'display actual/expected differences inline within each string')
   .option('--inspect', 'activate devtools in chrome')
+  .option('--inspect-brk', 'activate devtools in chrome and break on the first line')
   .option('--interfaces', 'display available interfaces')
   .option('--no-deprecation', 'silence deprecation warnings')
   .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')

--- a/bin/mocha
+++ b/bin/mocha
@@ -28,6 +28,7 @@ process.argv.slice(2).forEach(function (arg) {
     case '--debug':
     case '--debug-brk':
     case '--inspect':
+    case '--inspect-brk':
       args.unshift(arg);
       args.push('--no-timeouts');
       break;


### PR DESCRIPTION
There's already a support for `--inspect` option. This extends that support for the option, `--inspect-brk`.