### PR TITLE
no special case for macOS running Karma locally

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var baseBundleDirpath = path.join(__dirname, '.karma');
-var osName = require('os-name');
 
 module.exports = function (config) {
   var bundleDirpath;
@@ -48,7 +47,7 @@ module.exports = function (config) {
     },
     reporters: ['spec'],
     colors: true,
-    browsers: [osName() === 'macOS Sierra' ? 'Chrome' : 'PhantomJS'], // This is the default browser to run, locally
+    browsers: ['PhantomJS'], // This is the default browser to run, locally
     logLevel: config.LOG_INFO,
     client: {
       mocha: {
@@ -97,13 +96,14 @@ module.exports = function (config) {
       console.error('Local/unknown environment detected');
       bundleDirpath = path.join(baseBundleDirpath, 'local');
       // don't need to run sauce from appveyor b/c travis does it.
-      if (!(env.SAUCE_USERNAME || env.SAUCE_ACCESS_KEY)) {
-        console.error('No SauceLabs credentials present');
-      } else {
+      if (env.SAUCE_USERNAME || env.SAUCE_ACCESS_KEY) {
         sauceConfig = {
-          build: require('os').hostname() + ' (' + Date.now() + ')'
+          build: require('os')
+            .hostname() + ' (' + Date.now() + ')'
         };
         console.error('Configured SauceLabs');
+      } else {
+        console.error('No SauceLabs credentials present');
       }
     }
     mkdirp.sync(bundleDirpath);

--- a/package.json
+++ b/package.json
@@ -334,7 +334,6 @@
     "karma-sauce-launcher": "coderbyheart/karma-sauce-launcher",
     "karma-spec-reporter": "0.0.26",
     "nyc": "^10.0.0",
-    "os-name": "^2.0.1",
     "phantomjs": "1.9.8",
     "rimraf": "^2.5.2",
     "semistandard": "^9.2.1",


### PR DESCRIPTION
- also, reformat a conditional

https://github.com/ariya/phantomjs/issues/14558 was causing seg faults at the time this
change was made; it is no longer causing seg faults, so phantomjs should be the default.

this was prompted by #2759