### PR TITLE
reverts use of semistandard directly (#2648)

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,11 @@
+env:
+  node: true
+  browser: true
+parserOptions:
+  ecmaVersion: 5
+  sourceType: script
+extends: semistandard
+rules:
+  strict:
+    - error
+    - safe

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BROWSERIFY := "node_modules/.bin/browserify"
-SEMISTANDARD:= "node_modules/.bin/semistandard"
+ESLINT := "node_modules/.bin/eslint"
 KARMA := "node_modules/.bin/karma"
 MOCHA := "bin/mocha"
 NYC := "node_modules/.bin/nyc"
@@ -34,9 +34,7 @@ clean:
 
 lint:
 	@printf "==> [Test :: Lint]\n"
-	$(SEMISTANDARD) $(SRC)
-	$(SEMISTANDARD) --env mocha --global assert --global expect --global run $(TESTS)
-	$(SEMISTANDARD) bin/* scripts/*.js *.js
+	$(ESLINT) . "bin/*"
 
 test-node: test-bdd test-tdd test-qunit test-exports test-unit test-integration test-jsapi test-compilers test-glob test-requires test-reporters test-only test-global-only
 

--- a/lib/browser/.eslintrc.yaml
+++ b/lib/browser/.eslintrc.yaml
@@ -1,0 +1,4 @@
+env:
+  node: false
+  browser: false
+  commonjs: true

--- a/package.json
+++ b/package.json
@@ -323,6 +323,11 @@
     "browserify": "^13.0.0",
     "coffee-script": "^1.10.0",
     "coveralls": "^2.11.15",
+    "eslint": "^3.11.1",
+    "eslint-config-semistandard": "^7.0.0",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "2.0.1",
     "expect.js": "^0.3.1",
     "istanbul-combine": "^0.3.0",
     "karma": "1.3.0",
@@ -337,7 +342,6 @@
     "os-name": "^2.0.1",
     "phantomjs": "1.9.8",
     "rimraf": "^2.5.2",
-    "semistandard": "^9.2.1",
     "should": "^11.1.1",
     "through2": "^2.0.1",
     "watchify": "^3.7.0"
@@ -369,12 +373,6 @@
     "ignore": [
       "phantomjs",
       "lodash.create"
-    ]
-  },
-  "semistandard": {
-    "ignore": [
-      "/mocha.js",
-      "/lib/to-iso-string/**/*.js"
     ]
   }
 }

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,7 @@
+env:
+  mocha: true
+globals:
+  expect: false
+  assert: false
+  # https://github.com/sindresorhus/globals/pull/102
+  run: false

--- a/test/integration/fixtures/simple-reporter.js
+++ b/test/integration/fixtures/simple-reporter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var baseReporter = require('../../../lib/reporters/base');
 module.exports = simplereporter;
 


### PR DESCRIPTION
Abstractions around ESLint are not widely supported in text editors or IDEs.  For example, I could tell WebStorm to use `node_modules/eslint-config-semistandard/eslintrc.json`, but there's no way for WebStorm to know about the overrides in the [`semistandard` prop of `package.json`](https://github.com/mochajs/mocha/blob/master/package.json#L374), nor the overrides specified for [test files in `Makefile`](https://github.com/mochajs/mocha/blob/master/Makefile#L38).

`semistandard` is arguably easier to use on the CLI, and requires less configuration files, but the cost to users primarily interfacing with ESLint via contextual information in an IDE (like myself!) outweighs the benefit.

cc @kt3k