### PR TITLE
chore(package): bump growl to 1.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "diff": "3.2.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.1",
-    "growl": "1.9.2",
+    "growl": "1.9.3",
     "json3": "3.3.2",
     "lodash.create": "3.1.1",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
As suggested by mochajs/mocha#2791, try bumping growl to 1.9.3