### PR TITLE
#2811 - allowing functions to be passed in as titles as long as they have names 

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -43,6 +43,7 @@ exports.create = function (parent, title) {
  * @param {Context} parentContext
  */
 function Suite (title, parentContext) {
+  title = utils.getTitle(title);
   if (!utils.isString(title)) {
     throw new Error('Suite `title` should be a "string" but "' + typeof title + '" was given instead.');
   }

--- a/lib/test.js
+++ b/lib/test.js
@@ -7,6 +7,7 @@
 var Runnable = require('./runnable');
 var create = require('lodash.create');
 var isString = require('./utils').isString;
+var getTitle = require('./utils').getTitle;
 
 /**
  * Expose `Test`.
@@ -22,6 +23,7 @@ module.exports = Test;
  * @param {Function} fn
  */
 function Test (title, fn) {
+  title = getTitle(title);
   if (!isString(title)) {
     throw new Error('Test `title` should be a "string" but "' + typeof title + '" was given instead.');
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,6 +68,17 @@ exports.isString = function (obj) {
 };
 
 /**
+ * Gets the name of a function
+ *
+ * @api private
+ * @param {Object} obj
+ * @return {Object}
+ */
+exports.getTitle = function (title) {
+  return typeof (title) === 'function' ? (title.name) ? title.name : title : title;
+};
+
+/**
  * Array#map (<=IE8)
  *
  * @api private

--- a/test/suite.spec.js
+++ b/test/suite.spec.js
@@ -401,7 +401,7 @@ describe('Suite', function () {
 
   describe('initialization', function () {
     /* eslint no-new: off */
-    it('should throw an error if the title isn\'t a string', function () {
+    it('should throw an error if the title can\'t convert into a nice string', function () {
       (function () {
         new Suite(undefined, 'root');
       }).should.throw();
@@ -414,6 +414,18 @@ describe('Suite', function () {
     it('should not throw if the title is a string', function () {
       (function () {
         new Suite('Bdd suite', 'root');
+      }).should.not.throw();
+    });
+
+    it('should not throw if the title is a function with a name', function () {
+      function bddSuite () {}
+      (function () {
+        new Suite(bddSuite, 'root');
+      }).should.not.throw();
+
+      var variableBddSuite = function () {};
+      (function () {
+        new Suite(variableBddSuite, 'root');
       }).should.not.throw();
     });
   });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -55,6 +55,37 @@ describe('Test', function () {
     });
   });
 
+  describe('initialization', function () {
+    /* eslint no-new: off */
+    it('should throw an error if the title can\'t convert into a nice string', function () {
+      (function () {
+        new Test(undefined, 'root');
+      }).should.throw();
+
+      (function () {
+        new Test(function () {}, 'root');
+      }).should.throw();
+    });
+
+    it('should not throw if the title is a string', function () {
+      (function () {
+        new Test('Bdd suite', 'root');
+      }).should.not.throw();
+    });
+
+    it('should not throw if the title is a function with a name', function () {
+      function bddSuite () {}
+      (function () {
+        new Test(bddSuite, 'root');
+      }).should.not.throw();
+
+      var variableBddSuite = function () {};
+      (function () {
+        new Test(variableBddSuite, 'root');
+      }).should.not.throw();
+    });
+  });
+
   describe('.isPending()', function () {
     beforeEach(function () {
       this._test = new Test('Is it skipped', function () {});

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -4,6 +4,7 @@ var mocha = require('..');
 var utils = mocha.utils;
 var path = require('path');
 var JSON = require('json3');
+var should = require('should');
 
 describe('utils', function () {
   describe('.clean()', function () {
@@ -46,6 +47,31 @@ describe('utils', function () {
 
     it('should handle empty functions', function () {
       clean('function() {}').should.equal('');
+    });
+  });
+
+  describe('.getTitle()', function () {
+    var getTitle = utils.getTitle;
+    it('should return string if string is passed in', function () {
+      var title = 'this is a title';
+      getTitle(title).should.equal(title);
+    });
+
+    it('should return undefined if undefined is passed in', function () {
+      should.not.exist(getTitle(undefined));
+    });
+
+    it('should return the function if it has no name', function () {
+      var typeOfTitle = typeof (getTitle(function () {}));
+      typeOfTitle.should.equal('function');
+    });
+
+    it('should return the function name if it has a name', function () {
+      function nameFunction () {}
+      getTitle(nameFunction).should.equal('nameFunction');
+
+      var noNameFunction = function () {};
+      getTitle(noNameFunction).should.equal('noNameFunction');
     });
   });
 


### PR DESCRIPTION
#2811

This would allow functions or even React classes to be passed in when testing against them and allow for easier refactoring than praying IntelliJ finds all of your stings with that function in them.

For example: 

```
function addition (a, b) { return a+b; };
describe(addition, function () {
    it('will add the two numbers', function () {
       ....
    });
});
```

Now if `addition` were ever renamed to `addNumbers` our test would nicely be updated along the way.