### PR TITLE
Pass flags for NAPI modules

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -99,6 +99,7 @@ program
   .option('--no-warnings', 'silence all node process warnings')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
   .option('--perf-basic-prof', 'enable perf linux profiler (basic support)')
+  .option('--napi-modules', 'enable experimental NAPI modules')
   .option('--prof', 'log statistical profiling information')
   .option('--log-timer-events', 'Time events including external callbacks')
   .option('--recursive', 'include sub directories')

--- a/bin/mocha
+++ b/bin/mocha
@@ -48,6 +48,7 @@ process.argv.slice(2).forEach(function (arg) {
     case '--use_strict':
     case '--allow-natives-syntax':
     case '--perf-basic-prof':
+    case '--napi-modules':
       args.unshift(arg);
       break;
     default:


### PR DESCRIPTION
This change enables testing of NAPI modules[1]. This is achieved
by passing the appropriate flags to node inside the mocha executable.

[1]: https://nodejs.org/api/n-api.html