### PR TITLE
chore(package): bump debug to 2.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
   "dependencies": {
     "browser-stdout": "1.3.0",
     "commander": "2.9.0",
-    "debug": "2.6.0",
+    "debug": "2.6.8",
     "diff": "3.2.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.1",


### PR DESCRIPTION
as the version currently included is listed vulnerable by Snyk (https://snyk.io/test/npm/debug/2.6.0, https://snyk.io/test/npm/mocha/3.4.1)