### PR TITLE
Remove call to deprecated os.tmpDir (#2802)

### DIFF
--- a/test/acceptance/file-utils.spec.js
+++ b/test/acceptance/file-utils.spec.js
@@ -8,7 +8,7 @@ var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 
 describe('file utils', function () {
-  var tmpDir = path.join(os.tmpDir(), 'mocha-file-lookup');
+  var tmpDir = path.join(os.tmpdir(), 'mocha-file-lookup');
   var existsSync = fs.existsSync;
   var tmpFile = path.join.bind(path, tmpDir);
   var symlinkSupported = false;

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -36,7 +36,7 @@ describe('reporters', function () {
   describe('xunit', function () {
     it('prints test cases with --reporter-options output (issue: 1864)', function (done) {
       var randomStr = crypto.randomBytes(8).toString('hex');
-      var tmpDir = os.tmpDir().replace(new RegExp(path.sep + '$'), '');
+      var tmpDir = os.tmpdir().replace(new RegExp(path.sep + '$'), '');
       var tmpFile = tmpDir + path.sep + 'test-issue-1864-' + randomStr + '.xml';
 
       var args = ['--reporter=xunit', '--reporter-options', 'output=' + tmpFile];


### PR DESCRIPTION
fixes #2802 

`os.tmpdir` was added in 0.9.9 (see https://github.com/hapijs/hapi/issues/3369).
With mocha having a minimum node version of 0.10 it can be dropped without issues.