### PR TITLE
add config for probot-stale integration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,39 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 120
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pr-please
+  - confirmed
+  - future
+  - bug
+  - chore
+  - feature
+  - unconfirmed
+  - usability
+  - to-merge
+  - browser
+  - reporter
+  - feature
+  - documentation
+  - nice-to-have
+  - needs-review
+  - qa
+  - usability
+  - semver-minor
+  - semver-major
+  - semver-patch
+  - reporter
+  - common-mistake
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  I am a bot that watches issues for inactivity.
+
+  This issue hasn't had any recent activity, and I'm labeling it `stale`.  In 14 days, if there are no further comments or activity, I will close this issue.
+
+  Thanks for contributing to Mocha!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
closes #2828.

Issues and PRs will be marked `stale` after 4 mos. of inactivity and closed if there's no activity after 2 more weeks.

*Most* issues with labels are exempt from the check.  I'm not sure how well this is going to work, but we can always change it later.