### PR TITLE
Declare main eslintrc as `root`

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,3 +1,4 @@
+root: true
 env:
   node: true
   browser: true


### PR DESCRIPTION
It will prevent config lookup to exit Mocha's project folder.