### PR TITLE
Remove not-longer-necessary `run` global in .estlintrc

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -3,5 +3,3 @@ env:
 globals:
   expect: false
   assert: false
-  # https://github.com/sindresorhus/globals/pull/102
-  run: false


### PR DESCRIPTION
Sindre already merged it.