### PR TITLE
#2819 - this.skip() in before fails to skip tests with nested describe calls

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -148,6 +148,14 @@ Runnable.prototype.isPending = function () {
 };
 
 /**
+ * Mark the runnable as pending or not pending
+ * @param pending
+ */
+Runnable.prototype.setPending = function (pending) {
+  this.pending = pending;
+};
+
+/**
  * Set number of retries.
  *
  * @api private

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -314,13 +314,11 @@ Runner.prototype.hook = function (name, fn) {
       if (err) {
         if (err instanceof Pending) {
           if (name === 'beforeEach' || name === 'afterEach') {
-            self.test.pending = true;
+            self.test.setPending(true);
           } else {
-            utils.forEach(suite.tests, function (test) {
-              test.pending = true;
-            });
+            suite.setPending(true);
             // a pending hook won't be executed twice.
-            hook.pending = true;
+            hook.setPending(true);
           }
         } else {
           self.failHook(hook, err);
@@ -551,7 +549,7 @@ Runner.prototype.runTests = function (suite, fn) {
         if (err) {
           var retry = test.currentRetry();
           if (err instanceof Pending) {
-            test.pending = true;
+            test.setPending(true);
             self.emit('pending', test);
           } else if (retry < test.retries()) {
             var clonedTest = test.clone();

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -190,6 +190,14 @@ Suite.prototype.isPending = function () {
 };
 
 /**
+ * Mark the suite as pending or not pending
+ * @param pending
+ */
+Suite.prototype.setPending = function (pending) {
+  this.pending = pending;
+};
+
+/**
  * Run `fn(test[, done])` before running tests.
  *
  * @api private

--- a/test/acceptance/interfaces/bdd.spec.js
+++ b/test/acceptance/interfaces/bdd.spec.js
@@ -32,3 +32,33 @@ context('test suite', function () {
     expect(this.number).to.equal(5);
   });
 });
+
+describe('a suite skipped by "before" hook', function () {
+  before(function () {
+    this.skip();
+  });
+
+  it('should skip this test', function () {
+    expect(2).to.equal(1);
+  });
+
+  it('should skip this test too', function () {
+    expect(2).to.equal(1);
+  });
+});
+
+describe('a parent suite with "skip" in "before" hook', function () {
+  before(function () {
+    this.skip();
+  });
+
+  describe('a suite skipped by parent\'s "before" hook', function () {
+    it('should skip this test', function () {
+      expect(2).to.equal(1);
+    });
+
+    it('should skip this test too', function () {
+      expect(2).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
this.skip() in before fails to skip tests with nested describe calls