### PR TITLE
ignore lockfiles for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ npm-debug.log*
 .nyc_output/
 coverage/
 BUILDTMP/
+yarn.lock
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+


### PR DESCRIPTION
This ensures we don't have to deal with `package-lock.json` and `yarn.lock` for now.