### PR TITLE
upgrade to debug@2.6.8; closes #2859

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
   "dependencies": {
     "browser-stdout": "1.3.0",
     "commander": "2.9.0",
-    "debug": "2.6.0",
+    "debug": "2.6.8",
     "diff": "3.2.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     "os-name": "^2.0.1",
     "phantomjs": "1.9.8",
     "rimraf": "^2.5.2",
-    "should": "^11.1.1",
+    "should": "^9.0.2",
     "through2": "^2.0.1",
     "watchify": "^3.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -325,6 +325,7 @@
     "browserify": "^13.0.0",
     "coffee-script": "^1.10.0",
     "coveralls": "^2.11.15",
+    "cross-spawn": "^5.1.0",
     "eslint": "^3.11.1",
     "eslint-config-semistandard": "^7.0.0",
     "eslint-config-standard": "^6.2.1",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -2,7 +2,6 @@
 
 var spawn = require('child_process').spawn;
 var path = require('path');
-var fs = require('fs');
 var baseReporter = require('../../lib/reporters/base');
 
 module.exports = {
@@ -38,47 +37,6 @@ module.exports = {
       }
 
       done(null, getSummary(res));
-    });
-  },
-
-  /**
-   * Invokes the mocha binary on the code of the body of the function.
-   * Accepts an array of additional command line args to pass. The callback is
-   * invoked with a summary of the run, in addition to its output. The summary
-   * includes the number of passing, pending, and failing tests, as well as the
-   * exit code. Useful for testing different reporters.
-   *
-   * Example response:
-   * {
-   *   pending: 0,
-   *   passing: 0,
-   *   failing: 1,
-   *   code:    1,
-   *   output:  '...'
-   * }
-   *
-   * @param {function} fixture
-   * @param {array}    args
-   * @param {function} fn
-   */
-  runMochaFunction: function (fixture, args, fn) {
-    var path = resolveFixturePath(fixture.name + '.js' || 'tempfile.js');
-    args = args || [];
-
-    var fixtureContent = 'var fn = ' + fixture.toString() + '; fn()';
-    fs.writeFileSync(path, fixtureContent, 'utf8');
-
-    function cleanup () {
-      fs.unlink(path);
-      fn.apply(this, arguments);
-    }
-
-    invokeMocha(args.concat(['-C', path]), function (err, res) {
-      if (err) {
-        return cleanup(err);
-      }
-
-      cleanup(null, getSummary(res));
     });
   },
 
@@ -157,10 +115,10 @@ module.exports = {
 
 function invokeMocha (args, fn) {
   var output, mocha, listener;
-
+  // ensure DEBUG doesn't kill tests
   output = '';
   args = [path.join('bin', 'mocha')].concat(args);
-  mocha = spawn(process.execPath, args);
+  mocha = spawn(process.execPath, args, {env: {}});
 
   listener = function (data) {
     output += data;

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn').spawn;
 var path = require('path');
 var baseReporter = require('../../lib/reporters/base');
 

--- a/test/integration/hooks.spec.js
+++ b/test/integration/hooks.spec.js
@@ -10,7 +10,10 @@ describe('hooks', function () {
     runMocha('cascade.fixture.js', args, function (err, res) {
       var lines, expected;
 
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
 
       lines = res.output.split(splitRegExp).map(function (line) {
         return line.trim();

--- a/test/integration/only.spec.js
+++ b/test/integration/only.spec.js
@@ -7,7 +7,10 @@ describe('.only()', function () {
   describe('bdd', function () {
     it('should run only tests that marked as `only`', function (done) {
       run('options/only/bdd.fixture.js', ['--ui', 'bdd'], function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 11);
         assert.equal(res.stats.failures, 0);
@@ -20,7 +23,10 @@ describe('.only()', function () {
   describe('tdd', function () {
     it('should run only tests that marked as `only`', function (done) {
       run('options/only/tdd.fixture.js', ['--ui', 'tdd'], function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 8);
         assert.equal(res.stats.failures, 0);
@@ -33,7 +39,10 @@ describe('.only()', function () {
   describe('qunit', function () {
     it('should run only tests that marked as `only`', function (done) {
       run('options/only/qunit.fixture.js', ['--ui', 'qunit'], function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 5);
         assert.equal(res.stats.failures, 0);

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -12,7 +12,10 @@ describe('options', function () {
 
     it('should fail synchronous specs', function (done) {
       run('options/async-only-sync.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 0);
         assert.equal(res.stats.failures, 1);
@@ -25,7 +28,10 @@ describe('options', function () {
 
     it('should allow asynchronous specs', function (done) {
       run('options/async-only-async.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 1);
         assert.equal(res.stats.failures, 0);
@@ -44,7 +50,10 @@ describe('options', function () {
 
     it('should stop after the first error', function (done) {
       run('options/bail.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 1);
         assert.equal(res.stats.failures, 1);
@@ -64,7 +73,10 @@ describe('options', function () {
 
     it('should sort tests in alphabetical order', function (done) {
       run('options/sort*', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 2);
         assert.equal(res.stats.failures, 0);
@@ -84,7 +96,10 @@ describe('options', function () {
 
     it('should run the generated test suite', function (done) {
       run('options/delay.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 1);
         assert.equal(res.stats.failures, 0);
@@ -98,7 +113,10 @@ describe('options', function () {
 
     it('should throw an error if the test suite failed to run', function (done) {
       run('options/delay-fail.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 0);
         assert.equal(res.stats.failures, 1);
@@ -115,7 +133,10 @@ describe('options', function () {
     it('runs specs matching a string', function (done) {
       args = ['--grep', 'match'];
       run('options/grep.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 2);
         assert.equal(res.stats.failures, 0);
@@ -128,7 +149,10 @@ describe('options', function () {
       it('with RegExp like strings(pattern follow by flag)', function (done) {
         args = ['--grep', '/match/i'];
         run('options/grep.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 0);
           assert.equal(res.stats.passes, 4);
           assert.equal(res.stats.failures, 0);
@@ -140,7 +164,10 @@ describe('options', function () {
       it('string as pattern', function (done) {
         args = ['--grep', '.*'];
         run('options/grep.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 0);
           assert.equal(res.stats.passes, 4);
           assert.equal(res.stats.failures, 1);
@@ -154,7 +181,10 @@ describe('options', function () {
       it('runs specs that do not match the pattern', function (done) {
         args = ['--grep', 'fail', '--invert'];
         run('options/grep.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 0);
           assert.equal(res.stats.passes, 4);
           assert.equal(res.stats.failures, 0);
@@ -169,7 +199,10 @@ describe('options', function () {
     it('retries after a certain threshold', function (done) {
       args = ['--retries', '3'];
       run('options/retries.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 0);
         assert.equal(res.stats.passes, 0);
         assert.equal(res.stats.tests, 1);
@@ -188,7 +221,10 @@ describe('options', function () {
 
     it('succeeds if there are only passed tests', function (done) {
       run('options/forbid-only/passed.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.code, 0);
         done();
       });
@@ -196,7 +232,10 @@ describe('options', function () {
 
     it('fails if there are tests marked only', function (done) {
       run('options/forbid-only/only.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.code, 1);
         done();
       });
@@ -210,7 +249,10 @@ describe('options', function () {
 
     it('succeeds if there are only passed tests', function (done) {
       run('options/forbid-pending/passed.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.code, 0);
         done();
       });
@@ -218,7 +260,10 @@ describe('options', function () {
 
     it('fails if there are tests marked skip', function (done) {
       run('options/forbid-pending/skip.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.code, 1);
         done();
       });
@@ -226,7 +271,10 @@ describe('options', function () {
 
     it('fails if there are pending tests', function (done) {
       run('options/forbid-pending/pending.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.code, 1);
         done();
       });

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -8,7 +8,10 @@ describe('pending', function () {
   describe('pending specs', function () {
     it('should be created by omitting a function', function (done) {
       run('pending/spec.fixture.js', args, function (err, res) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(res.stats.pending, 1);
         assert.equal(res.stats.passes, 0);
         assert.equal(res.stats.failures, 0);
@@ -22,7 +25,10 @@ describe('pending', function () {
     describe('in spec', function () {
       it('should immediately skip the spec and run all others', function (done) {
         run('pending/skip-sync-spec.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 1);
           assert.equal(res.stats.passes, 1);
           assert.equal(res.stats.failures, 0);
@@ -35,7 +41,10 @@ describe('pending', function () {
     describe('in before', function () {
       it('should skip all suite specs', function (done) {
         run('pending/skip-sync-before.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
           assert.equal(res.stats.failures, 0);
@@ -48,7 +57,10 @@ describe('pending', function () {
     describe('in beforeEach', function () {
       it('should skip all suite specs', function (done) {
         run('pending/skip-sync-beforeEach.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
           assert.equal(res.stats.failures, 0);
@@ -63,7 +75,10 @@ describe('pending', function () {
     describe('in spec', function () {
       it('should immediately skip the spec and run all others', function (done) {
         run('pending/skip-async-spec.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 1);
           assert.equal(res.stats.passes, 1);
           assert.equal(res.stats.failures, 0);
@@ -76,7 +91,10 @@ describe('pending', function () {
     describe('in before', function () {
       it('should skip all suite specs', function (done) {
         run('pending/skip-async-before.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
           assert.equal(res.stats.failures, 0);
@@ -89,7 +107,10 @@ describe('pending', function () {
     describe('in beforeEach', function () {
       it('should skip all suite specs', function (done) {
         run('pending/skip-sync-beforeEach.fixture.js', args, function (err, res) {
-          assert(!err);
+          if (err) {
+            done(err);
+            return;
+          }
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 0);
           assert.equal(res.stats.failures, 0);

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -15,7 +15,10 @@ describe('regressions', function () {
         return (res.output.match(pattern) || []).length;
       };
 
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(occurences('testbody1'), 1);
       assert.equal(occurences('testbody2'), 1);
       assert.equal(occurences('testbody3'), 1);
@@ -36,7 +39,10 @@ describe('regressions', function () {
     var simpleUiPath = path.join(__dirname, 'fixtures', 'regression', '1794', 'simple-ui.js');
     var args = ['--require', simpleUiPath, '--ui', 'simple-ui'];
     run('regression/1794/issue-1794.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.code, 0, 'Custom UI should be loaded');
       done();
     });
@@ -47,7 +53,10 @@ describe('regressions', function () {
     // Could easily take longer on even weaker machines (Travis-CI containers for example).
     this.timeout(120000);
     run('regression/issue-1991.fixture.js', [], function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(/process out of memory/.test(res.output), false, 'fixture\'s process out of memory!');
       assert.equal(res.code, 0, 'Runnable fn (it/before[Each]/after[Each]) references should be deleted to avoid memory leaks');
       done();
@@ -68,7 +77,10 @@ describe('regressions', function () {
 
   it('issue-2315: cannot read property currentRetry of undefined', function (done) {
     runJSON('regression/issue-2315.fixture.js', [], function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 1);
@@ -80,7 +92,10 @@ describe('regressions', function () {
   it('issue-2406: should run nested describe.only suites', function (done) {
     this.timeout(2000);
     runJSON('regression/issue-2406.fixture.js', [], function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 2);
       assert.equal(res.stats.failures, 0);
@@ -91,7 +106,10 @@ describe('regressions', function () {
 
   it('issue-2417: should not recurse infinitely with .only suites nested within each other', function () {
     runJSON('regression/issue-2417.fixture.js', [], function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 1);
       assert.equal(res.stats.failures, 0);
@@ -101,7 +119,10 @@ describe('regressions', function () {
 
   it('issue-1417 uncaught exceptions from async specs', function (done) {
     runJSON('regression/issue-1417.fixture.js', [], function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 2);

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -104,7 +104,7 @@ describe('regressions', function () {
     });
   });
 
-  it('issue-2417: should not recurse infinitely with .only suites nested within each other', function () {
+  it('issue-2417: should not recurse infinitely with .only suites nested within each other', function (done) {
     runJSON('regression/issue-2417.fixture.js', [], function (err, res) {
       if (err) {
         done(err);

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -68,7 +68,10 @@ describe('reporters', function () {
       var args = ['--reporter=' + reporterAtARelativePath];
 
       run('passing.fixture.js', args, function (err, result) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(result.code, 0);
         done();
       });
@@ -81,7 +84,10 @@ describe('reporters', function () {
       var args = ['--reporter=' + reporterAtAnAbsolutePath];
 
       run('passing.fixture.js', args, function (err, result) {
-        assert(!err);
+        if (err) {
+          done(err);
+          return;
+        }
         assert.equal(result.code, 0);
         done();
       });

--- a/test/integration/retries.spec.js
+++ b/test/integration/retries.spec.js
@@ -10,7 +10,10 @@ describe('retries', function () {
     helpers.runMocha('retries/hooks.fixture.js', args, function (err, res) {
       var lines, expected;
 
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
 
       lines = res.output.split(helpers.splitRegExp).map(function (line) {
         return line.trim();
@@ -49,7 +52,10 @@ describe('retries', function () {
 
   it('should exit early if test passes', function (done) {
     helpers.runMochaJSON('retries/early-pass.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.passes, 1);
       assert.equal(res.stats.failures, 0);
       assert.equal(res.tests[0].currentRetry, 1);
@@ -61,7 +67,10 @@ describe('retries', function () {
 
   it('should let test override', function (done) {
     helpers.runMochaJSON('retries/nested.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 1);
       assert.equal(res.stats.tests, 1);
@@ -75,7 +84,10 @@ describe('retries', function () {
     helpers.runMocha('retries/async.fixture.js', args, function (err, res) {
       var lines, expected;
 
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
 
       lines = res.output.split(helpers.splitRegExp).map(function (line) {
         return line.trim();

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -8,7 +8,10 @@ describe('suite w/no callback', function () {
   this.timeout(2000);
   it('should throw a helpful error message when a callback for suite is not supplied', function (done) {
     run('suite/suite-no-callback.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       var result = res.output.match(/no callback was supplied/) || [];
       assert.equal(result.length, 1);
       done();
@@ -20,7 +23,10 @@ describe('skipped suite w/no callback', function () {
   this.timeout(2000);
   it('should not throw an error when a callback for skipped suite is not supplied', function (done) {
     run('suite/suite-skipped-no-callback.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       var pattern = new RegExp('Error', 'g');
       var result = res.output.match(pattern) || [];
       assert.equal(result.length, 0);
@@ -33,7 +39,10 @@ describe('skipped suite w/ callback', function () {
   this.timeout(2000);
   it('should not throw an error when a callback for skipped suite is supplied', function (done) {
     run('suite/suite-skipped-callback.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       var pattern = new RegExp('Error', 'g');
       var result = res.output.match(pattern) || [];
       assert.equal(result.length, 0);

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -7,7 +7,10 @@ var args = [];
 describe('this.timeout()', function () {
   it('is respected by sync and async suites', function (done) {
     run('timeout.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 2);

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -7,7 +7,10 @@ var args = [];
 describe('uncaught exceptions', function () {
   it('handles uncaught exceptions from hooks', function (done) {
     run('uncaught-hook.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 1);
@@ -21,7 +24,10 @@ describe('uncaught exceptions', function () {
 
   it('handles uncaught exceptions from async specs', function (done) {
     run('uncaught.fixture.js', args, function (err, res) {
-      assert(!err);
+      if (err) {
+        done(err);
+        return;
+      }
       assert.equal(res.stats.pending, 0);
       assert.equal(res.stats.passes, 0);
       assert.equal(res.stats.failures, 2);

--- a/test/node-unit/file-utils.spec.js
+++ b/test/node-unit/file-utils.spec.js
@@ -13,6 +13,10 @@ describe('file utils', function () {
   var tmpFile = path.join.bind(path, tmpDir);
   var symlinkSupported = false;
 
+  beforeEach(function () {
+    this.timeout(2000);
+  });
+
   (function testSymlinkSupport () {
     makeTempDir();
 


### PR DESCRIPTION
- ensure we can run the test suite with `DEBUG=mocha*` by removing it
  when spawning `mocha`
- remove some cruft in the test helpers