### PR TITLE
FEATURE Allow comments in `mocha.opts` file.

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -23,7 +23,7 @@ function getOptions () {
 
   try {
     var opts = fs.readFileSync(optsPath, 'utf8')
-      .replace(/^\s*#.*/gm, '')
+      .replace(/^\s*([^#]*)#.*/gm, '')
       .replace(/\\\s/g, '%20')
       .split(/\s/)
       .filter(Boolean)

--- a/bin/options.js
+++ b/bin/options.js
@@ -23,7 +23,7 @@ function getOptions () {
 
   try {
     var opts = fs.readFileSync(optsPath, 'utf8')
-      .replace(/^\s*([^#]*)#.*/gm, '')
+      .replace(/^\s*([^#]*)#.*$/gm, '')
       .replace(/\\\s/g, '%20')
       .split(/\s/)
       .filter(Boolean)

--- a/bin/options.js
+++ b/bin/options.js
@@ -23,6 +23,7 @@ function getOptions () {
 
   try {
     var opts = fs.readFileSync(optsPath, 'utf8')
+      .replace(/^\s*#.*/gm, '')
       .replace(/\\\s/g, '%20')
       .split(/\s/)
       .filter(Boolean)


### PR DESCRIPTION
This should enable switching an option off/on with ease by commenting/uncommenting the option.

It can be useful to document certain options to facilitate better collaborations.

/cc @jwalton, @ELLIOTTCABLE 