### PR TITLE
Print failures for pending/only forbidden

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -537,11 +537,10 @@ Runner.prototype.runTests = function (suite, fn) {
         test.isPending = alwaysFalse;
         self.fail(test, new Error("Pending test forbidden"));
         delete test.isPending;
-        self.emit('test end', test);
       } else {
         self.emit('pending', test);
-        self.emit('test end', test);
       }
+      self.emit('test end', test);
       return next();
     }
 
@@ -553,11 +552,10 @@ Runner.prototype.runTests = function (suite, fn) {
           test.isPending = alwaysFalse;
           self.fail(test, new Error("Pending test forbidden"));
           delete test.isPending;
-          self.emit('test end', test);
         } else {
           self.emit('pending', test);
-          self.emit('test end', test);
         }
+        self.emit('test end', test);
         return next();
       }
       if (err) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -429,6 +429,10 @@ Runner.prototype.runTest = function (fn) {
   if (!test) {
     return;
   }
+  if (this.forbidOnly && this.hasOnly) {
+    fn(new Error("`.only` forbidden"))
+    return
+  }
   if (this.asyncOnly) {
     test.asyncOnly = true;
   }
@@ -529,8 +533,15 @@ Runner.prototype.runTests = function (suite, fn) {
     }
 
     if (test.isPending()) {
-      self.emit('pending', test);
-      self.emit('test end', test);
+      if (self.forbidPending) {
+        test.isPending = alwaysFalse;
+        self.fail(test, new Error("Pending test forbidden"));
+        delete test.isPending;
+        self.emit('test end', test);
+      } else {
+        self.emit('pending', test);
+        self.emit('test end', test);
+      }
       return next();
     }
 
@@ -538,8 +549,15 @@ Runner.prototype.runTests = function (suite, fn) {
     self.emit('test', self.test = test);
     self.hookDown('beforeEach', function (err, errSuite) {
       if (test.isPending()) {
-        self.emit('pending', test);
-        self.emit('test end', test);
+        if (self.forbidPending) {
+          test.isPending = alwaysFalse;
+          self.fail(test, new Error("Pending test forbidden"));
+          delete test.isPending;
+          self.emit('test end', test);
+        } else {
+          self.emit('pending', test);
+          self.emit('test end', test);
+        }
         return next();
       }
       if (err) {
@@ -550,7 +568,9 @@ Runner.prototype.runTests = function (suite, fn) {
         test = self.test;
         if (err) {
           var retry = test.currentRetry();
-          if (err instanceof Pending) {
+          if (err instanceof Pending && self.forbidPending) {
+            self.fail(test, new Error("Pending test forbidden"))
+          } else if (err instanceof Pending) {
             test.pending = true;
             self.emit('pending', test);
           } else if (retry < test.retries()) {
@@ -585,6 +605,10 @@ Runner.prototype.runTests = function (suite, fn) {
   this.hookErr = hookErr;
   next();
 };
+
+function alwaysFalse() {
+  return false
+}
 
 /**
  * Run the given `suite` and invoke the callback `fn()` when complete.
@@ -820,12 +844,6 @@ Runner.prototype.run = function (fn) {
 
   // callback
   this.on('end', function () {
-    if (self.forbidOnly && self.hasOnly) {
-      self.failures += self.stats.tests;
-    }
-    if (self.forbidPending) {
-      self.failures += self.stats.pending;
-    }
     debug('end');
     process.removeListener('uncaughtException', uncaught);
     fn(self.failures);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -430,8 +430,8 @@ Runner.prototype.runTest = function (fn) {
     return;
   }
   if (this.forbidOnly && this.hasOnly) {
-    fn(new Error("`.only` forbidden"))
-    return
+    fn(new Error('`.only` forbidden'));
+    return;
   }
   if (this.asyncOnly) {
     test.asyncOnly = true;
@@ -535,7 +535,7 @@ Runner.prototype.runTests = function (suite, fn) {
     if (test.isPending()) {
       if (self.forbidPending) {
         test.isPending = alwaysFalse;
-        self.fail(test, new Error("Pending test forbidden"));
+        self.fail(test, new Error('Pending test forbidden'));
         delete test.isPending;
       } else {
         self.emit('pending', test);
@@ -550,7 +550,7 @@ Runner.prototype.runTests = function (suite, fn) {
       if (test.isPending()) {
         if (self.forbidPending) {
           test.isPending = alwaysFalse;
-          self.fail(test, new Error("Pending test forbidden"));
+          self.fail(test, new Error('Pending test forbidden'));
           delete test.isPending;
         } else {
           self.emit('pending', test);
@@ -567,7 +567,7 @@ Runner.prototype.runTests = function (suite, fn) {
         if (err) {
           var retry = test.currentRetry();
           if (err instanceof Pending && self.forbidPending) {
-            self.fail(test, new Error("Pending test forbidden"))
+            self.fail(test, new Error('Pending test forbidden'));
           } else if (err instanceof Pending) {
             test.pending = true;
             self.emit('pending', test);
@@ -604,8 +604,8 @@ Runner.prototype.runTests = function (suite, fn) {
   next();
 };
 
-function alwaysFalse() {
-  return false
+function alwaysFalse () {
+  return false;
 }
 
 /**

--- a/test/integration/fixtures/options/forbid-only/only-suite.js
+++ b/test/integration/fixtures/options/forbid-only/only-suite.js
@@ -1,0 +1,5 @@
+'use strict';
+
+describe.only('forbid only - suite marked with only', function () {
+  it('test1', function () {});
+});

--- a/test/integration/fixtures/options/forbid-pending/before-this.skip.js
+++ b/test/integration/fixtures/options/forbid-pending/before-this.skip.js
@@ -1,0 +1,6 @@
+'use strict';
+
+describe('forbid pending - before calls `skip()`', function () {
+  it('test', function () {});
+  before(function () { this.skip(); });
+});

--- a/test/integration/fixtures/options/forbid-pending/beforeEach-this.skip.js
+++ b/test/integration/fixtures/options/forbid-pending/beforeEach-this.skip.js
@@ -1,0 +1,6 @@
+'use strict';
+
+describe('forbid pending - beforeEach calls `skip()`', function () {
+  it('test', function () {});
+  beforeEach(function () { this.skip(); });
+});

--- a/test/integration/fixtures/options/forbid-pending/skip-suite.js
+++ b/test/integration/fixtures/options/forbid-pending/skip-suite.js
@@ -1,0 +1,5 @@
+'use strict';
+
+describe.skip('forbid pending - suite marked with skip', function () {
+  it('test1', function () {});
+});

--- a/test/integration/fixtures/options/forbid-pending/this.skip.js
+++ b/test/integration/fixtures/options/forbid-pending/this.skip.js
@@ -2,6 +2,6 @@
 
 describe('forbid pending - test calls `skip()`', function () {
   it('test1', function () {});
-  it('test2', function () { this.skip() });
+  it('test2', function () { this.skip(); });
   it('test3', function () {});
 });

--- a/test/integration/fixtures/options/forbid-pending/this.skip.js
+++ b/test/integration/fixtures/options/forbid-pending/this.skip.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('forbid pending - test calls `skip()`', function () {
+  it('test1', function () {});
+  it('test2', function () { this.skip() });
+  it('test3', function () {});
+});

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -231,5 +231,13 @@ describe('options', function () {
         done();
       });
     });
+
+    it('fails if tests call `skip()`', function (done) {
+      run('options/forbid-pending/this.skip.js', args, function (err, res) {
+        assert(!err);
+        assert.equal(res.code, 1);
+        done();
+      });
+    });
   });
 });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -182,6 +182,8 @@ describe('options', function () {
   });
 
   describe('--forbid-only', function () {
+    var onlyErrorMessage = '`.only` forbidden';
+
     before(function () {
       args = ['--forbid-only'];
     });
@@ -198,7 +200,16 @@ describe('options', function () {
       run('options/forbid-only/only.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
-        assert.equal(res.failures[0].err.message, '`.only` forbidden');
+        assert.equal(res.failures[0].err.message, onlyErrorMessage);
+        done();
+      });
+    });
+
+    it('fails if there are tests in suites marked only', function (done) {
+      run('options/forbid-only/only-suite.js', args, function (err, res) {
+        assert(!err);
+        assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, onlyErrorMessage);
         done();
       });
     });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -245,5 +245,14 @@ describe('options', function () {
         done();
       });
     });
+
+    it('fails if beforeEach calls `skip()`', function (done) {
+      run('options/forbid-pending/beforeEach-this.skip.js', args, function (err, res) {
+        assert(!err);
+        assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, pendingErrorMessage);
+        done();
+      });
+    });
   });
 });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -263,5 +263,14 @@ describe('options', function () {
         done();
       });
     });
+
+    it('fails if there are tests in suites marked skip', function (done) {
+      run('options/forbid-pending/skip-suite.js', args, function (err, res) {
+        assert(!err);
+        assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, pendingErrorMessage);
+        done();
+      });
+    });
   });
 });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -198,7 +198,7 @@ describe('options', function () {
       run('options/forbid-only/only.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
-        assert.equal(res.failures[0].err.message, '`.only` forbidden')
+        assert.equal(res.failures[0].err.message, '`.only` forbidden');
         done();
       });
     });
@@ -223,7 +223,7 @@ describe('options', function () {
       run('options/forbid-pending/skip.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
-        assert.equal(res.failures[0].err.message, pendingErrorMessage)
+        assert.equal(res.failures[0].err.message, pendingErrorMessage);
         done();
       });
     });
@@ -232,7 +232,7 @@ describe('options', function () {
       run('options/forbid-pending/pending.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
-        assert.equal(res.failures[0].err.message, pendingErrorMessage)
+        assert.equal(res.failures[0].err.message, pendingErrorMessage);
         done();
       });
     });
@@ -241,7 +241,7 @@ describe('options', function () {
       run('options/forbid-pending/this.skip.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
-        assert.equal(res.failures[0].err.message, pendingErrorMessage)
+        assert.equal(res.failures[0].err.message, pendingErrorMessage);
         done();
       });
     });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -254,5 +254,14 @@ describe('options', function () {
         done();
       });
     });
+
+    it('fails if before calls `skip()`', function (done) {
+      run('options/forbid-pending/before-this.skip.js', args, function (err, res) {
+        assert(!err);
+        assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, pendingErrorMessage);
+        done();
+      });
+    });
   });
 });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -198,12 +198,15 @@ describe('options', function () {
       run('options/forbid-only/only.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, '`.only` forbidden')
         done();
       });
     });
   });
 
   describe('--forbid-pending', function () {
+    var pendingErrorMessage = 'Pending test forbidden';
+
     before(function () {
       args = ['--forbid-pending'];
     });
@@ -220,6 +223,7 @@ describe('options', function () {
       run('options/forbid-pending/skip.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, pendingErrorMessage)
         done();
       });
     });
@@ -228,6 +232,7 @@ describe('options', function () {
       run('options/forbid-pending/pending.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, pendingErrorMessage)
         done();
       });
     });
@@ -236,6 +241,7 @@ describe('options', function () {
       run('options/forbid-pending/this.skip.js', args, function (err, res) {
         assert(!err);
         assert.equal(res.code, 1);
+        assert.equal(res.failures[0].err.message, pendingErrorMessage)
         done();
       });
     });


### PR DESCRIPTION
Followup to #2696; this is going to look crazy when somebody puts `.only` or `.skip` on a suite, but I can live with that (whereas I can't take not having any printout for these failures at all) and if we figure out how to emit one failure per relevant suite we can always tweak that later (whether it has to be semver-major or not).