### PR TITLE
Fix Node 0.10 AppVeyor failure

### DIFF
--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -115,10 +115,10 @@ module.exports = {
 
 function invokeMocha (args, fn) {
   var output, mocha, listener;
-  // ensure DEBUG doesn't kill tests
+
   output = '';
   args = [path.join('bin', 'mocha')].concat(args);
-  mocha = spawn(process.execPath, args, {env: {}});
+  mocha = spawn(process.execPath, args);
 
   listener = function (data) {
     output += data;


### PR DESCRIPTION
During the `debug` package upgrade, a tweak to the integration test helper's spawn usage was applied that cleared the environment variables. For whatever reason, that worked on every OS and version of Node except for 0.10 on Windows. This PR reverts that particular tweak, and nothing else, allowing CI to pass again.

If not clearing the environment variables is still an issue for some usage, we should attempt a new, separate fix that we can wait on merging till we can get it to avoid breaking anything.

(It is not immediately clear to me whether the breakage is due to lack of environment variables and could be fixed just by changing `{ env: {} }` to something old-Node-compatible equivalent of `{ env: Object.assign({}, process.env, { DEBUG: ""}) }`, or whether the breakage is instead due to some other effect of passing the options object argument to `spawn` -- perhaps in Node 0.10 for Windows it unset some other default setting?)

We may wish to switch back to `child_process` instead of dev-depending on `cross-spawn` if the reason `cross-spawn` was added was an attempt to fix these Node 0.10 AppVeyor failures (it did not).