### PR TITLE
Fix Travis browser tests dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,6 +343,7 @@
     "nyc": "^10.0.0",
     "os-name": "^2.0.1",
     "phantomjs": "1.9.8",
+    "readable-stream": "2.2.11",
     "rimraf": "^2.5.2",
     "should": "^9.0.2",
     "through2": "^2.0.1",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -115,10 +115,10 @@ module.exports = {
 
 function invokeMocha (args, fn) {
   var output, mocha, listener;
-  // ensure DEBUG doesn't kill tests
+
   output = '';
   args = [path.join('bin', 'mocha')].concat(args);
-  mocha = spawn(process.execPath, args, {env: {}});
+  mocha = spawn(process.execPath, args);
 
   listener = function (data) {
     output += data;


### PR DESCRIPTION
Does NOT fix the Sauce 20,000ms disconnect issue.

Does fix the newer issues that appeared just this past day.

This fixes Travis browser tests (except for the Sauce 20,000ms disconnect issue), #2897 fixes AppVeyor Node 0.10 tests; put them both in master and then merge into anything else that's waiting for CI checks to pass, then hope the Sauce 20,000ms issue stays away for a while, ha.

(For the record: the issue is that readable-stream 2.3.0 breaks Phantom 1.x due to use of `Function.prototype.bind` and breaks IE7 and 8 due to pulling in `safe-buffer`, which uses `Object.keys`.)