### PR TITLE
Add err to test.retryErr list if retrying the test #2529

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -556,6 +556,8 @@ Runner.prototype.runTests = function (suite, fn) {
           } else if (retry < test.retries()) {
             var clonedTest = test.clone();
             clonedTest.currentRetry(retry + 1);
+            clonedTest.retryErr = test.retryErr || [];
+            clonedTest.retryErr.push(err);
             tests.unshift(clonedTest);
 
             // Early return + hook trigger so that it doesn't


### PR DESCRIPTION
Adds the ability to see the errors from earlier attempts.  Occasional
the test state is different during the retry and the last test error is
not helpful.  Is this case the first error (test.retryErr[0]) is
useful.