### PR TITLE
Tap reporter: report thrown error messages

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -46,6 +46,9 @@ function TAP (runner) {
   runner.on('fail', function (test, err) {
     failures++;
     console.log('not ok %d %s', n, title(test));
+    if (err.message) {
+      console.log(err.message.replace(/^/gm, '  '));
+    }
     if (err.stack) {
       console.log(err.stack.replace(/^/gm, '  '));
     }

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -102,6 +102,41 @@ describe('TAP reporter', function () {
   });
 
   describe('on fail', function () {
+    describe('if there is an error message', function () {
+      it('should write expected message and error message', function () {
+        var expectedTitle = 'some title';
+        var countAfterTestEnd = 2;
+        var expectedErrorMessage = 'some error';
+        var test = {
+          fullTitle: function () {
+            return expectedTitle;
+          },
+          slow: function () {}
+        };
+        var error = {
+          message: expectedErrorMessage
+        };
+        runner.on = function (event, callback) {
+          if (event === 'test end') {
+            callback();
+          }
+          if (event === 'fail') {
+            callback(test, error);
+          }
+        };
+        runner.suite = '';
+        runner.grepTotal = function () { };
+        TAP.call({}, runner);
+
+        process.stdout.write = stdoutWrite;
+
+        var expectedArray = [
+          'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+          '  ' + expectedErrorMessage + '\n'
+        ];
+        stdout.should.deepEqual(expectedArray);
+      });
+    });
     describe('if there is an error stack', function () {
       it('should write expected message and stack', function () {
         var expectedTitle = 'some title';
@@ -137,7 +172,45 @@ describe('TAP reporter', function () {
         stdout.should.deepEqual(expectedArray);
       });
     });
-    describe('if there is no error stack', function () {
+    describe('if there is an error stack and error message', function () {
+      it('should write expected message and stack', function () {
+        var expectedTitle = 'some title';
+        var countAfterTestEnd = 2;
+        var expectedStack = 'some stack';
+        var expectedErrorMessage = 'some error';
+        var test = {
+          fullTitle: function () {
+            return expectedTitle;
+          },
+          slow: function () {}
+        };
+        var error = {
+          stack: expectedStack,
+          message: expectedErrorMessage
+        };
+        runner.on = function (event, callback) {
+          if (event === 'test end') {
+            callback();
+          }
+          if (event === 'fail') {
+            callback(test, error);
+          }
+        };
+        runner.suite = '';
+        runner.grepTotal = function () { };
+        TAP.call({}, runner);
+
+        process.stdout.write = stdoutWrite;
+
+        var expectedArray = [
+          'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+          '  ' + expectedErrorMessage + '\n',
+          '  ' + expectedStack + '\n'
+        ];
+        stdout.should.deepEqual(expectedArray);
+      });
+    });
+    describe('if there is no error stack or error message', function () {
       it('should write expected message only', function () {
         var expectedTitle = 'some title';
         var countAfterTestEnd = 2;


### PR DESCRIPTION
This PR extendis tap reporter to print error messages. It is useful in faster understanding on what exactly when wrong. 