### PR TITLE
chore(package): bump growl to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "diff": "3.2.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.1",
-    "growl": "1.9.2",
+    "growl": "1.10.0",
     "json3": "3.3.2",
     "lodash.create": "3.1.1",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Following-up on mochajs/mocha#2798 & mochajs/mocha#2791, update growl that is known to be vulnerable