### PR TITLE
Upgrade Growl to 1.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "diff": "3.2.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.1",
-    "growl": "1.9.2",
+    "growl": "^1.10.2",
     "json3": "3.3.2",
     "lodash.create": "3.1.1",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
* Growl 1.9.2 is vulnerable to arbitrary code injection,
  and causes security warnings for Mocha users
* Upgrade Growl to 1.10.2, and address issue #2791 