### PR TITLE
chore(package): bump growl

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -239,7 +239,7 @@ Mocha.prototype.loadFiles = function (fn) {
  * @api private
  */
 Mocha.prototype._growl = function (runner, reporter) {
-  var notify = require('growl');
+  var notify = require('mygrowl');
 
   runner.on('end', function () {
     var stats = reporter.stats;

--- a/mocha.js
+++ b/mocha.js
@@ -1499,7 +1499,7 @@ Mocha.prototype.loadFiles = function (fn) {
  * @api private
  */
 Mocha.prototype._growl = function (runner, reporter) {
-  var notify = require('growl');
+  var notify = require('mygrowl');
 
   runner.on('end', function () {
     var stats = reporter.stats;

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "diff": "3.2.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.1",
-    "growl": "1.9.2",
+    "mygrowl": "1.10.3",
     "json3": "3.3.2",
     "lodash.create": "3.1.1",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
mocha currently includes a version of growl that is known to be vulnerable (https://snyk.io/test/npm/mocha/3.4.2)

vulnerability got fixed, eventually. although support for nodejs pre-4 broke.
node-growl maintainer was warned, he recommends adding an option (`--harmony`) running node, ...
forking growl to provide with aforementioned fix, without dropping older nodejs versions support.

Now, in  all fairness, having mocha tests pass with the original growl would be better.
Otherwise, I don't mind forking, growl has no dependency, not much code, relatively clear, ...

FYI:
Exhaustive diff between current node-growl and fork: https://github.com/tj/node-growl/compare/master...faust64:master
Exhaustive diff between vulnerability fix and our fork: https://github.com/tj/node-growl/compare/d71177d5331c9de4658aca62e0ac921f178b0669...faust64:master