### PR TITLE
Add coverage of Base reporter cursor

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -33,7 +33,7 @@ var clearInterval = global.clearInterval;
  * Check if both stdio streams are associated with a tty.
  */
 
-var isatty = tty.isatty(1) && tty.isatty(2);
+exports.isatty = tty.isatty(1) && tty.isatty(2);
 
 /**
  * Enable coloring by default, except in the browser interface.
@@ -118,7 +118,7 @@ exports.window = {
   width: 75
 };
 
-if (isatty) {
+if (exports.isatty) {
   exports.window.width = process.stdout.getWindowSize
       ? process.stdout.getWindowSize(1)[0]
       : tty.getWindowSize()[1];
@@ -130,23 +130,23 @@ if (isatty) {
 
 exports.cursor = {
   hide: function () {
-    isatty && process.stdout.write('\u001b[?25l');
+    exports.isatty && process.stdout.write('\u001b[?25l');
   },
 
   show: function () {
-    isatty && process.stdout.write('\u001b[?25h');
+    exports.isatty && process.stdout.write('\u001b[?25h');
   },
 
   deleteLine: function () {
-    isatty && process.stdout.write('\u001b[2K');
+    exports.isatty && process.stdout.write('\u001b[2K');
   },
 
   beginningOfLine: function () {
-    isatty && process.stdout.write('\u001b[0G');
+    exports.isatty && process.stdout.write('\u001b[0G');
   },
 
   CR: function () {
-    if (isatty) {
+    if (exports.isatty) {
       exports.cursor.deleteLine();
       exports.cursor.beginningOfLine();
     } else {

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -160,6 +160,62 @@ describe('Base reporter', function () {
     });
   });
 
+  describe('cursor', function () {
+    var isatty;
+
+    beforeEach(function () {
+      isatty = Base.isatty;
+      Base.isatty = true;
+    });
+
+    afterEach(function () {
+      Base.isatty = isatty;
+    });
+
+    it('hides the cursor', function () {
+      var errOut;
+      Base.cursor.hide();
+      errOut = stdout.join('\n');
+      errOut.should.equal('\u001b[?25l');
+    });
+
+    it('shows the cursor', function () {
+      var errOut;
+      Base.cursor.show();
+      errOut = stdout.join('\n');
+      errOut.should.equal('\u001b[?25h');
+    });
+
+    it('deletes a line', function () {
+      var errOut;
+      Base.cursor.deleteLine();
+      errOut = stdout.join('\n');
+      errOut.should.equal('\u001b[2K');
+    });
+
+    it('moves the cursor to the beginning of the line', function () {
+      var errOut;
+      Base.cursor.beginningOfLine();
+      errOut = stdout.join('\n');
+      errOut.should.equal('\u001b[0G');
+    });
+
+    it('clears and restarts a line on carriage return in a tty', function () {
+      var errOut;
+      Base.cursor.CR();
+      errOut = stdout.join('\n');
+      errOut.should.equal('\u001b[2K\n\u001b[0G');
+    });
+
+    it('outputs a carriage return when not in a tty', function () {
+      Base.isatty = false;
+      var errOut;
+      Base.cursor.CR();
+      errOut = stdout.join('\n');
+      errOut.should.equal('\r');
+    });
+  });
+
   it('should stringify objects', function () {
     var err = new Error('test');
     var errOut;


### PR DESCRIPTION
This gets coverage of `lib/reporters/base.js` to over 92% on branches, statements, functions and lines.

I had to add `isatty` to exports to be able to control it during tests.