### PR TITLE
don't attempt to import growl in browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -367,6 +367,7 @@
     "./index.js": "./browser-entry.js",
     "fs": false,
     "glob": false,
+    "growl": false,
     "path": false,
     "supports-color": false
   },


### PR DESCRIPTION
Does growl work in the browser?  I had to add this in order to perform es6 imports in a webpack build.