### PR TITLE
Print dim text with dim color without concrete color

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -52,7 +52,7 @@ exports.inlineDiffs = false;
  */
 
 exports.colors = {
-  pass: 90,
+  pass: 2,
   fail: 31,
   'bright pass': 92,
   'bright fail': 91,
@@ -61,14 +61,14 @@ exports.colors = {
   suite: 0,
   'error title': 0,
   'error message': 31,
-  'error stack': 90,
+  'error stack': 2,
   checkmark: 32,
-  fast: 90,
+  fast: 2,
   medium: 33,
   slow: 31,
   green: 32,
-  light: 90,
-  'diff gutter': 90,
+  light: 2,
+  'diff gutter': 2,
   'diff added': 32,
   'diff removed': 31
 };


### PR DESCRIPTION
This aims to fix #2945. The control code `2` means `dim` and it will be printed with suitable color on various color schemes, including Solarized Dark.