### PR TITLE
Fail test with timeout 0 that completes without calling `done` or resolving a returned promise

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -249,6 +249,17 @@ Runnable.prototype.globals = function (globals) {
 };
 
 /**
+ * Allow uncaught-exception failures to trigger cleanup that would otherwise be altogether missed
+ *
+ * @api private
+ */
+Runnable.prototype.cleanUpHandlers = function () {
+  if (this._closeIntercept) {
+    process.removeListener('beforeExit', this._closeIntercept);
+  }
+};
+
+/**
  * Run the test and invoke `fn(err)`.
  *
  * @param {Function} fn
@@ -260,6 +271,15 @@ Runnable.prototype.run = function (fn) {
   var ctx = this.ctx;
   var finished;
   var emitted;
+  process.on('beforeExit', detectAsyncUnscheduled);
+  if (this._closeIntercept) {
+    process.removeListener('beforeExit', this._closeIntercept);
+  }
+  this._closeIntercept = detectAsyncUnscheduled;
+
+  function detectAsyncUnscheduled () {
+    done(new Error('After ' + (new Date() - start) + ' milliseconds there were no more asynchronous actions scheduled. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.'));
+  }
 
   // Sometimes the ctx exists, but it is not runnable
   if (ctx && ctx.runnable) {
@@ -277,6 +297,7 @@ Runnable.prototype.run = function (fn) {
 
   // finished
   function done (err) {
+    process.removeListener('beforeExit', detectAsyncUnscheduled);
     var ms = self.timeout();
     if (self.timedOut) {
       return;
@@ -312,7 +333,12 @@ Runnable.prototype.run = function (fn) {
     };
 
     if (this.allowUncaught) {
-      return callFnAsync(this.fn);
+      try {
+        return callFnAsync(this.fn);
+      } catch (err) {
+        process.removeListener('beforeExit', detectAsyncUnscheduled);
+        throw err;
+      }
     }
     try {
       callFnAsync(this.fn);
@@ -327,7 +353,12 @@ Runnable.prototype.run = function (fn) {
     if (this.isPending()) {
       done();
     } else {
-      callFn(this.fn);
+      try {
+        callFn(this.fn);
+      } catch (err) {
+        process.removeListener('beforeExit', detectAsyncUnscheduled);
+        throw err;
+      }
     }
     return;
   }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -707,6 +707,7 @@ Runner.prototype.uncaught = function (err) {
     return;
   }
 
+  runnable.cleanUpHandlers();
   runnable.clearTimeout();
 
   // Ignore errors if complete or pending

--- a/test/integration/fixtures/timeout-0-done.fixture.js
+++ b/test/integration/fixtures/timeout-0-done.fixture.js
@@ -1,0 +1,5 @@
+'use strict';
+
+it('never finishes', function (done) {
+  this.timeout(0);
+});

--- a/test/integration/fixtures/timeout-0-noexit.fixture.js
+++ b/test/integration/fixtures/timeout-0-noexit.fixture.js
@@ -1,0 +1,39 @@
+'use strict';
+
+describe('all test possibilities', function () {
+  it('finishes', function () {
+    process.send('process started');
+  });
+
+  it('finishes asynchronously', function (done) {
+    setTimeout(done, 0);
+  });
+
+  it('finishes with a promise', function () {
+    return Promise.resolve();
+  });
+
+  it('errors synchronously', function () {
+    throw new Error('ignore me');
+  });
+
+  it('errors synchronously for an async test', function (done) {
+    throw new Error('ignore me');
+  });
+
+  it('returns a rejected promise', function () {
+    return Promise.reject(new Error('ignore me'));
+  });
+
+  it('errors asynchronously', function (done) {
+    setTimeout(function () { throw new Error('ignore me'); }, 10);
+  });
+
+  it('fails (with done) asynchronously', function (done) {
+    setTimeout(done.bind(null, new Error('ignore me')), 10);
+  });
+
+  it('returns a promise that eventually rejects', function () {
+    return new Promise(function (resolve, reject) { setTimeout(reject.bind(null, new Error('ignore me')), 10); });
+  });
+});

--- a/test/integration/fixtures/timeout-0-promise.fixture.js
+++ b/test/integration/fixtures/timeout-0-promise.fixture.js
@@ -1,0 +1,6 @@
+'use strict';
+
+it('never finishes', function () {
+  this.timeout(0);
+  return new Promise(function () {});
+});

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -2,6 +2,8 @@
 
 var assert = require('assert');
 var run = require('./helpers').runMochaJSON;
+var fork = require('child_process').fork;
+var path = require('path');
 var args = [];
 
 describe('options', function () {
@@ -278,6 +280,112 @@ describe('options', function () {
         assert.equal(res.code, 1);
         done();
       });
+    });
+  });
+
+  describe('--no-exit', function () {
+    before(function () {
+      args = ['--no-exit'];
+    });
+
+    it('still allows process to finish', function (done) {
+      this.timeout(10 * 1000);
+      var child = fork(path.join(__dirname, '..', '..', 'bin', '_mocha'), args.concat([path.join(__dirname, 'fixtures', 'timeout-0-noexit.fixture.js')]), { silent: true });
+      child.on('error', function (error) {
+        if (timeout) { clearTimeout(timeout); }
+        if (done) { done(error); }
+        done = null;
+      });
+      var timeout;
+      child.on('message', function () {
+        timeout = setTimeout(function () {
+          child.kill('SIGINT');
+          if (done) { done(new Error('Test did not end right away like it should have')); }
+          done = null;
+        }, 5000);
+      });
+      child.on('exit', pass);
+      child.on('close', pass);
+      function pass () {
+        clearTimeout(timeout);
+        if (done) { done(); }
+        done = null;
+      }
+    });
+
+    it('still allows process to finish when --allow-uncaught', function (done) {
+      this.timeout(10 * 1000);
+      var child = fork(path.join(__dirname, '..', '..', 'bin', '_mocha'), args.concat(['--allow-uncaught', path.join(__dirname, 'fixtures', 'timeout-0-noexit.fixture.js')]), { silent: true });
+      child.on('error', function (error) {
+        if (timeout) { clearTimeout(timeout); }
+        if (done) { done(error); }
+        done = null;
+      });
+      var timeout;
+      child.on('message', function () {
+        timeout = setTimeout(function () {
+          child.kill('SIGINT');
+          if (done) { done(new Error('Test did not end right away like it should have')); }
+          done = null;
+        }, 5000);
+      });
+      child.on('exit', pass);
+      child.on('close', pass);
+      function pass () {
+        clearTimeout(timeout);
+        if (done) { done(); }
+        done = null;
+      }
+    });
+
+    it('still allows process to finish with --timeout 0', function (done) {
+      this.timeout(10 * 1000);
+      var child = fork(path.join(__dirname, '..', '..', 'bin', '_mocha'), args.concat(['--timeout', '0', path.join(__dirname, 'fixtures', 'timeout-0-noexit.fixture.js')]), { silent: true });
+      child.on('error', function (error) {
+        if (timeout) { clearTimeout(timeout); }
+        if (done) { done(error); }
+        done = null;
+      });
+      var timeout;
+      child.on('message', function () {
+        timeout = setTimeout(function () {
+          child.kill('SIGINT');
+          if (done) { done(new Error('Test did not end right away like it should have')); }
+          done = null;
+        }, 5000);
+      });
+      child.on('exit', pass);
+      child.on('close', pass);
+      function pass () {
+        clearTimeout(timeout);
+        if (done) { done(); }
+        done = null;
+      }
+    });
+
+    it('still allows process to finish with --timeout 0 when --allow-uncaught', function (done) {
+      this.timeout(10 * 1000);
+      var child = fork(path.join(__dirname, '..', '..', 'bin', '_mocha'), args.concat(['--timeout', '0', '--allow-uncaught', path.join(__dirname, 'fixtures', 'timeout-0-noexit.fixture.js')]), { silent: true });
+      child.on('error', function (error) {
+        if (timeout) { clearTimeout(timeout); }
+        if (done) { done(error); }
+        done = null;
+      });
+      var timeout;
+      child.on('message', function () {
+        timeout = setTimeout(function () {
+          child.kill('SIGINT');
+          if (done) { done(new Error('Test did not end right away like it should have')); }
+          done = null;
+        }, 5000);
+      });
+      child.on('exit', pass);
+      child.on('close', pass);
+      function pass () {
+        clearTimeout(timeout);
+        if (done) { done(); }
+        done = null;
+      }
     });
   });
 });

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -18,4 +18,73 @@ describe('this.timeout()', function () {
       done();
     });
   });
+
+  describe('0 (no timeout)', function () {
+    var itIfNodeWorthy = (function () {
+      var version = process.versions.node.split('.').map(Number);
+      return version[0] === 0 && version[1] === 10;
+    })() ? it.skip.bind(it) : it;
+
+    itIfNodeWorthy('does not spuriously end async tests that miss calling `done`', function (done) {
+      run('timeout-0-done.fixture.js', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 0);
+        assert.equal(res.stats.failures, 1);
+        assert.equal(res.code, 1);
+        done();
+      });
+    });
+
+    itIfNodeWorthy('does not spuriously end promise tests that never resolve', function (done) {
+      run('timeout-0-promise.fixture.js', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 0);
+        assert.equal(res.stats.failures, 1);
+        assert.equal(res.code, 1);
+        done();
+      });
+    });
+
+    describe('with --allow-uncaught', function () {
+      before(function () {
+        args = args.concat('--allow-uncaught');
+      });
+
+      itIfNodeWorthy('does not spuriously end async tests that miss calling `done`', function (done) {
+        run('timeout-0-done.fixture.js', args, function (err, res) {
+          if (err) {
+            done(err);
+            return;
+          }
+          assert.equal(res.stats.pending, 0);
+          assert.equal(res.stats.passes, 0);
+          assert.equal(res.stats.failures, 1);
+          assert.equal(res.code, 1);
+          done();
+        });
+      });
+
+      itIfNodeWorthy('does not spuriously end promise tests that never resolve', function (done) {
+        run('timeout-0-promise.fixture.js', args, function (err, res) {
+          if (err) {
+            done(err);
+            return;
+          }
+          assert.equal(res.stats.pending, 0);
+          assert.equal(res.stats.passes, 0);
+          assert.equal(res.stats.failures, 1);
+          assert.equal(res.code, 1);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #2537 

Also improves on the original attempt (in the `timeout-0-indefinite` branch, where the process is kept alive doing nothing forever in the same situation this fixes to an error) in handling `allowUncaught`, which could otherwise lead to situations wherein the handler was not removed at the end of a test.