### PR TITLE
Allow comments in mocha.opts

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -23,6 +23,7 @@ function getOptions () {
 
   try {
     var opts = fs.readFileSync(optsPath, 'utf8')
+      .replace(/^\/\/.*$/mg, '')
       .replace(/\\\s/g, '%20')
       .split(/\s/)
       .filter(Boolean)


### PR DESCRIPTION
Any line starting with // in mocha.opts will be ignored, viz treated as a comment