### PR TITLE
Add Notifications for Mocha in browser

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -168,6 +168,40 @@ mocha.run = function (fn) {
 };
 
 /**
+ * Use HTML notifications instead of Growl
+ */
+Mocha.prototype._growl = mocha._growl = function (runner, reporter) {
+  runner.on('end', function () {
+    var stats = reporter.stats;
+    if (!('Notification' in window)) return;
+    var notification, title, msg;
+    if (stats.failures) {
+      title = 'Failed';
+      msg = stats.failures + ' of ' + runner.total + ' tests failed';
+    } else {
+      title = 'Passed';
+      msg = stats.passes + ' tests passed in ' + stats.duration + 'ms';
+    }
+    var options = { body: msg };
+    if (Notification.permission === 'granted') {
+      notification = new Notification(title, options);
+    } else if (Notification.permission !== 'denied') {
+      Notification.requestPermission(function (permission) {
+        if (permission === 'granted') {
+          notification = new Notification(title, options);
+        }
+      });
+    }
+    if (notification) {
+      notification.onclick = function () {
+        window.focus();
+        this.close();
+      };
+    }
+  });
+};
+
+/**
  * Expose the process shim.
  * https://github.com/mochajs/mocha/pull/916
  */

--- a/test/browser/notification.html
+++ b/test/browser/notification.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Mocha</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../mocha.css" />
+    <script src="../../mocha.js"></script>
+    <script>mocha.setup('bdd')</script>
+    <script>
+      function assert(expr, msg) {
+        if (!expr) throw new Error(msg || 'failed');
+      }
+    </script>
+    <script src="notification.spec.js"></script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+  <script>
+      (function() {
+        mocha.checkLeaks();
+        mocha.growl()
+        mocha.run();
+      })();
+  </script>
+  </body>
+</html>

--- a/test/browser/notification.spec.js
+++ b/test/browser/notification.spec.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('Notification', function () {
+  it('should ask for notification, or show a notification', function () {
+    assert(true);
+  });
+});


### PR DESCRIPTION
This PR reference the thread started on PR #2938. It allows user to use `growl` option even if he is in browser, by replacing growl notifications for [Web API Notifications](https://developer.mozilla.org/en-US/docs/Web/API/notification).

Unit tests have not been made yet, I'd like to see first if this PR suits you. However I've already tried it in a personal project and it works like a charm.