### PR TITLE
fixing `process.nexTick` (should be `process.nextTick`), which invalidated tests

### DIFF
--- a/test/unit/throw.spec.js
+++ b/test/unit/throw.spec.js
@@ -45,16 +45,21 @@ describe('a test that throws', function () {
 
     it('should not pass if throwing async and test is async', function (done) {
       var test = new Test('im async and throw undefined async', function (done2) {
-        process.nexTick(function () {
+        process.nextTick(function () {
           throw undefined;
         });
       });
       suite.addTest(test);
       runner = new Runner(suite);
+      var uncaught = Runner.prototype.uncaught;
+      Runner.prototype.uncaught = function () {
+        Runner.prototype.uncaught = uncaught;
+        done();
+      };
       runner.on('end', function () {
         expect(runner.failures).to.equal(1);
         expect(test.state).to.equal('failed');
-        done();
+        expect(runner.uncaught).toBeCalled();
       });
       runner.run();
     });
@@ -91,16 +96,21 @@ describe('a test that throws', function () {
 
     it('should not pass if throwing async and test is async', function (done) {
       var test = new Test('im async and throw null async', function (done2) {
-        process.nexTick(function () {
+        process.nextTick(function () {
           throw null;
         });
       });
       suite.addTest(test);
       runner = new Runner(suite);
+      var uncaught = Runner.prototype.uncaught;
+      Runner.prototype.uncaught = function () {
+        Runner.prototype.uncaught = uncaught;
+        done();
+      };
       runner.on('end', function () {
         expect(runner.failures).to.equal(1);
         expect(test.state).to.equal('failed');
-        done();
+        expect(runner.uncaught).toBeCalled();
       });
       runner.run();
     });


### PR DESCRIPTION
### Requirements

### Description of the Change

This is intended to fix a spelling error -- Split from #2981.

### Alternate Designs

Instead of fixing the spelling error, the misspelled token can be replaced by a clear call to a nonexistent (but properly spelled) method.

### Why should this be in core?

This is existing test code (that happens to be incorrectly documenting what it claims to be testing).

### Benefits

Once someone fixes this to work correctly it will be easier to understand what the test is testing.

### Possible Drawbacks

`process.nexTick` could be intentionally misspelled, but that's unlikely, if that's the goal, there are better ways to cause a similar error.

### Applicable issues

* Is it a bug fix, or does it not impact production code (patch release)?
This isn't a proper bug fix at this time. Someone will have to decide how to properly fix it.