### PR TITLE
update coveralls strategy; closes #2984

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_script: scripts/travis-before-script.sh
 
 script: make $TARGET
 
-after_success: "npm run postcoverage && <coverage/lcov.info ./node_modules/coveralls/bin/coveralls.js"
+after_success: npm run coveralls
 
 notifications:
   urls:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NYC := "node_modules/.bin/nyc"
 
 ifdef COVERAGE
 define test_node
-	$(NYC) --report-dir coverage/reports/$(1) $(MOCHA)
+	$(NYC) --no-clean --report-dir coverage/reports/$(1) $(MOCHA)
 endef
 else
 	test_node := $(MOCHA)

--- a/package.json
+++ b/package.json
@@ -301,10 +301,8 @@
   "scripts": {
     "lint": "eslint . bin/*",
     "test": "make test && make clean",
-    "precoverage": "rm -rf coverage",
-    "coverage": "COVERAGE=true npm run test",
-    "postcoverage": "istanbul-combine -d coverage -r lcov -r html coverage/reports/*/*.json",
-    "preversion": "make test && rm mocha.js && make mocha.js && git add mocha.js"
+    "preversion": "make test && rm mocha.js && make mocha.js && git add mocha.js",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
     "browser-stdout": "1.3.0",
@@ -333,7 +331,6 @@
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "2.0.1",
     "expect.js": "^0.3.1",
-    "istanbul-combine": "^0.3.0",
     "karma": "1.3.0",
     "karma-browserify": "^5.0.5",
     "karma-chrome-launcher": "^2.0.0",

--- a/scripts/travis-before-script.sh
+++ b/scripts/travis-before-script.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
+# bundle artifacts to AWS go here
 mkdir -p .karma
+
+# because https://github.com/istanbuljs/nyc/pull/664
+mkdir -p .nyc_output


### PR DESCRIPTION
we don't seem to need `istanbul-combine`, as we are only generating coverage from one test run in CI.  the data can then be piped directly to the `coveralls` executable.