### PR TITLE
update nyc to latest; remove workaround in travis script

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "0.2.3",
     "karma-spec-reporter": "0.0.26",
-    "nyc": "^10.0.0",
+    "nyc": "^11.2.1",
     "os-name": "^2.0.1",
     "phantomjs": "1.9.8",
     "readable-stream": "2.2.11",

--- a/scripts/travis-before-script.sh
+++ b/scripts/travis-before-script.sh
@@ -2,6 +2,3 @@
 
 # bundle artifacts to AWS go here
 mkdir -p .karma
-
-# because https://github.com/istanbuljs/nyc/pull/664
-mkdir -p .nyc_output


### PR DESCRIPTION
#2985 cont'd now that my PR has been merged into nyc