### PR TITLE
fix AMD bundle by hacking around check in `he` module; closes #3000

### DIFF
--- a/scripts/dedefine.js
+++ b/scripts/dedefine.js
@@ -6,8 +6,7 @@
  */
 
 var through = require('through2');
-var defineRx = /typeof define === ['"]function['"] && define\.amd/g;
-
+var defineRx = /typeof\s+define\s*===?\s*['"]function['"]\s*&&\s*(?:define\.amd|typeof\s+define\.amd\s*===?\s*['"]object['"]\s*&&\s*define\.amd)/g;
 function createStream () {
   return through.obj(function (chunk, enc, next) {
     this.push(String(chunk)

--- a/scripts/travis-before-script.sh
+++ b/scripts/travis-before-script.sh
@@ -2,3 +2,6 @@
 
 # bundle artifacts to AWS go here
 mkdir -p .karma
+
+# ensure we are building a non-broken bundle for AMD
+make BUILDTMP/mocha.js && [[ -z "$(grep 'define.amd' BUILDTMP/mocha.js)" ]] || exit 1


### PR DESCRIPTION
I opted to just hack the regex.  There's now a flimsy check *on Travis only* that tries to make sure this doesn't happen again.

cc @ScottFreeCode @FelixHenninger