### PR TITLE
Use safer XML escaping

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ exports.inherits = require('util').inherits;
  * @return {string}
  */
 exports.escape = function (html) {
-  return he.encode(String(html), { useNamedReferences: true });
+  return he.encode(String(html), { useNamedReferences: false });
 };
 
 /**

--- a/test/reporters/doc.spec.js
+++ b/test/reporters/doc.spec.js
@@ -43,7 +43,7 @@ describe('Doc reporter', function () {
           root: false,
           title: unescapedTitle
         };
-        expectedTitle = '&lt;div&gt;' + expectedTitle + '&lt;/div&gt;';
+        expectedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
         runner.on = function (event, callback) {
           if (event === 'suite') {
             callback(suite);
@@ -142,8 +142,8 @@ describe('Doc reporter', function () {
       test.title = unescapedTitle;
       test.body = unescapedBody;
 
-      var expectedEscapedTitle = '&lt;div&gt;' + expectedTitle + '&lt;/div&gt;';
-      var expectedEscapedBody = '&lt;div&gt;' + expectedBody + '&lt;/div&gt;';
+      var expectedEscapedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
+      var expectedEscapedBody = '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
       runner.on = function (event, callback) {
         if (event === 'pass') {
           callback(test);
@@ -192,9 +192,9 @@ describe('Doc reporter', function () {
       test.title = unescapedTitle;
       test.body = unescapedBody;
 
-      var expectedEscapedTitle = '&lt;div&gt;' + expectedTitle + '&lt;/div&gt;';
-      var expectedEscapedBody = '&lt;div&gt;' + expectedBody + '&lt;/div&gt;';
-      var expectedEscapedError = '&lt;div&gt;' + expectedError + '&lt;/div&gt;';
+      var expectedEscapedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
+      var expectedEscapedBody = '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
+      var expectedEscapedError = '&#x3C;div&#x3E;' + expectedError + '&#x3C;/div&#x3E;';
       runner.on = function (event, callback) {
         if (event === 'fail') {
           callback(test, unescapedError);

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -627,13 +627,13 @@ describe('lib/utils', function () {
 
   describe('escape', function () {
     it('replaces the usual xml suspects', function () {
-      expect(utils.escape('<a<bc<d<')).to.be('&lt;a&lt;bc&lt;d&lt;');
-      expect(utils.escape('>a>bc>d>')).to.be('&gt;a&gt;bc&gt;d&gt;');
-      expect(utils.escape('"a"bc"d"')).to.be('&quot;a&quot;bc&quot;d&quot;');
-      expect(utils.escape('<>"&')).to.be('&lt;&gt;&quot;&amp;');
+      expect(utils.escape('<a<bc<d<')).to.be('&#x3C;a&#x3C;bc&#x3C;d&#x3C;');
+      expect(utils.escape('>a>bc>d>')).to.be('&#x3E;a&#x3E;bc&#x3E;d&#x3E;');
+      expect(utils.escape('"a"bc"d"')).to.be('&#x22;a&#x22;bc&#x22;d&#x22;');
+      expect(utils.escape('<>"&')).to.be('&#x3C;&#x3E;&#x22;&#x26;');
 
-      expect(utils.escape('&a&bc&d&')).to.be('&amp;a&amp;bc&amp;d&amp;');
-      expect(utils.escape('&amp;&lt;')).to.be('&amp;amp;&amp;lt;');
+      expect(utils.escape('&a&bc&d&')).to.be('&#x26;a&#x26;bc&#x26;d&#x26;');
+      expect(utils.escape('&amp;&lt;')).to.be('&#x26;amp;&#x26;lt;');
     });
 
     it('replaces invalid xml characters', function () {


### PR DESCRIPTION
### Description of the Change

Fixes a regression introduced in https://github.com/mochajs/mocha/pull/2957. It was too aggressive in its use of named escapes which broke XML files that might not support all of the named escapes available in HTML.

### Alternate Designs

We could try to get support for safe named escapes into `he`. But given that this won't affect the visible output, I focussed on fixing the functionality first.

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This makes the HTML output a bit uglier. E.g. it won't use the nice `&quot;` anymore.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
