### PR TITLE
Test glob pattern equivalent of --compilers

### DIFF
--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -6,7 +6,7 @@ var path = require('path');
 
 describe('globbing like --compilers', function () {
   it('should find a file of each type', function (done) {
-    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require compiler-fixtures/foo.js -R json "compiler/*.@(coffee,foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
+    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require compiler-fixtures/foo.js -R json "./compiler/*.@(coffee,foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
       if (error) { return done(error); }
       var results = JSON.parse(stdout);
       expect(results).to.have.property('passes');

--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var expect = require('expect.js');
+var exec = require('child_process').exec;
+var path = require('path');
+
+describe('globbing like --compilers', function () {
+  it('should find a file of each type', function (done) {
+    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require compiler-fixtures/foo.js -R json "compiler/*.@(coffee,foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
+      if (error) { return done(error); }
+      var results = JSON.parse(stdout);
+      expect(results).to.have.property('passes');
+      var titles = [];
+      for (var index = 0; index < results.passes.length; index += 1) {
+        expect(results.passes[index]).to.have.property('fullTitle');
+        titles.push(results.passes[index].fullTitle);
+      }
+      expect(results.passes).to.have.length(2);
+      expect(results.passes).to.contain('coffeescript should work');
+      expect(results.passes).to.contain('custom compiler should work');
+      done();
+    });
+  });
+});

--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -6,14 +6,14 @@ var path = require('path');
 
 describe('globbing like --compilers', function () {
   it('should find a file of each type', function (done) {
-    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require coffee-script/register --require compiler-fixtures/foo.js -R json "compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
-      if (error) { return done(error); }
+    exec('"' + process.execPath + '" "' + path.join('bin', 'mocha') + '" --require coffee-script/register --require test/compiler-fixtures/foo -R json "test/compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..', '..') }, function (error, stdout) {
+      if (error && !stdout) { return done(error); }
       var results = JSON.parse(stdout);
-      expect(results).to.have.property('passes');
+      expect(results).to.have.property('tests');
       var titles = [];
-      for (var index = 0; index < results.passes.length; index += 1) {
-        expect(results.passes[index]).to.have.property('fullTitle');
-        titles.push(results.passes[index].fullTitle);
+      for (var index = 0; index < results.tests.length; index += 1) {
+        expect(results.tests[index]).to.have.property('fullTitle');
+        titles.push(results.tests[index].fullTitle);
       }
       expect(titles).to.contain('coffeescript should work');
       expect(titles).to.contain('custom compiler should work');

--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -6,7 +6,7 @@ var path = require('path');
 
 describe('globbing like --compilers', function () {
   it('should find a file of each type', function (done) {
-    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require compiler-fixtures/foo.js -R json "compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
+    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require coffee-script/register --require compiler-fixtures/foo.js -R json "compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
       if (error) { return done(error); }
       var results = JSON.parse(stdout);
       expect(results).to.have.property('passes');

--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -15,9 +15,9 @@ describe('globbing like --compilers', function () {
         expect(results.passes[index]).to.have.property('fullTitle');
         titles.push(results.passes[index].fullTitle);
       }
-      expect(results.passes).to.have.length(2);
-      expect(results.passes).to.contain('coffeescript should work');
-      expect(results.passes).to.contain('custom compiler should work');
+      expect(titles).to.contain('coffeescript should work');
+      expect(titles).to.contain('custom compiler should work');
+      expect(titles).to.have.length(2);
       done();
     });
   });

--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -6,7 +6,7 @@ var path = require('path');
 
 describe('globbing like --compilers', function () {
   it('should find a file of each type', function (done) {
-    exec('"' + process.execPath + '" "' + path.join('bin', 'mocha') + '" --require coffee-script/register --require test/compiler-fixtures/foo -R json "test/compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..', '..') }, function (error, stdout) {
+    exec('"' + process.execPath + '" "' + path.join('bin', 'mocha') + '" -R json --require coffee-script/register --require test/compiler-fixtures/foo "test/compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..', '..') }, function (error, stdout) {
       if (error && !stdout) { return done(error); }
       var results = JSON.parse(stdout);
       expect(results).to.have.property('tests');

--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -6,7 +6,7 @@ var path = require('path');
 
 describe('globbing like --compilers', function () {
   it('should find a file of each type', function (done) {
-    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require compiler-fixtures/foo.js -R json "./compiler/*.@(coffee,foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
+    exec('"' + process.execPath + '" "' + path.join('..', 'bin', 'mocha') + '" --require compiler-fixtures/foo.js -R json "compiler/*.@(coffee|foo)"', { cwd: path.join(__dirname, '..') }, function (error, stdout) {
       if (error) { return done(error); }
       var results = JSON.parse(stdout);
       expect(results).to.have.property('passes');


### PR DESCRIPTION
Per https://github.com/mochajs/mocha/issues/2493#issuecomment-303929358 and https://github.com/mochajs/mocha/issues/2493#issuecomment-324807709, this ensures that one can use a glob pattern to capture multiple file extensions without `--compilers`.