### PR TITLE
Switch default from forced exit to no-exit

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -94,7 +94,7 @@ program
   .option('--inspect-brk', 'activate devtools in chrome and break on the first line')
   .option('--interfaces', 'display available interfaces')
   .option('--no-deprecation', 'silence deprecation warnings')
-  .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
+  .option('--exit', 'force shutdown of the event loop after test run: mocha will call process.exit')
   .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
   .option('--no-warnings', 'silence all node process warnings')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -374,7 +374,7 @@ describe('options', function () {
     };
 
     describe('default behavior', function () {
-      it('should force exit after root suite completion', runExit(true));
+      it('should force exit after root suite completion', runExit(false));
     });
 
     describe('with exit enabled', function () {


### PR DESCRIPTION
Allows `--exit` to override and force exit as before. Resolves #2879
