### PR TITLE
Nuke `should` #3035

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "Nathan Houle <nathan+github@nathanhoule.com> (https://github.com/ndhoule)",
     "Nathan Rajlich <nathan@tootallnate.net> (https://github.com/TooTallNate)",
     "Nick Fitzgerald (https://github.com/fitzgen)",
+    "Nikolaos Georgiou (https://github.com/ngeor)",
     "noirlab (https://github.com/noirlab)",
     "Noshir Patel <nosh@blackpiano.com> (https://github.com/noshir-patel)",
     "OlegTsyba <oleg.tsyba.ua@gmail.com> (https://github.com/OlegTsyba)",
@@ -342,7 +343,6 @@
     "karma-sauce-launcher": "^1.2.0",
     "nyc": "^11.2.1",
     "rimraf": "^2.5.2",
-    "should": "^13.1.0",
     "through2": "^2.0.1",
     "watchify": "^3.7.0"
   },

--- a/test/compiler-fixtures/foo.fixture.js
+++ b/test/compiler-fixtures/foo.fixture.js
@@ -6,6 +6,6 @@ require.extensions['.foo'] = function (module, filename) {
   var content;
   content = fs.readFileSync(filename, 'utf8');
   var test = 'describe("custom compiler",function(){ it("should work",function() { ' +
-    content + '.should.eql(1); }); });';
+    'expect(' + content + ').to.eql(1); }); });';
   return module._compile(test, filename);
 };

--- a/test/integration/fixtures/diffs/diffs.fixture.js
+++ b/test/integration/fixtures/diffs/diffs.fixture.js
@@ -10,19 +10,19 @@ describe('diffs', function () {
   it('should display a diff for small strings', function () {
     actual = 'foo rar baz';
     expected = 'foo bar baz';
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a diff of canonicalized objects', function () {
     actual = { name: 'travis j', age: 23 };
     expected = { age: 23, name: 'travis' };
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a diff for medium strings', function () {
     actual = 'foo bar baz\nfoo rar baz\nfoo bar raz';
     expected = 'foo bar baz\nfoo bar baz\nfoo bar baz';
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a diff for entire object dumps', function () {
@@ -42,13 +42,13 @@ describe('diffs', function () {
         country: 'us'
       }
     };
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a diff for multi-line strings', function () {
     actual = 'one two three\nfour zzzz six\nseven eight nine';
     expected = 'one two three\nfour five six\nseven eight nine';
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a diff for entire object dumps', function () {
@@ -68,17 +68,17 @@ describe('diffs', function () {
         country: 'us'
       }
     };
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a full-comparison with escaped special characters', function () {
     actual = 'one\ttab\ntwo\t\t\ttabs';
     expected = 'one\ttab\ntwo\t\ttabs';
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display a word diff for large strings', function () {
-    cssin.should.equal(cssout);
+    expect(cssin).to.eql(cssout);
   });
 
   it('should work with objects', function () {
@@ -96,18 +96,18 @@ describe('diffs', function () {
       age: 2
     };
 
-    actual.should.eql(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should show value diffs and not be affected by commas', function () {
     actual = { a: 123 };
     expected = { a: 123, b: 456 };
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 
   it('should display diff by data and not like an objects', function () {
     actual = new Buffer([0x01]);
     expected = new Buffer([0x02]);
-    actual.should.equal(expected);
+    expect(actual).to.eql(expected);
   });
 });

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -72,7 +72,7 @@ describe('regressions', function () {
       it('should be pending', function () {});
     });
     after('meta test', function () {
-      afterWasRun.should.be.ok();
+      expect(afterWasRun).to.be.ok();
     });
   });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
---require should
 --require ./test/setup
 --ui bdd
 --globals okGlobalA,okGlobalB

--- a/test/node-unit/stack-trace-filter.spec.js
+++ b/test/node-unit/stack-trace-filter.spec.js
@@ -28,9 +28,8 @@ describe('stackTraceFilter()', function () {
           'Immediate._onImmediate (/usr/local/lib/node_modules/mocha/lib/runner.js:276:5)',
           'at processImmediate [as _immediateCallback] (timers.js:321:17)'
         ];
-        filter(stack.join('\n'))
-          .should
-          .equal(stack.slice(0, 3)
+        expect(filter(stack.join('\n')))
+          .to.equal(stack.slice(0, 3)
             .join('\n'));
 
         stack = [
@@ -47,9 +46,8 @@ describe('stackTraceFilter()', function () {
           'at processImmediate [as _immediateCallback] (timers.js:321:17)'
         ];
 
-        filter(stack.join('\n'))
-          .should
-          .equal(stack.slice(0, 7)
+        expect(filter(stack.join('\n')))
+          .to.equal(stack.slice(0, 7)
             .join('\n'));
       });
 
@@ -69,9 +67,8 @@ describe('stackTraceFilter()', function () {
           'at file:///.../components/mochajs/mocha/2.1.0/mocha.js:4970:12',
           'at next (file:///.../components/mochajs/mocha/2.1.0/mocha.js:4817:14)'
         ];
-        filter(stack.join('\n'))
-          .should
-          .equal(stack.slice(0, 7)
+        expect(filter(stack.join('\n')))
+          .to.equal(stack.slice(0, 7)
             .join('\n'));
       });
 
@@ -88,9 +85,8 @@ describe('stackTraceFilter()', function () {
           'at bar (/usr/local/dev/own/tmp/node_modules/bluebird/js/main/promise.js:11:26)'
         ];
 
-        filter(stack.join('\n'))
-          .should
-          .equal(expected.join('\n'));
+        expect(filter(stack.join('\n')))
+          .to.equal(expected.join('\n'));
       });
     });
 
@@ -114,9 +110,8 @@ describe('stackTraceFilter()', function () {
           'at next (C:\\Users\\ishida\\src\\test\\node_modules\\mocha\\lib\\runner.js:284:14)',
           'at Immediate._onImmediate (C:\\Users\\ishida\\src\\test\\node_modules\\mocha\\lib\\runner.js:320:5)'
         ];
-        filter(stack.join('\n'))
-          .should
-          .equal(stack.slice(0, 2)
+        expect(filter(stack.join('\n')))
+          .to.equal(stack.slice(0, 2)
             .join('\n'));
       });
     });
@@ -142,9 +137,8 @@ describe('stackTraceFilter()', function () {
         'at localhost:3000/foo/bar/node_modules/mocha.js:4970:12',
         'at next (node_modules/mocha.js:4817:14)'
       ];
-      filter(stack.join('\n'))
-        .should
-        .equal(stack.slice(0, 7)
+      expect(filter(stack.join('\n')))
+        .to.equal(stack.slice(0, 7)
           .join('\n'));
     });
 

--- a/test/only/bdd.spec.js
+++ b/test/only/bdd.spec.js
@@ -2,58 +2,58 @@
 
 describe('should only run .only test in this bdd suite', function () {
   it('should not run this test', function () {
-    (0).should.equal(1, 'this test should have been skipped');
+    expect(0).to.equal(1, 'this test should have been skipped');
   });
   it.only('should run this test', function () {
-    (0).should.equal(0, 'this .only test should run');
+    expect(0).to.equal(0, 'this .only test should run');
   });
   it('should run this test, not (includes the title of the .only test)', function () {
-    (0).should.equal(1, 'this test should have been skipped');
+    expect(0).to.equal(1, 'this test should have been skipped');
   });
 });
 
 describe('should not run this suite', function () {
   it('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
 
   it('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
 
   it('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
 });
 
 describe.only('should run all tests in this bdd suite', function () {
   it('should run this test #1', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 
   it('should run this test #2', function () {
-    (1).should.equal(1);
+    expect(1).to.equal(1);
   });
 
   it('should run this test #3', function () {
-    ('foo').should.equal('foo');
+    expect('foo').to.equal('foo');
   });
 });
 
 describe('should run only suites that marked as `only`', function () {
   describe.only('should run all this tdd suite', function () {
     it('should run this test #1', function () {
-      (true).should.equal(true);
+      expect(true).to.equal(true);
     });
 
     it('should run this test #2', function () {
-      (true).should.equal(true);
+      expect(true).to.equal(true);
     });
   });
 
   describe('should not run this suite', function () {
     it('should run this test', function () {
-      (true).should.equal(false);
+      expect(true).to.equal(false);
     });
   });
 });
@@ -61,18 +61,18 @@ describe('should run only suites that marked as `only`', function () {
 // Nested situation
 describe('should not run parent tests', function () {
   it('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
   describe('and not the child tests too', function () {
     it('should not run this test', function () {
-      (true).should.equal(false);
+      expect(true).to.equal(false);
     });
     describe.only('but run all the tests in this suite', function () {
       it('should run this test #1', function () {
-        (true).should.equal(true);
+        expect(true).to.equal(true);
       });
       it('should run this test #2', function () {
-        (true).should.equal(true);
+        expect(true).to.equal(true);
       });
     });
   });
@@ -81,47 +81,47 @@ describe('should not run parent tests', function () {
 // mark test as `only` override the suite behavior
 describe.only('should run only tests that marked as `only`', function () {
   it('should not run this test #1', function () {
-    (false).should.equal(true);
+    expect(false).to.equal(true);
   });
 
   it.only('should run this test #2', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 
   it('should not run this test #3', function () {
-    (false).should.equal(true);
+    expect(false).to.equal(true);
   });
 
   it.only('should run this test #4', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 });
 
 describe.only('Should run only test cases that mark as only', function () {
   it.only('should runt his test', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 
   it('should not run this test', function () {
-    (false).should.equal(true);
+    expect(false).to.equal(true);
   });
 
   describe('should not run this suite', function () {
     it('should not run this test', function () {
-      (false).should.equal(true);
+      expect(false).to.equal(true);
     });
   });
 });
 
 // Root Suite
 it.only('#Root-Suite, should run this test-case #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 it.only('#Root-Suite, should run this test-case #2', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 it('#Root-Suite, should not run this test', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });

--- a/test/only/global/bdd.spec.js
+++ b/test/only/global/bdd.spec.js
@@ -2,13 +2,13 @@
 
 // Root-only test cases
 it.only('#Root-Suite, should run this bdd test-case #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 it('#Root-Suite, should not run this bdd test-case #2', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 it('#Root-Suite, should not run this bdd test-case #3', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });

--- a/test/only/global/qunit.spec.js
+++ b/test/only/global/qunit.spec.js
@@ -2,13 +2,13 @@
 
 // Root-only test cases
 test.only('#Root-Suite, should run this qunit test-case #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('#Root-Suite, should not run this qunit test-case #2', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 test('#Root-Suite, should not run this qunit test-case #3', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });

--- a/test/only/global/tdd.spec.js
+++ b/test/only/global/tdd.spec.js
@@ -2,13 +2,13 @@
 
 // Root-only test cases
 test.only('#Root-Suite, should run this tdd test-case #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('#Root-Suite, should not run this tdd test-case #2', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 test('#Root-Suite, should not run this tdd test-case #3', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });

--- a/test/only/qunit.spec.js
+++ b/test/only/qunit.spec.js
@@ -2,74 +2,74 @@
 
 // Root Suite
 test.only('#Root-Suite, should run this test-case #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test.only('#Root-Suite, should run this test-case #2', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('#Root-Suite, should not run this test', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 suite('should only run .only test in this qunit suite');
 
 test('should not run this test', function () {
-  (0).should.equal(1, 'this test should have been skipped');
+  expect(0).to.equal(1, 'this test should have been skipped');
 });
 test.only('should run this test', function () {
-  (0).should.equal(0, 'this .only test should run');
+  expect(0).to.equal(0, 'this .only test should run');
 });
 test('should run this test, not (includes the title of the .only test)', function () {
-  (0).should.equal(1, 'this test should have been skipped');
+  expect(0).to.equal(1, 'this test should have been skipped');
 });
 
 // Mark suite
 suite.only('should run all tests in this suite');
 
 test('should run this test #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('should run this test #2', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('should run this test #3', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 // Unmark this suite
 suite('should not run any of this suite\'s tests');
 
 test('should not run this test', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 test('should not run this test', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 test('should not run this test', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 // Mark test as `only` override the suite behavior
 suite.only('should run only tests that marked as `only`');
 
 test('should not run this test #1', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 test.only('should not run this test #2', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('should not run this test #3', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });
 
 test.only('should not run this test #4', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });

--- a/test/only/tdd.spec.js
+++ b/test/only/tdd.spec.js
@@ -2,58 +2,58 @@
 
 suite('should only run .only test in this tdd suite', function () {
   test('should not run this test', function () {
-    (0).should.equal(1, 'this test should have been skipped');
+    expect(0).to.equal(1, 'this test should have been skipped');
   });
   test.only('should run this test', function () {
-    (0).should.equal(0, 'this .only test should run');
+    expect(0).to.equal(0, 'this .only test should run');
   });
   test('should run this test, not (includes the title of the .only test)', function () {
-    (0).should.equal(1, 'this test should have been skipped');
+    expect(0).to.equal(1, 'this test should have been skipped');
   });
 });
 
 suite('should not run this suite', function () {
   test('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
 
   test('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
 
   test('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
 });
 
 suite.only('should run all tests in this tdd suite', function () {
   test('should run this test #1', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 
   test('should run this test #2', function () {
-    (1).should.equal(1);
+    expect(1).to.equal(1);
   });
 
   test('should run this test #3', function () {
-    ('foo').should.equal('foo');
+    expect('foo').to.equal('foo');
   });
 });
 
 suite('should run only suites that marked as `only`', function () {
   suite.only('should run all this tdd suite', function () {
     test('should run this test #1', function () {
-      (true).should.equal(true);
+      expect(true).to.equal(true);
     });
 
     test('should run this test #2', function () {
-      (true).should.equal(true);
+      expect(true).to.equal(true);
     });
   });
 
   suite('should not run this suite', function () {
     test('should not run this test', function () {
-      (true).should.equal(false);
+      expect(true).to.equal(false);
     });
   });
 });
@@ -61,18 +61,18 @@ suite('should run only suites that marked as `only`', function () {
 // Nested situation
 suite('should not run parent tests', function () {
   test('should not run this test', function () {
-    (true).should.equal(false);
+    expect(true).to.equal(false);
   });
   suite('and not the child tests too', function () {
     test('should not run this test', function () {
-      (true).should.equal(false);
+      expect(true).to.equal(false);
     });
     suite.only('but run all the tests in this suite', function () {
       test('should run this test #1', function () {
-        (true).should.equal(true);
+        expect(true).to.equal(true);
       });
       test('should run this test #2', function () {
-        (true).should.equal(true);
+        expect(true).to.equal(true);
       });
     });
   });
@@ -81,47 +81,47 @@ suite('should not run parent tests', function () {
 // mark test as `only` override the suite behavior
 suite.only('should run only tests that marked as `only`', function () {
   test('should not run this test #1', function () {
-    (false).should.equal(true);
+    expect(false).to.equal(true);
   });
 
   test.only('should run this test #2', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 
   test('should not run this test #3', function () {
-    (false).should.equal(true);
+    expect(false).to.equal(true);
   });
 
   test.only('should run this test #4', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 });
 
 suite.only('Should run only test cases that mark as only', function () {
   test.only('should runt his test', function () {
-    (true).should.equal(true);
+    expect(true).to.equal(true);
   });
 
   test('should not run this test', function () {
-    (false).should.equal(true);
+    expect(false).to.equal(true);
   });
 
   suite('should not run this suite', function () {
     test('should not run this test', function () {
-      (false).should.equal(true);
+      expect(false).to.equal(true);
     });
   });
 });
 
 // Root Suite
 test.only('#Root-Suite, should run this test-case #1', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test.only('#Root-Suite, should run this test-case #2', function () {
-  (true).should.equal(true);
+  expect(true).to.equal(true);
 });
 
 test('#Root-Suite, should not run this test', function () {
-  (false).should.equal(true);
+  expect(false).to.equal(true);
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -52,8 +52,8 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.match(/- actual/);
-      errOut.should.match(/\+ expected/);
+      expect(errOut).to.match(/- actual/);
+      expect(errOut).to.match(/\+ expected/);
     });
 
     it('should show diffs if property set to `true`', function () {
@@ -66,8 +66,8 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.match(/- actual/);
-      errOut.should.match(/\+ expected/);
+      expect(errOut).to.match(/- actual/);
+      expect(errOut).to.match(/\+ expected/);
     });
 
     it('should not show diffs when showDiff property set to `false`', function () {
@@ -80,8 +80,8 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.not.match(/- actual/);
-      errOut.should.not.match(/\+ expected/);
+      expect(errOut).to.not.match(/- actual/);
+      expect(errOut).to.not.match(/\+ expected/);
     });
 
     it('should not show diffs when expected is not defined', function () {
@@ -93,8 +93,8 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.not.match(/- actual/);
-      errOut.should.not.match(/\+ expected/);
+      expect(errOut).to.not.match(/- actual/);
+      expect(errOut).to.not.match(/\+ expected/);
     });
   });
 
@@ -113,11 +113,11 @@ describe('Base reporter', function () {
 
       errOut = stdout.join('\n');
 
-      errOut.should.not.match(/"foo\\nbar"/);
-      errOut.should.match(/foo/).and.match(/bar/);
-      errOut.should.match(/test/);
-      errOut.should.match(/actual/);
-      errOut.should.match(/expected/);
+      expect(errOut).to.not.match(/"foo\\nbar"/);
+      expect(errOut).to.match(/foo/).and.match(/bar/);
+      expect(errOut).to.match(/test/);
+      expect(errOut).to.match(/actual/);
+      expect(errOut).to.match(/expected/);
     });
   });
 
@@ -136,10 +136,10 @@ describe('Base reporter', function () {
 
       errOut = stdout.join('\n');
 
-      errOut.should.match(/a foobar inline diff/);
-      errOut.should.match(/test/);
-      errOut.should.match(/actual/);
-      errOut.should.match(/expected/);
+      expect(errOut).to.match(/a foobar inline diff/);
+      expect(errOut).to.match(/test/);
+      expect(errOut).to.match(/actual/);
+      expect(errOut).to.match(/expected/);
     });
 
     it('should split lines when string has more than 4 line breaks', function () {
@@ -156,15 +156,15 @@ describe('Base reporter', function () {
 
       errOut = stdout.join('\n');
 
-      errOut.should.match(/1 \| a/);
-      errOut.should.match(/2 \| foobar/);
-      errOut.should.match(/3 \| inline/);
-      errOut.should.match(/4 \| diff/);
-      errOut.should.match(/5 \| with/);
-      errOut.should.match(/6 \| multiple lines/);
-      errOut.should.match(/test/);
-      errOut.should.match(/actual/);
-      errOut.should.match(/expected/);
+      expect(errOut).to.match(/1 \| a/);
+      expect(errOut).to.match(/2 \| foobar/);
+      expect(errOut).to.match(/3 \| inline/);
+      expect(errOut).to.match(/4 \| diff/);
+      expect(errOut).to.match(/5 \| with/);
+      expect(errOut).to.match(/6 \| multiple lines/);
+      expect(errOut).to.match(/test/);
+      expect(errOut).to.match(/actual/);
+      expect(errOut).to.match(/expected/);
     });
   });
 
@@ -203,7 +203,7 @@ describe('Base reporter', function () {
       ];
 
       regexesToMatch.forEach(function (aRegex) {
-        errOut.should.match(aRegex);
+        expect(errOut).to.match(aRegex);
       });
     });
   });
@@ -220,10 +220,10 @@ describe('Base reporter', function () {
     Base.list([test]);
 
     errOut = stdout.join('\n');
-    errOut.should.match(/"key"/);
-    errOut.should.match(/test/);
-    errOut.should.match(/- actual/);
-    errOut.should.match(/\+ expected/);
+    expect(errOut).to.match(/"key"/);
+    expect(errOut).to.match(/test/);
+    expect(errOut).to.match(/- actual/);
+    expect(errOut).to.match(/\+ expected/);
   });
 
   it('should stringify Object.create(null)', function () {
@@ -240,10 +240,10 @@ describe('Base reporter', function () {
     Base.list([test]);
 
     errOut = stdout.join('\n');
-    errOut.should.match(/"hasOwnProperty"/);
-    errOut.should.match(/test/);
-    errOut.should.match(/- actual/);
-    errOut.should.match(/\+ expected/);
+    expect(errOut).to.match(/"hasOwnProperty"/);
+    expect(errOut).to.match(/test/);
+    expect(errOut).to.match(/- actual/);
+    expect(errOut).to.match(/\+ expected/);
   });
 
   it('should handle error messages that are not strings', function () {
@@ -260,10 +260,10 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.match(/\+true/);
-      errOut.should.match(/-false/);
-      errOut.should.match(/- actual/);
-      errOut.should.match(/\+ expected/);
+      expect(errOut).to.match(/\+true/);
+      expect(errOut).to.match(/-false/);
+      expect(errOut).to.match(/- actual/);
+      expect(errOut).to.match(/\+ expected/);
     }
   });
 
@@ -283,11 +283,11 @@ describe('Base reporter', function () {
       Base.list([test]);
 
       errOut = stdout.join('\n');
-      errOut.should.match(/custom error message\n/);
-      errOut.should.match(/\+42/);
-      errOut.should.match(/-43/);
-      errOut.should.match(/- actual/);
-      errOut.should.match(/\+ expected/);
+      expect(errOut).to.match(/custom error message\n/);
+      expect(errOut).to.match(/\+42/);
+      expect(errOut).to.match(/-43/);
+      expect(errOut).to.match(/- actual/);
+      expect(errOut).to.match(/\+ expected/);
     }
   });
 
@@ -302,7 +302,7 @@ describe('Base reporter', function () {
     Base.list([test]);
 
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar');
+    expect(errOut).to.equal('1) test title:\n     Error\n  foo\n  bar');
   });
 
   it('should use the inspect() property if `message` is not set', function () {
@@ -313,7 +313,7 @@ describe('Base reporter', function () {
     var test = makeTest(err);
     Base.list([test]);
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal('1) test title:\n     an error happened');
+    expect(errOut).to.equal('1) test title:\n     an error happened');
   });
 
   it('should set an empty message if `message` and `inspect()` are not set', function () {
@@ -323,7 +323,7 @@ describe('Base reporter', function () {
     var test = makeTest(err);
     Base.list([test]);
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal('1) test title:');
+    expect(errOut).to.equal('1) test title:');
   });
 
   it('should not modify stack if it does not contain message', function () {
@@ -337,6 +337,6 @@ describe('Base reporter', function () {
     Base.list([test]);
 
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal('1) test title:\n     Error\n  foo\n  bar');
+    expect(errOut).to.equal('1) test title:\n     Error\n  foo\n  bar');
   });
 });

--- a/test/reporters/doc.spec.js
+++ b/test/reporters/doc.spec.js
@@ -36,7 +36,7 @@ describe('Doc reporter', function () {
           '      <h1>' + expectedTitle + '</h1>\n',
           '      <dl>\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
       it('should escape title where necessary', function () {
         var suite = {
@@ -56,7 +56,7 @@ describe('Doc reporter', function () {
           '      <h1>' + expectedTitle + '</h1>\n',
           '      <dl>\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if suite root does exist', function () {
@@ -71,7 +71,7 @@ describe('Doc reporter', function () {
         };
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
-        stdout.should.be.empty();
+        expect(stdout).to.be.empty();
       });
     });
   });
@@ -92,7 +92,7 @@ describe('Doc reporter', function () {
         var expectedArray = [
           '  </dl>\n', '</section>\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if suite root does exist', function () {
@@ -107,7 +107,7 @@ describe('Doc reporter', function () {
         };
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
-        stdout.should.be.empty();
+        expect(stdout).to.be.empty();
       });
     });
   });
@@ -134,7 +134,7 @@ describe('Doc reporter', function () {
         '    <dt>' + expectedTitle + '</dt>\n',
         '    <dd><pre><code>' + expectedBody + '</code></pre></dd>\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
     it('should escape title and body where necessary', function () {
       var unescapedTitle = '<div>' + expectedTitle + '</div>';
@@ -155,7 +155,7 @@ describe('Doc reporter', function () {
         '    <dt>' + expectedEscapedTitle + '</dt>\n',
         '    <dd><pre><code>' + expectedEscapedBody + '</code></pre></dd>\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 
@@ -183,7 +183,7 @@ describe('Doc reporter', function () {
         '    <dd class="error"><pre><code>' + expectedBody + '</code></pre></dd>\n',
         '    <dd class="error">' + expectedError + '</dd>\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
     it('should escape title, body and error where necessary', function () {
       var unescapedTitle = '<div>' + expectedTitle + '</div>';
@@ -207,7 +207,7 @@ describe('Doc reporter', function () {
         '    <dd class="error"><pre><code>' + expectedEscapedBody + '</code></pre></dd>\n',
         '    <dd class="error">' + expectedEscapedError + '</dd>\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 });

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -41,7 +41,7 @@ describe('Dot reporter', function () {
       var expectedArray = [
         '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
   describe('on pending', function () {
@@ -61,7 +61,7 @@ describe('Dot reporter', function () {
           '\n  ',
           Base.symbols.comma
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if window width is equal to or less than 1', function () {
@@ -76,7 +76,7 @@ describe('Dot reporter', function () {
         var expectedArray = [
           Base.symbols.comma
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
   });
@@ -102,7 +102,7 @@ describe('Dot reporter', function () {
             '\n  ',
             Base.symbols.dot
           ];
-          stdout.should.deepEqual(expectedArray);
+          expect(stdout).to.eql(expectedArray);
         });
       });
     });
@@ -123,7 +123,7 @@ describe('Dot reporter', function () {
           var expectedArray = [
             Base.symbols.dot
           ];
-          stdout.should.deepEqual(expectedArray);
+          expect(stdout).to.eql(expectedArray);
         });
       });
       describe('if test speed is slow', function () {
@@ -142,7 +142,7 @@ describe('Dot reporter', function () {
           var expectedArray = [
             Base.symbols.dot
           ];
-          stdout.should.deepEqual(expectedArray);
+          expect(stdout).to.eql(expectedArray);
         });
       });
     });
@@ -169,7 +169,7 @@ describe('Dot reporter', function () {
           '\n  ',
           Base.symbols.bang
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if window width is equal to or less than 1', function () {
@@ -189,7 +189,7 @@ describe('Dot reporter', function () {
         var expectedArray = [
           Base.symbols.bang
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
   });
@@ -206,7 +206,7 @@ describe('Dot reporter', function () {
       };
       Dot.call({epilogue: epilogue}, runner);
       process.stdout.write = stdoutWrite;
-      epilogueCalled.should.be.true();
+      expect(epilogueCalled).to.be(true);
     });
   });
 });

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -30,7 +30,7 @@ describe('Json Stream reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.deepEqual('["start",{"total":' + expectedTotal + '}]\n');
+      expect(stdout[0]).to.eql('["start",{"total":' + expectedTotal + '}]\n');
     });
   });
 
@@ -56,7 +56,7 @@ describe('Json Stream reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.deepEqual('["pass",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + '}]\n');
+      expect(stdout[0]).to.eql('["pass",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + '}]\n');
     });
   });
 
@@ -89,7 +89,7 @@ describe('Json Stream reporter', function () {
 
         process.stdout.write = stdoutWrite;
 
-        stdout[0].should.deepEqual('["fail",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + ',"err":"' + expectedErrorMessage + '","stack":"' + expectedErrorStack + '"}]\n');
+        expect(stdout[0]).to.eql('["fail",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + ',"err":"' + expectedErrorMessage + '","stack":"' + expectedErrorStack + '"}]\n');
       });
     });
     describe('if error stack does not exist', function () {
@@ -118,7 +118,7 @@ describe('Json Stream reporter', function () {
 
         process.stdout.write = stdoutWrite;
 
-        stdout[0].should.deepEqual('["fail",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + ',"err":"' + expectedErrorMessage + '","stack":null}]\n');
+        expect(stdout[0]).to.eql('["fail",{"title":"' + expectedTitle + '","fullTitle":"' + expectedFullTitle + '","duration":' + expectedDuration + ',"currentRetry":' + currentRetry + ',"err":"' + expectedErrorMessage + '","stack":null}]\n');
       });
     });
   });
@@ -134,7 +134,7 @@ describe('Json Stream reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.match(/end/);
+      expect(stdout[0]).to.match(/end/);
     });
   });
 });

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -31,7 +31,7 @@ describe('json reporter', function () {
       expect(runner).to.have.property('testResults');
       expect(runner.testResults).to.have.property('failures');
       expect(runner.testResults.failures).to.be.an('array');
-      expect(runner.testResults.failures.length).to.equal(1);
+      expect(runner.testResults.failures).to.have.length(1);
 
       var failure = runner.testResults.failures[0];
       expect(failure).to.have.property('title', testTitle);
@@ -52,7 +52,7 @@ describe('json reporter', function () {
       expect(runner).to.have.property('testResults');
       expect(runner.testResults).to.have.property('pending');
       expect(runner.testResults.pending).to.be.an('array');
-      expect(runner.testResults.pending.length).to.equal(1);
+      expect(runner.testResults.pending).to.have.length(1);
 
       var pending = runner.testResults.pending[0];
       expect(pending).to.have.property('title', testTitle);

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -27,16 +27,16 @@ describe('json reporter', function () {
     }));
 
     runner.run(function (failureCount) {
-      failureCount.should.be.exactly(1);
-      runner.should.have.property('testResults');
-      runner.testResults.should.have.property('failures');
-      runner.testResults.failures.should.be.an.instanceOf(Array);
-      runner.testResults.failures.should.have.a.lengthOf(1);
+      expect(failureCount).to.be(1);
+      expect(runner).to.have.property('testResults');
+      expect(runner.testResults).to.have.property('failures');
+      expect(runner.testResults.failures).to.be.an('array');
+      expect(runner.testResults.failures.length).to.equal(1);
 
       var failure = runner.testResults.failures[0];
-      failure.should.have.property('title', testTitle);
-      failure.err.message.should.equal(error.message);
-      failure.should.have.properties('err');
+      expect(failure).to.have.property('title', testTitle);
+      expect(failure.err.message).to.equal(error.message);
+      expect(failure).to.have.property('err');
 
       done();
     });
@@ -48,14 +48,14 @@ describe('json reporter', function () {
     suite.addTest(new Test(testTitle));
 
     runner.run(function (failureCount) {
-      failureCount.should.be.exactly(0);
-      runner.should.have.property('testResults');
-      runner.testResults.should.have.property('pending');
-      runner.testResults.pending.should.be.an.instanceOf(Array);
-      runner.testResults.pending.should.have.a.lengthOf(1);
+      expect(failureCount).to.be(0);
+      expect(runner).to.have.property('testResults');
+      expect(runner.testResults).to.have.property('pending');
+      expect(runner.testResults.pending).to.be.an('array');
+      expect(runner.testResults.pending.length).to.equal(1);
 
       var pending = runner.testResults.pending[0];
-      pending.should.have.property('title', testTitle);
+      expect(pending).to.have.property('title', testTitle);
 
       done();
     });

--- a/test/reporters/landing.spec.js
+++ b/test/reporters/landing.spec.js
@@ -43,7 +43,7 @@ describe('Landing reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.deepEqual('\n\n\n  ');
+      expect(stdout[0]).to.eql('\n\n\n  ');
       Base.cursor = cachedCursor;
     });
 
@@ -61,7 +61,7 @@ describe('Landing reporter', function () {
       Landing.call({}, runner);
 
       process.stdout.write = stdoutWrite;
-      calledCursorHide.should.be.true();
+      expect(calledCursorHide).to.be(true);
 
       Base.cursor = cachedCursor;
     });
@@ -93,7 +93,7 @@ describe('Landing reporter', function () {
           '  ',
           resetCode
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if test has not failed', function () {
@@ -121,7 +121,7 @@ describe('Landing reporter', function () {
           '  ',
           resetCode
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
   });
@@ -145,8 +145,8 @@ describe('Landing reporter', function () {
       }, runner);
 
       process.stdout.write = stdoutWrite;
-      calledEpilogue.should.be.true();
-      calledCursorShow.should.be.true();
+      expect(calledEpilogue).to.be(true);
+      expect(calledCursorShow).to.be(true);
 
       Base.cursor = cachedCursor;
     });

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -50,7 +50,7 @@ describe('List reporter', function () {
         startString,
         testString
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
   describe('on pending', function () {
@@ -70,7 +70,7 @@ describe('List reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.deepEqual('  - ' + expectedTitle + '\n');
+      expect(stdout[0]).to.eql('  - ' + expectedTitle + '\n');
     });
   });
   describe('on pass', function () {
@@ -98,7 +98,7 @@ describe('List reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      calledCursorCR.should.be.true();
+      expect(calledCursorCR).to.be(true);
 
       Base.cursor = cachedCursor;
     });
@@ -126,7 +126,7 @@ describe('List reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.equal('  ' + expectedOkSymbol + ' ' + expectedTitle + ': ' + expectedDuration + 'ms\n');
+      expect(stdout[0]).to.equal('  ' + expectedOkSymbol + ' ' + expectedTitle + ': ' + expectedDuration + 'ms\n');
 
       Base.cursor = cachedCursor;
       Base.symbols = cachedSymbols;
@@ -157,7 +157,7 @@ describe('List reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      calledCursorCR.should.be.true();
+      expect(calledCursorCR).to.be(true);
 
       Base.cursor = cachedCursor;
     });
@@ -188,7 +188,7 @@ describe('List reporter', function () {
 
       process.stdout.write = stdoutWrite;
 
-      stdout[0].should.equal('  ' + expectedErrorCount + ') ' + expectedTitle + '\n');
+      expect(stdout[0]).to.equal('  ' + expectedErrorCount + ') ' + expectedTitle + '\n');
 
       Base.cursor = cachedCursor;
     });
@@ -209,7 +209,7 @@ describe('List reporter', function () {
       }, runner);
       process.stdout.write = stdoutWrite;
 
-      calledEpilogue.should.be.true();
+      expect(calledEpilogue).to.be(true);
     });
   });
 });

--- a/test/reporters/markdown.spec.js
+++ b/test/reporters/markdown.spec.js
@@ -52,7 +52,7 @@ describe('Markdown reporter', function () {
         '<a name="' + sluggedFullTitle + '"></a>\n ' + expectedTitle + '\n'
       ];
 
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
   describe('on \'pass\'', function () {
@@ -94,7 +94,7 @@ describe('Markdown reporter', function () {
         expectedTitle + '.\n\n```js\n' + expectedBody + '\n```\n\n'
       ];
 
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 });

--- a/test/reporters/min.spec.js
+++ b/test/reporters/min.spec.js
@@ -31,7 +31,7 @@ describe('Min reporter', function () {
         '\u001b[2J',
         '\u001b[1;3H'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 
@@ -50,7 +50,7 @@ describe('Min reporter', function () {
       }, runner);
       process.stdout.write = stdoutWrite;
 
-      calledEpilogue.should.be.true();
+      expect(calledEpilogue).to.be(true);
     });
   });
 });

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -35,7 +35,7 @@ describe('Nyan reporter', function () {
         }, runner);
         process.stdout.write = stdoutWrite;
 
-        calledDraw.should.be.true();
+        expect(calledDraw).to.be(true);
       });
     });
     describe('on pending', function () {
@@ -54,7 +54,7 @@ describe('Nyan reporter', function () {
         }, runner);
         process.stdout.write = stdoutWrite;
 
-        calledDraw.should.be.true();
+        expect(calledDraw).to.be(true);
       });
     });
     describe('on pass', function () {
@@ -77,7 +77,7 @@ describe('Nyan reporter', function () {
         }, runner);
         process.stdout.write = stdoutWrite;
 
-        calledDraw.should.be.true();
+        expect(calledDraw).to.be(true);
       });
     });
     describe('on fail', function () {
@@ -99,7 +99,7 @@ describe('Nyan reporter', function () {
         }, runner);
         process.stdout.write = stdoutWrite;
 
-        calledDraw.should.be.true();
+        expect(calledDraw).to.be(true);
       });
     });
     describe('on end', function () {
@@ -119,7 +119,7 @@ describe('Nyan reporter', function () {
         }, runner);
         process.stdout.write = stdoutWrite;
 
-        calledEpilogue.should.be.true();
+        expect(calledEpilogue).to.be(true);
       });
       it('should write numberOfLines amount of new lines', function () {
         var expectedNumberOfLines = 4;
@@ -137,7 +137,7 @@ describe('Nyan reporter', function () {
         var arrayOfNewlines = stdout.filter(function (value) { return value === '\n'; });
         process.stdout.write = stdoutWrite;
 
-        arrayOfNewlines.should.have.length(expectedNumberOfLines);
+        expect(arrayOfNewlines).to.have.length(expectedNumberOfLines);
       });
       it('should call Base show', function () {
         var showCalled = false;
@@ -157,7 +157,7 @@ describe('Nyan reporter', function () {
         }, runner);
 
         process.stdout.write = stdoutWrite;
-        showCalled.should.be.true();
+        expect(showCalled).to.be(true);
         Base.cursor.show = cachedShow;
       });
     });
@@ -208,7 +208,7 @@ describe('Nyan reporter', function () {
           '  ""  "" ',
           '\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if tick is true', function () {
@@ -244,7 +244,7 @@ describe('Nyan reporter', function () {
           ' ""  "" ',
           '\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
   });
@@ -270,7 +270,7 @@ describe('Nyan reporter', function () {
       var expectedArray = [
         '\u001b[' + expectedNumber + 'B'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 
@@ -295,7 +295,7 @@ describe('Nyan reporter', function () {
       var expectedArray = [
         '\u001b[' + expectedNumber + 'A'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 
@@ -317,7 +317,7 @@ describe('Nyan reporter', function () {
         var expectedString = 'hello';
         var outputString = nyanCat.rainbowify(expectedString);
 
-        outputString.should.equal(expectedString);
+        expect(outputString).to.equal(expectedString);
       });
     });
     describe('useColors is true', function () {
@@ -345,7 +345,7 @@ describe('Nyan reporter', function () {
           },
           expectedString);
 
-        outputString.should.equal(expectedRainbowifyString);
+        expect(outputString).to.equal(expectedRainbowifyString);
       });
     });
   });
@@ -367,7 +367,7 @@ describe('Nyan reporter', function () {
           trajectories: trajectories
         });
 
-        expectedSegment.should.deepEqual('_');
+        expect(expectedSegment).to.equal('_');
       });
       it('should shift each trajectory item, if its length is greater of equal to its max width', function () {
         var nyanCat = new NyanCat({on: function () {}});
@@ -385,7 +385,7 @@ describe('Nyan reporter', function () {
           trajectories: trajectories
         });
 
-        trajectories.should.deepEqual(expectedTrajectories);
+        expect(trajectories).to.eql(expectedTrajectories);
       });
     });
     describe('if tick is false', function () {
@@ -404,7 +404,7 @@ describe('Nyan reporter', function () {
           trajectories: trajectories
         });
 
-        expectedSegment.should.deepEqual('-');
+        expect(expectedSegment).to.eql('-');
       });
     });
   });
@@ -442,7 +442,7 @@ describe('Nyan reporter', function () {
         '\n',
         '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
       process.stdout.write = stdoutWrite;
       Base.color = cachedColor;
     });
@@ -464,7 +464,7 @@ describe('Nyan reporter', function () {
         numberOfLines: expectedNumberOfLines
       });
 
-      expectedCursorArgument.should.equal(expectedNumberOfLines);
+      expect(expectedCursorArgument).to.equal(expectedNumberOfLines);
       process.stdout.write = stdoutWrite;
     });
   });
@@ -495,7 +495,7 @@ describe('Nyan reporter', function () {
         expectedContents,
         '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
 
     it('should call cursorUp with given numberOfLines', function () {
@@ -517,7 +517,7 @@ describe('Nyan reporter', function () {
         numberOfLines: expectedNumberOfLines
       });
 
-      expectedCursorArgument.should.equal(expectedNumberOfLines);
+      expect(expectedCursorArgument).to.equal(expectedNumberOfLines);
       process.stdout.write = stdoutWrite;
     });
   });
@@ -525,25 +525,25 @@ describe('Nyan reporter', function () {
     it('expected face:(x .x) when "failures" at least one', function () {
       var nyanCat = new NyanCat({on: function () {}});
       nyanCat.stats = { passes: 2, pending: 1, failures: 1 };
-      nyanCat.face().should.equal('( x .x)');
+      expect(nyanCat.face()).to.equal('( x .x)');
     });
 
     it('expected face:(x .x) when "pending" at least one and no failing', function () {
       var nyanCat = new NyanCat({on: function () {}});
       nyanCat.stats = { passes: 2, pending: 1, failures: 0 };
-      nyanCat.face().should.equal('( o .o)');
+      expect(nyanCat.face()).to.equal('( o .o)');
     });
 
     it('expected face:(^ .^) when "passing" only', function () {
       var nyanCat = new NyanCat({on: function () {}});
       nyanCat.stats = { passes: 1, pending: 0, failures: 0 };
-      nyanCat.face().should.equal('( ^ .^)');
+      expect(nyanCat.face()).to.equal('( ^ .^)');
     });
 
     it('expected face:(- .-) when otherwise', function (done) {
       var nyanCat = new NyanCat({on: function () {}});
       nyanCat.stats = { passes: 0, pending: 0, failures: 0 };
-      nyanCat.face().should.equal('( - .-)');
+      expect(nyanCat.face()).to.equal('( - .-)');
       done();
     });
   });

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -33,7 +33,7 @@ describe('Progress reporter', function () {
       Progress.call({}, runner);
 
       process.stdout.write = stdoutWrite;
-      calledCursorHide.should.be.true();
+      expect(calledCursorHide).to.be(true);
 
       Base.cursor = cachedCursor;
     });
@@ -61,7 +61,7 @@ describe('Progress reporter', function () {
 
         process.stdout.write = stdoutWrite;
 
-        stdout.should.deepEqual([]);
+        expect(stdout).to.eql([]);
 
         Base.cursor = cachedCursor;
         Base.useColors = useColors;
@@ -106,8 +106,8 @@ describe('Progress reporter', function () {
           expectedIncomplete,
           expectedClose
         ];
-        calledCursorCR.should.be.true();
-        stdout.should.deepEqual(expectedArray);
+        expect(calledCursorCR).to.be(true);
+        expect(stdout).to.eql(expectedArray);
 
         Base.cursor = cachedCursor;
         Base.useColors = useColors;
@@ -136,8 +136,8 @@ describe('Progress reporter', function () {
       }, runner);
 
       process.stdout.write = stdoutWrite;
-      calledEpilogue.should.be.true();
-      calledCursorShow.should.be.true();
+      expect(calledEpilogue).to.be(true);
+      expect(calledCursorShow).to.be(true);
 
       Base.cursor = cachedCursor;
     });

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -41,7 +41,7 @@ describe('Spec reporter', function () {
       var expectedArray = [
         expectedTitle + '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
   describe('on pending', function () {
@@ -60,7 +60,7 @@ describe('Spec reporter', function () {
       var expectedArray = [
         '  - ' + expectedTitle + '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
   describe('on pass', function () {
@@ -81,7 +81,7 @@ describe('Spec reporter', function () {
         Spec.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedString = '  ' + Base.symbols.ok + ' ' + expectedTitle + ' (' + expectedDuration + 'ms)' + '\n';
-        stdout[0].should.equal(expectedString);
+        expect(stdout[0]).to.equal(expectedString);
       });
     });
     describe('if test speed is fast', function () {
@@ -101,7 +101,7 @@ describe('Spec reporter', function () {
         Spec.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedString = '  ' + Base.symbols.ok + ' ' + expectedTitle + '\n';
-        stdout[0].should.equal(expectedString);
+        expect(stdout[0]).to.equal(expectedString);
       });
     });
   });
@@ -122,7 +122,7 @@ describe('Spec reporter', function () {
       var expectedArray = [
         '  ' + functionCount + ') ' + expectedTitle + '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 });

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -39,8 +39,8 @@ describe('TAP reporter', function () {
       ];
       process.stdout.write = stdoutWrite;
 
-      stdout.should.deepEqual(expectedArray);
-      expectedString.should.equal(expectedSuite);
+      expect(stdout).to.eql(expectedArray);
+      expect(expectedString).to.equal(expectedSuite);
     });
   });
 
@@ -68,7 +68,7 @@ describe('TAP reporter', function () {
       process.stdout.write = stdoutWrite;
 
       var expectedMessage = 'ok ' + countAfterTestEnd + ' ' + expectedTitle + ' # SKIP -\n';
-      stdout[0].should.deepEqual(expectedMessage);
+      expect(stdout[0]).to.eql(expectedMessage);
     });
   });
 
@@ -97,7 +97,7 @@ describe('TAP reporter', function () {
       process.stdout.write = stdoutWrite;
 
       var expectedMessage = 'ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n';
-      stdout[0].should.deepEqual(expectedMessage);
+      expect(stdout[0]).to.eql(expectedMessage);
     });
   });
 
@@ -134,7 +134,7 @@ describe('TAP reporter', function () {
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
           '  ' + expectedStack + '\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
     describe('if there is no error stack', function () {
@@ -165,7 +165,7 @@ describe('TAP reporter', function () {
         var expectedArray = [
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n'
         ];
-        stdout.should.deepEqual(expectedArray);
+        expect(stdout).to.eql(expectedArray);
       });
     });
   });
@@ -206,7 +206,7 @@ describe('TAP reporter', function () {
         '# pass ' + numberOfPasses + '\n',
         '# fail ' + numberOfFails + '\n'
       ];
-      stdout.should.deepEqual(expectedArray);
+      expect(stdout).to.eql(expectedArray);
     });
   });
 });

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -32,7 +32,7 @@ describe('XUnit reporter', function () {
         fs.createWriteStream = false;
 
         var boundXUnit = XUnit.bind({}, runner, options);
-        boundXUnit.should.throw('file output not supported in browser');
+        expect(boundXUnit).to.throwException('file output not supported in browser');
         fs.createWriteStream = fsCreateWriteStream;
       });
     });
@@ -51,8 +51,8 @@ describe('XUnit reporter', function () {
         };
         XUnit.call(contextVariables, runner, options);
 
-        expectedDirectory.should.equal(expectedOutput);
-        contextVariables.fileStream.should.equal(expectedOutput);
+        expect(expectedDirectory).to.equal(expectedOutput);
+        expect(contextVariables.fileStream).to.equal(expectedOutput);
 
         fs.createWriteStream = fsCreateWriteStream;
         mkdirp.sync = mkdirpSync;
@@ -103,7 +103,7 @@ describe('XUnit reporter', function () {
         passTest,
         failTest
       ];
-      calledTests.should.deepEqual(expectedCalledTests);
+      expect(calledTests).to.eql(expectedCalledTests);
     });
   });
 
@@ -129,8 +129,8 @@ describe('XUnit reporter', function () {
           callback
         );
 
-        calledEnd.should.be.true();
-        callbackArgument.should.equal(expectedFailure);
+        expect(calledEnd).to.be(true);
+        expect(callbackArgument).to.equal(expectedFailure);
       });
     });
     describe('if fileStream is falsy', function () {
@@ -147,7 +147,7 @@ describe('XUnit reporter', function () {
           callback
         );
 
-        callbackArgument.should.equal(expectedFailure);
+        expect(callbackArgument).to.equal(expectedFailure);
       });
     });
   });
@@ -168,7 +168,7 @@ describe('XUnit reporter', function () {
           expectedLine
         );
 
-        expectedWrite.should.equal(expectedLine + '\n');
+        expect(expectedWrite).to.equal(expectedLine + '\n');
       });
     });
     describe('if fileStream is falsy and stdout exists', function () {
@@ -187,7 +187,7 @@ describe('XUnit reporter', function () {
 
         process.stdout.write = stdoutWrite;
 
-        stdout[0].should.equal(expectedLine + '\n');
+        expect(stdout[0]).to.equal(expectedLine + '\n');
       });
     });
     describe('if fileStream is falsy and stdout does not exist', function () {
@@ -208,7 +208,7 @@ describe('XUnit reporter', function () {
 
         console.log = cachedConsoleLog;
         process = stdoutWrite; // eslint-disable-line no-native-reassign, no-global-assign
-        stdout[0].should.equal(expectedLine);
+        expect(stdout[0]).to.equal(expectedLine);
       });
     });
   });
@@ -248,7 +248,7 @@ describe('XUnit reporter', function () {
 
         var expectedTag = '<testcase classname="' + expectedClassName + '" name="' + expectedTitle + '" time="1"><failure>' + expectedMessage + '\n' + expectedStack + '</failure></testcase>';
 
-        expectedWrite.should.equal(expectedTag);
+        expect(expectedWrite).to.equal(expectedTag);
       });
     });
     describe('on test pending', function () {
@@ -279,7 +279,7 @@ describe('XUnit reporter', function () {
 
         var expectedTag = '<testcase classname="' + expectedClassName + '" name="' + expectedTitle + '" time="1"><skipped/></testcase>';
 
-        expectedWrite.should.equal(expectedTag);
+        expect(expectedWrite).to.equal(expectedTag);
       });
     });
     describe('on test in any other state', function () {
@@ -310,7 +310,7 @@ describe('XUnit reporter', function () {
 
         var expectedTag = '<testcase classname="' + expectedClassName + '" name="' + expectedTitle + '" time="0"/>';
 
-        expectedWrite.should.equal(expectedTag);
+        expect(expectedWrite).to.equal(expectedTag);
       });
     });
   });


### PR DESCRIPTION
### Description of the Change

The `should` library has been removed. All tests that were using it are now using expectJS.

Note that I also removed completely the diff integration test, because it was testing the output format provided by `should`.

### Benefits

One less package to worry about.

### Applicable issues

* This PR solves [issue 3035](https://github.com/mochajs/mocha/issues/3035)
* It shouldn't impact production code as this removes a dev dependency and only tests have been modified