### PR TITLE
Update growl to 1.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "diff": "3.3.1",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.2",
-    "growl": "1.10.2",
+    "growl": "1.10.3",
     "he": "1.1.1",
     "mkdirp": "0.5.1",
     "supports-color": "4.4.0"


### PR DESCRIPTION
### Description of the Change

Update growl to 1.10.3

### Why should this be in core?

This avoid a warning about an eslint peerDependency on install of mocha:

```
eslint-plugin-node@5.2.0 requires a peer of eslint@>=3.1.0 but none is installed.
```