### PR TITLE
Add test for Mocha.bail()

### DIFF
--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -167,4 +167,13 @@ describe('Mocha', function () {
       expect(mocha.options.delay).to.equal(true);
     });
   });
+
+  describe('.bail()', function () {
+    it('should set the suite._bail to true if there is no arguments', function () {
+      var mocha = new Mocha({bail: false});
+      expect(mocha.suite._bail).to.equal(false);
+      mocha.bail();
+      expect(mocha.suite._bail).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Change

This adds a test case when `mocha.bail()` has  no arguments.