### PR TITLE
add coverage to Context; remove unused Context#inspect()

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var utils = require('./utils');
-
 /**
  * Expose `Context`.
  */

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var utils = require('./utils');
+
 /**
  * Expose `Context`.
  */
@@ -90,16 +92,4 @@ Context.prototype.retries = function (n) {
   }
   this.runnable().retries(n);
   return this;
-};
-
-/**
- * Inspect the context void of `._runnable`.
- *
- * @api private
- * @return {string}
- */
-Context.prototype.inspect = function () {
-  return JSON.stringify(this, function (key, val) {
-    return key === 'runnable' || key === 'test' ? undefined : val;
-  }, 2);
 };

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -66,8 +66,16 @@ describe('Context Siblings', function () {
   });
 });
 
-describe('timeout()', function () {
-  it('should return the timeout', function () {
-    expect(this.timeout()).to.equal(200);
+describe('methods', function () {
+  describe('timeout()', function () {
+    it('should return the timeout', function () {
+      expect(this.timeout()).to.equal(200);
+    });
+  });
+
+  describe('retries', function () {
+    it('should return the number of retries', function () {
+      expect(this.retries()).to.equal(-1);
+    });
   });
 });


### PR DESCRIPTION
`Context#inspect()` is a private debugging method which is not consumed by Mocha, nor is it documented anywhere, so away it goes