### PR TITLE
Remove unused variables

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -367,7 +367,7 @@ function pad (str, len) {
  * @return {string} Diff
  */
 function inlineDiff (err) {
-  var msg = errorDiff(err, 'WordsWithSpace', false);
+  var msg = errorDiff(err);
 
   // linenos
   var lines = msg.split('\n');
@@ -433,14 +433,10 @@ function unifiedDiff (err) {
  *
  * @api private
  * @param {Error} err
- * @param {string} type
- * @param {boolean} escape
  * @return {string}
  */
-function errorDiff (err, type, escape) {
-  var actual = escape ? escapeInvisibles(err.actual) : err.actual;
-  var expected = escape ? escapeInvisibles(err.expected) : err.expected;
-  return diff['diff' + type](actual, expected).map(function (str) {
+function errorDiff (err) {
+  return diff.diffWordsWithSpace(err.actual, err.expected).map(function (str) {
     if (str.added) {
       return colorLines('diff added', str.value);
     }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -185,7 +185,6 @@ exports.list = function (failures) {
     var index = message ? stack.indexOf(message) : -1;
     var actual = err.actual;
     var expected = err.expected;
-    var escape = true;
 
     if (index === -1) {
       msg = message;
@@ -202,7 +201,6 @@ exports.list = function (failures) {
     }
     // explicitly show diff
     if (err.showDiff !== false && sameType(actual, expected) && expected !== undefined) {
-      escape = false;
       if (!(utils.isString(actual) && utils.isString(expected))) {
         err.actual = actual = utils.stringify(actual);
         err.expected = expected = utils.stringify(expected);
@@ -213,9 +211,9 @@ exports.list = function (failures) {
       msg = '\n      ' + color('error message', match ? match[1] : msg);
 
       if (exports.inlineDiffs) {
-        msg += inlineDiff(err, escape);
+        msg += inlineDiff(err);
       } else {
-        msg += unifiedDiff(err, escape);
+        msg += unifiedDiff(err);
       }
     }
 
@@ -366,11 +364,10 @@ function pad (str, len) {
  *
  * @api private
  * @param {Error} err with actual/expected
- * @param {boolean} escape
  * @return {string} Diff
  */
-function inlineDiff (err, escape) {
-  var msg = errorDiff(err, 'WordsWithSpace', escape);
+function inlineDiff (err) {
+  var msg = errorDiff(err, 'WordsWithSpace', false);
 
   // linenos
   var lines = msg.split('\n');
@@ -400,15 +397,11 @@ function inlineDiff (err, escape) {
  *
  * @api private
  * @param {Error} err with actual/expected
- * @param {boolean} escape
  * @return {string} The diff.
  */
-function unifiedDiff (err, escape) {
+function unifiedDiff (err) {
   var indent = '      ';
   function cleanUp (line) {
-    if (escape) {
-      line = escapeInvisibles(line);
-    }
     if (line[0] === '+') {
       return indent + colorLines('diff added', line);
     }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -448,19 +448,6 @@ function errorDiff (err) {
 }
 
 /**
- * Returns a string with all invisible characters in plain text
- *
- * @api private
- * @param {string} line
- * @return {string}
- */
-function escapeInvisibles (line) {
-  return line.replace(/\t/g, '<tab>')
-    .replace(/\r/g, '<CR>')
-    .replace(/\n/g, '<LF>\n');
-}
-
-/**
  * Color lines for `str`, using the color `name`.
  *
  * @api private


### PR DESCRIPTION
### Requirements

The `escape` argument for `inlineDiff()` and `unifiedDiff()` in `Base.list()` is always false.
[inlineDiff()](https://github.com/mochajs/mocha/blob/9f204ba2b27e254e70e88ab353e8c4cedc7b67f6/lib/reporters/base.js#L372) and [unifiedDiff()](https://github.com/mochajs/mocha/blob/9f204ba2b27e254e70e88ab353e8c4cedc7b67f6/lib/reporters/base.js#L406) are only used in `Base.list()` .
I think the `escape` argument is unnecessary.


https://github.com/mochajs/mocha/blob/9f204ba2b27e254e70e88ab353e8c4cedc7b67f6/lib/reporters/base.js#L188-L220