### PR TITLE
Allow to set reporterOptions from setup

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -185,7 +185,7 @@ Mocha.prototype.reporter = function (reporter, reporterOptions) {
  */
 Mocha.prototype.reporterOptions = function (reporterOptions) {
 
-  this.options.reporterOptions = this.options.reporterOptions || reporterOptions;
+  Object.assign(this.options.reporterOptions, reporterOptions);
   return this;
 
 }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -180,6 +180,17 @@ Mocha.prototype.reporter = function (reporter, reporterOptions) {
 };
 
 /**
+ * Set reporter options from mocha.setup call
+ * @param {Object} reporterOptions optional options
+ */
+Mocha.prototype.reporterOptions = function (reporterOptions) {
+
+  this.options.reporterOptions = this.options.reporterOptions || reporterOptions;
+  return this;
+
+}
+
+/**
  * Set test UI `name`, defaults to "bdd".
  *
  * @api public

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -185,7 +185,15 @@ Mocha.prototype.reporter = function (reporter, reporterOptions) {
  */
 Mocha.prototype.reporterOptions = function (reporterOptions) {
 
-  Object.assign(this.options.reporterOptions, reporterOptions);
+  if( reporterOptions === null || reporterOptions === undefined ) {
+    return; // Should throw ?
+  }
+
+  if( this.options.reporterOptions ) {
+    Object.assign(this.options.reporterOptions, reporterOptions);
+  } else {
+    this.options.reporterOptions = reporterOptions;
+  }
   return this;
 
 }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -175,7 +175,7 @@ Mocha.prototype.reporter = function (reporter, reporterOptions) {
     }
     this._reporter = _reporter;
   }
-  this.options.reporterOptions = reporterOptions;
+  this.reporterOptions(reporterOptions);
   return this;
 };
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -4,7 +4,7 @@ var Mocha = require('../../lib/mocha');
 var Test = Mocha.Test;
 
 describe('Mocha', function () {
-  var blankOpts = { reporter: function () {} }; // no output
+  var blankOpts = { reporter: function () {}, reporterOptions: {} }; // no output
 
   describe('.run(fn)', function () {
     it('should not raise errors if callback was not provided', function () {
@@ -175,5 +175,37 @@ describe('Mocha', function () {
       mocha.bail();
       expect(mocha.suite._bail).to.equal(true);
     });
+  });
+
+  describe('.reporterOptions()', function () {
+
+    it('should be equal when pass reporterOptions by ctor or by setup', function(){
+      var blankMocha = new Mocha(blankOpts);
+      var setupMocha = new Mocha();
+      setupMocha.setup(blankOpts);
+      expect(blankMocha.options).to.equal(setupMocha.options);
+    })
+
+    it('should merge reporterOptions', function(){
+      var fooOptions = { reporter: function () {}, reporterOptions: { foo: 'bar' } }
+      var bazOptions = { reporter: function () {}, reporterOptions: { baz: 'qux' } }
+      var mocha = new Mocha(fooOptions);
+      mocha.reporterOptions(bazOptions);
+      expect(mocha.options.reporterOptions).to.eql({foo: 'bar', baz: 'qux'})
+    })
+
+    it('should override previous reporterOptions', function(){
+      var fooOptions = { reporter: function () {}, reporterOptions: { foo: 'bar' } }
+      var bazOptions = { reporter: function () {}, reporterOptions: { foo: 'qux' } }
+      var mocha = new Mocha(fooOptions);
+      mocha.reporterOptions(bazOptions);
+      expect(mocha.options.reporterOptions).to.eql({foo: 'qux'})
+    })
+
+    it('should be chainable', function () {
+      var mocha = new Mocha(blankOpts);
+      expect(mocha.reporterOptions()).to.equal(mocha);
+    });
+
   });
 });


### PR DESCRIPTION
This is a hot fix for #3068 

When karma start running Mocha it set the Mocha options with mocha.setup with apply options like this:

```javascript
mocha.setup = function (opts) {

  if (typeof opts === 'string') {
    opts = { ui: opts };
  }

  for (var opt in opts) {
    if (opts.hasOwnProperty(opt)) {
      this[opt](opts[opt]);                 // BOOM !!!
    }
  }
  return this;
};
```

But... reporterOptions is not a function so karma crash at line 144.

This PR fix it

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Add a Mocha prototype to handle the reporterOptions as function when call inside mocha.setup

### Alternate Designs
Check for options type inside setup instead of make a savage function call ?

### Why should this be in core?
Because this fix a bug that crash test runner ?

### Benefits
This fix the crash

### Possible Drawbacks
Allow user to set the reporterOptions ?

### Applicable issues
This is a patch !
