### PR TITLE
have Base generate the strings for error messages immediately 

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -155,8 +155,15 @@ exports.cursor = {
   }
 };
 
-function showDiff(err) {
+function showDiff (err) {
   return err && err.showDiff !== false && sameType(err.actual, err.expected) && err.expected !== undefined;
+}
+
+function stringifyDiffObjs (err) {
+  if (!utils.isString(err.actual) || !utils.isString(err.expected)) {
+    err.actual = utils.stringify(err.actual);
+    err.expected = utils.stringify(err.expected);
+  }
 }
 
 /**
@@ -204,6 +211,7 @@ exports.list = function (failures) {
     }
     // explicitly show diff
     if (showDiff(err)) {
+      stringifyDiffObjs(err);
       escape = false;
       fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
@@ -290,10 +298,7 @@ function Base (runner) {
     stats.failures = stats.failures || 0;
     stats.failures++;
     if (showDiff(err)) {
-      if (!utils.isString(err.actual) || !utils.isString(err.expected)) {
-        err.actual = utils.stringify(err.actual);
-        err.expected = utils.stringify(err.expected);
-      }
+      stringifyDiffObjs(err);
     }
     test.err = err;
     failures.push(test);

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -155,6 +155,10 @@ exports.cursor = {
   }
 };
 
+function showDiff(err) {
+  return err && err.showDiff !== false && sameType(err.actual, err.expected) && err.expected !== undefined;
+}
+
 /**
  * Output the given `failures` as a list.
  *
@@ -183,8 +187,6 @@ exports.list = function (failures) {
     }
     var stack = err.stack || message;
     var index = message ? stack.indexOf(message) : -1;
-    var actual = err.actual;
-    var expected = err.expected;
     var escape = true;
 
     if (index === -1) {
@@ -201,13 +203,8 @@ exports.list = function (failures) {
       msg = 'Uncaught ' + msg;
     }
     // explicitly show diff
-    if (err.showDiff !== false && sameType(actual, expected) && expected !== undefined) {
+    if (showDiff(err)) {
       escape = false;
-      if (!(utils.isString(actual) && utils.isString(expected))) {
-        err.actual = actual = utils.stringify(actual);
-        err.expected = expected = utils.stringify(expected);
-      }
-
       fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);
@@ -292,6 +289,12 @@ function Base (runner) {
   runner.on('fail', function (test, err) {
     stats.failures = stats.failures || 0;
     stats.failures++;
+    if (showDiff(err)) {
+      if (!utils.isString(err.actual) || !utils.isString(err.expected)) {
+        err.actual = utils.stringify(err.actual);
+        err.expected = utils.stringify(err.expected);
+      }
+    }
     test.err = err;
     failures.push(test);
   });

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -192,7 +192,7 @@ describe('List reporter', function () {
 
       Base.cursor = cachedCursor;
     });
-    it('should immediately construct fail strings', function() {
+    it('should immediately construct fail strings', function () {
       var actual = { a: 'actual' };
       var expected = { a: 'expected' };
       var test = {};

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -192,6 +192,28 @@ describe('List reporter', function () {
 
       Base.cursor = cachedCursor;
     });
+    it('should immediately construct fail strings', function() {
+      var actual = { a: 'actual' };
+      var expected = { a: 'expected' };
+      var test = {};
+      var checked = false;
+      var err;
+      runner.on = function (event, callback) {
+        if (!checked && event === 'fail') {
+          err = new Error('fake failure object with actual/expected');
+          err.actual = actual;
+          err.expected = expected;
+          err.showDiff = true;
+          callback(test, err);
+          checked = true;
+        }
+      };
+      List.call({epilogue: function () {}}, runner);
+
+      process.stdout.write = stdoutWrite;
+      expect(typeof err.actual).to.equal('string');
+      expect(typeof err.expected).to.equal('string');
+    });
   });
 
   describe('on end', function () {


### PR DESCRIPTION
instead of delaying until epilogue

### Requirements

### Description of the Change

An object referred to by a test failure can be mutated between the point of test failing and when the object is converted to a string and output. For instance if an `afterEach` clears the fields in an object pointed to by a `chai.expect.eql` AssertionError's `expected` or `actual` fields then the reporter's error message will be misleading

see https://codepen.io/abrady0/pen/pWGBxR?editors=1111 for running example.

Here is a snippet that assumes 'spec' reporter:

```
describe('example', function() {
  var foo = {
    a: 'before'
  };

  afterEach(function() {
    console.log('afterEach');
    foo.a = 'after';
  })
  it('should print the error properly', function() {
    var bar = { a: 'during' };
    console.log('foo2')
    // HERE: output *should* say 'before' instead of 'after' for the previous line
    //  + expected - actual
    //   {
    //  -  'a': 'after'
    //  +  'a': 'during'
    //   }
    // 
    //  + expected - actual
    //   {
    //  -  'a': 'before'
    //  +  'a': 'during'
    //   }
    expect(foo).to.deep.equal(bar);
  });  
});
```

### Alternate Designs

To fix this in chai would require either cloning or stringifying the `actual` and `expected` objects at the time of error creation. 

Cloning the objects is a potentially expensive, and not always possible operation that would put new constraints on what could be used in an `eql` comparison. 

Stringifying is a possibility as that is an existing requirement for using the Base reporter, however mocha has its own stringifying function with its own configuration and behavior (such as sorting fields in an object) and would require that chai, and any other libraries similar to chai, import mocha and use `mocha.utils.stringify` (or perhaps another stringifier depending on the reporter), which feels like it breaks modularity pretty hard

Even if this was fixed in the chai module, other modules would have to take on the burden of making sure their `actual` and `expected` objects were in mocha compatible string form.

### Why should this be in core?

This functionality directly affects the Base reporter.

### Benefits

The benefit realized by this code change is correct error messages in situations where objects that can be mutated after changing are passed to the Base reporter

### Possible Drawbacks

Code that would have executed later is now run when a test fails. This puts an extra burden on memory requirements at the time of test failure and could possibly result in running out of memory space in a tightly constrained test when it fails. 

The cost of execution should be the same, but any time you change when things happen it risks having side effects. It is possible the configuration of the reporter is changed in some way that would make the output different before and after this change.

Possibly the string representation of an object is larger than its non-string representation and causes too much memory to be used over the lifetime of the test.

Unlikely but there might be side effects from having the `expected` and `actual` no longer referenced such that they get garbage collected at a different time (and maybe are referenced by a weakmap? I'm reaching here)

It is possible this bug will appear again in new reporters depending on if they build on the Base reporter or not.

### Applicable issues

I didn't make an issue for the fix, just noticed it today in a test and thought I'd take a shot at fixing it.

This is just a bug fix