### PR TITLE
ensure file is not in cache before calling require

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -10,6 +10,7 @@
  * Module dependencies.
  */
 
+var decache = require('decache');
 var escapeRe = require('escape-string-regexp');
 var path = require('path');
 var reporters = require('./reporters');
@@ -227,6 +228,11 @@ Mocha.prototype.loadFiles = function (fn) {
   var suite = this.suite;
   this.files.forEach(function (file) {
     file = path.resolve(file);
+    // Ensure the file is not in the require cache. Otherwise,
+    // calling require(file) below could find it in the cache and
+    // skip parsing the file and no-op (instead of calling mocha
+    // methods to create suites and tests).
+    decache(file);
     suite.emit('pre-require', global, file, self);
     suite.emit('require', require(file), file, self);
     suite.emit('post-require', global, file, self);

--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
     "browser-stdout": "1.3.0",
     "commander": "2.11.0",
     "debug": "3.1.0",
+    "decache": "^4.2.0",
     "diff": "3.3.1",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.2",

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Mocha = require('../../lib/mocha');
+var path = require('path');
 var Test = Mocha.Test;
 
 describe('Mocha', function () {
@@ -174,6 +175,26 @@ describe('Mocha', function () {
       expect(mocha.suite._bail).to.equal(false);
       mocha.bail();
       expect(mocha.suite._bail).to.equal(true);
+    });
+  });
+
+  describe('.loadFiles()', function () {
+    beforeEach(function () {
+      if (path.sep !== '/') {
+        this.skip();
+      }
+    });
+
+    it('makes sure files are decached before calling require on them', function () {
+      var mocha1 = new Mocha(blankOpts);
+      mocha1.addFile('test/unit/suite.spec.js');
+      mocha1.loadFiles();
+      expect(mocha1.suite.suites.length).to.equal(2);
+
+      var mocha2 = new Mocha(blankOpts);
+      mocha2.addFile('test/unit/suite.spec.js');
+      mocha2.loadFiles();
+      expect(mocha2.suite.suites.length).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

Fixes https://github.com/mochajs/mocha/issues/3084.

### Alternate Designs

Could have modified `require.cache` directly, but seems easier to add the `decache` dependency and it handle modifying the `require.cache` for us.

### Why should this be in core?

Mocha makes an assumption that when loading files, `require(file)` will parse a file and encounter mocha directives. For this to be valid, mocha should ensure the file is not in the require cache.

### Benefits

Allows mocha to be used programmatically in scripts/environments where modules mocha is going to run tests on have already been loaded (perhaps by a previous invocation of mocha itself).

### Possible Drawbacks

None that come to mind immediately, other than risk by having the `decache` dependency, though I think having that dependency makes sense here.

### Applicable issues

bug fix
