### PR TITLE
Remove unused argument of lib/ms

### DIFF
--- a/lib/ms.js
+++ b/lib/ms.js
@@ -19,16 +19,13 @@ var y = d * 365.25;
  *
  * @api public
  * @param {string|number} val
- * @param {Object} options
  * @return {string|number}
  */
-module.exports = function (val, options) {
-  options = options || {};
+module.exports = function (val) {
   if (typeof val === 'string') {
     return parse(val);
   }
-  // https://github.com/mochajs/mocha/pull/1035
-  return options['long'] ? longFormat(val) : shortFormat(val);
+  return format(val);
 };
 
 /**
@@ -74,13 +71,13 @@ function parse (str) {
 }
 
 /**
- * Short format for `ms`.
+ * Format for `ms`.
  *
  * @api private
  * @param {number} ms
  * @return {string}
  */
-function shortFormat (ms) {
+function format (ms) {
   if (ms >= d) {
     return Math.round(ms / d) + 'd';
   }
@@ -94,37 +91,4 @@ function shortFormat (ms) {
     return Math.round(ms / s) + 's';
   }
   return ms + 'ms';
-}
-
-/**
- * Long format for `ms`.
- *
- * @api private
- * @param {number} ms
- * @return {string}
- */
-function longFormat (ms) {
-  return plural(ms, d, 'day') ||
-    plural(ms, h, 'hour') ||
-    plural(ms, m, 'minute') ||
-    plural(ms, s, 'second') ||
-    ms + ' ms';
-}
-
-/**
- * Pluralization helper.
- *
- * @api private
- * @param {number} ms
- * @param {number} n
- * @param {string} name
- */
-function plural (ms, n, name) {
-  if (ms < n) {
-    return;
-  }
-  if (ms < n * 1.5) {
-    return Math.floor(ms / n) + ' ' + name;
-  }
-  return Math.ceil(ms / n) + ' ' + name + 's';
 }

--- a/lib/ms.js
+++ b/lib/ms.js
@@ -13,10 +13,6 @@ var y = d * 365.25;
 /**
  * Parse or format the given `val`.
  *
- * Options:
- *
- *  - `long` verbose formatting [false]
- *
  * @api public
  * @param {string|number} val
  * @return {string|number}

--- a/test/unit/ms.spec.js
+++ b/test/unit/ms.spec.js
@@ -21,22 +21,11 @@ describe('.ms()', function () {
     it('should return short format', function () {
       expect(ms(2000)).to.equal('2s');
     });
-
-    it('should return long format', function () {
-      expect(ms(2000, { long: true })).to.equal('2 seconds');
-      expect(ms(1000, { long: true })).to.equal('1 second');
-      expect(ms(1010, { long: true })).to.equal('1 second');
-    });
   });
 
   describe('minutes representation', function () {
     it('should return short format', function () {
       expect(ms(time.minutes(1))).to.equal('1m');
-    });
-
-    it('should return long format', function () {
-      expect(ms(time.minutes(1), { long: true })).to.equal('1 minute');
-      expect(ms(time.minutes(3), { long: true })).to.equal('3 minutes');
     });
   });
 
@@ -44,21 +33,11 @@ describe('.ms()', function () {
     it('should return short format', function () {
       expect(ms(time.hours(1))).to.equal('1h');
     });
-
-    it('should return long format', function () {
-      expect(ms(time.hours(1), { long: true })).to.equal('1 hour');
-      expect(ms(time.hours(3), { long: true })).to.equal('3 hours');
-    });
   });
 
   describe('days representation', function () {
     it('should return short format', function () {
       expect(ms(time.days(1))).to.equal('1d');
-    });
-
-    it('should return long format', function () {
-      expect(ms(time.days(1), { long: true })).to.equal('1 day');
-      expect(ms(time.days(3), { long: true })).to.equal('3 days');
     });
   });
 


### PR DESCRIPTION
### Description of the Change

Since `options` argument is unused in Mocha, this removes it.

https://github.com/mochajs/mocha/blob/2303c669ef1b47fef7cf86f5ef486d537033d443/lib/suite.js#L108-L110

https://github.com/mochajs/mocha/blob/2303c669ef1b47fef7cf86f5ef486d537033d443/lib/runnable.js#L82-L84

https://github.com/mochajs/mocha/blob/1bb6b3977a482c144a61d68ea2e499b22a7db01b/lib/reporters/base.js#L324-L326