### PR TITLE
return the created test in `xit` for bdd interface

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ install:
   - set CI=true
   - set PATH=%APPDATA%\npm;c:\MinGW\bin;%PATH%
   - set PHANTOMJS_CDNURL=https://cnpmjs.org/downloads
+  - npm install -g npm
   - npm install
   - copy c:\MinGW\bin\mingw32-make.exe c:\MinGW\bin\make.exe
 matrix:

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -102,7 +102,7 @@ module.exports = function (suite) {
      */
 
     context.xit = context.xspecify = context.it.skip = function (title) {
-      context.it(title);
+      return context.it(title);
     };
 
     /**

--- a/test/integration/fixtures/pending/skip-shorthand.fixture.js
+++ b/test/integration/fixtures/pending/skip-shorthand.fixture.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('pending shorthand', function () {
+  xit('pending spec', function () {}).timeout(0);
+  xspecify('pending spec', function () {}).timeout(0);
+  it.skip('pending spec', function () {}).timeout(0);
+});

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -19,6 +19,19 @@ describe('pending', function () {
         done();
       });
     });
+    it('should return the test object when used via shorthand methods', function (done) {
+      run('pending/skip-shorthand.fixture.js', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(res.stats.pending, 3);
+        assert.equal(res.stats.passes, 0);
+        assert.equal(res.stats.failures, 0);
+        assert.equal(res.code, 0);
+        done();
+      });
+    });
   });
 
   describe('synchronous skip()', function () {

--- a/test/interfaces/bdd.spec.js
+++ b/test/interfaces/bdd.spec.js
@@ -48,7 +48,7 @@ describe('pending tests', function () {
 });
 
 describe('setting timeout by appending it to test', function () {
-  var runningTest = it('enables users to call timeout on pending tests', function () {
+  var runningTest = it('enables users to call timeout on active tests', function () {
     expect(1 + 1).to.equal(2);
   }).timeout(1003);
 

--- a/test/interfaces/bdd.spec.js
+++ b/test/interfaces/bdd.spec.js
@@ -40,3 +40,27 @@ describe('pending suite', function () {
     });
   });
 });
+
+describe('pending tests', function () {
+  it.skip('should not run', function () {
+    expect(1 + 1).to.equal(3);
+  });
+});
+
+describe('setting timeout by appending it to test', function () {
+  var runningTest = it('enables users to call timeout on pending tests', function () {
+    expect(1 + 1).to.equal(2);
+  }).timeout(1003);
+
+  var skippedTest = xit('enables users to call timeout on pending tests', function () {
+    expect(1 + 1).to.equal(3);
+  }).timeout(1002);
+
+  it('sets timeout on pending tests', function () {
+    expect(skippedTest._timeout).to.equal(1002);
+  });
+
+  it('sets timeout on running tests', function () {
+    expect(runningTest._timeout).to.equal(1003);
+  });
+});


### PR DESCRIPTION
### Description of the Change

Fixes #3142 

The bigger reason for this fix is to ensure consistency across across both active and pending tests (ie `it` and `xit`).

I've also added a test suite for `setting timeout by appending it to test`

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We can also remove the return statement to disable this feature in the bdd interface, but i personally favor having it around, maybe even document it after adding some more test cases!


### Benefits

<!-- What benefits will be realized by the code change? -->

Since @boneskull does not encourage the use of the `this` keyword in writing tests, documenting this change might create a shift to increased usage of arrow functions and less usage of `this`.


### Applicable issues
**patch**

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
