### PR TITLE
Fix TypeError: Cannot read property 'isPending' of undefined

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -542,7 +542,7 @@ Runner.prototype.runTests = function (suite, fn) {
     // execute test and hook(s)
     self.emit('test', self.test = test);
     self.hookDown('beforeEach', function (err, errSuite) {
-      if (test.isPending()) {
+      if (test && test.isPending()) {
         if (self.forbidPending) {
           test.isPending = alwaysFalse;
           self.fail(test, new Error('Pending test forbidden'));


### PR DESCRIPTION
### Description of the Change

Sometimes beforeEach hook runs with no defined test, eg if there is an err passed when no test has started yet.

### Alternate Designs

not sure why this happens, this is more of a sticking plaster solution

### Why should this be in core?

can't be patched by another module easily

### Benefits

My CI will pass.

### Possible Drawbacks

N/A

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
