### PR TITLE
Revert "`options.reporterOptions` are used for progress reporter"

### DIFF
--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -39,13 +39,11 @@ function Progress (runner, options) {
 
   // default chars
   options = options || {};
-  var reporterOptions = options.reporterOptions || {};
-
-  options.open = reporterOptions.open || '[';
-  options.complete = reporterOptions.complete || '▬';
-  options.incomplete = reporterOptions.incomplete || Base.symbols.dot;
-  options.close = reporterOptions.close || ']';
-  options.verbose = reporterOptions.verbose || false;
+  options.open = options.open || '[';
+  options.complete = options.complete || '▬';
+  options.incomplete = options.incomplete || Base.symbols.dot;
+  options.close = options.close || ']';
+  options.verbose = false;
 
   // tests started
   runner.on('start', function () {


### PR DESCRIPTION
This reverts commit 78b686f3663fbe52ecd54827e5c00af0378292ba which introduced a breaking build via PR #2649.  I'm not sure *why*, because the build was passing before it was merged.