### PR TITLE
lint the markdown, closes #3172

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,3 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
 # Mocha Code of Conduct
 
 ## Be friendly and patient
+
 We understand that everyone has different levels of experience or knowledge in many diverse fields, be it technical or
 non-technical in nature. We also have areas of knowledge we are eager to expand; we want to be a community where people
 can not only contribute, but feel comfortable to ask questions as well and learn along the way. If someone says something
@@ -8,23 +9,27 @@ wrong, or says something accidentally offensive, respond with patience and try t
 we all were newbies at one point.
 
 ## Be welcoming
+
 We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not
 limited to, members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class,
 educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief,
 religion, and mental and physical ability.
 
 ## Be considerate
+
 Your work will be used by other people, and you in turn will depend on the work of others. Any decision you make will affect
 users and colleagues, and you should take those consequences into account when making decisions. Remember that we’re a world-wide
 community, so you might not be communicating in someone else’s primary language.
 
 ## Be respectful
+
 Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all
 experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important
 to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the JS Foundation
 community should be respectful when dealing with other members as well as with people outside the JS Foundation community.
 
 ## Be careful in the words that you choose
+
 We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put
 down other participants. Harassment and other exclusionary behavior aren’t acceptable. This includes, but is not limited to:
 
@@ -38,6 +43,7 @@ down other participants. Harassment and other exclusionary behavior aren’t acc
 * Repeated harassment of others. In general, if someone asks you to stop, then stop.
 
 ## When we disagree, try to understand why
+
 Disagreements, both social and technical, happen all the time and JS Foundation projects are no exception. It is important
 that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of the JS
 Foundation comes from its varied community, people from a wide range of backgrounds. Different people have different
@@ -48,4 +54,5 @@ and learning from mistakes.
 Original text courtesy of the Speak Up! project and Django Project.
 
 ## QUESTIONS?
+
 If you have questions, please see the FAQ. If that doesn’t answer your questions, feel free to email conduct@js.foundation.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,35 +40,35 @@ We ask you please keep these goals in mind when making or proposing changes.
 
 Follow these steps to get going.  If you are having trouble, don't be afraid to [ask for help](#got-a-question).
 
-1.  [Install Node.js 4.x or newer](https://nodejs.org/download).
-1.  Install [GNU Make](https://www.gnu.org/software/make/) or equivalent.
-1.  Follow [Github's documentation](https://help.github.com/articles/fork-a-repo/) on setting up Git, forking and cloning.
-1.  Create a new branch in your working copy.  Give your branch a descriptive name, such as `issue/12345`: `git checkout -b issue/12345`.
-1.  Execute `npm install` to install the development dependencies.
-1.  Make your changes and add them via `git add`.
-  - **Do not modify** the root `mocha.js` file directly; it is automatically generated.
-  - Your changes will likely be somewhere in `lib/`, `bin/` or `browser-entry.js` if your changes are browser-specific.
-  - Please add unit and/or integration tests (depending on the nature of your changes).
-  - Keep your PR focused.  Don't fix two things at once, or make formatting changes alongside bug fixes.
-1.  Before committing, run `npm test`.
-  - This will run unit tests, Node.js and browser integration tests, and lint the source code.
-  - The "browser" tests use Mocha to test itself; it will rebuild the root `mocha.js` file with your changes.
-  - **Please avoid committing changes to `mocha.js`**.
-  - Ultimately, your pull request will be built on our continuous integration servers ([Travis CI](https://travis-ci.org/mochajs/mocha) and [AppVeyor](https://ci.appveyor.com/project/boneskull/mocha)).  The first step to ensuring these checks pass is to test on your own machine.
-1.  Commit your changes.
-  - Use a brief message on the first line, referencing a relevant issue (e.g. `#12345`).
-  - Add detail in subsequent lines.
-1.  Push your changes to your fork.
-1.  Navigate to the source repository.  You should see a notification about your recent changes in your fork's branch, with a button to create a pull request.  Click it.
-1.  Describe your changes in detail here.  Once you're satisfied, submit the form.
-  - *PRO TIP*: If you've used a multi-line commit message, Github will pre-fill the PR's description with it.
-1.  If you have not signed our Contributor License Agreement, a friendly robot will prompt you to do so.  A [CLA](https://cla.js.foundation/mochajs/mocha) (electronic) signature is **required** for all contributions of code to Mocha.
-1.  CI will run against your changes.
-  - If the changes fail the checks, you will need to address those before merging.
-  - You don't need to make a new PR to make changes.  Instead, commit on top of your changes, and push these to your fork's branch.  The PR will be updated, and CI will re-run.
-  - Github will indicate if there's a conflict.  If this happens, you will need to [rebase](https://help.github.com/articles/about-git-rebase/) your branch onto the `master` branch of the source repository.  *Don't merge.*
-  - It's no longer necessary to "squash" your changes.
-1.  Be patient while your PR is reviewed.  This can take awhile ([why?](https://github.com/orgs/mochajs/projects/4)).  We may request changes; don't be afraid to question them.
+1. [Install Node.js 4.x or newer](https://nodejs.org/download).
+1. Install [GNU Make](https://www.gnu.org/software/make/) or equivalent.
+1. Follow [Github's documentation](https://help.github.com/articles/fork-a-repo/) on setting up Git, forking and cloning.
+1. Create a new branch in your working copy.  Give your branch a descriptive name, such as `issue/12345`: `git checkout -b issue/12345`.
+1. Execute `npm install` to install the development dependencies.
+1. Make your changes and add them via `git add`.
+    - **Do not modify** the root `mocha.js` file directly; it is automatically generated.
+    - Your changes will likely be somewhere in `lib/`, `bin/` or `browser-entry.js` if your changes are browser-specific.
+    - Please add unit and/or integration tests (depending on the nature of your changes).
+    - Keep your PR focused.  Don't fix two things at once, or make formatting changes alongside bug fixes.
+1. Before committing, run `npm test`.
+    - This will run unit tests, Node.js and browser integration tests, and lint the source code.
+    - The "browser" tests use Mocha to test itself; it will rebuild the root `mocha.js` file with your changes.
+    - **Please avoid committing changes to `mocha.js`**.
+    - Ultimately, your pull request will be built on our continuous integration servers ([Travis CI](https://travis-ci.org/mochajs/mocha) and [AppVeyor](https://ci.appveyor.com/project/boneskull/mocha)).  The first step to ensuring these checks pass is to test on your own machine.
+1. Commit your changes.
+    - Use a brief message on the first line, referencing a relevant issue (e.g. `#12345`).
+    - Add detail in subsequent lines.
+1. Push your changes to your fork.
+1. Navigate to the source repository.  You should see a notification about your recent changes in your fork's branch, with a button to create a pull request.  Click it.
+1. Describe your changes in detail here.  Once you're satisfied, submit the form.
+    - *PRO TIP*: If you've used a multi-line commit message, Github will pre-fill the PR's description with it.
+1. If you have not signed our Contributor License Agreement, a friendly robot will prompt you to do so.  A [CLA](https://cla.js.foundation/mochajs/mocha) (electronic) signature is **required** for all contributions of code to Mocha.
+1. CI will run against your changes.
+    - If the changes fail the checks, you will need to address those before merging.
+    - You don't need to make a new PR to make changes.  Instead, commit on top of your changes, and push these to your fork's branch.  The PR will be updated, and CI will re-run.
+    - Github will indicate if there's a conflict.  If this happens, you will need to [rebase](https://help.github.com/articles/about-git-rebase/) your branch onto the `master` branch of the source repository.  *Don't merge.*
+    - It's no longer necessary to "squash" your changes.
+1. Be patient while your PR is reviewed.  This can take awhile ([why?](https://github.com/orgs/mochajs/projects/4)).  We may request changes; don't be afraid to question them.
 
 ## :angel: I Just Want To Help
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,16 +4,18 @@ For more, check out the Mocha Gitter chat room: https://gitter.im/mochajs/mocha
 -->
 
 ### Prerequisites
+
 <!--
 Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
 -->
-* [ ] Checked that your issue isn't already filed by cross referencing [issues with the `common mistake` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Acommon-mistake%20)
-* [ ] Checked next-gen ES issues and syntax problems by using the same environment and/or transpiler configuration without Mocha to ensure it isn't just a feature that actually isn't supported in the environment in question or a bug in your code.
-* [ ] 'Smoke tested' the code to be tested by running it outside the real test suite to get a better sense of whether the problem is in the code under test, your usage of Mocha, or Mocha itself
-* [ ] Ensured that there is no discrepancy between the locally and globally installed versions of Mocha. You can find them with:
-`node node_modules/.bin/mocha --version`(Local) and `mocha --version`(Global). We recommend avoiding the use of globally installed Mocha.
+
+- [ ] Checked that your issue isn't already filed by cross referencing [issues with the `common mistake` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Acommon-mistake%20)
+- [ ] Checked next-gen ES issues and syntax problems by using the same environment and/or transpiler configuration without Mocha to ensure it isn't just a feature that actually isn't supported in the environment in question or a bug in your code.
+- [ ] 'Smoke tested' the code to be tested by running it outside the real test suite to get a better sense of whether the problem is in the code under test, your usage of Mocha, or Mocha itself
+- [ ] Ensured that there is no discrepancy between the locally and globally installed versions of Mocha. You can find them with: `node node_modules/.bin/mocha --version`(Local) and `mocha --version`(Global). We recommend avoiding the use of globally installed Mocha.
 
 ### Description
+
 <!--
 [Description of the issue]
 -->
@@ -32,18 +34,19 @@ on how to create a minimal, complete, and verifiable example.
 **Reproduces how often:** [What percentage of the time does it reproduce?]
 
 ### Versions
-<!--
- If applicable, please specify:
- * The output of `mocha --version` and `node node_modules/.bin/mocha --version`:
- * The output of `node --version`:
- * The version and architecture of your operating system:
- * Your shell (bash, zsh, PowerShell, cmd, etc.):
- * Your browser and version (if running browser tests):
- * Any other third party Mocha related modules (with versions):
- * The code transpiler being used:
--->
+
+<!-- If applicable, please specify: -->
+
+- The output of `mocha --version` and `node node_modules/.bin/mocha --version`:
+- The output of `node --version`:
+- The version and architecture of your operating system:
+- Your shell (bash, zsh, PowerShell, cmd, etc.):
+- Your browser and version (if running browser tests):
+- Any other third party Mocha related modules (with versions):
+- The code transpiler being used:
 
 ### Additional Information
+
 <!--
 Any additional information, configuration or data that might be necessary to reproduce the issue.
 -->

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "no-inline-html": false,
+  "line-length": false,
+  "no-trailing-punctuation": false,
+  "no-duplicate-header": false,
+  "first-header-h1": false,
+  "first-line-h1": false,
+  "commands-show-output": false,
+  "single-h1": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ For more info, please [read this article](https://boneskull.com/mocha-v4-nears-r
 - [#2918]: Drop bash dependency for glob-related tests ([@ScottFreeCode])
 - [#2922]: Improve `--compilers` coverage ([@ScottFreeCode])
 - [#2981]: Fix tpyos and spelling errors ([@jsoref])
- 
+
 [#2997]: https://github.com/mochajs/mocha/pull/2997
 [#2957]: https://github.com/mochajs/mocha/pull/2957
 [#2918]: https://github.com/mochajs/mocha/pull/2918
@@ -403,7 +403,7 @@ Thanks to all our contributors, sponsors and backers!  Keep on the lookout for a
 ## :bug: Bug Fix
 
 - [#1417]: Don't report `done()` was called multiple times when it wasn't ([@frankleonrose])
- 
+
 ## :nut_and_bolt: Other
 
 - [#2490]: Lint with [semistandard](https://npmjs.com/package/semistandard) config ([@makepanic])
@@ -432,7 +432,7 @@ Thanks to all our contributors, sponsors and backers!  Keep on the lookout for a
 - [#2445]: Exits with expected code 130 when `SIGINT` encountered; exit code can no longer rollover at 256 ([@Munter])
 - [#2315]: Fix uncaught TypeError thrown from callback stack ([@1999])
 - Fix broken `only()`/`skip()` in IE7/IE8 ([@boneskull])
-- [#2502]: Fix broken stack trace filter on Node.js under Windows ([@boneskull]) 
+- [#2502]: Fix broken stack trace filter on Node.js under Windows ([@boneskull])
 - [#2496]: Fix diff output for objects instantiated with `String` constructor ([more](https://youtrack.jetbrains.com/issue/WEB-23383)) ([@boneskull])
 
 [#2496]: https://github.com/mochajs/mocha/issues/2496
@@ -455,7 +455,7 @@ Thanks to all our contributors, sponsors and backers!  Keep on the lookout for a
 
 - [#2424]: Fix error loading Mocha via Require.js ([@boneskull])
 - [#2417]: Fix execution of *deeply* nested `describe.only()` suites ([@not-an-aardvark])
-- Remove references to `json-cov` and `html-cov` reporters in CLI ([@boneskull]) 
+- Remove references to `json-cov` and `html-cov` reporters in CLI ([@boneskull])
 
 [#2417]: https://github.com/mochajs/mocha/issues/2417
 [#2424]: https://github.com/mochajs/mocha/issues/2424
@@ -526,8 +526,7 @@ Thanks to all our contributors, sponsors and backers!  Keep on the lookout for a
 
 ## :nut_and_bolt: Other
 
-- Upgrade production dependencies to address security advisories (and because now we can): `glob`, `commander`, `escape-string-regexp`,
-and `supports-color`. ([@boneskull], [@RobLoach])
+- Upgrade production dependencies to address security advisories (and because now we can): `glob`, `commander`, `escape-string-regexp`, and `supports-color`. ([@boneskull], [@RobLoach])
 - Add Windows to CI. ([@boneskull], [@TimothyGu])
 - Ensure appropriate `engines` field in `package.json`. ([@shinnn], [@boneskull])
 - [#2348]: Upgrade ESLint to v2 ([@anthony-redfox])
@@ -598,30 +597,33 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
 
 # 2.5.0 / 2016-05-23
 
-> This has been awhile coming!  We needed to feel confident that the next release wouldn't break browser compatibility (e.g. the last few patch releases).
->
-> ### Browser Tests in CI
->
-> We now run unit tests against PhantomJS v1.x and an assortment of browsers on [SauceLabs](https://saucelabs.com), including:
-> - Internet Explorer v8.0
-> - Chrome (latest)
-> - Firefox (latest)
-> - Safari (latest)
-> - Microsoft Edge (latest)
->
-> To accomplish this, we now run Mocha's unit tests (and a handful of integration tests) via [Karma](https://npmjs.com/package/karma) and a modified [karma-mocha](https://npmjs.com/package/karma-mocha).  Along the way, we had to solve issue [#880] (apologies to @mderijcke and @sukima who had PRs addressing this), as well as replace most usages of [should](https://npmjs.com/package/should) with [expect.js](https://npmjs.com/package/expect.js) for IE8.
->
-> Going forward, when sending PRs, your code will *only* run against PhantomJS v1.x (and not hit SauceLabs) [because security](https://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests).
->
-> ### Node.js 6.x
-> Node.js 6.x "just worked" before, but now it's in the CI matrix, so it's "officially" supported.  Mocha *still retains support* for Node.js 0.8.x.
->
-> ### "Minor" Release
-> You'll see mostly bug fixes below, but also a couple features--as such, it's a "minor" release.
->
-> ### TYVM
->
-> Thanks to everyone who contributed, and our fabulous [sponsors and backers](https://opencollective.com/mochajs)!
+This has been awhile coming!  We needed to feel confident that the next release wouldn't break browser compatibility (e.g. the last few patch releases).
+
+## Browser Tests in CI
+
+We now run unit tests against PhantomJS v1.x and an assortment of browsers on [SauceLabs](https://saucelabs.com), including:
+
+- Internet Explorer v8.0
+- Chrome (latest)
+- Firefox (latest)
+- Safari (latest)
+- Microsoft Edge (latest)
+
+To accomplish this, we now run Mocha's unit tests (and a handful of integration tests) via [Karma](https://npmjs.com/package/karma) and a modified [karma-mocha](https://npmjs.com/package/karma-mocha).  Along the way, we had to solve issue [#880] (apologies to @mderijcke and @sukima who had PRs addressing this), as well as replace most usages of [should](https://npmjs.com/package/should) with [expect.js](https://npmjs.com/package/expect.js) for IE8.
+
+Going forward, when sending PRs, your code will *only* run against PhantomJS v1.x (and not hit SauceLabs) [because security](https://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests).
+
+## Node.js 6.x
+
+ Node.js 6.x "just worked" before, but now it's in the CI matrix, so it's "officially" supported.  Mocha *still retains support* for Node.js 0.8.x.
+
+## "Minor" Release
+
+You'll see mostly bug fixes below, but also a couple features--as such, it's a "minor" release.
+
+## TYVM
+
+Thanks to everyone who contributed, and our fabulous [sponsors and backers](https://opencollective.com/mochajs)!
 
 - [#2079] - Add browser checks to CI; update [browserify](https://npmjs.com/package/browserify) to v13.0.0 ([@dasilvacontin], [@ScottFreeCode], [@boneskull] via c04c1d7, 0b1e9b3, 0dde0fa, f8a3d86, 9e8cbaa)
 - [#880] - Make Mocha browserifyable ([@boneskull] via 524862b)
@@ -681,35 +683,31 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
 [@astorije]: https://github.com/astorije
 [@dasilvacontin]: https://github.com/dasilvacontin
 
-2.4.5 / 2016-01-28
-==================
+# 2.4.5 / 2016-01-28
 
-* [#2080], [#2078], [#2072], [#2073], [#1200] - Revert changes to console colors in changeset [1192914](https://github.com/mochajs/mocha/commit/119291449cd03a11cdeda9e37cf718a69a012896) and subsequent related changes thereafter.  Restores compatibility with IE8 & PhantomJS.  See also [mantoni/mochify.js#129](https://github.com/mantoni/mochify.js/issues/129) and [openlayers/ol3#4746](https://github.com/openlayers/ol3/pull/4746) ([@boneskull])
-* [#2082] - Fix several test assertions ([@mislav])
+- [#2080], [#2078], [#2072], [#2073], [#1200] - Revert changes to console colors in changeset [1192914](https://github.com/mochajs/mocha/commit/119291449cd03a11cdeda9e37cf718a69a012896) and subsequent related changes thereafter.  Restores compatibility with IE8 & PhantomJS.  See also [mantoni/mochify.js#129](https://github.com/mantoni/mochify.js/issues/129) and [openlayers/ol3#4746](https://github.com/openlayers/ol3/pull/4746) ([@boneskull])
+- [#2082] - Fix several test assertions ([@mislav])
 
 [#1200]: https://github.com/mochajs/mocha/issues/1200
 [#2082]: https://github.com/mochajs/mocha/pull/2082
 
-2.4.4 / 2016-01-27
-==================
+# 2.4.4 / 2016-01-27
 
-* [#2080] - Fix broken RequireJS compatibility ([@boneskull])
+- [#2080] - Fix broken RequireJS compatibility ([@boneskull])
 
 [#2080]: https://github.com/mochajs/mocha/issues/2080
 
-2.4.3 / 2016-01-27
-==================
+# 2.4.3 / 2016-01-27
 
-* [#2078] - Fix broken IE8 ([@boneskull])
+- [#2078] - Fix broken IE8 ([@boneskull])
 
 [#2078]: https://github.com/mochajs/mocha/issues/2078
 
-2.4.2 / 2016-01-26
-==================
+# 2.4.2 / 2016-01-26
 
-* [#2053] - Fix web worker compatibility ([@mislav])
-* [#2072] - Fix Windows color output ([@thedark1337])
-* [#2073] - Fix colors in `progress` and `landing` reporters ([@gyandeeps])
+- [#2053] - Fix web worker compatibility ([@mislav])
+- [#2072] - Fix Windows color output ([@thedark1337])
+- [#2073] - Fix colors in `progress` and `landing` reporters ([@gyandeeps])
 
 [#2053]: https://github.com/mochajs/mocha/pull/2053
 [#2072]: https://github.com/mochajs/mocha/pull/2072
@@ -717,40 +715,38 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
 [@gyandeeps]: https://github.com/gyandeeps
 [@thedark1337]: https://github.com/thedark1337
 
-2.4.1 / 2016-01-26
-==================
+# 2.4.1 / 2016-01-26
 
-* [#2067] - Fix HTML/doc reporter regressions ([@danielstjules])
+- [#2067] - Fix HTML/doc reporter regressions ([@danielstjules])
 
 [#2067]: https://github.com/mochajs/mocha/pull/2067
 
-2.4.0 / 2016-01-25
-==================
+# 2.4.0 / 2016-01-25
 
-* [#1945] - Correctly skip tests when skipping in suite's before() ([@ryanshawty])
-* [#2056] - chore(license): update license year to 2016 ([@pra85])
-* [#2048] - Fix `this.skip` from spec with HTML reporter ([@mislav])
-* [#2033] - Update tests for newer versions of should.js ([@tomhughes])
-* [#2037] - Fix for memory leak caused by referenced to deferred test ([@bd82])
-* [#2038] - Also run Travis-CI on node.js 4 & 5 ([@bd82])
-* [#2028] - Remove reference to test before afterAll hook runs ([@stonelgh])
-* Bump mkdirp to 0.5.1 to support strict mode ([@danielstjules])
-* [#1977] - safely stringify PhantomJS undefined value ([@ahamid])
-* Add the ability to retry tests ([@@longlho])
-* [#1982] - Enable --log-timer-events option [@Alaneor]
-* Fix #1980: Load mocha.opts from bin/mocha and bin/_mocha ([@danielstjules])
-* [#1976] - Simplify function call ([@iclanzan])
-* [#1963] - Add support --perf-basic-prof ([@robraux])
-* [#1981] - Fix HTML reporter handling of done and exceptions ([@Standard8])
-* [#1993] - propagate "file" property for "exports" interface ([@segrey])
-* [#1999] - Add support for strict mode ([@tmont])
-* [#2005] - XUnit Reporter Writes to stdout, falls back to console.log ([@jonnyreeves])
-* [#2021] - Fix non ES5 compliant regexp ([@zetaben])
-* [#1965] - Don't double install BDD UI ([@cowboyd])
-* [#1995] - Make sure the xunit output dir exists before writing to it ([@ianwremmel])
-* Use chalk for the base reporter colors; closes #1200 ([@boneskull])
-* Fix requiring custom interfaces ([@jgkim])
-* [#1967] Silence Bluebird js warnings ([@krisr])
+- [#1945] - Correctly skip tests when skipping in suite's before() ([@ryanshawty])
+- [#2056] - chore(license): update license year to 2016 ([@pra85])
+- [#2048] - Fix `this.skip` from spec with HTML reporter ([@mislav])
+- [#2033] - Update tests for newer versions of should.js ([@tomhughes])
+- [#2037] - Fix for memory leak caused by referenced to deferred test ([@bd82])
+- [#2038] - Also run Travis-CI on node.js 4 & 5 ([@bd82])
+- [#2028] - Remove reference to test before afterAll hook runs ([@stonelgh])
+- Bump mkdirp to 0.5.1 to support strict mode ([@danielstjules])
+- [#1977] - safely stringify PhantomJS undefined value ([@ahamid])
+- Add the ability to retry tests ([@@longlho])
+- [#1982] - Enable --log-timer-events option [@Alaneor]
+- Fix #1980: Load mocha.opts from bin/mocha and bin/_mocha ([@danielstjules])
+- [#1976] - Simplify function call ([@iclanzan])
+- [#1963] - Add support --perf-basic-prof ([@robraux])
+- [#1981] - Fix HTML reporter handling of done and exceptions ([@Standard8])
+- [#1993] - propagate "file" property for "exports" interface ([@segrey])
+- [#1999] - Add support for strict mode ([@tmont])
+- [#2005] - XUnit Reporter Writes to stdout, falls back to console.log ([@jonnyreeves])
+- [#2021] - Fix non ES5 compliant regexp ([@zetaben])
+- [#1965] - Don't double install BDD UI ([@cowboyd])
+- [#1995] - Make sure the xunit output dir exists before writing to it ([@ianwremmel])
+- Use chalk for the base reporter colors; closes #1200 ([@boneskull])
+- Fix requiring custom interfaces ([@jgkim])
+- [#1967] Silence Bluebird js warnings ([@krisr])
 
 [#1945]: https://github.com/mochajs/mocha/pull/1945
 [#2056]: https://github.com/mochajs/mocha/pull/2056
@@ -794,27 +790,25 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
 [@jgkim]: https://github.com/jgkim
 [@krisr]: https://github.com/krisr
 
-2.3.4 / 2015-11-15
-==================
+# 2.3.4 / 2015-11-15
 
-  * Update debug dependency to 2.2.0
-  * remove duplication of mocha.opts on process.argv
-  * Fix typo in test/reporters/nyan.js
+- Update debug dependency to 2.2.0
+- remove duplication of mocha.opts on process.argv
+- Fix typo in test/reporters/nyan.js
 
-2.3.3 / 2015-09-19
-==================
+# 2.3.3 / 2015-09-19
 
- * [#1875] - Fix Markdown reporter exceeds maximum call stack size ([@danielstjules])
- * [#1864] - Fix xunit missing output with --reporter-options output ([@danielstjules])
- * [#1846] - Support all harmony flags ([@danielstjules])
- * Fix fragile xunit reporter spec ([@danielstjules])
- * [#1669] - Fix catch uncaught errors outside test suite execution ([@danielstjules])
- * [#1868] - Revert jade to support npm < v1.3.7 ([@danielstjules])
- * [#1766] - Don't remove modules/components from stack trace in the browser ([@danielstjules])
- * [#1798] - Fix correctly attribute mutiple done err with hooks ([@danielstjules])
- * Fix use utils.reduce for IE8 compatibility ([@wsw0108])
- * Some linting errors fixed by [@danielstjules]
- * Call the inspect() function if message is not set ([@kevinburke])
+- [#1875] - Fix Markdown reporter exceeds maximum call stack size ([@danielstjules])
+- [#1864] - Fix xunit missing output with --reporter-options output ([@danielstjules])
+- [#1846] - Support all harmony flags ([@danielstjules])
+- Fix fragile xunit reporter spec ([@danielstjules])
+- [#1669] - Fix catch uncaught errors outside test suite execution ([@danielstjules])
+- [#1868] - Revert jade to support npm < v1.3.7 ([@danielstjules])
+- [#1766] - Don't remove modules/components from stack trace in the browser ([@danielstjules])
+- [#1798] - Fix correctly attribute mutiple done err with hooks ([@danielstjules])
+- Fix use utils.reduce for IE8 compatibility ([@wsw0108])
+- Some linting errors fixed by [@danielstjules]
+- Call the inspect() function if message is not set ([@kevinburke])
 
 [#1875]: https://github.com/mochajs/mocha/issues/1875
 [#1864]: https://github.com/mochajs/mocha/issues/1864
@@ -827,55 +821,53 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
 [@wsw0108]: https://github.com/wsw0108
 [@kevinburke]: https://github.com/kevinburke
 
-2.3.2 / 2015-09-07
-==================
- * [#1868] - Fix compatibility with older versions of NPM ([@boneskull])
+# 2.3.2 / 2015-09-07
+
+- [#1868] - Fix compatibility with older versions of NPM ([@boneskull])
 
   [#1868]: https://github.com/mochajs/mocha/issues/1868
 
-2.3.1 / 2015-09-06
-==================
+# 2.3.1 / 2015-09-06
 
-  * [#1812] - Fix: Bail flag causes before() hooks to be run even after a failure ([@aaroncrows])
+- [#1812] - Fix: Bail flag causes before() hooks to be run even after a failure ([@aaroncrows])
 
   [#1812]: https://github.com/mochajs/mocha/issues/1812
   [aaroncrows]: https://github.com/aaroncrows
 
-2.3.0 / 2015-08-30
-==================
+# 2.3.0 / 2015-08-30
 
-  * [#553] - added --allowUncaught option ([@amsul])
-  * [#1490] - Allow --async-only to be satisfied by returning a promise ([@jlai])
-  * [#1829] - support --max-old-space-size ([@gigadude])
-  * [#1811] - upgrade Jade dependency ([@outsideris])
-  * [#1769] - Fix async hook error handling ([@ajaykodali])
-  * [#1230] - More descriptive beforeEach/afterEach messages ([@duncanbeevers])
-  * [#1787] - Scope loading behaviour instead of using early return ([@aryeguy])
-  * [#1789] - Fix: html-runner crashing ([@sunesimonsen])
-  * [#1749] - Fix maximum call stack error on large amount of tests ([@tinganho])
-  * [#1230] - Decorate failed hook titles with test title ([@duncanbeevers])
-  * [#1260] - Build using Browserify ([@ndhoule])
-  * [#1728] - Don't use `__proto__` ([@ndhoule])
-  * [#1781] - Fix hook error tests ([@glenjamin])
-  * [#1754] - Allow boolean --reporter-options ([@papandreou])
-  * [#1766] - Fix overly aggressive stack suppression ([@moll])
-  * [#1752] - Avoid potential infinite loop ([@gsilk])
-  * [#1761] - Fix problems running under PhantomJS ([@chromakode])
-  * [#1700] - Fix more problems running under PhantomJS ([@jbnicolai])
-  * [#1774] - Support escaped spaces in CLI options ([@adamgruber])
-  * [#1687] - Fix HTML reporter links with special chars ([@benvinegar])
-  * [#1359] - Adopt code style and enforce it using ESLint ([@ndhoule] w/ assist from [@jbnicolai] & [@boneskull])
-  * various refactors ([@jbnicolai])
-  * [#1758] - Add cross-frame compatible Error checking ([@outdooricon])
-  * [#1741] - Remove moot `version` property from bower.json ([@kkirsche])
-  * [#1739] - Improve `HISTORY.md` ([@rstacruz])
-  * [#1730] - Support more io.js flags ([@ryedog])
-  * [#1349] - Allow HTML in HTML reporter errors ([@papandreou] / [@sunesimonsen])
-  * [#1572] - Prevent default browser behavior for failure/pass links ([@jschilli])
-  * [#1630] - Support underscored harmony flags ([@dominicbarnes])
-  * [#1718] - Support more harmony flags ([@slyg])
-  * [#1689] - Add stack to JSON-stream reporter ([@jonathandelgado])
-  * [#1654] - Fix `ReferenceError` "location is not defined" ([@jakemmarsh])
+- [#553] - added --allowUncaught option ([@amsul])
+- [#1490] - Allow --async-only to be satisfied by returning a promise ([@jlai])
+- [#1829] - support --max-old-space-size ([@gigadude])
+- [#1811] - upgrade Jade dependency ([@outsideris])
+- [#1769] - Fix async hook error handling ([@ajaykodali])
+- [#1230] - More descriptive beforeEach/afterEach messages ([@duncanbeevers])
+- [#1787] - Scope loading behaviour instead of using early return ([@aryeguy])
+- [#1789] - Fix: html-runner crashing ([@sunesimonsen])
+- [#1749] - Fix maximum call stack error on large amount of tests ([@tinganho])
+- [#1230] - Decorate failed hook titles with test title ([@duncanbeevers])
+- [#1260] - Build using Browserify ([@ndhoule])
+- [#1728] - Don't use `__proto__` ([@ndhoule])
+- [#1781] - Fix hook error tests ([@glenjamin])
+- [#1754] - Allow boolean --reporter-options ([@papandreou])
+- [#1766] - Fix overly aggressive stack suppression ([@moll])
+- [#1752] - Avoid potential infinite loop ([@gsilk])
+- [#1761] - Fix problems running under PhantomJS ([@chromakode])
+- [#1700] - Fix more problems running under PhantomJS ([@jbnicolai])
+- [#1774] - Support escaped spaces in CLI options ([@adamgruber])
+- [#1687] - Fix HTML reporter links with special chars ([@benvinegar])
+- [#1359] - Adopt code style and enforce it using ESLint ([@ndhoule] w/ assist from [@jbnicolai] & [@boneskull])
+- various refactors ([@jbnicolai])
+- [#1758] - Add cross-frame compatible Error checking ([@outdooricon])
+- [#1741] - Remove moot `version` property from bower.json ([@kkirsche])
+- [#1739] - Improve `HISTORY.md` ([@rstacruz])
+- [#1730] - Support more io.js flags ([@ryedog])
+- [#1349] - Allow HTML in HTML reporter errors ([@papandreou] / [@sunesimonsen])
+- [#1572] - Prevent default browser behavior for failure/pass links ([@jschilli])
+- [#1630] - Support underscored harmony flags ([@dominicbarnes])
+- [#1718] - Support more harmony flags ([@slyg])
+- [#1689] - Add stack to JSON-stream reporter ([@jonathandelgado])
+- [#1654] - Fix `ReferenceError` "location is not defined" ([@jakemmarsh])
 
   [#553]: https://github.com/mochajs/mocha/issues/553
   [#1490]: https://github.com/mochajs/mocha/issues/1490
@@ -937,16 +929,15 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
   [@sunesimonsen]: https://github.com/sunesimonsen
   [@tinganho]: https://github.com/tinganho
 
-2.2.5 / 2015-05-14
-==================
+# 2.2.5 / 2015-05-14
 
-  * [#1699] - Upgrade jsdiff to v1.4.0 ([@nylen])
-  * [#1648] - fix diff background colors in the console ([@nylen])
-  * [#1327] - fix tests running twice, a regression issue. ([#1686], [@danielstjules])
-  * [#1675] - add integration tests ([@danielstjules])
-  * [#1682] - use a valid SPDX license identifier in package.json ([@kemitchell])
-  * [#1660] - fix assertion of invalid dates ([#1661], [@a8m])
-  * [#1241] - fix issue with multiline diffs appearing as single line ([#1655], [@a8m])
+- [#1699] - Upgrade jsdiff to v1.4.0 ([@nylen])
+- [#1648] - fix diff background colors in the console ([@nylen])
+- [#1327] - fix tests running twice, a regression issue. ([#1686], [@danielstjules])
+- [#1675] - add integration tests ([@danielstjules])
+- [#1682] - use a valid SPDX license identifier in package.json ([@kemitchell])
+- [#1660] - fix assertion of invalid dates ([#1661], [@a8m])
+- [#1241] - fix issue with multiline diffs appearing as single line ([#1655], [@a8m])
 
 [#1699]: https://github.com/mochajs/mocha/issues/1699
 [#1648]: https://github.com/mochajs/mocha/issues/1648
@@ -963,875 +954,777 @@ Thanks @entertainyou, @SimenB, @just-paja for the heads-up.
 [@kemitchell]: https://github.com/kemitchell
 [@a8m]: https://github.com/a8m
 
-2.2.4 / 2015-04-08
-==================
-
-  * Load mocha.opts in _mocha for now (close #1645)
-
-2.2.3 / 2015-04-07
-==================
-
-  * fix(reporter/base): string diff - issue #1241
-  * fix(reporter/base): string diff - issue #1241
-  * fix(reporter/base): don't show diffs for errors without expectation
-  * fix(reporter/base): don't assume error message is first line of stack
-  * improve: dry up reporter/base test
-  * fix(reporter/base): explicitly ignore showDiff #1614
-  * Add iojs to travis build
-  * Pass `--allow-natives-syntax` flag to node.
-  * Support --harmony_classes flag for io.js
-  * Fix 1556: Update utils.clean to handle newlines in func declarations
-  * Fix 1606: fix err handling in IE <= 8 and non-ES5 browsers
-  * Fix 1585: make _mocha executable again
-  * chore(package.json): add a8m as a contributor
-  * Fixed broken link on html-cov reporter
-  * support --es_staging flag
-  * fix issue where menu overlaps content.
-  * update contributors in package.json
-  * Remove trailing whitespace from reporter output
-  * Remove contributors list from readme
-  * log third-party reporter errors
-  * [Fix] Exclude not own properties when looping on options
-  * fix: support node args in mocha.opts (close #1573)
-  * fix(reporter/base): string diff - issue #1241
-
-2.2.1 / 2015-03-09
-==================
-
-  * Fix passing of args intended for node/iojs.
-
-2.2.0 / 2015-03-06
-==================
-
-  * Update mocha.js
-  * Add --fgrep. Use grep for RegExp, fgrep for str
-  * Ignore async global errors after spec resolution
-  * Fixing errors that prevent mocha.js from loading in the browser - fixes #1558
-  * fix(utils): issue #1558 + make
-  * add ability to delay root suite; closes #362, closes #1124
-  * fix insanity in http tests
-  * update travis: add node 0.12, add gitter, remove slack
-  * building
-  * resolve #1548: ensure the environment's "node" executable is used
-  * reporters/base: use supports-color to detect colorable term
-  * travis: use docker containers
-  * small fix: commander option for --expose-gc
-  * Ignore asynchronous errors after global failure
-  * Improve error output when a test fails with a non-error
-  * updated travis badge, uses svg instead of img
-  * Allow skip from test context for #332
-  * [JSHINT] Unnecessary semicolon fixed in bin/_mocha
-  * Added a reminder about the done() callback to test timeout error messages
-  * fixes #1496, in Mocha.run(fn), check if fn exists before executing it, added tests too
-  * Add Harmony Proxy flag for iojs
-  * test(utils|ms|*): test existing units
-  * add support for some iojs flags
-  * fix(utils.stringify): issue #1229, diff viewer
-  * Remove slack link
-  * Prevent multiple 'grep=' querystring params in html reporter
-  * Use grep as regexp (close #1381)
-  * utils.stringify should handle objects without an Object prototype
-  * in runnable test, comparing to undefined error's message rather than a literal
-  * Fix test running output truncation on async STDIO
-  * amended for deprecated customFds option in child_process
-
-2.1.0 / 2014-12-23
-==================
-
- * showDiff: don’t stringify strings
- * Clean up unused module dependencies.
- * Filter zero-length strings from mocha.opts
- * only write to stdout in reporters
- * Revert "only write to stdout in reporters"
- * Print colored output only to a tty
- * update summary in README.md
- * rename Readme.md/History.md to README.md/HISTORY.md because neurotic
- * add .mailmap to fix "git shortlog" or "git summary" output
- * fixes #1461: nyan-reporter now respects Base.useColors, fixed bug where Base.color would not return a string when str wasn't a string.
- * Use existing test URL builder in failed replay links
- * modify .travis.yml: use travis_retry; closes #1449
- * fix -t 0 behavior; closes #1446
- * fix tests (whoops)
- * improve diff behavior
- * Preserve pathname when linking to individual tests
- * Fix test
- * Tiny typo in comments fixed
- * after hooks now being called on failed tests when using bail, fixes #1093
- * fix throwing undefined/null now makes tests fail, fixes #1395
- * compiler extensions are added as watched extensions, removed non-standard extensions from watch regex, resolves #1221
- * prefix/namespace for suite titles in markdown reporter, fixes #554
- * fix more bad markdown in CONTRIBUTING.md
- * fix bad markdown in CONTRIBUTING.md
- * add setImmediate/clearImmediate to globals; closes #1435
- * Fix buffer diffs (closes #1132, closes #1433)
- * add a CONTRIBUTING.md.  closes #882
- * fix intermittent build failures (maybe). closes #1407
- * add Slack notification to .travis.yml
- * Fix slack link
- * Add slack room to readme
- * Update maintainers
- * update maintainers and contributors
- * resolves #1393: kill children with more effort on SIGINT
- * xunit reporter support for optionally writing to a file
- * if a reporter has a .done method, call it before exiting
- * add support for reporter options
- * only write to stdout in reporters
-
-2.0.0 / 2014-10-21
-==================
-
- * remove: support for node 0.6.x, 0.4.x
- * fix: landing reporter with non ansi characters (#211)
- * fix: html reporter - preserve query params when navigating to suites/tests (#1358)
- * fix: json stream reporter add error message to failed test
- * fix: fixes for visionmedia -> mochajs
- * fix: use stdio, fixes node deprecation warnings (#1391)
-
-1.21.5 / 2014-10-11
-==================
-
- * fix: build for NodeJS v0.6.x
- * fix: do not attempt to highlight syntax when non-HTML reporter is used
- * update: escape-string-regexp to 1.0.2.
- * fix: botched indentation in canonicalize()
- * fix: .gitignore: ignore .patch and .diff files
- * fix: changed 'Catched' to 'Caught' in uncaught exception error handler messages
- * add: `pending` field for json reporter
- * fix: Runner.prototype.uncaught: don't double-end runnables that already have a state.
- * fix: --recursive, broken by f0facd2e
- * update: replaces escapeRegexp with the escape-string-regexp package.
- * update: commander to 2.3.0.
- * update: diff to 1.0.8.
- * fix: ability to disable syntax highlighting (#1329)
- * fix: added empty object to errorJSON() call to catch when no error is present
- * fix: never time out after calling enableTimeouts(false)
- * fix: timeout(0) will work at suite level (#1300)
- * Fix for --watch+only() issue (#888 )
- * fix: respect err.showDiff, add Base reporter test (#810)
-
-1.22.1-3 / 2014-07-27
-==================
-
-  * fix: disabling timeouts with this.timeout(0) (#1301)
-
-1.22.1-3 / 2014-07-27
-==================
-
-  * fix: local uis and reporters (#1288)
-  * fix: building 1.21.0's changes in the browser (#1284)
-
-1.21.0 / 2014-07-23
-==================
-
-  * add: --no-timeouts option (#1262, #1268)
-  * add: --*- deprecation node flags (#1217)
-  * add: --watch-extensions argument (#1247)
-  * change: spec reporter is default (#1228)
-  * fix: diff output showing incorrect +/- (#1182)
-  * fix: diffs of circular structures (#1179)
-  * fix: re-render the progress bar when progress has changed only (#1151)
-  * fix support for environments with global and window (#1159)
-  * fix: reverting to previously defined onerror handler (#1178)
-  * fix: stringify non error objects passed to done() (#1270)
-  * fix: using local ui, reporters (#1267)
-  * fix: cleaning es6 arrows (#1176)
-  * fix: don't include attrs in failure tag for xunit (#1244)
-  * fix: fail tests that return a promise if promise is rejected w/o a reason (#1224)
-  * fix: showing failed tests in doc reporter (#1117)
-  * fix: dot reporter dots being off (#1204)
-  * fix: catch empty throws (#1219)
-  * fix: honoring timeout for sync operations (#1242)
-  * update: growl to 1.8.0
-
-1.20.1 / 2014-06-03
-==================
-
-  * update: should dev dependency to ~4.0.0 (#1231)
-
-1.20.0 / 2014-05-28
-==================
-
-  * add: filenames to suite objects (#1222)
-
-1.19.0 / 2014-05-17
-==================
-
-  * add: browser script option to package.json
-  * add: export file in Mocha.Test objects (#1174)
-  * add: add docs for wrapped node flags
-  * fix: mocha.run() to return error status in browser (#1216)
-  * fix: clean() to show failure details (#1205)
-  * fix: regex that generates html for new keyword (#1201)
-  * fix: sibling suites have inherited but separate contexts (#1164)
-
-
-1.18.2 / 2014-03-18
-==================
-
-  * fix: html runner was prevented from using #mocha as the default root el (#1162)
-
-1.18.1 / 2014-03-18
-==================
-
-  * fix: named before/after hooks in bdd, tdd, qunit interfaces (#1161)
-
-1.18.0 / 2014-03-13
-==================
-
-  * add: promise support (#329)
-  * add: named before/after hooks (#966)
-
-1.17.1 / 2014-01-22
-==================
-
-  * fix: expected messages in should.js (should.js#168)
-  * fix: expect errno global in node versions < v0.9.11 (#1111)
-  * fix: unreliable checkGlobals optimization (#1110)
-
-1.17.0 / 2014-01-09
-==================
-
-  * add: able to require globals (describe, it, etc.) through mocha (#1077)
-  * fix: abort previous run on --watch change (#1100)
-  * fix: reset context for each --watch triggered run (#1099)
-  * fix: error when cli can't resolve path or pattern (#799)
-  * fix: canonicalize objects before stringifying and diffing them (#1079)
-  * fix: make CR call behave like carriage return for non tty (#1087)
-
-
-1.16.2 / 2013-12-23
-==================
-
-  * fix: couple issues with ie 8 (#1082, #1081)
-  * fix: issue running the xunit reporter in browsers (#1068)
-  * fix: issue with firefox < 3.5 (#725)
-
-
-1.16.1 / 2013-12-19
-==================
-
-  * fix: recompiled for missed changes from the last release
-
-
-1.16.0 / 2013-12-19
-==================
-
-  * add: Runnable.globals(arr) for per test global whitelist (#1046)
-  * add: mocha.throwError(err) for assertion libs to call (#985)
-  * remove: --watch's spinner (#806)
-  * fix: duplicate test output for multi-line specs in spec reporter (#1006)
-  * fix: gracefully exit on SIGINT (#1063)
-  * fix expose the specified ui only in the browser (#984)
-  * fix: ensure process exit code is preserved when using --no-exit (#1059)
-  * fix: return true from window.onerror handler (#868)
-  * fix: xunit reporter to use process.stdout.write (#1068)
-  * fix: utils.clean(str) indentation (#761)
-  * fix: xunit reporter returning test duration a NaN (#1039)
-
-1.15.1 / 2013-12-03
-==================
-
-  * fix: recompiled for missed changes from the last release
-
-1.15.0 / 2013-12-02
-==================
-
-  * add: `--no-exit` to prevent `process.exit()` (#1018)
-  * fix: using inline diffs (#1044)
-  * fix: show pending test details in xunit reporter (#1051)
-  * fix: faster global leak detection (#1024)
-  * fix: yui compression (#1035)
-  * fix: wrapping long lines in test results (#1030, #1031)
-  * fix: handle errors in hooks (#1043)
-
-1.14.0 / 2013-11-02
-==================
-
-  * add: unified diff (#862)
-  * add: set MOCHA_COLORS env var to use colors (#965)
-  * add: able to override tests links in html reporters (#776)
-  * remove: teamcity reporter (#954)
-  * update: commander dependency to 2.0.0 (#1010)
-  * fix: mocha --ui will try to require the ui if not built in, as --reporter does (#1022)
-  * fix: send cursor commands only if isatty (#184, #1003)
-  * fix: include assertion message in base reporter (#993, #991)
-  * fix: consistent return of it, it.only, and describe, describe.only (#840)
-
-1.13.0 / 2013-09-15
-==================
-
-  * add: sort test files with --sort (#813)
-  * update: diff dependency to 1.0.7
-  * update: glob dependency to 3.2.3 (#927)
-  * fix: diffs show whitespace differences (#976)
-  * fix: improve global leaks (#783)
-  * fix: firefox window.getInterface leak
-  * fix: accessing iframe via window[iframeIndex] leak
-  * fix: faster global leak checking
-  * fix: reporter pending css selector (#970)
-
-1.12.1 / 2013-08-29
-==================
-
- * remove test.js from .gitignore
- * update included version of ms.js
-
-1.12.0 / 2013-07-01
-==================
-
- * add: prevent diffs for differing types. Closes #900
- * add `Mocha.process` hack for phantomjs
- * fix: use compilers with requires
- * fix regexps in diffs. Closes #890
- * fix xunit NaN on failure. Closes #894
- * fix: strip tab indentation in `clean` utility method
- * fix: textmate bundle installation
-
-1.11.0 / 2013-06-12
-==================
-
- * add --prof support
- * add --harmony support
- * add --harmony-generators support
- * add "Uncaught " prefix to uncaught exceptions
- * add web workers support
- * add `suite.skip()`
- * change to output # of pending / passing even on failures. Closes #872
- * fix: prevent hooks from being called if we are bailing
- * fix `this.timeout(0)`
-
-1.10.0 / 2013-05-21
-==================
-
- * add add better globbing support for windows via `glob` module
- * add support to pass through flags such as --debug-brk=1234. Closes #852
- * add test.only, test.skip to qunit interface
- * change to always use word-based diffs for now. Closes #733
- * change `mocha init` tests.html to index.html
- * fix `process` global leak in the browser
- * fix: use resolve() instead of join() for --require
- * fix: filterLeaks() condition to not consider indices in global object as leaks
- * fix: restrict mocha.css styling to #mocha id
- * fix: save timer references to avoid Sinon interfering in the browser build.
-
-1.9.0 / 2013-04-03
-==================
-
-  * add improved setImmediate implementation
-  * replace --ignore-leaks with --check-leaks
-  * change default of ignoreLeaks to true. Closes #791
-  * remove scrolling for HTML reporter
-  * fix retina support
-  * fix tmbundle, restrict to js scope
-
-1.8.2 / 2013-03-11
-==================
-
-  * add `setImmediate` support for 0.10.x
-  * fix mocha -w spinner on windows
-
-1.8.1 / 2013-01-09
-==================
-
-  * fix .bail() arity check causing it to default to true
-
-1.8.0 / 2013-01-08
-==================
-
-  * add Mocha() options bail support
-  * add `Mocha#bail()` method
-  * add instanceof check back for inheriting from Error
-  * add component.json
-  * add diff.js to browser build
-  * update growl
-  * fix TAP reporter failures comment :D
-
-1.7.4 / 2012-12-06
-==================
-
-  * add total number of passes and failures to TAP
-  * remove .bind() calls. re #680
-  * fix indexOf. Closes #680
-
-1.7.3 / 2012-11-30
-==================
-
-  * fix uncaught error support for the browser
-  * revert uncaught "fix" which breaks node
-
-1.7.2 / 2012-11-28
-==================
-
-  * fix uncaught errors to expose the original error message
-
-1.7.0 / 2012-11-07
-==================
-
-  * add `--async-only` support to prevent false positives for missing `done()`
-  * add sorting by filename in code coverage
-  * add HTML 5 doctype to browser template.
-  * add play button to html reporter to rerun a single test
-  * add `this.timeout(ms)` as Suite#timeout(ms). Closes #599
-  * update growl dependency to 1.6.x
-  * fix encoding of test-case ?grep. Closes #637
-  * fix unicode chars on windows
-  * fix dom globals in Opera/IE. Closes #243
-  * fix markdown reporter a tags
-  * fix `this.timeout("5s")` support
-
-1.6.0 / 2012-10-02
-==================
-
-  * add object diffs when `err.showDiff` is present
-  * add hiding of empty suites when pass/failures are toggled
-  * add faster `.length` checks to `checkGlobals()` before performing the filter
-
-1.5.0 / 2012-09-21
-==================
-
-  * add `ms()` to `.slow()` and `.timeout()`
-  * add `Mocha#checkLeaks()` to re-enable global leak checks
-  * add `this.slow()` option [aheckmann]
-  * add tab, CR, LF to error diffs for now
-  * add faster `.checkGlobals()` solution [guille]
-  * remove `fn.call()` from reduce util
-  * remove `fn.call()` from filter util
-  * fix forEach. Closes #582
-  * fix relaying of signals [TooTallNate]
-  * fix TAP reporter grep number
-
-1.4.2 / 2012-09-01
-==================
-
-  * add support to multiple `Mocha#globals()` calls, and strings
-  * add `mocha.reporter()` constructor support [jfirebaugh]
-  * add `mocha.timeout()`
-  * move query-string parser to utils.js
-  * move highlight code to utils.js
-  * fix third-party reporter support [exogen]
-  * fix client-side API to match node-side [jfirebaugh]
-  * fix mocha in iframe [joliss]
-
-1.4.1 / 2012-08-28
-==================
-
-  * add missing `Markdown` export
-  * fix `Mocha#grep()`, escape regexp strings
-  * fix reference error when `devicePixelRatio` is not defined. Closes #549
-
-1.4.0 / 2012-08-22
-==================
-
-  * add mkdir -p to `mocha init`. Closes #539
-  * add `.only()`. Closes #524
-  * add `.skip()`. Closes #524
-  * change str.trim() to use utils.trim(). Closes #533
-  * fix HTML progress indicator retina display
-  * fix url-encoding of click-to-grep HTML functionality
-
-1.3.2 / 2012-08-01
-==================
-
-  * fix exports double-execution regression. Closes #531
-
-1.3.1 / 2012-08-01
-==================
-
-  * add passes/failures toggling to HTML reporter
-  * add pending state to `xit()` and `xdescribe()` [Brian Moore]
-  * add the @charset "UTF-8"; to fix #522 with FireFox. [Jonathan Creamer]
-  * add border-bottom to #stats links
-  * add check for runnable in `Runner#uncaught()`. Closes #494
-  * add 0.4 and 0.6 back to travis.yml
-  * add `-E, --growl-errors` to growl on failures only
-  * add prefixes to debug() names. Closes #497
-  * add `Mocha#invert()` to js api
-  * change dot reporter to use sexy unicode dots
-  * fix error when clicking pending test in HTML reporter
-  * fix `make tm`
-
-1.3.0 / 2012-07-05
-==================
-
-  * add window scrolling to `HTML` reporter
-  * add v8 `--trace-*` option support
-  * add support for custom reports via `--reporter MODULE`
-  * add `--invert` switch to invert `--grep` matches
-  * fix export of `Nyan` reporter. Closes #495
-  * fix escaping of `HTML` suite titles. Closes #486
-  * fix `done()` called multiple times with an error test
-  * change `--grep` - regexp escape the input
-
-1.2.2 / 2012-06-28
-==================
-
-  * Added 0.8.0 support
-
-1.2.1 / 2012-06-25
-==================
-
-  * Added `this.test.error(err)` support to after each hooks. Closes #287
-  * Added: export top-level suite on global mocha object (mocha.suite). Closes #448
-  * Fixed `js` code block format error in markdown reporter
-  * Fixed deprecation warning when using `path.existsSync`
-  * Fixed --globals with wildcard
-  * Fixed chars in nyan when his head moves back
-  * Remove `--growl` from test/mocha.opts. Closes #289
-
-1.2.0 / 2012-06-17
-==================
-
-  * Added `nyan` reporter [Atsuya Takagi]
-  * Added `mocha init <path>` to copy client files
-  * Added "specify" synonym for "it" [domenic]
-  * Added global leak wildcard support [nathanbowser]
-  * Fixed runner emitter leak. closes #432
-  * Fixed omission of .js extension. Closes #454
-
-1.1.0 / 2012-05-30
-==================
-
-  * Added: check each `mocha(1)` arg for directories to walk
-  * Added `--recursive` [tricknotes]
-  * Added `context` for BDD [hokaccha]
-  * Added styling for new clickable titles
-  * Added clickable suite titles to HTML reporter
-  * Added warning when strings are thrown as errors
-  * Changed: green arrows again in HTML reporter styling
-  * Changed ul/li elements instead of divs for better copy-and-pasting [joliss]
-  * Fixed issue #325 - add better grep support to js api
-  * Fixed: save timer references to avoid Sinon interfering.
-
-1.0.3 / 2012-04-30
-==================
-
-  * Fixed string diff newlines
-  * Fixed: removed mocha.css target. Closes #401
-
-1.0.2 / 2012-04-25
-==================
-
-  * Added HTML reporter duration. Closes #47
-  * Fixed: one postMessage event listener [exogen]
-  * Fixed: allow --globals to be used multiple times. Closes #100 [brendannee]
-  * Fixed #158: removes jquery include from browser tests
-  * Fixed grep. Closes #372 [brendannee]
-  * Fixed #166 - When grepping don't display the empty suites
-  * Removed test/browser/style.css. Closes #385
-
-1.0.1 / 2012-04-04
-==================
-
-  * Fixed `.timeout()` in hooks
-  * Fixed: allow callback for `mocha.run()` in client version
-  * Fixed browser hook error display. Closes #361
-
-1.0.0 / 2012-03-24
-==================
-
-  * Added js API. Closes #265
-  * Added: initial run of tests with `--watch`. Closes #345
-  * Added: mark `location` as a global on the CS. Closes #311
-  * Added `markdown` reporter (github flavour)
-  * Added: scrolling menu to coverage.html. Closes #335
-  * Added source line to html report for Safari [Tyson Tate]
-  * Added "min" reporter, useful for `--watch` [Jakub Nešetřil]
-  * Added support for arbitrary compilers via . Closes #338 [Ian Young]
-  * Added Teamcity export to lib/reporters/index [Michael Riley]
-  * Fixed chopping of first char in error reporting. Closes #334 [reported by topfunky]
-  * Fixed terrible FF / Opera stack traces
-
-0.14.1 / 2012-03-06
-==================
-
-  * Added lib-cov to _.npmignore_
-  * Added reporter to `mocha.run([reporter])` as argument
-  * Added some margin-top to the HTML reporter
-  * Removed jQuery dependency
-  * Fixed `--watch`: purge require cache. Closes #266
-
-0.14.0 / 2012-03-01
-==================
-
-  * Added string diff support for terminal reporters
-
-0.13.0 / 2012-02-23
-==================
-
-  * Added preliminary test coverage support. Closes #5
-  * Added `HTMLCov` reporter
-  * Added `JSONCov` reporter [kunklejr]
-  * Added `xdescribe()` and `xit()` to the BDD interface. Closes #263 (docs   * Changed: make json reporter output pretty json
-  * Fixed node-inspector support, swapped `--debug` for `debug` to match node.
-needed)
-Closes #247
-
-0.12.1 / 2012-02-14
-==================
-
-  * Added `npm docs mocha` support [TooTallNate]
-  * Added a `Context` object used for hook and test-case this. Closes #253
-  * Fixed `Suite#clone()` `.ctx` reference. Closes #262
-
-0.12.0 / 2012-02-02
-==================
-
-  * Added .coffee `--watch` support. Closes #242
-  * Added support to `--require` files relative to the CWD. Closes #241
-  * Added quick n dirty syntax highlighting. Closes #248
-  * Changed: made HTML progress indicator smaller
-  * Fixed xunit errors attribute [dhendo]
-
-0.10.2 / 2012-01-21
-==================
-
-  * Fixed suite count in reporter stats. Closes #222
-  * Fixed `done()` after timeout error reporting [Phil Sung]
-  * Changed the 0-based errors to 1
-
-0.10.1 / 2012-01-17
-==================
-
-  * Added support for node 0.7.x
-  * Fixed absolute path support. Closes #215 [kompiro]
-  * Fixed `--no-colors` option [Jussi Virtanen]
-  * Fixed Arial CSS typo in the correct file
-
-0.10.0 / 2012-01-13
-==================
-
-  * Added `-b, --bail` to exit on first exception [guillermo]
-  * Added support for `-gc` / `--expose-gc` [TooTallNate]
-  * Added `qunit`-inspired interface
-  * Added MIT LICENSE. Closes #194
-  * Added: `--watch` all .js in the CWD. Closes #139
-  * Fixed `self.test` reference in runner. Closes #189
-  * Fixed double reporting of uncaught exceptions after timeout. Closes #195
-
-0.8.2 / 2012-01-05
-==================
-
-  * Added test-case context support. Closes #113
-  * Fixed exit status. Closes #187
-  * Update commander. Closes #190
-
-0.8.1 / 2011-12-30
-==================
-
-  * Fixed reporting of uncaught exceptions. Closes #183
-  * Fixed error message defaulting [indutny]
-  * Changed mocha(1) from bash to node for windows [Nathan Rajlich]
-
-0.8.0 / 2011-12-28
-==================
-
-  * Added `XUnit` reporter [FeeFighters/visionmedia]
-  * Added `say(1)` notification support [Maciej Małecki]
-  * Changed: fail when done() is invoked with a non-Error. Closes #171
-  * Fixed `err.stack`, defaulting to message. Closes #180
-  * Fixed: `make tm` mkdir -p the dest. Closes #137
-  * Fixed mocha(1) --help bin name
-  * Fixed `-d` for `--debug` support
-
-0.7.1 / 2011-12-22
-==================
-
-  * Removed `mocha-debug(1)`, use `mocha --debug`
-  * Fixed CWD relative requires
-  * Fixed growl issue on windows [Raynos]
-  * Fixed: platform specific line endings [TooTallNate]
-  * Fixed: escape strings in HTML reporter. Closes #164
-
-0.7.0 / 2011-12-18
-==================
-
-  * Added support for IE{7,8} [guille]
-  * Changed: better browser nextTick implementation [guille]
-
-0.6.0 / 2011-12-18
-==================
-
-  * Added setZeroTimeout timeout for browser (nicer stack traces). Closes #153
-  * Added "view source" on hover for HTML reporter to make it obvious
-  * Changed: replace custom growl with growl lib
-  * Fixed duplicate reporting for HTML reporter. Closes #154
-  * Fixed silent hook errors in the HTML reporter. Closes #150
-
-0.5.0 / 2011-12-14
-==================
-
-  * Added: push node_modules directory onto module.paths for relative require Closes #93
-  * Added teamcity reporter [blindsey]
-  * Fixed: recover from uncaught exceptions for tests. Closes #94
-  * Fixed: only emit "test end" for uncaught within test, not hook
-
-0.4.0 / 2011-12-14
-==================
-
-  * Added support for test-specific timeouts via `this.timeout(0)`. Closes #134
-  * Added guillermo's client-side EventEmitter. Closes #132
-  * Added progress indicator to the HTML reporter
-  * Fixed slow browser tests. Closes #135
-  * Fixed "suite" color for light terminals
-  * Fixed `require()` leak spotted by [guillermo]
-
-0.3.6 / 2011-12-09
-==================
-
-  * Removed suite merging (for now)
-
-0.3.5 / 2011-12-08
-==================
-
-  * Added support for `window.onerror` [guillermo]
-  * Fixed: clear timeout on uncaught exceptions. Closes #131 [guillermo]
-  * Added `mocha.css` to PHONY list.
-  * Added `mocha.js` to PHONY list.
-
-0.3.4 / 2011-12-08
-==================
-
-  * Added: allow `done()` to be called with non-Error
-  * Added: return Runner from `mocha.run()`. Closes #126
-  * Fixed: run afterEach even on failures. Closes #125
-  * Fixed clobbering of current runnable. Closes #121
-
-0.3.3 / 2011-12-08
-==================
-
-  * Fixed hook timeouts. Closes #120
-  * Fixed uncaught exceptions in hooks
-
-0.3.2 / 2011-12-05
-==================
-
-  * Fixed weird reporting when `err.message` is not present
-
-0.3.1 / 2011-12-04
-==================
-
-  * Fixed hook event emitter leak. Closes #117
-  * Fixed: export `Spec` constructor. Closes #116
-
-0.3.0 / 2011-12-04
-==================
-
-  * Added `-w, --watch`. Closes #72
-  * Added `--ignore-leaks` to ignore global leak checking
-  * Added browser `?grep=pattern` support
-  * Added `--globals <names>` to specify accepted globals. Closes #99
-  * Fixed `mocha-debug(1)` on some systems. Closes #232
-  * Fixed growl total, use `runner.total`
-
-0.2.0 / 2011-11-30
-==================
-
-  * Added `--globals <names>` to specify accepted globals. Closes #99
-  * Fixed funky highlighting of messages. Closes #97
-  * Fixed `mocha-debug(1)`. Closes #232
-  * Fixed growl total, use runner.total
-
-0.1.0 / 2011-11-29
-==================
-
-  * Added `suiteSetup` and `suiteTeardown` to TDD interface [David Henderson]
-  * Added growl icons. Closes #84
-  * Fixed coffee-script support
-
-0.0.8 / 2011-11-25
-==================
-
-  * Fixed: use `Runner#total` for accurate reporting
-
-0.0.7 / 2011-11-25
-==================
-
-  * Added `Hook`
-  * Added `Runnable`
-  * Changed: `Test` is `Runnable`
-  * Fixed global leak reporting in hooks
-  * Fixed: > 2 calls to done() only report the error once
-  * Fixed: clear timer on failure. Closes #80
-
-0.0.6 / 2011-11-25
-==================
-
-  * Fixed return on immediate async error. Closes #80
-
-0.0.5 / 2011-11-24
-==================
-
-  * Fixed: make mocha.opts whitespace less picky [kkaefer]
-
-0.0.4 / 2011-11-24
-==================
-
-  * Added `--interfaces`
-  * Added `--reporters`
-  * Added `-c, --colors`. Closes #69
-  * Fixed hook timeouts
-
-0.0.3 / 2011-11-23
-==================
-
-  * Added `-C, --no-colors` to explicitly disable
-  * Added coffee-script support
-
-0.0.2 / 2011-11-22
-==================
-
-  * Fixed global leak detection due to Safari bind() change
-  * Fixed: escape html entities in Doc reporter
-  * Fixed: escape html entities in HTML reporter
-  * Fixed pending test support for HTML reporter. Closes #66
-
-0.0.1 / 2011-11-22
-==================
-
-  * Added `--timeout` second shorthand support, ex `--timeout 3s`.
-  * Fixed "test end" event for uncaughtExceptions. Closes #61
-
-0.0.1-alpha6 / 2011-11-19
-==================
-
-  * Added travis CI support (needs enabling when public)
-  * Added preliminary browser support
-  * Added `make mocha.css` target. Closes #45
-  * Added stack trace to TAP errors. Closes #52
-  * Renamed tearDown to teardown. Closes #49
-  * Fixed: cascading hooksc. Closes #30
-  * Fixed some colors for non-tty
-  * Fixed errors thrown in sync test-cases due to nextTick
-  * Fixed Base.window.width... again give precedence to 0.6.x
-
-0.0.1-alpha5 / 2011-11-17
-==================
-
-  * Added `doc` reporter. Closes #33
-  * Added suite merging. Closes #28
-  * Added TextMate bundle and `make tm`. Closes #20
-
-0.0.1-alpha4 / 2011-11-15
-==================
-
-  * Fixed getWindowSize() for 0.4.x
-
-0.0.1-alpha3 / 2011-11-15
-==================
-
-  * Added `-s, --slow <ms>` to specify "slow" test threshold
-  * Added `mocha-debug(1)`
-  * Added `mocha.opts` support. Closes #31
-  * Added: default [files] to _test/*.js_
-  * Added protection against multiple calls to `done()`. Closes #35
-  * Changed: bright yellow for slow Dot reporter tests
-
-0.0.1-alpha1 / 2011-11-08
-==================
-
-  * Missed this one :)
-
-0.0.1-alpha1 / 2011-11-08
-==================
-
-  * Initial release
+# 2.2.4 / 2015-04-08
+
+- Load mocha.opts in _mocha for now (close #1645)
+
+# 2.2.3 / 2015-04-07
+
+- fix(reporter/base): string diff - issue #1241
+- fix(reporter/base): string diff - issue #1241
+- fix(reporter/base): don't show diffs for errors without expectation
+- fix(reporter/base): don't assume error message is first line of stack
+- improve: dry up reporter/base test
+- fix(reporter/base): explicitly ignore showDiff #1614
+- Add iojs to travis build
+- Pass `--allow-natives-syntax` flag to node.
+- Support --harmony_classes flag for io.js
+- Fix 1556: Update utils.clean to handle newlines in func declarations
+- Fix 1606: fix err handling in IE <= 8 and non-ES5 browsers
+- Fix 1585: make _mocha executable again
+- chore(package.json): add a8m as a contributor
+- Fixed broken link on html-cov reporter
+- support --es_staging flag
+- fix issue where menu overlaps content.
+- update contributors in package.json
+- Remove trailing whitespace from reporter output
+- Remove contributors list from readme
+- log third-party reporter errors
+- [Fix] Exclude not own properties when looping on options
+- fix: support node args in mocha.opts (close #1573)
+- fix(reporter/base): string diff - issue #1241
+
+# 2.2.1 / 2015-03-09
+
+- Fix passing of args intended for node/iojs.
+
+# 2.2.0 / 2015-03-06
+
+- Update mocha.js
+- Add --fgrep. Use grep for RegExp, fgrep for str
+- Ignore async global errors after spec resolution
+- Fixing errors that prevent mocha.js from loading in the browser - fixes #1558
+- fix(utils): issue #1558 + make
+- add ability to delay root suite; closes #362, closes #1124
+- fix insanity in http tests
+- update travis: add node 0.12, add gitter, remove slack
+- building
+- resolve #1548: ensure the environment's "node" executable is used
+- reporters/base: use supports-color to detect colorable term
+- travis: use docker containers
+- small fix: commander option for --expose-gc
+- Ignore asynchronous errors after global failure
+- Improve error output when a test fails with a non-error
+- updated travis badge, uses svg instead of img
+- Allow skip from test context for #332
+- [JSHINT] Unnecessary semicolon fixed in bin/_mocha
+- Added a reminder about the done() callback to test timeout error messages
+- fixes #1496, in Mocha.run(fn), check if fn exists before executing it, added tests too
+- Add Harmony Proxy flag for iojs
+- test(utils|ms|*): test existing units
+- add support for some iojs flags
+- fix(utils.stringify): issue #1229, diff viewer
+- Remove slack link
+- Prevent multiple 'grep=' querystring params in html reporter
+- Use grep as regexp (close #1381)
+- utils.stringify should handle objects without an Object prototype
+- in runnable test, comparing to undefined error's message rather than a literal
+- Fix test running output truncation on async STDIO
+- amended for deprecated customFds option in child_process
+
+# 2.1.0 / 2014-12-23
+
+- showDiff: don’t stringify strings
+- Clean up unused module dependencies.
+- Filter zero-length strings from mocha.opts
+- only write to stdout in reporters
+- Revert "only write to stdout in reporters"
+- Print colored output only to a tty
+- update summary in README.md
+- rename Readme.md/History.md to README.md/HISTORY.md because neurotic
+- add .mailmap to fix "git shortlog" or "git summary" output
+- fixes #1461: nyan-reporter now respects Base.useColors, fixed bug where Base.color would not return a string when str wasn't a string.
+- Use existing test URL builder in failed replay links
+- modify .travis.yml: use travis_retry; closes #1449
+- fix -t 0 behavior; closes #1446
+- fix tests (whoops)
+- improve diff behavior
+- Preserve pathname when linking to individual tests
+- Fix test
+- Tiny typo in comments fixed
+- after hooks now being called on failed tests when using bail, fixes #1093
+- fix throwing undefined/null now makes tests fail, fixes #1395
+- compiler extensions are added as watched extensions, removed non-standard extensions from watch regex, resolves #1221
+- prefix/namespace for suite titles in markdown reporter, fixes #554
+- fix more bad markdown in CONTRIBUTING.md
+- fix bad markdown in CONTRIBUTING.md
+- add setImmediate/clearImmediate to globals; closes #1435
+- Fix buffer diffs (closes #1132, closes #1433)
+- add a CONTRIBUTING.md.  closes #882
+- fix intermittent build failures (maybe). closes #1407
+- add Slack notification to .travis.yml
+- Fix slack link
+- Add slack room to readme
+- Update maintainers
+- update maintainers and contributors
+- resolves #1393: kill children with more effort on SIGINT
+- xunit reporter support for optionally writing to a file
+- if a reporter has a .done method, call it before exiting
+- add support for reporter options
+- only write to stdout in reporters
+
+# 2.0.0 / 2014-10-21
+
+- remove: support for node 0.6.x, 0.4.x
+- fix: landing reporter with non ansi characters (#211)
+- fix: html reporter - preserve query params when navigating to suites/tests (#1358)
+- fix: json stream reporter add error message to failed test
+- fix: fixes for visionmedia -> mochajs
+- fix: use stdio, fixes node deprecation warnings (#1391)
+
+# 1.21.5 / 2014-10-11
+
+- fix: build for NodeJS v0.6.x
+- fix: do not attempt to highlight syntax when non-HTML reporter is used
+- update: escape-string-regexp to 1.0.2.
+- fix: botched indentation in canonicalize()
+- fix: .gitignore: ignore .patch and .diff files
+- fix: changed 'Catched' to 'Caught' in uncaught exception error handler messages
+- add: `pending` field for json reporter
+- fix: Runner.prototype.uncaught: don't double-end runnables that already have a state.
+- fix: --recursive, broken by f0facd2e
+- update: replaces escapeRegexp with the escape-string-regexp package.
+- update: commander to 2.3.0.
+- update: diff to 1.0.8.
+- fix: ability to disable syntax highlighting (#1329)
+- fix: added empty object to errorJSON() call to catch when no error is present
+- fix: never time out after calling enableTimeouts(false)
+- fix: timeout(0) will work at suite level (#1300)
+- Fix for --watch+only() issue (#888 )
+- fix: respect err.showDiff, add Base reporter test (#810)
+
+# 1.22.1-3 / 2014-07-27
+
+- fix: disabling timeouts with this.timeout(0) (#1301)
+
+# 1.22.1-3 / 2014-07-27
+
+- fix: local uis and reporters (#1288)
+- fix: building 1.21.0's changes in the browser (#1284)
+
+# 1.21.0 / 2014-07-23
+
+- add: --no-timeouts option (#1262, #1268)
+- add: --*- deprecation node flags (#1217)
+- add: --watch-extensions argument (#1247)
+- change: spec reporter is default (#1228)
+- fix: diff output showing incorrect +/- (#1182)
+- fix: diffs of circular structures (#1179)
+- fix: re-render the progress bar when progress has changed only (#1151)
+- fix support for environments with global and window (#1159)
+- fix: reverting to previously defined onerror handler (#1178)
+- fix: stringify non error objects passed to done() (#1270)
+- fix: using local ui, reporters (#1267)
+- fix: cleaning es6 arrows (#1176)
+- fix: don't include attrs in failure tag for xunit (#1244)
+- fix: fail tests that return a promise if promise is rejected w/o a reason (#1224)
+- fix: showing failed tests in doc reporter (#1117)
+- fix: dot reporter dots being off (#1204)
+- fix: catch empty throws (#1219)
+- fix: honoring timeout for sync operations (#1242)
+- update: growl to 1.8.0
+
+# 1.20.1 / 2014-06-03
+
+- update: should dev dependency to ~4.0.0 (#1231)
+
+# 1.20.0 / 2014-05-28
+
+- add: filenames to suite objects (#1222)
+
+# 1.19.0 / 2014-05-17
+
+- add: browser script option to package.json
+- add: export file in Mocha.Test objects (#1174)
+- add: add docs for wrapped node flags
+- fix: mocha.run() to return error status in browser (#1216)
+- fix: clean() to show failure details (#1205)
+- fix: regex that generates html for new keyword (#1201)
+- fix: sibling suites have inherited but separate contexts (#1164)
+
+# 1.18.2 / 2014-03-18
+
+- fix: html runner was prevented from using #mocha as the default root el (#1162)
+
+# 1.18.1 / 2014-03-18
+
+- fix: named before/after hooks in bdd, tdd, qunit interfaces (#1161)
+
+# 1.18.0 / 2014-03-13
+
+- add: promise support (#329)
+- add: named before/after hooks (#966)
+
+# 1.17.1 / 2014-01-22
+
+- fix: expected messages in should.js (should.js#168)
+- fix: expect errno global in node versions < v0.9.11 (#1111)
+- fix: unreliable checkGlobals optimization (#1110)
+
+# 1.17.0 / 2014-01-09
+
+- add: able to require globals (describe, it, etc.) through mocha (#1077)
+- fix: abort previous run on --watch change (#1100)
+- fix: reset context for each --watch triggered run (#1099)
+- fix: error when cli can't resolve path or pattern (#799)
+- fix: canonicalize objects before stringifying and diffing them (#1079)
+- fix: make CR call behave like carriage return for non tty (#1087)
+
+# 1.16.2 / 2013-12-23
+
+- fix: couple issues with ie 8 (#1082, #1081)
+- fix: issue running the xunit reporter in browsers (#1068)
+- fix: issue with firefox < 3.5 (#725)
+
+# 1.16.1 / 2013-12-19
+
+- fix: recompiled for missed changes from the last release
+
+# 1.16.0 / 2013-12-19
+
+- add: Runnable.globals(arr) for per test global whitelist (#1046)
+- add: mocha.throwError(err) for assertion libs to call (#985)
+- remove: --watch's spinner (#806)
+- fix: duplicate test output for multi-line specs in spec reporter (#1006)
+- fix: gracefully exit on SIGINT (#1063)
+- fix expose the specified ui only in the browser (#984)
+- fix: ensure process exit code is preserved when using --no-exit (#1059)
+- fix: return true from window.onerror handler (#868)
+- fix: xunit reporter to use process.stdout.write (#1068)
+- fix: utils.clean(str) indentation (#761)
+- fix: xunit reporter returning test duration a NaN (#1039)
+
+# 1.15.1 / 2013-12-03
+
+- fix: recompiled for missed changes from the last release
+
+# 1.15.0 / 2013-12-02
+
+- add: `--no-exit` to prevent `process.exit()` (#1018)
+- fix: using inline diffs (#1044)
+- fix: show pending test details in xunit reporter (#1051)
+- fix: faster global leak detection (#1024)
+- fix: yui compression (#1035)
+- fix: wrapping long lines in test results (#1030, #1031)
+- fix: handle errors in hooks (#1043)
+
+# 1.14.0 / 2013-11-02
+
+- add: unified diff (#862)
+- add: set MOCHA_COLORS env var to use colors (#965)
+- add: able to override tests links in html reporters (#776)
+- remove: teamcity reporter (#954)
+- update: commander dependency to 2.0.0 (#1010)
+- fix: mocha --ui will try to require the ui if not built in, as --reporter does (#1022)
+- fix: send cursor commands only if isatty (#184, #1003)
+- fix: include assertion message in base reporter (#993, #991)
+- fix: consistent return of it, it.only, and describe, describe.only (#840)
+
+# 1.13.0 / 2013-09-15
+
+- add: sort test files with --sort (#813)
+- update: diff dependency to 1.0.7
+- update: glob dependency to 3.2.3 (#927)
+- fix: diffs show whitespace differences (#976)
+- fix: improve global leaks (#783)
+- fix: firefox window.getInterface leak
+- fix: accessing iframe via window[iframeIndex] leak
+- fix: faster global leak checking
+- fix: reporter pending css selector (#970)
+
+# 1.12.1 / 2013-08-29
+
+- remove test.js from .gitignore
+- update included version of ms.js
+
+# 1.12.0 / 2013-07-01
+
+- add: prevent diffs for differing types. Closes #900
+- add `Mocha.process` hack for phantomjs
+- fix: use compilers with requires
+- fix regexps in diffs. Closes #890
+- fix xunit NaN on failure. Closes #894
+- fix: strip tab indentation in `clean` utility method
+- fix: textmate bundle installation
+
+# 1.11.0 / 2013-06-12
+
+- add --prof support
+- add --harmony support
+- add --harmony-generators support
+- add "Uncaught " prefix to uncaught exceptions
+- add web workers support
+- add `suite.skip()`
+- change to output # of pending / passing even on failures. Closes #872
+- fix: prevent hooks from being called if we are bailing
+- fix `this.timeout(0)`
+
+# 1.10.0 / 2013-05-21
+
+- add add better globbing support for windows via `glob` module
+- add support to pass through flags such as --debug-brk=1234. Closes #852
+- add test.only, test.skip to qunit interface
+- change to always use word-based diffs for now. Closes #733
+- change `mocha init` tests.html to index.html
+- fix `process` global leak in the browser
+- fix: use resolve() instead of join() for --require
+- fix: filterLeaks() condition to not consider indices in global object as leaks
+- fix: restrict mocha.css styling to #mocha id
+- fix: save timer references to avoid Sinon interfering in the browser build.
+
+# 1.9.0 / 2013-04-03
+
+- add improved setImmediate implementation
+- replace --ignore-leaks with --check-leaks
+- change default of ignoreLeaks to true. Closes #791
+- remove scrolling for HTML reporter
+- fix retina support
+- fix tmbundle, restrict to js scope
+
+# 1.8.2 / 2013-03-11
+
+- add `setImmediate` support for 0.10.x
+- fix mocha -w spinner on windows
+
+# 1.8.1 / 2013-01-09
+
+- fix .bail() arity check causing it to default to true
+
+# 1.8.0 / 2013-01-08
+
+- add Mocha() options bail support
+- add `Mocha#bail()` method
+- add instanceof check back for inheriting from Error
+- add component.json
+- add diff.js to browser build
+- update growl
+- fix TAP reporter failures comment :D
+
+# 1.7.4 / 2012-12-06
+
+- add total number of passes and failures to TAP
+- remove .bind() calls. re #680
+- fix indexOf. Closes #680
+
+# 1.7.3 / 2012-11-30
+
+- fix uncaught error support for the browser
+- revert uncaught "fix" which breaks node
+
+# 1.7.2 / 2012-11-28
+
+- fix uncaught errors to expose the original error message
+
+# 1.7.0 / 2012-11-07
+
+- add `--async-only` support to prevent false positives for missing `done()`
+- add sorting by filename in code coverage
+- add HTML 5 doctype to browser template.
+- add play button to html reporter to rerun a single test
+- add `this.timeout(ms)` as Suite#timeout(ms). Closes #599
+- update growl dependency to 1.6.x
+- fix encoding of test-case ?grep. Closes #637
+- fix unicode chars on windows
+- fix dom globals in Opera/IE. Closes #243
+- fix markdown reporter a tags
+- fix `this.timeout("5s")` support
+
+# 1.6.0 / 2012-10-02
+
+- add object diffs when `err.showDiff` is present
+- add hiding of empty suites when pass/failures are toggled
+- add faster `.length` checks to `checkGlobals()` before performing the filter
+
+# 1.5.0 / 2012-09-21
+
+- add `ms()` to `.slow()` and `.timeout()`
+- add `Mocha#checkLeaks()` to re-enable global leak checks
+- add `this.slow()` option [aheckmann]
+- add tab, CR, LF to error diffs for now
+- add faster `.checkGlobals()` solution [guille]
+- remove `fn.call()` from reduce util
+- remove `fn.call()` from filter util
+- fix forEach. Closes #582
+- fix relaying of signals [TooTallNate]
+- fix TAP reporter grep number
+
+# 1.4.2 / 2012-09-01
+
+- add support to multiple `Mocha#globals()` calls, and strings
+- add `mocha.reporter()` constructor support [jfirebaugh]
+- add `mocha.timeout()`
+- move query-string parser to utils.js
+- move highlight code to utils.js
+- fix third-party reporter support [exogen]
+- fix client-side API to match node-side [jfirebaugh]
+- fix mocha in iframe [joliss]
+
+# 1.4.1 / 2012-08-28
+
+- add missing `Markdown` export
+- fix `Mocha#grep()`, escape regexp strings
+- fix reference error when `devicePixelRatio` is not defined. Closes #549
+
+# 1.4.0 / 2012-08-22
+
+- add mkdir -p to `mocha init`. Closes #539
+- add `.only()`. Closes #524
+- add `.skip()`. Closes #524
+- change str.trim() to use utils.trim(). Closes #533
+- fix HTML progress indicator retina display
+- fix url-encoding of click-to-grep HTML functionality
+
+# 1.3.2 / 2012-08-01
+
+- fix exports double-execution regression. Closes #531
+
+# 1.3.1 / 2012-08-01
+
+- add passes/failures toggling to HTML reporter
+- add pending state to `xit()` and `xdescribe()` [Brian Moore]
+- add the @charset "UTF-8"; to fix #522 with FireFox. [Jonathan Creamer]
+- add border-bottom to #stats links
+- add check for runnable in `Runner#uncaught()`. Closes #494
+- add 0.4 and 0.6 back to travis.yml
+- add `-E, --growl-errors` to growl on failures only
+- add prefixes to debug() names. Closes #497
+- add `Mocha#invert()` to js api
+- change dot reporter to use sexy unicode dots
+- fix error when clicking pending test in HTML reporter
+- fix `make tm`
+
+# 1.3.0 / 2012-07-05
+
+- add window scrolling to `HTML` reporter
+- add v8 `--trace-*` option support
+- add support for custom reports via `--reporter MODULE`
+- add `--invert` switch to invert `--grep` matches
+- fix export of `Nyan` reporter. Closes #495
+- fix escaping of `HTML` suite titles. Closes #486
+- fix `done()` called multiple times with an error test
+- change `--grep` - regexp escape the input
+
+# 1.2.2 / 2012-06-28
+
+- Added 0.8.0 support
+
+# 1.2.1 / 2012-06-25
+
+- Added `this.test.error(err)` support to after each hooks. Closes #287
+- Added: export top-level suite on global mocha object (mocha.suite). Closes #448
+- Fixed `js` code block format error in markdown reporter
+- Fixed deprecation warning when using `path.existsSync`
+- Fixed --globals with wildcard
+- Fixed chars in nyan when his head moves back
+- Remove `--growl` from test/mocha.opts. Closes #289
+
+# 1.2.0 / 2012-06-17
+
+- Added `nyan` reporter [Atsuya Takagi]
+- Added `mocha init <path>` to copy client files
+- Added "specify" synonym for "it" [domenic]
+- Added global leak wildcard support [nathanbowser]
+- Fixed runner emitter leak. closes #432
+- Fixed omission of .js extension. Closes #454
+
+# 1.1.0 / 2012-05-30
+
+- Added: check each `mocha(1)` arg for directories to walk
+- Added `--recursive` [tricknotes]
+- Added `context` for BDD [hokaccha]
+- Added styling for new clickable titles
+- Added clickable suite titles to HTML reporter
+- Added warning when strings are thrown as errors
+- Changed: green arrows again in HTML reporter styling
+- Changed ul/li elements instead of divs for better copy-and-pasting [joliss]
+- Fixed issue #325 - add better grep support to js api
+- Fixed: save timer references to avoid Sinon interfering.
+
+# 1.0.3 / 2012-04-30
+
+- Fixed string diff newlines
+- Fixed: removed mocha.css target. Closes #401
+
+# 1.0.2 / 2012-04-25
+
+- Added HTML reporter duration. Closes #47
+- Fixed: one postMessage event listener [exogen]
+- Fixed: allow --globals to be used multiple times. Closes #100 [brendannee]
+- Fixed #158: removes jquery include from browser tests
+- Fixed grep. Closes #372 [brendannee]
+- Fixed #166 - When grepping don't display the empty suites
+- Removed test/browser/style.css. Closes #385
+
+# 1.0.1 / 2012-04-04
+
+- Fixed `.timeout()` in hooks
+- Fixed: allow callback for `mocha.run()` in client version
+- Fixed browser hook error display. Closes #361
+
+# 1.0.0 / 2012-03-24
+
+- Added js API. Closes #265
+- Added: initial run of tests with `--watch`. Closes #345
+- Added: mark `location` as a global on the CS. Closes #311
+- Added `markdown` reporter (github flavour)
+- Added: scrolling menu to coverage.html. Closes #335
+- Added source line to html report for Safari [Tyson Tate]
+- Added "min" reporter, useful for `--watch` [Jakub Nešetřil]
+- Added support for arbitrary compilers via . Closes #338 [Ian Young]
+- Added Teamcity export to lib/reporters/index [Michael Riley]
+- Fixed chopping of first char in error reporting. Closes #334 [reported by topfunky]
+- Fixed terrible FF / Opera stack traces
+
+# 0.14.1 / 2012-03-06
+
+- Added lib-cov to _.npmignore_
+- Added reporter to `mocha.run([reporter])` as argument
+- Added some margin-top to the HTML reporter
+- Removed jQuery dependency
+- Fixed `--watch`: purge require cache. Closes #266
+
+# 0.14.0 / 2012-03-01
+
+- Added string diff support for terminal reporters
+
+# 0.13.0 / 2012-02-23
+
+- Added preliminary test coverage support. Closes #5
+- Added `HTMLCov` reporter
+- Added `JSONCov` reporter [kunklejr]
+- Added `xdescribe()` and `xit()` to the BDD interface. Closes #263 (docs   * Changed: make json reporter output pretty json
+- Fixed node-inspector support, swapped `--debug` for `debug` to match node. Closes #247
+
+# 0.12.1 / 2012-02-14
+
+- Added `npm docs mocha` support [TooTallNate]
+- Added a `Context` object used for hook and test-case this. Closes #253
+- Fixed `Suite#clone()` `.ctx` reference. Closes #262
+
+# 0.12.0 / 2012-02-02
+
+- Added .coffee `--watch` support. Closes #242
+- Added support to `--require` files relative to the CWD. Closes #241
+- Added quick n dirty syntax highlighting. Closes #248
+- Changed: made HTML progress indicator smaller
+- Fixed xunit errors attribute [dhendo]
+
+# 0.10.2 / 2012-01-21
+
+- Fixed suite count in reporter stats. Closes #222
+- Fixed `done()` after timeout error reporting [Phil Sung]
+- Changed the 0-based errors to 1
+
+# 0.10.1 / 2012-01-17
+
+- Added support for node 0.7.x
+- Fixed absolute path support. Closes #215 [kompiro]
+- Fixed `--no-colors` option [Jussi Virtanen]
+- Fixed Arial CSS typo in the correct file
+
+# 0.10.0 / 2012-01-13
+
+- Added `-b, --bail` to exit on first exception [guillermo]
+- Added support for `-gc` / `--expose-gc` [TooTallNate]
+- Added `qunit`-inspired interface
+- Added MIT LICENSE. Closes #194
+- Added: `--watch` all .js in the CWD. Closes #139
+- Fixed `self.test` reference in runner. Closes #189
+- Fixed double reporting of uncaught exceptions after timeout. Closes #195
+
+# 0.8.2 / 2012-01-05
+
+- Added test-case context support. Closes #113
+- Fixed exit status. Closes #187
+- Update commander. Closes #190
+
+# 0.8.1 / 2011-12-30
+
+- Fixed reporting of uncaught exceptions. Closes #183
+- Fixed error message defaulting [indutny]
+- Changed mocha(1) from bash to node for windows [Nathan Rajlich]
+
+# 0.8.0 / 2011-12-28
+
+- Added `XUnit` reporter [FeeFighters/visionmedia]
+- Added `say(1)` notification support [Maciej Małecki]
+- Changed: fail when done() is invoked with a non-Error. Closes #171
+- Fixed `err.stack`, defaulting to message. Closes #180
+- Fixed: `make tm` mkdir -p the dest. Closes #137
+- Fixed mocha(1) --help bin name
+- Fixed `-d` for `--debug` support
+
+# 0.7.1 / 2011-12-22
+
+- Removed `mocha-debug(1)`, use `mocha --debug`
+- Fixed CWD relative requires
+- Fixed growl issue on windows [Raynos]
+- Fixed: platform specific line endings [TooTallNate]
+- Fixed: escape strings in HTML reporter. Closes #164
+
+# 0.7.0 / 2011-12-18
+
+- Added support for IE{7,8} [guille]
+- Changed: better browser nextTick implementation [guille]
+
+# 0.6.0 / 2011-12-18
+
+- Added setZeroTimeout timeout for browser (nicer stack traces). Closes #153
+- Added "view source" on hover for HTML reporter to make it obvious
+- Changed: replace custom growl with growl lib
+- Fixed duplicate reporting for HTML reporter. Closes #154
+- Fixed silent hook errors in the HTML reporter. Closes #150
+
+# 0.5.0 / 2011-12-14
+
+- Added: push node_modules directory onto module.paths for relative require Closes #93
+- Added teamcity reporter [blindsey]
+- Fixed: recover from uncaught exceptions for tests. Closes #94
+- Fixed: only emit "test end" for uncaught within test, not hook
+
+# 0.4.0 / 2011-12-14
+
+- Added support for test-specific timeouts via `this.timeout(0)`. Closes #134
+- Added guillermo's client-side EventEmitter. Closes #132
+- Added progress indicator to the HTML reporter
+- Fixed slow browser tests. Closes #135
+- Fixed "suite" color for light terminals
+- Fixed `require()` leak spotted by [guillermo]
+
+# 0.3.6 / 2011-12-09
+
+- Removed suite merging (for now)
+
+# 0.3.5 / 2011-12-08
+
+- Added support for `window.onerror` [guillermo]
+- Fixed: clear timeout on uncaught exceptions. Closes #131 [guillermo]
+- Added `mocha.css` to PHONY list.
+- Added `mocha.js` to PHONY list.
+
+# 0.3.4 / 2011-12-08
+
+- Added: allow `done()` to be called with non-Error
+- Added: return Runner from `mocha.run()`. Closes #126
+- Fixed: run afterEach even on failures. Closes #125
+- Fixed clobbering of current runnable. Closes #121
+
+# 0.3.3 / 2011-12-08
+
+- Fixed hook timeouts. Closes #120
+- Fixed uncaught exceptions in hooks
+
+# 0.3.2 / 2011-12-05
+
+- Fixed weird reporting when `err.message` is not present
+
+# 0.3.1 / 2011-12-04
+
+- Fixed hook event emitter leak. Closes #117
+- Fixed: export `Spec` constructor. Closes #116
+
+# 0.3.0 / 2011-12-04
+
+- Added `-w, --watch`. Closes #72
+- Added `--ignore-leaks` to ignore global leak checking
+- Added browser `?grep=pattern` support
+- Added `--globals <names>` to specify accepted globals. Closes #99
+- Fixed `mocha-debug(1)` on some systems. Closes #232
+- Fixed growl total, use `runner.total`
+
+# 0.2.0 / 2011-11-30
+
+- Added `--globals <names>` to specify accepted globals. Closes #99
+- Fixed funky highlighting of messages. Closes #97
+- Fixed `mocha-debug(1)`. Closes #232
+- Fixed growl total, use runner.total
+
+# 0.1.0 / 2011-11-29
+
+- Added `suiteSetup` and `suiteTeardown` to TDD interface [David Henderson]
+- Added growl icons. Closes #84
+- Fixed coffee-script support
+
+# 0.0.8 / 2011-11-25
+
+- Fixed: use `Runner#total` for accurate reporting
+
+# 0.0.7 / 2011-11-25
+
+- Added `Hook`
+- Added `Runnable`
+- Changed: `Test` is `Runnable`
+- Fixed global leak reporting in hooks
+- Fixed: > 2 calls to done() only report the error once
+- Fixed: clear timer on failure. Closes #80
+
+# 0.0.6 / 2011-11-25
+
+- Fixed return on immediate async error. Closes #80
+
+# 0.0.5 / 2011-11-24
+
+- Fixed: make mocha.opts whitespace less picky [kkaefer]
+
+# 0.0.4 / 2011-11-24
+
+- Added `--interfaces`
+- Added `--reporters`
+- Added `-c, --colors`. Closes #69
+- Fixed hook timeouts
+
+# 0.0.3 / 2011-11-23
+
+- Added `-C, --no-colors` to explicitly disable
+- Added coffee-script support
+
+# 0.0.2 / 2011-11-22
+
+- Fixed global leak detection due to Safari bind() change
+- Fixed: escape html entities in Doc reporter
+- Fixed: escape html entities in HTML reporter
+- Fixed pending test support for HTML reporter. Closes #66
+
+# 0.0.1 / 2011-11-22
+
+- Added `--timeout` second shorthand support, ex `--timeout 3s`.
+- Fixed "test end" event for uncaughtExceptions. Closes #61
+
+# 0.0.1-alpha6 / 2011-11-19
+
+- Added travis CI support (needs enabling when public)
+- Added preliminary browser support
+- Added `make mocha.css` target. Closes #45
+- Added stack trace to TAP errors. Closes #52
+- Renamed tearDown to teardown. Closes #49
+- Fixed: cascading hooksc. Closes #30
+- Fixed some colors for non-tty
+- Fixed errors thrown in sync test-cases due to nextTick
+- Fixed Base.window.width... again give precedence to 0.6.x
+
+# 0.0.1-alpha5 / 2011-11-17
+
+- Added `doc` reporter. Closes #33
+- Added suite merging. Closes #28
+- Added TextMate bundle and `make tm`. Closes #20
+
+# 0.0.1-alpha4 / 2011-11-15
+
+- Fixed getWindowSize() for 0.4.x
+
+# 0.0.1-alpha3 / 2011-11-15
+
+- Added `-s, --slow <ms>` to specify "slow" test threshold
+- Added `mocha-debug(1)`
+- Added `mocha.opts` support. Closes #31
+- Added: default [files] to _test/*.js_
+- Added protection against multiple calls to `done()`. Closes #35
+- Changed: bright yellow for slow Dot reporter tests
+
+# 0.0.1-alpha2 / 2011-11-08
+
+- Missed this one :)
+
+# 0.0.1-alpha1 / 2011-11-08
+
+- Initial release

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,8 +3,8 @@
 Hi stranger!  We've written this document for:
 
 1. Active maintainers of Mocha
-2. Prospective maintainers of Mocha
-3. Anyone curious about how Mocha's maintainers maintain Mocha
+1. Prospective maintainers of Mocha
+1. Anyone curious about how Mocha's maintainers maintain Mocha
 
 The purpose of this document is to *describe our processes*.  We want to avoid conflicts and confusion around "unwritten rules".  In our opinion, the most straightforward way to address this is to *write them down*.  This *also* happens to be the most straightforward way to change them!
 
@@ -34,34 +34,34 @@ This is the most important thing:
 A "contributor" is any individual who has *given back* in some way to the project and its community.  Contributions include (but are not limited to):
 
 1. Reporting bugs which follow the reporting guidelines
-2. Suggesting and debating enhancements that have wide applicability
-3. Helping others with Mocha-related questions on [Gitter](https://gitter.im/mochajs/mocha), [StackOverflow](https://stackoverflow.com), Google groups, or other sites
-4. Sending pull requests which fix bugs, improve documentation, improve developer experience, improve code quality, and/or implement requested enhancements
-5. Reviewing code on pull requests
-6. Providing design assets
-7. Posting a tutorial on a personal blog or blogging site
-8. Suggesting usages for project funds
-9. Organizing a "Mocha-branded" event or workshop
-10. Recruiting more contributors! Don't spam.
-11. Researching the user base, getting feedback, etc. Don't spam.
+1. Suggesting and debating enhancements that have wide applicability
+1. Helping others with Mocha-related questions on [Gitter](https://gitter.im/mochajs/mocha), [StackOverflow](https://stackoverflow.com), Google groups, or other sites
+1. Sending pull requests which fix bugs, improve documentation, improve developer experience, improve code quality, and/or implement requested enhancements
+1. Reviewing code on pull requests
+1. Providing design assets
+1. Posting a tutorial on a personal blog or blogging site
+1. Suggesting usages for project funds
+1. Organizing a "Mocha-branded" event or workshop
+1. Recruiting more contributors! Don't spam.
+1. Researching the user base, getting feedback, etc. Don't spam.
 
 A contributor is *usually* a user as well, but this isn't a hard-and-fast rule. A contributor is also expected to adhere to the [code of conduct](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md) as a user would.
 
 As you can see, it's wide open!  Think of it another way: if you are *adding value to Mocha*, then you are a contributor.
 
 > Due to the nature of GitHub, it's a challenge to recognize those who've made contributions *elsewhere* on the web, or even contributions of the "non-code" variety.  If you know of any great contributions which have gone unnoticed, please bring them to the maintainers' attention!
- 
+
 #### A Note About Donations
 
-A [donation](https://opencollective.com/mochajs) is also a great way to help Mocha if you want to help sustain OSS, but can't find time to contribute in other ways, or just want to say "thanks!"  
+A [donation](https://opencollective.com/mochajs) is also a great way to help Mocha if you want to help sustain OSS, but can't find time to contribute in other ways, or just want to say "thanks!"
 
-We love our backers and sponsors! 💕 
+We love our backers and sponsors! 💕
 
 ### Maintainer
 
-A maintainer has certain "rights" (or "permissions") to the Mocha project and other projects under the `mochajs` organization.  There's no way to dance around this: with these rights come increased responsibilities.  
+A maintainer has certain "rights" (or "permissions") to the Mocha project and other projects under the `mochajs` organization.  There's no way to dance around this: with these rights come increased responsibilities.
 
-However, **there is no expectation of a standard of technical ability** to be a maintainer of Mocha.  This doesn't imply a lack of technical oversight--every pull request will eventually be reviewed.  
+However, **there is no expectation of a standard of technical ability** to be a maintainer of Mocha.  This doesn't imply a lack of technical oversight--every pull request will eventually be reviewed.
 
 **If you think you aren't experienced enough to maintain a project like Mocha, you are incorrect.** The only requirements are the above responsibilities and a desire to help the project.  It bears repeating:
 
@@ -73,12 +73,13 @@ However, **there is no expectation of a standard of technical ability** to be a 
 
 As a maintainer, you are expected to *not just* "follow" the code of conduct, but embody its values.  Your public behavior, whether in the physical or virtual world, reflects upon the project and other maintainers.
 
-> If you don't understand the code of conduct, or why it exists, it is *your responsibility* to educate yourself.  
+> If you don't understand the code of conduct, or why it exists, it is *your responsibility* to educate yourself.
 > This does not imply the CoC is immutable.
 
 Furthermore, a maintainer is a contributor who **contributes regularly**, or expresses a *desire to do so.*  That could be every day--but it might be once a week, or even once a month.  Your boss doesn't work here; contribute as often as you wish.  We are all people with Real Lives, and for many of us, contributing to OSS is just a hobby!
 
 Finally, a maintainer must help define what makes Mocha "Mocha".  At minimum, a maintainer must *understand* the current definition (if a maintainer is not interested in decision-making).  Some of these questions include:
+
 - What's the scope of Mocha?
 - Where should we focus efforts?
 - What's urgent, what can wait?
@@ -98,7 +99,7 @@ You may choose to do zero or more of these *at their discretion*:
 - Merge pull requests
 - Modify issues (closing, adding labels, assigning them other maintainers, etc.)
 - Modify GitHub [Projects](https://github.com/mochajs/mocha/projects)
-- Cancel builds, restart jobs, or otherwise interact with our CI server(s) 
+- Cancel builds, restart jobs, or otherwise interact with our CI server(s)
 - CRUD operations on GitHub integrations
 - Participate in the decision-making process
 - Add new maintainers to the team
@@ -114,6 +115,7 @@ Some maintainers will have full admin rights to the [mochajs org](https://github
 - This level of access will be granted by the current owners to those maintainers who have earned the project's trust.
 
 ## Mocha's Decision-Making Process
+
 Mocha follows a [consensus-seeking decision-making](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) process.  In other words, all maintainers attempt to come to agreement.  If that fails, we decide by a simple vote.
 
 Active maintainers will make an effort to solicit feedback from others before making important or potentially controversial decisions.  Given the varying geographical distribution and availability of the maintenance team, we resolve to do the best we can to solicit feedback.
@@ -144,14 +146,14 @@ The following list is incomplete, but it's better than nothing:
 To be clear:
 
 - Features, bugs, and updated tests are examples of issues which will be resolved by commit(s).
-- Support questions, unconfirmed bugs and [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality) are examples of issues which do *not* need `semver-*` labels, since they won't necessarily result in any changes to the codebase.  
+- Support questions, unconfirmed bugs and [bikeshedding](https://en.wikipedia.org/wiki/Law_of_triviality) are examples of issues which do *not* need `semver-*` labels, since they won't necessarily result in any changes to the codebase.
 - Pull requests *do not* need `semver-*` labels, *unless there is no associated issue* (PRO TIP: make an issue!)
 - An issue or PR which will introduce a breaking change will be `semver-major`, *regardless* of any other label.
-- **Breaking changes to private APIs will be `semver-major`, if and only if they are known to be consumed by actively developed project(s).** 
+- **Breaking changes to private APIs will be `semver-major`, if and only if they are known to be consumed by actively developed project(s).**
 
 ### Questions
 
-Support questions should be answered if possible, but the user should be directed to the chat room, StackOverflow, or Google Groups for further help, *if* it is indeed a Mocha-related issue.  
+Support questions should be answered if possible, but the user should be directed to the chat room, StackOverflow, or Google Groups for further help, *if* it is indeed a Mocha-related issue.
 
 If it's *not* a Mocha problem (people tend not to believe this), you may want to show a counter-example.  It's often helpful to direct the issue author to the responsible project, if you can determine what that is.
 
@@ -193,7 +195,7 @@ Issues or PRs which require action or feedback from a *specific* maintainer, sho
 
 ### Closing Issues
 
-Write "closes #<ISSUE>" or "resolves #<ISSUE>" in a commit or PR to have the original issue closed automatically once the PR is merged. 
+Write "closes #<ISSUE>" or "resolves #<ISSUE>" in a commit or PR to have the original issue closed automatically once the PR is merged.
 
 For any issue which is a duplicate, write "duplicate of #<ISSUE>" in a new comment, and close the issue.  [Read more about marking issues as duplicates](https://help.github.com/articles/about-duplicate-issues-and-pull-requests/).
 
@@ -236,20 +238,20 @@ However, this behavior is often indicative of someone who is "new" to open sourc
 Here are some suggestions:
 
 1. If u mad, wait 20 minutes before writing a comment.
-2. "Kill them with kindness".  Explain how they are presenting themselves; maybe link to a good article or two about it.
-3. Don't make it about "users vs. maintainers".  Treat them like a potential future maintainer. 
-4. Avoid adding to the drama.  You could try to reach out privately; email may be in their GitHub profile.  You will likely never hear from that individual again (problem solved)
-5. If an issue is getting out of control, lock it.
-6. If someone is *repeatedly* rude and does not correct their mistakes, you may ban them from participating in the `mochajs` org.  If you do not have permission to do so, contact one which does (an "owner").
+1. "Kill them with kindness".  Explain how they are presenting themselves; maybe link to a good article or two about it.
+1. Don't make it about "users vs. maintainers".  Treat them like a potential future maintainer.
+1. Avoid adding to the drama.  You could try to reach out privately; email may be in their GitHub profile.  You will likely never hear from that individual again (problem solved)
+1. If an issue is getting out of control, lock it.
+1. If someone is *repeatedly* rude and does not correct their mistakes, you may ban them from participating in the `mochajs` org.  If you do not have permission to do so, contact one which does (an "owner").
 
 #### Code of Conduct Violations
 
 **This section is theoretical, as it's yet to happen**.
 
 1. Inform the individual of the violation; link to the CoC
-2. Follow up with JS Foundation for further guidance
-3. Repeated violators will be banned inasmuch as that is technically possible
-4. No maintainer nor contributor is exempt from the CoC
+1. Follow up with JS Foundation for further guidance
+1. Repeated violators will be banned inasmuch as that is technically possible
+1. No maintainer nor contributor is exempt from the CoC
 
 ## Branches
 
@@ -261,8 +263,8 @@ Maintainers may push new branches to a repo, as long as they remove them when fi
 GitHub has several options for how to merge a PR.  Here's what we do:
 
 1. *If a PR has multiple commits*, "Squash".
-2. *If a PR has a single commit*, "Rebase".
-3. Don't "Merge".
+1. *If a PR has a single commit*, "Rebase".
+1. Don't "Merge".
 
 ### Merging `semver-major` PRs
 
@@ -275,15 +277,15 @@ This is not necessarily ideal, and we should consider another method of using br
 *It's easier to release often.*
 
 1. Decide whether this is a `patch`, `minor`, or `major` release by the PRs which have been merged since the last release.
-2. Checkout `master` in your working copy & pull.
-3. Modify `CHANGELOG.md`; follow the existing conventions in that file.  Commit this file only; add `[ci skip]` to the commit message to avoid a build.
-4. Use `npm version` to bump the version; see `npm version --help` for more info.  (Hint--use `-m`: e.g. `npm version patch -m 'Release v%s'`)
-5. Push `master` to origin with your new tag; e.g. `git push origin master --tags`
-6. Copy & paste the added lines to a new GitHub "release".  Be sure to add any missing link references (use "preview" button).  Save release as draft.
-7. Meanwhile, you can check [the build](https://travis-ci.org/mochajs/mocha) on Travis-CI.
-8. Once it's green and you're satisfied with the release notes, open your draft release on GitHub, then click "publish"
-9. Back in your working copy, run `npm publish`.
-10. Announce the update on Twitter or just tell your dog or something.
+1. Checkout `master` in your working copy & pull.
+1. Modify `CHANGELOG.md`; follow the existing conventions in that file.  Commit this file only; add `[ci skip]` to the commit message to avoid a build.
+1. Use `npm version` to bump the version; see `npm version --help` for more info.  (Hint--use `-m`: e.g. `npm version patch -m 'Release v%s'`)
+1. Push `master` to origin with your new tag; e.g. `git push origin master --tags`
+1. Copy & paste the added lines to a new GitHub "release".  Be sure to add any missing link references (use "preview" button).  Save release as draft.
+1. Meanwhile, you can check [the build](https://travis-ci.org/mochajs/mocha) on Travis-CI.
+1. Once it's green and you're satisfied with the release notes, open your draft release on GitHub, then click "publish"
+1. Back in your working copy, run `npm publish`.
+1. Announce the update on Twitter or just tell your dog or something.
 
 *Note: there are too many steps above.*
 
@@ -301,7 +303,7 @@ As a maintainer, you have access to the resources the JS Foundation provides.
 
 ## About OpenCollective
 
-Mocha collects donations [via OpenCollective](https://opencollective.com/mochajs).  As a maintainer, you may help decide how the funds are used.  These decisions are made via a consensus-seeking process, much like any other decision.  
+Mocha collects donations [via OpenCollective](https://opencollective.com/mochajs).  As a maintainer, you may help decide how the funds are used.  These decisions are made via a consensus-seeking process, much like any other decision.
 
 Expense transparency is built in to OpenCollective.
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 lint:
 	@printf "==> [Test :: Lint]\n"
 	npm run lint
+	npm run markdownlint
 
 test-node: test-bdd test-tdd test-qunit test-exports test-unit test-integration test-jsapi test-compilers test-requires test-reporters test-only test-global-only
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@
      - **UPDATE - May 24 2017**: Thanks to [community contributions](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#mag-coverage), the coverage on most reporters has increased dramatically!  The `html` reporter is still in [dire need of coverage](https://coveralls.io/builds/11674428/source?filename=lib%2Freporters%2Fhtml.js).
    - Increase coverage against all interfaces (`exports` in particular).  Ideally this becomes a "matrix" where we repeat sets of integration tests across all interfaces.
    - Refactor non-Node.js-specific tests to allow them to run in a browser context.  Node.js-specific tests include those which *require* the CLI or filesystem.  Most everything else is fair game.
-2.  Review current open pull requests
+1. Review current open pull requests
     - We need individuals familiar with Mocha's codebase. Got questions?  Ask them in [our chat room](https://gitter.im/mochajs/mocha).
     - Pull requests **must** have supporting tests.  The only exceptions are pure cosmetic or non-functional changes.
     - Pull request contributors must sign [the CLA](https://cla.js.foundation/mochajs/mocha).
-3. Close old, inactive issues and pull requests
+1. Close old, inactive issues and pull requests
     - ~~A bot should do this.  We need a bot. Got a bot?~~ We now use GitHub's own [probot-stale](https://www.npmjs.com/package/probot-stale).
-4. Triage issues
+1. Triage issues
    - If we run into "critical" bugs, they need fixing.
    - "Critical" means Mocha is broken w/o workarounds for a *large percentage* of users
    - Otherwise: respond to issues, close new dupe issues, confirm bugs, ask for more info, etc.
@@ -47,73 +47,71 @@ Once we gain ground on the above items, we can work together formalize our contr
 
 ## Links
 
-  - [Documentation](http://mochajs.org)
-  - [Changelog](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md)
-  - [Google Group](http://groups.google.com/group/mochajs)
-  - [Wiki](https://github.com/mochajs/mocha/wiki)
-  - Mocha [Extensions and reporters](https://github.com/mochajs/mocha/wiki)
-
+- [Documentation](http://mochajs.org)
+- [Changelog](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md)
+- [Google Group](http://groups.google.com/group/mochajs)
+- [Wiki](https://github.com/mochajs/mocha/wiki)
+- Mocha [Extensions and reporters](https://github.com/mochajs/mocha/wiki)
 
 ## Backers
 
-[Become a backer]((https://opencollective.com/mochajs#backer)) and show your support to our open source project.
+[Become a backer](https://opencollective.com/mochajs#backer) and show your support to our open source project.
 
-<a href="https://opencollective.com/mochajs/backer/0/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/0/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/1/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/1/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/2/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/2/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/3/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/3/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/4/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/4/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/5/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/5/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/6/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/6/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/7/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/7/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/8/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/8/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/9/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/9/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/10/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/10/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/11/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/11/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/12/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/12/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/13/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/13/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/14/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/14/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/15/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/15/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/16/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/16/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/17/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/17/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/18/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/18/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/19/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/19/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/20/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/20/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/21/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/21/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/22/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/22/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/23/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/23/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/24/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/24/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/25/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/25/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/26/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/26/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/27/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/27/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/28/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/28/avatar"></a>
-<a href="https://opencollective.com/mochajs/backer/29/website" target="_blank"><img src="https://opencollective.com/mochajs/backer/29/avatar"></a>
-
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/0/avatar)](https://opencollective.com/mochajs/backer/0/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/1/avatar)](https://opencollective.com/mochajs/backer/1/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/2/avatar)](https://opencollective.com/mochajs/backer/2/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/3/avatar)](https://opencollective.com/mochajs/backer/3/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/4/avatar)](https://opencollective.com/mochajs/backer/4/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/5/avatar)](https://opencollective.com/mochajs/backer/5/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/6/avatar)](https://opencollective.com/mochajs/backer/6/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/7/avatar)](https://opencollective.com/mochajs/backer/7/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/8/avatar)](https://opencollective.com/mochajs/backer/8/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/9/avatar)](https://opencollective.com/mochajs/backer/9/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/10/avatar)](https://opencollective.com/mochajs/backer/10/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/11/avatar)](https://opencollective.com/mochajs/backer/11/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/12/avatar)](https://opencollective.com/mochajs/backer/12/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/13/avatar)](https://opencollective.com/mochajs/backer/13/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/14/avatar)](https://opencollective.com/mochajs/backer/14/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/15/avatar)](https://opencollective.com/mochajs/backer/15/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/16/avatar)](https://opencollective.com/mochajs/backer/16/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/17/avatar)](https://opencollective.com/mochajs/backer/17/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/18/avatar)](https://opencollective.com/mochajs/backer/18/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/19/avatar)](https://opencollective.com/mochajs/backer/19/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/20/avatar)](https://opencollective.com/mochajs/backer/20/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/21/avatar)](https://opencollective.com/mochajs/backer/21/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/22/avatar)](https://opencollective.com/mochajs/backer/22/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/23/avatar)](https://opencollective.com/mochajs/backer/23/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/24/avatar)](https://opencollective.com/mochajs/backer/24/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/25/avatar)](https://opencollective.com/mochajs/backer/25/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/26/avatar)](https://opencollective.com/mochajs/backer/26/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/27/avatar)](https://opencollective.com/mochajs/backer/27/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/28/avatar)](https://opencollective.com/mochajs/backer/28/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/backer/29/avatar)](https://opencollective.com/mochajs/backer/29/website)
 
 ## Sponsors
 
 Does your company use Mocha?  Ask your manager or marketing team if your company would be interested in supporting our project.  Support will allow the maintainers to dedicate more time for maintenance and new features for everyone.  Also, your company's logo will show [on GitHub](https://github.com/mochajs/mocha#readme) and on [our site](https://mochajs.org) - who doesn't want a little extra exposure?  [Here's the info](https://opencollective.com/mochajs#sponsor).
 
-<a href="https://opencollective.com/mochajs/sponsor/0/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/0/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/1/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/1/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/2/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/2/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/3/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/3/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/4/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/4/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/5/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/5/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/6/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/6/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/7/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/7/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/8/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/8/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/9/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/9/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/10/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/10/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/11/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/11/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/12/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/12/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/13/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/13/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/14/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/14/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/15/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/15/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/16/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/16/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/17/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/17/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/18/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/18/avatar"></a>
-<a href="https://opencollective.com/mochajs/sponsor/19/website" target="_blank"><img src="https://opencollective.com/mochajs/sponsor/19/avatar"></a>
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/0/avatar)](https://opencollective.com/mochajs/sponsor/0/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/1/avatar)](https://opencollective.com/mochajs/sponsor/1/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/2/avatar)](https://opencollective.com/mochajs/sponsor/2/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/3/avatar)](https://opencollective.com/mochajs/sponsor/3/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/4/avatar)](https://opencollective.com/mochajs/sponsor/4/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/5/avatar)](https://opencollective.com/mochajs/sponsor/5/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/6/avatar)](https://opencollective.com/mochajs/sponsor/6/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/7/avatar)](https://opencollective.com/mochajs/sponsor/7/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/8/avatar)](https://opencollective.com/mochajs/sponsor/8/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/9/avatar)](https://opencollective.com/mochajs/sponsor/9/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/10/avatar)](https://opencollective.com/mochajs/sponsor/10/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/11/avatar)](https://opencollective.com/mochajs/sponsor/11/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/12/avatar)](https://opencollective.com/mochajs/sponsor/12/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/13/avatar)](https://opencollective.com/mochajs/sponsor/13/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/14/avatar)](https://opencollective.com/mochajs/sponsor/14/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/15/avatar)](https://opencollective.com/mochajs/sponsor/15/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/16/avatar)](https://opencollective.com/mochajs/sponsor/16/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/17/avatar)](https://opencollective.com/mochajs/sponsor/17/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/18/avatar)](https://opencollective.com/mochajs/sponsor/18/website)
+[![MochaJS Backer](https://opencollective.com/mochajs/sponsor/19/avatar)](https://opencollective.com/mochajs/sponsor/19/website)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,10 +13,10 @@
 
 ## Development
 
-1.  Run `npm install` to get Node.js deps.
-2.  Run `bundle install` to install Jekyll and its dependencies.  This may or may not require elevated privileges, depending on your system.
-3. To serve the site and rebuild as changes are made, execute `npm run serveDocs`.
-4. To rebuild the site *once*, execute `npm start buildDocs`.
+1. Run `npm install` to get Node.js deps.
+1. Run `bundle install` to install Jekyll and its dependencies.  This may or may not require elevated privileges, depending on your system.
+1. To serve the site and rebuild as changes are made, execute `npm run serveDocs`.
+1. To rebuild the site *once*, execute `npm start buildDocs`.
 
 ### Notes
 

--- a/docs/_includes/backers.md
+++ b/docs/_includes/backers.md
@@ -1,6 +1,7 @@
 ## Backers
 
-Find Mocha helpful?  Become a [backer](https://opencollective.com/mochajs#support) and support Mocha with a monthly donation. 
+Find Mocha helpful?  Become a [backer](https://opencollective.com/mochajs#support) and support Mocha with a monthly donation.
 
+<!-- markdownlint-disable MD034 -->
 {: id="_backers" class="image-list" }
 {% for i in (0..29) %}[![](https://opencollective.com/mochajs/backer/{{ i }}/avatar.jpg)](https://opencollective.com/mochajs/backer/{{ i }}/website){: target="_blank" rel="noopener"}{% endfor %}

--- a/docs/_includes/sponsors.md
+++ b/docs/_includes/sponsors.md
@@ -2,6 +2,7 @@
 
 Use Mocha at Work?  Ask your manager or marketing team if they'd help [support](https://opencollective.com/mochajs#support) our project.  Your company's logo will also be displayed on [npmjs.com](http://npmjs.com/package/mocha) and our [GitHub repository](https://github.com/mochajs/mocha#sponsors).
 
+<!-- markdownlint-disable MD034 -->
 {: class="image-list faded-images" }
 {% for i in (0..15) %}[![](https://opencollective.com/mochajs/sponsor/{{ i }}/avatar.jpg)](https://opencollective.com/mochajs/sponsor/{{ i }}/website){: target="_blank"} {% endfor %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,17 +25,17 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js](https://n
 - [maps uncaught exceptions to the correct test case](#browser-specific-methods)
 - [async test timeout support](#delayed-root-suite)
 - [test retry support](#retry-tests)
-- [test-specific timeouts](#test-level) 
+- [test-specific timeouts](#test-level)
 - [growl notification support](#mochaopts)
 - [reports test durations](#test-duration)
 - [highlights slow tests](#dot-matrix)
-- [file watcher support](#min) 
-- [global variable leak detection](#--check-leaks) 
-- [optionally run tests that match a regexp](#-g---grep-pattern) 
+- [file watcher support](#min)
+- [global variable leak detection](#--check-leaks)
+- [optionally run tests that match a regexp](#-g---grep-pattern)
 - [auto-exit to prevent "hanging" with an active loop](#--exit----no-exit)
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [mocha.opts file support](#mochaopts)
-- clickable suite titles to filter test execution  
+- clickable suite titles to filter test execution
 - [node debugger support](#-d---debug)
 - detects multiple calls to `done()`
 - [use any assertion library you want](#assertions)
@@ -297,7 +297,7 @@ describe('hooks', function() {
 });
 ```
 
-> Tests can appear before, after, or interspersed with your hooks.  Hooks will run in the order they are defined, as appropriate; all `before()` hooks run (once), then any `beforeEach()` hooks, tests, any `afterEach()` hooks, and finally `after()` hooks (once).  
+> Tests can appear before, after, or interspersed with your hooks.  Hooks will run in the order they are defined, as appropriate; all `before()` hooks run (once), then any `beforeEach()` hooks, tests, any `afterEach()` hooks, and finally `after()` hooks (once).
 
 ### Describing Hooks
 
@@ -529,9 +529,9 @@ it('should only test in the correct environment', function() {
 });
 ```
 
-The above test will be reported as [pending](#pending-tests).  It's also important to note that calling `this.skip()` will effectively *abort* the test.  
+The above test will be reported as [pending](#pending-tests).  It's also important to note that calling `this.skip()` will effectively *abort* the test.
 
-> *Best practice*: To avoid confusion, do not execute further instructions in a test or hook after calling `this.skip()`.  
+> *Best practice*: To avoid confusion, do not execute further instructions in a test or hook after calling `this.skip()`.
 
 Contrast the above test with the following code:
 
@@ -649,7 +649,6 @@ describe('something slow', function() {
 });
 ```
 
-
 ## Timeouts
 
 ### Suite-level
@@ -706,7 +705,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
 
 ## Usage
 
-```
+```text
   Usage: mocha [debug] [options] [files]
 
 
@@ -780,7 +779,7 @@ Executes tests on changes to JavaScript in the CWD, and once initially.
 
 ### `--exit` / `--no-exit`
 
-*Updated in Mocha v4.0.0*
+> *Updated in Mocha v4.0.0*
 
 *Prior to* version v4.0.0, *by default*, Mocha would force its own process to exit once it was finished executing all tests.  This behavior enables a set of potential problems; it's indicative of tests (or fixtures, harnesses, code under test, etc.) which don't clean up after themselves properly.  Ultimately, "dirty" tests can (but not always) lead to *false positive* or *false negative* results.
 
@@ -799,7 +798,7 @@ To ensure your tests aren't leaving messes around, here are some ideas to get st
 
 ### `--compilers`
 
-*Updated in Mocha v4.0.0*
+> *Updated in Mocha v4.0.0*
 
 **`--compilers` is deprecated as of Mocha v4.0.0.  See [further explanation and workarounds](https://github.com/mochajs/mocha/wiki/compilers-deprecation).**
 
@@ -1112,9 +1111,9 @@ The SuperAgent request library [test documentation](https://visionmedia.github.i
 
 ```makefile
 test-docs:
-	$(MAKE) test REPORTER=doc \
-		| cat docs/head.html - docs/tail.html \
-		> docs/test.html
+  $(MAKE) test REPORTER=doc \
+    | cat docs/head.html - docs/tail.html \
+    > docs/test.html
 ```
 
 View the entire [Makefile](https://github.com/visionmedia/superagent/blob/master/Makefile) for reference.
@@ -1212,7 +1211,7 @@ The following option(s) *only* function in a browser context:
 
 Back on the server, Mocha will attempt to load `./test/mocha.opts` as a configuration file of sorts. The lines in this file are combined with any command-line arguments.  The command-line arguments take precedence.  For example, suppose you have the following `mocha.opts` file:
 
-```
+```sh
   --require should
   --reporter dot
   --ui bdd
@@ -1255,6 +1254,7 @@ The plugin is titled **NodeJS**, and can be installed via **Preferences** > **Pl
 ![Wallaby.js in Action](images/wallaby.png?withoutEnlargement&resize=920,9999&pngquant){:class="screenshot"}
 
 ### Emacs
+
 [Emacs](https://www.gnu.org/software/emacs/) support for running Mocha tests is available via a 3rd party package [mocha.el](https://github.com/scottaj/mocha.el). The package is available on MELPA, and can be installed via `M-x package-install mocha`.
 
 ![Emacs Mocha Runner in Action](images/emacs.png?withoutEnlargement&resize=920,9999&pngquant){:class="screenshot"}
@@ -1265,10 +1265,10 @@ The plugin is titled **NodeJS**, and can be installed via **Preferences** > **Pl
 
 #### Features
 
-* see all tests in VS Code sidebar menu
-* run & debug tests for each level hierarchy from all tests to a single test (and each describe of course)
-* auto run tests on file save
-* see tests results directly in the code editor
+- see all tests in VS Code sidebar menu
+- run & debug tests for each level hierarchy from all tests to a single test (and each describe of course)
+- auto run tests on file save
+- see tests results directly in the code editor
 
 ![mocha side bar in Action](images/mocha_side_bar.png?withoutEnlargement&resize=920,9999&pngquant){:class="screenshot"}
 
@@ -1301,4 +1301,3 @@ $ REPORTER=nyan npm test
 ## More Information
 
 In addition to chatting with us on [Gitter](https://gitter.im/mochajs/mocha), for additional information such as using spies, mocking, and shared behaviours be sure to check out the [Mocha Wiki](https://github.com/mochajs/mocha/wiki) on GitHub. For discussions join the [Google Group](https://groups.google.com/group/mochajs). For a running example of Mocha, view [example/tests.html](example/tests.html). For the JavaScript API, view the [source](https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L51).
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -2825,6 +2825,12 @@
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -6470,6 +6476,15 @@
         "astw": "2.2.0"
       }
     },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "dev": true,
+      "requires": {
+        "uc.micro": "1.0.3"
+      }
+    },
     "list-item": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
@@ -6604,6 +6619,12 @@
       "requires": {
         "lodash._root": "3.0.1"
       }
+    },
+    "lodash.flatten": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.3.0.tgz",
+      "integrity": "sha1-5exO/ofvxZzlL5F8uovxYGNkac8=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -6833,6 +6854,19 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "markdown-it": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.2.tgz",
+      "integrity": "sha512-4J92IhJq1kGoyXddwzzfjr9cEKGexBfFsZooKYMhMLLlWa4+dlSPDUUP7y+xQOCebIj61aLmKlowg//YcdPP1w==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "entities": "1.1.1",
+        "linkify-it": "2.0.3",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.3"
+      }
+    },
     "markdown-link": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
@@ -6867,6 +6901,79 @@
         }
       }
     },
+    "markdownlint": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.6.4.tgz",
+      "integrity": "sha512-gcojwPjnWIE6qJh16veEN2k62rkJdXEznAaupbNiBpwHlMqFqh5SMA5/YPJO6/uEpwn2NJjSYkYk2OcIWvgkeQ==",
+      "dev": true,
+      "requires": {
+        "markdown-it": "8.3.2"
+      }
+    },
+    "markdownlint-cli": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.6.0.tgz",
+      "integrity": "sha512-gRkrvv2WrUTp/jbY+GZxyKPc10Bad5AmX0pnJWHX2eoaRDzFcrTGKTHzSXkyyy0fhBoXF7kgR/7FLvlz+agi3A==",
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "deep-extend": "0.4.2",
+        "glob": "7.0.6",
+        "lodash.flatten": "4.3.0",
+        "lodash.values": "4.2.0",
+        "markdownlint": "0.6.4",
+        "rc": "1.1.7"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "lodash.values": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.2.0.tgz",
+          "integrity": "sha1-kyYl99LJVLY9uJUlVUjztJ8SDpo=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "rc": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+          "dev": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          }
+        }
+      }
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -6894,6 +7001,12 @@
           }
         }
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -13946,6 +14059,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
+      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -300,6 +300,7 @@
   },
   "scripts": {
     "lint": "eslint . bin/*",
+    "markdownlint": "markdownlint \"*.md\" \"docs/**/*.md\" \".github/*.md\"",
     "test": "make clean && make test",
     "prepublishOnly": "npm test && make clean && make mocha.js",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
@@ -345,6 +346,7 @@
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-sauce-launcher": "^1.2.0",
     "markdown-toc": "^1.2.0",
+    "markdownlint-cli": "^0.6.0",
     "nyc": "^11.2.1",
     "rimraf": "^2.5.2",
     "svgo": "^0.7.2",


### PR DESCRIPTION
add `@mocha/markdownlint-cli`; closes #3172

- forked [markdownlint-cli](https://npm.im/markdownlint-cli) to fix a glob-related bug; will abandon our version if/when it's merged
- add `.markdownlint.json` config
- remove "allow trailing spaces" for Markdown in `.editorconfig`
- add to `lint` target & create `markdownlint` script in `package.json`, which is dumb, but we're stuck with it for now
- linted the markdown
