### PR TITLE
Added Node.js 9 support, removed Node.js 7 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ env:
 matrix:
   fast_finish: true
   include:
-    - node_js: '8'
+    - node_js: '9'
       env: TARGET=test-node COVERAGE=true
-    - node_js: '7'
+    - node_js: '8'
       env: TARGET=test-node
     - node_js: '6'
       env: TARGET=test-node


### PR DESCRIPTION
I wasn't able to edit the old PR (https://github.com/mochajs/mocha/pull/3160), so i make this one. As @boneskull requested, i removed the coverage from Node.js 8.