### PR TITLE
Add ability to pass in test files to be ran before positional files via --file

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -81,10 +81,7 @@ const list = str => str.split(/ *, */);
 /**
  * Parse multiple flag.
  */
-const collect = (val, memo) => {
-  memo.push(val);
-  return memo;
-};
+const collect = (val, memo) => memo.concat(val);
 
 /**
  * Hide the cursor.
@@ -208,7 +205,7 @@ program
   .option('--allow-uncaught', 'enable uncaught errors to propagate')
   .option('--forbid-only', 'causes test marked with only to fail the suite')
   .option('--forbid-pending', 'causes pending tests and test marked with skip to fail the suite')
-  .option('--file [file]', 'include a file to be ran during the suite', collect, []);
+  .option('--file <file>', 'include a file to be ran during the suite', collect, []);
 
 program._name = 'mocha';
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -121,6 +121,12 @@ const play = (arr, interval) => {
 let files = [];
 
 /**
+ * File args.
+ */
+
+let fileArgs = [];
+
+/**
  * Globals.
  */
 
@@ -199,7 +205,8 @@ program
   .option('--delay', 'wait for async suite definition')
   .option('--allow-uncaught', 'enable uncaught errors to propagate')
   .option('--forbid-only', 'causes test marked with only to fail the suite')
-  .option('--forbid-pending', 'causes pending tests and test marked with skip to fail the suite');
+  .option('--forbid-pending', 'causes pending tests and test marked with skip to fail the suite')
+  .option('--file <file>', 'include a file to be ran during the suite', list, []);
 
 program._name = 'mocha';
 
@@ -269,6 +276,12 @@ program.on('option:require', mod => {
     mod = resolve(mod);
   }
   requires.push(mod);
+});
+
+// --file
+
+program.on('option:file', mod => {
+  fileArgs.push(mod);
 });
 
 // If not already done, load mocha.opts
@@ -497,12 +510,15 @@ if (!files.length) {
 }
 
 // resolve
-
+fileArgs = fileArgs.map(path => resolve(path));
 files = files.map(path => resolve(path));
 
 if (program.sort) {
   files.sort();
 }
+
+// add files given through --file to be ran first
+files = fileArgs.concat(files);
 
 // --watch
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -79,6 +79,14 @@ const exit = code => {
 const list = str => str.split(/ *, */);
 
 /**
+ * Parse multiple flag.
+ */
+const collect = (val, memo) => {
+  memo.push(val);
+  return memo;
+};
+
+/**
  * Hide the cursor.
  */
 const hideCursor = () => {
@@ -119,12 +127,6 @@ const play = (arr, interval) => {
  */
 
 let files = [];
-
-/**
- * File args.
- */
-
-let fileArgs = [];
 
 /**
  * Globals.
@@ -206,7 +208,7 @@ program
   .option('--allow-uncaught', 'enable uncaught errors to propagate')
   .option('--forbid-only', 'causes test marked with only to fail the suite')
   .option('--forbid-pending', 'causes pending tests and test marked with skip to fail the suite')
-  .option('--file <file>', 'include a file to be ran during the suite', list, []);
+  .option('--file [file]', 'include a file to be ran during the suite', collect, []);
 
 program._name = 'mocha';
 
@@ -276,12 +278,6 @@ program.on('option:require', mod => {
     mod = resolve(mod);
   }
   requires.push(mod);
-});
-
-// --file
-
-program.on('option:file', mod => {
-  fileArgs.push(mod);
 });
 
 // If not already done, load mocha.opts
@@ -510,7 +506,7 @@ if (!files.length) {
 }
 
 // resolve
-fileArgs = fileArgs.map(path => resolve(path));
+let fileArgs = program.file.map(path => resolve(path));
 files = files.map(path => resolve(path));
 
 if (program.sort) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,17 +25,17 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js](https://n
 - [maps uncaught exceptions to the correct test case](#browser-specific-methods)
 - [async test timeout support](#delayed-root-suite)
 - [test retry support](#retry-tests)
-- [test-specific timeouts](#test-level)
+- [test-specific timeouts](#test-level) 
 - [growl notification support](#mochaopts)
 - [reports test durations](#test-duration)
 - [highlights slow tests](#dot-matrix)
-- [file watcher support](#min)
-- [global variable leak detection](#--check-leaks)
-- [optionally run tests that match a regexp](#-g---grep-pattern)
+- [file watcher support](#min) 
+- [global variable leak detection](#--check-leaks) 
+- [optionally run tests that match a regexp](#-g---grep-pattern) 
 - [auto-exit to prevent "hanging" with an active loop](#--exit----no-exit)
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [mocha.opts file support](#mochaopts)
-- clickable suite titles to filter test execution
+- clickable suite titles to filter test execution  
 - [node debugger support](#-d---debug)
 - detects multiple calls to `done()`
 - [use any assertion library you want](#assertions)
@@ -297,7 +297,7 @@ describe('hooks', function() {
 });
 ```
 
-> Tests can appear before, after, or interspersed with your hooks.  Hooks will run in the order they are defined, as appropriate; all `before()` hooks run (once), then any `beforeEach()` hooks, tests, any `afterEach()` hooks, and finally `after()` hooks (once).
+> Tests can appear before, after, or interspersed with your hooks.  Hooks will run in the order they are defined, as appropriate; all `before()` hooks run (once), then any `beforeEach()` hooks, tests, any `afterEach()` hooks, and finally `after()` hooks (once).  
 
 ### Describing Hooks
 
@@ -529,9 +529,9 @@ it('should only test in the correct environment', function() {
 });
 ```
 
-The above test will be reported as [pending](#pending-tests).  It's also important to note that calling `this.skip()` will effectively *abort* the test.
+The above test will be reported as [pending](#pending-tests).  It's also important to note that calling `this.skip()` will effectively *abort* the test.  
 
-> *Best practice*: To avoid confusion, do not execute further instructions in a test or hook after calling `this.skip()`.
+> *Best practice*: To avoid confusion, do not execute further instructions in a test or hook after calling `this.skip()`.  
 
 Contrast the above test with the following code:
 
@@ -736,7 +736,6 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --debug-brk                             enable node's debugger breaking on the first line
     --globals <names>                       allow the given comma-delimited global [names]
     --es_staging                            enable all staged features
-    --file <file>                           include a file to be ran during the suite [file]
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
     --icu-data-dir                          include ICU data

--- a/docs/index.md
+++ b/docs/index.md
@@ -736,6 +736,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --debug-brk                             enable node's debugger breaking on the first line
     --globals <names>                       allow the given comma-delimited global [names]
     --es_staging                            enable all staged features
+    --file <file>                           include a file to be ran during the suite [file]
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
     --icu-data-dir                          include ICU data

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,17 +25,17 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js](https://n
 - [maps uncaught exceptions to the correct test case](#browser-specific-methods)
 - [async test timeout support](#delayed-root-suite)
 - [test retry support](#retry-tests)
-- [test-specific timeouts](#test-level) 
+- [test-specific timeouts](#test-level)
 - [growl notification support](#mochaopts)
 - [reports test durations](#test-duration)
 - [highlights slow tests](#dot-matrix)
-- [file watcher support](#min) 
-- [global variable leak detection](#--check-leaks) 
-- [optionally run tests that match a regexp](#-g---grep-pattern) 
+- [file watcher support](#min)
+- [global variable leak detection](#--check-leaks)
+- [optionally run tests that match a regexp](#-g---grep-pattern)
 - [auto-exit to prevent "hanging" with an active loop](#--exit----no-exit)
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [mocha.opts file support](#mochaopts)
-- clickable suite titles to filter test execution  
+- clickable suite titles to filter test execution
 - [node debugger support](#-d---debug)
 - detects multiple calls to `done()`
 - [use any assertion library you want](#assertions)
@@ -297,7 +297,7 @@ describe('hooks', function() {
 });
 ```
 
-> Tests can appear before, after, or interspersed with your hooks.  Hooks will run in the order they are defined, as appropriate; all `before()` hooks run (once), then any `beforeEach()` hooks, tests, any `afterEach()` hooks, and finally `after()` hooks (once).  
+> Tests can appear before, after, or interspersed with your hooks.  Hooks will run in the order they are defined, as appropriate; all `before()` hooks run (once), then any `beforeEach()` hooks, tests, any `afterEach()` hooks, and finally `after()` hooks (once).
 
 ### Describing Hooks
 
@@ -529,9 +529,9 @@ it('should only test in the correct environment', function() {
 });
 ```
 
-The above test will be reported as [pending](#pending-tests).  It's also important to note that calling `this.skip()` will effectively *abort* the test.  
+The above test will be reported as [pending](#pending-tests).  It's also important to note that calling `this.skip()` will effectively *abort* the test.
 
-> *Best practice*: To avoid confusion, do not execute further instructions in a test or hook after calling `this.skip()`.  
+> *Best practice*: To avoid confusion, do not execute further instructions in a test or hook after calling `this.skip()`.
 
 Contrast the above test with the following code:
 
@@ -736,6 +736,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --debug-brk                             enable node's debugger breaking on the first line
     --globals <names>                       allow the given comma-delimited global [names]
     --es_staging                            enable all staged features
+    --file <file>                           include a file to be ran during the suite [file]
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
     --icu-data-dir                          include ICU data
@@ -848,6 +849,10 @@ Specifies the test-case timeout, defaulting to 2 seconds. To override you may pa
 ### `-s, --slow <ms>`
 
 Specify the "slow" test threshold, defaulting to 75ms. Mocha uses this to highlight test-cases that are taking too long.
+
+### `--file <file>`
+
+Add a file you want included first in a test suite. This is useful if you have some generic setup code that must be included within the test suite. The file passed is not effected by any other flags (`--recursive` or `--sort` have no effect). Accepts multiple `--file` flags to include multiple files.
 
 ### `-g, --grep <pattern>`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -852,7 +852,7 @@ Specify the "slow" test threshold, defaulting to 75ms. Mocha uses this to highli
 
 ### `--file <file>`
 
-Add a file you want included first in a test suite. This is useful if you have some generic setup code that must be included within the test suite. The file passed is not effected by any other flags (`--recursive` or `--sort` have no effect). Accepts multiple `--file` flags to include multiple files.
+Add a file you want included first in a test suite. This is useful if you have some generic setup code that must be included within the test suite. The file passed is not affected by any other flags (`--recursive` or `--sort` have no effect). Accepts multiple `--file` flags to include multiple files, the order in which the flags are given are the order in which the files are included in the test suite. Can also be used in `mocha.opts`.
 
 ### `-g, --grep <pattern>`
 

--- a/test/integration/fixtures/options/file-alpha.fixture.js
+++ b/test/integration/fixtures/options/file-alpha.fixture.js
@@ -1,0 +1,9 @@
+'use strict';
+
+describe('alpha', function () {
+  it('should be executed first', function () {
+    if (global.beta) {
+      throw new Error('alpha was not executed first');
+    }
+  });
+});

--- a/test/integration/fixtures/options/file-alpha.fixture.js
+++ b/test/integration/fixtures/options/file-alpha.fixture.js
@@ -2,7 +2,7 @@
 
 describe('alpha', function () {
   it('should be executed first', function () {
-    if (global.beta) {
+    if (global.beta !== undefined) {
       throw new Error('alpha was not executed first');
     }
   });

--- a/test/integration/fixtures/options/file-alpha.fixture.js
+++ b/test/integration/fixtures/options/file-alpha.fixture.js
@@ -5,5 +5,9 @@ describe('alpha', function () {
     if (global.beta !== undefined) {
       throw new Error('alpha was not executed first');
     }
+
+    if (global.theta !== undefined) {
+      throw new Error('alpha was not executed first');
+    }
   });
 });

--- a/test/integration/fixtures/options/file-beta.fixture.js
+++ b/test/integration/fixtures/options/file-beta.fixture.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('beta', function () {
+  it('should be executed second', function () {
+    global.beta = 1;
+  });
+});

--- a/test/integration/fixtures/options/file-beta.fixture.js
+++ b/test/integration/fixtures/options/file-beta.fixture.js
@@ -3,5 +3,9 @@
 describe('beta', function () {
   it('should be executed second', function () {
     global.beta = 1;
+
+    if (global.theta !== undefined) {
+      throw new Error('beta was not executed second');
+    }
   });
 });

--- a/test/integration/fixtures/options/file-theta.fixture.js
+++ b/test/integration/fixtures/options/file-theta.fixture.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('theta', function () {
+  it('should be executed third', function () {
+    global.theta = 1;
+  });
+});

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -129,7 +129,12 @@ module.exports = {
    * @param {Function} done - Callback
    * @param {string} cwd - Current working directory for mocha run, optional
    */
-  invokeMocha: invokeMocha
+  invokeMocha: invokeMocha,
+
+  /**
+   * Resolves the path to a fixture to the full path.
+   */
+  resolveFixturePath: resolveFixturePath
 };
 
 function invokeMocha (args, fn, cwd) {

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -94,11 +94,9 @@ describe('options', function () {
   });
 
   describe('--file', function () {
-    beforeEach(function () {
-      args = ['--file', resolvePath('options/file-alpha.fixture.js')];
-    });
-
     it('should run tests passed via file first', function (done) {
+      args = ['--file', resolvePath('options/file-alpha.fixture.js')];
+
       run('options/file-beta.fixture.js', args, function (err, res) {
         if (err) {
           done(err);
@@ -110,6 +108,32 @@ describe('options', function () {
 
         assert.equal(res.passes[0].fullTitle,
           'alpha should be executed first');
+        assert.equal(res.code, 0);
+        done();
+      });
+    });
+
+    it('should run multiple tests passed via file first', function (done) {
+      args = [
+        '--file', resolvePath('options/file-alpha.fixture.js'),
+        '--file', resolvePath('options/file-beta.fixture.js')
+      ];
+
+      run('options/file-theta.fixture.js', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 3);
+        assert.equal(res.stats.failures, 0);
+
+        assert.equal(res.passes[0].fullTitle,
+          'alpha should be executed first');
+        assert.equal(res.passes[1].fullTitle,
+          'beta should be executed second');
+        assert.equal(res.passes[2].fullTitle,
+          'theta should be executed third');
         assert.equal(res.code, 0);
         done();
       });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -4,6 +4,7 @@ var path = require('path');
 var assert = require('assert');
 var run = require('./helpers').runMochaJSON;
 var directInvoke = require('./helpers').invokeMocha;
+var resolvePath = require('./helpers').resolveFixturePath;
 var args = [];
 
 describe('options', function () {
@@ -75,6 +76,29 @@ describe('options', function () {
 
     it('should sort tests in alphabetical order', function (done) {
       run('options/sort*', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 2);
+        assert.equal(res.stats.failures, 0);
+
+        assert.equal(res.passes[0].fullTitle,
+          'alpha should be executed first');
+        assert.equal(res.code, 0);
+        done();
+      });
+    });
+  });
+
+  describe.only('--file', function () {
+    before(function () {
+      args = ['--file', resolvePath('options/file-alpha.fixture.js')];
+    });
+
+    it('should run tests passed via file first', function (done) {
+      run('options/file-beta.fixture.js', args, function (err, res) {
         if (err) {
           done(err);
           return;

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -2,9 +2,10 @@
 
 var path = require('path');
 var assert = require('assert');
-var run = require('./helpers').runMochaJSON;
-var directInvoke = require('./helpers').invokeMocha;
-var resolvePath = require('./helpers').resolveFixturePath;
+var helpers = require('./helpers');
+var run = helpers.runMochaJSON;
+var directInvoke = helpers.invokeMocha;
+var resolvePath = helpers.resolveFixturePath;
 var args = [];
 
 describe('options', function () {
@@ -92,8 +93,8 @@ describe('options', function () {
     });
   });
 
-  describe.only('--file', function () {
-    before(function () {
+  describe('--file', function () {
+    beforeEach(function () {
       args = ['--file', resolvePath('options/file-alpha.fixture.js')];
     });
 


### PR DESCRIPTION
This is to resolve #3181.

I was a little unsure how to describe this change. I think including something about how these args are ran first should be noted but I'm not exactly sure how best to do that.

Also I didn't do any file path sanitization to anything passed into `--file` nor did I apply `--recursive` to the path as right now I'm of the mind that any file passed to this argument should be explicit and not be effected by any sibling flags.

Happy to change anything that people disagree with.

Also apologies for the trailing whitespace cleanup, that was done by my editor. Happy to remove that change if you want.

Cheers! Excited to contribute! :D 