### PR TITLE
Added Netlify config file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+# Netlify deploy configuration
+# See https://www.netlify.com/docs/continuous-deployment/#deploy-contexts
+
+# Global settings applied to the whole site.  
+# 
+# “publish” is the directory to publish (relative to root of your repo),
+# “command” is your build command,
+# “base” is directory to change to before starting build. if you set base:
+#    that is where we will look for package.json/.nvmrc/etc not repo root!
+
+[build]
+  publish = "docs/_dist/"
+  command = "npm start buildDocs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@
 
 [build]
   publish = "docs/_dist/"
-  command = "npm start buildDocs"
+  command = "npm run buildDocs"


### PR DESCRIPTION
The Netlify build configuration currently only resides in their admin panel. This configuration file should hopefully override those settings to allow outside contributors to make refactoring changes

Refs https://github.com/mochajs/mocha/pull/3195

I'm letting this first build run with a non-valid configuration to see it fail. Then I'll switch it over to be in sync with the admin panel. After merge, current PR's can rebase and make changes to it