### PR TITLE
Seperate diff generation code from Base reporter; closes #3011

### DIFF
--- a/lib/colorUtils.js
+++ b/lib/colorUtils.js
@@ -1,0 +1,41 @@
+'use strict';
+
+exports.colors = {
+  pass: 90,
+  fail: 31,
+  'bright pass': 92,
+  'bright fail': 91,
+  'bright yellow': 93,
+  pending: 36,
+  suite: 0,
+  'error title': 0,
+  'error message': 31,
+  'error stack': 90,
+  checkmark: 32,
+  fast: 90,
+  medium: 33,
+  slow: 31,
+  green: 32,
+  light: 90,
+  'diff gutter': 90,
+  'diff added': 32,
+  'diff removed': 31
+};
+
+/**
+ * Color `str` with the given `type`.
+ *
+ * **Note:** `str` will only be coloured if `options.useColors === true`.
+ *
+ * @param {string} type
+ * @param {string} str
+ * @param {object} options
+ * @return {string}
+ * @api private
+ */
+exports.color = function color (type, str, options) {
+  if (!options.useColors) {
+    return String(str);
+  }
+  return '\u001b[' + exports.colors[type] + 'm' + str + '\u001b[0m';
+};

--- a/lib/formatDiffs.js
+++ b/lib/formatDiffs.js
@@ -1,0 +1,126 @@
+'use strict';
+
+var colorUtils = require('./colorUtils');
+var diff = require('diff');
+
+/**
+ * Pad the given `str` to `len`.
+ *
+ * @api private
+ * @param {string} str
+ * @param {string} len
+ * @return {string}
+ */
+function pad (str, len) {
+  str = String(str);
+  return Array(len - str.length + 1).join(' ') + str;
+}
+
+/**
+ * Returns an inline diff between 2 strings with coloured ANSI output
+ *
+ * @api private
+ * @param {Error} err with actual/expected
+ * @return {string} Diff
+ */
+exports.inlineDiff = function inlineDiff (err, options) {
+  var msg = errorDiff(err, options);
+
+  // linenos
+  var lines = msg.split('\n');
+  if (lines.length > 4) {
+    var width = String(lines.length).length;
+    msg = lines.map(function (str, i) {
+      return pad(++i, width) + ' |' + ' ' + str;
+    }).join('\n');
+  }
+
+  // legend
+  msg = '\n' +
+    colorUtils.color('diff removed', 'actual', options) +
+    ' ' +
+    colorUtils.color('diff added', 'expected', options) +
+    '\n\n' +
+    msg +
+    '\n';
+
+  // indent
+  msg = msg.replace(/^/gm, '      ');
+  return msg;
+};
+
+/**
+ * Returns a unified diff between two strings.
+ *
+ * @api private
+ * @param {Error} err with actual/expected
+ * @param {object} options
+ * @param {boolean} options.useColors Should the diff be displayed in color.
+ * @return {string} The diff.
+ */
+exports.unifiedDiff = function unifiedDiff (err, options) {
+  var indent = '      ';
+  function cleanUp (line) {
+    if (line[0] === '+') {
+      return indent + colorLines('diff added', line, options);
+    }
+    if (line[0] === '-') {
+      return indent + colorLines('diff removed', line, options);
+    }
+    if (line.match(/@@/)) {
+      return '--';
+    }
+    if (line.match(/\\ No newline/)) {
+      return null;
+    }
+    return indent + line;
+  }
+  function notBlank (line) {
+    return typeof line !== 'undefined' && line !== null;
+  }
+  var msg = diff.createPatch('string', err.actual, err.expected);
+  var lines = msg.split('\n').splice(5);
+  return '\n      ' +
+    colorLines('diff added', '+ expected', options) + ' ' +
+    colorLines('diff removed', '- actual', options) +
+    '\n\n' +
+    lines.map(cleanUp).filter(notBlank).join('\n');
+};
+
+/**
+ * Return a character diff for `err`.
+ *
+ * @api private
+ * @param {Error} err with actual/expected
+ * @param {object} options
+ * @param {boolean} options.useColors Should the diff be displayed in color.
+ * @return {string}
+ */
+function errorDiff (err, options) {
+  return diff.diffWordsWithSpace(err.actual, err.expected).map(function (str) {
+    if (str.added) {
+      return colorLines('diff added', str.value, options);
+    }
+    if (str.removed) {
+      return colorLines('diff removed', str.value, options);
+    }
+    return str.value;
+  }).join('');
+}
+
+/**
+ * Color lines for `str`, using the color `name`.
+ *
+ * **Note:** lines in `str` will only be coloured if `options.useColors === true`.
+ *
+ * @api private
+ * @param {string} name
+ * @param {string} str
+ * @param {object} options
+ * @return {string}
+ */
+function colorLines (name, str, options) {
+  return str.split('\n').map(function (str) {
+    return colorUtils.color(name, str, options);
+  }).join('\n');
+}

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -8,6 +8,7 @@ var tty = require('tty');
 var diff = require('diff');
 var ms = require('../ms');
 var utils = require('../utils');
+var colorUtils = require('../colorUtils');
 var supportsColor = process.browser ? null : require('supports-color');
 
 /**
@@ -51,27 +52,7 @@ exports.inlineDiffs = false;
  * Default color map.
  */
 
-exports.colors = {
-  pass: 90,
-  fail: 31,
-  'bright pass': 92,
-  'bright fail': 91,
-  'bright yellow': 93,
-  pending: 36,
-  suite: 0,
-  'error title': 0,
-  'error message': 31,
-  'error stack': 90,
-  checkmark: 32,
-  fast: 90,
-  medium: 33,
-  slow: 31,
-  green: 32,
-  light: 90,
-  'diff gutter': 90,
-  'diff added': 32,
-  'diff removed': 31
-};
+exports.colors = colorUtils.colors;
 
 /**
  * Default symbol map.
@@ -104,10 +85,7 @@ if (process.platform === 'win32') {
  * @api private
  */
 var color = exports.color = function (type, str) {
-  if (!exports.useColors) {
-    return String(str);
-  }
-  return '\u001b[' + exports.colors[type] + 'm' + str + '\u001b[0m';
+  return colorUtils.color(type, str, exports);
 };
 
 /**

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -5,10 +5,10 @@
  */
 
 var tty = require('tty');
-var diff = require('diff');
 var ms = require('../ms');
 var utils = require('../utils');
 var colorUtils = require('../colorUtils');
+var formatError = require('../formatDiffs');
 var supportsColor = process.browser ? null : require('supports-color');
 
 /**
@@ -194,9 +194,9 @@ exports.list = function (failures) {
       msg = '\n      ' + color('error message', match ? match[1] : msg);
 
       if (exports.inlineDiffs) {
-        msg += inlineDiff(err);
+        msg += formatError.inlineDiff(err, { useColors: exports.useColors });
       } else {
-        msg += unifiedDiff(err);
+        msg += formatError.unifiedDiff(err, { useColors: exports.useColors });
       }
     }
 
@@ -331,121 +331,6 @@ Base.prototype.epilogue = function () {
 
   console.log();
 };
-
-/**
- * Pad the given `str` to `len`.
- *
- * @api private
- * @param {string} str
- * @param {string} len
- * @return {string}
- */
-function pad (str, len) {
-  str = String(str);
-  return Array(len - str.length + 1).join(' ') + str;
-}
-
-/**
- * Returns an inline diff between 2 strings with coloured ANSI output
- *
- * @api private
- * @param {Error} err with actual/expected
- * @return {string} Diff
- */
-function inlineDiff (err) {
-  var msg = errorDiff(err);
-
-  // linenos
-  var lines = msg.split('\n');
-  if (lines.length > 4) {
-    var width = String(lines.length).length;
-    msg = lines.map(function (str, i) {
-      return pad(++i, width) + ' |' + ' ' + str;
-    }).join('\n');
-  }
-
-  // legend
-  msg = '\n' +
-    color('diff removed', 'actual') +
-    ' ' +
-    color('diff added', 'expected') +
-    '\n\n' +
-    msg +
-    '\n';
-
-  // indent
-  msg = msg.replace(/^/gm, '      ');
-  return msg;
-}
-
-/**
- * Returns a unified diff between two strings.
- *
- * @api private
- * @param {Error} err with actual/expected
- * @return {string} The diff.
- */
-function unifiedDiff (err) {
-  var indent = '      ';
-  function cleanUp (line) {
-    if (line[0] === '+') {
-      return indent + colorLines('diff added', line);
-    }
-    if (line[0] === '-') {
-      return indent + colorLines('diff removed', line);
-    }
-    if (line.match(/@@/)) {
-      return '--';
-    }
-    if (line.match(/\\ No newline/)) {
-      return null;
-    }
-    return indent + line;
-  }
-  function notBlank (line) {
-    return typeof line !== 'undefined' && line !== null;
-  }
-  var msg = diff.createPatch('string', err.actual, err.expected);
-  var lines = msg.split('\n').splice(5);
-  return '\n      ' +
-    colorLines('diff added', '+ expected') + ' ' +
-    colorLines('diff removed', '- actual') +
-    '\n\n' +
-    lines.map(cleanUp).filter(notBlank).join('\n');
-}
-
-/**
- * Return a character diff for `err`.
- *
- * @api private
- * @param {Error} err
- * @return {string}
- */
-function errorDiff (err) {
-  return diff.diffWordsWithSpace(err.actual, err.expected).map(function (str) {
-    if (str.added) {
-      return colorLines('diff added', str.value);
-    }
-    if (str.removed) {
-      return colorLines('diff removed', str.value);
-    }
-    return str.value;
-  }).join('');
-}
-
-/**
- * Color lines for `str`, using the color `name`.
- *
- * @api private
- * @param {string} name
- * @param {string} str
- * @return {string}
- */
-function colorLines (name, str) {
-  return str.split('\n').map(function (str) {
-    return color(name, str);
-  }).join('\n');
-}
 
 /**
  * Object#toString reference.


### PR DESCRIPTION
### Description of the Change

Moves the code used to generate "nice diffs" out of `lib/reporters/base.js` and into a new file which I have called `lib/formatDiffs.js`. This allows access to "nice diffs" by IDE's.

To make this change I also had to move move code which deals with the coloring of mocha output out of `lib/reporters/base.js` as it is needed to generate the diffs. I put this into `lib/colorUtils.js`.

### Alternate Designs

This is a first step towards exposing a public API, I have left function definitions as unchanged as possible but they should be changed if this API is to be exposed.

### Benefits

Allows IDE to produce prettier output (#3011)

### Possible Drawbacks

Doing `Base.colors = { /* ... */ }` will no longer change the colors used by mocha as `Base.colors` is now a reference to the object defined in `lib/colorUtils.js`.

If this is a problem `Base.colors` could be defined using getters/setters or made readonly.

### Applicable issues
#3011 


This should be semver patch.
