### PR TITLE
Exposes generation of diffs from base reporter

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -172,17 +172,14 @@ function stringifyDiffObjs (err) {
  * The diff will be either inline or unified dependant on the value
  * of `Base.inlineDiff`.
  *
- * @api private
- * @param {String} actual
- * @param {String} expected
+ * @param {string} actual
+ * @param {string} expected
  * @return {string} Diff
  */
 var generateDiff = exports.generateDiff = function (actual, expected) {
-  if (exports.inlineDiffs) {
-    return inlineDiff(actual, expected);
-  } else {
-    return unifiedDiff(actual, expected);
-  }
+  return exports.inlineDiffs
+    ? inlineDiff(actual, expected)
+    : unifiedDiff(actual, expected);
 };
 
 /**

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -167,6 +167,25 @@ function stringifyDiffObjs (err) {
 }
 
 /**
+ * Returns a diff between 2 strings with coloured ANSI output.
+ *
+ * The diff will be either inline or unified dependant on the value
+ * of `Base.inlineDiff`.
+ *
+ * @api private
+ * @param {String} actual
+ * @param {String} expected
+ * @return {string} Diff
+ */
+var generateDiff = exports.generateDiff = function (actual, expected) {
+  if (exports.inlineDiffs) {
+    return inlineDiff(actual, expected);
+  } else {
+    return unifiedDiff(actual, expected);
+  }
+};
+
+/**
  * Output the given `failures` as a list.
  *
  * @param {Array} failures
@@ -215,11 +234,7 @@ exports.list = function (failures) {
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);
 
-      if (exports.inlineDiffs) {
-        msg += inlineDiff(err);
-      } else {
-        msg += unifiedDiff(err);
-      }
+      msg += generateDiff(err.actual, err.expected);
     }
 
     // indent stack trace
@@ -368,14 +383,15 @@ function pad (str, len) {
 }
 
 /**
- * Returns an inline diff between 2 strings with coloured ANSI output
+ * Returns an inline diff between 2 strings with coloured ANSI output.
  *
  * @api private
- * @param {Error} err with actual/expected
+ * @param {String} actual
+ * @param {String} expected
  * @return {string} Diff
  */
-function inlineDiff (err) {
-  var msg = errorDiff(err);
+function inlineDiff (actual, expected) {
+  var msg = errorDiff(actual, expected);
 
   // linenos
   var lines = msg.split('\n');
@@ -401,13 +417,14 @@ function inlineDiff (err) {
 }
 
 /**
- * Returns a unified diff between two strings.
+ * Returns a unified diff between two strings with coloured ANSI output.
  *
  * @api private
- * @param {Error} err with actual/expected
+ * @param {String} actual
+ * @param {String} expected
  * @return {string} The diff.
  */
-function unifiedDiff (err) {
+function unifiedDiff (actual, expected) {
   var indent = '      ';
   function cleanUp (line) {
     if (line[0] === '+') {
@@ -427,7 +444,7 @@ function unifiedDiff (err) {
   function notBlank (line) {
     return typeof line !== 'undefined' && line !== null;
   }
-  var msg = diff.createPatch('string', err.actual, err.expected);
+  var msg = diff.createPatch('string', actual, expected);
   var lines = msg.split('\n').splice(5);
   return '\n      ' +
     colorLines('diff added', '+ expected') + ' ' +
@@ -440,11 +457,12 @@ function unifiedDiff (err) {
  * Return a character diff for `err`.
  *
  * @api private
- * @param {Error} err
- * @return {string}
+ * @param {String} actual
+ * @param {String} expected
+ * @return {string} the diff
  */
-function errorDiff (err) {
-  return diff.diffWordsWithSpace(err.actual, err.expected).map(function (str) {
+function errorDiff (actual, expected) {
+  return diff.diffWordsWithSpace(actual, expected).map(function (str) {
     if (str.added) {
       return colorLines('diff added', str.value);
     }

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -137,16 +137,22 @@ describe('Base reporter', function () {
   });
 
   describe('Diff generation', function () {
+    var oldInlineDiffs;
+
+    beforeEach(function () {
+      oldInlineDiffs = Base.inlineDiffs;
+    });
+
+    afterEach(function () {
+      Base.inlineDiffs = oldInlineDiffs;
+    });
+
     it('should generate unified diffs if `inlineDiff === false`', function () {
       var actual = 'a foo unified diff';
       var expected = 'a bar unified diff';
 
-      var oldInlineDiffs = Base.inlineDiffs;
       Base.inlineDiffs = false;
-
       var output = Base.generateDiff(actual, expected);
-
-      Base.inlineDiffs = oldInlineDiffs;
 
       expect(output).to.equal('\n      + expected - actual\n\n      -a foo unified diff\n      +a bar unified diff\n      ');
     });
@@ -155,12 +161,8 @@ describe('Base reporter', function () {
       var actual = 'a foo inline diff';
       var expected = 'a bar inline diff';
 
-      var oldInlineDiffs = Base.inlineDiffs;
       Base.inlineDiffs = true;
-
       var output = Base.generateDiff(actual, expected);
-
-      Base.inlineDiffs = oldInlineDiffs;
 
       expect(output).to.equal('      \n      actual expected\n      \n      a foobar inline diff\n      ');
     });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -136,6 +136,36 @@ describe('Base reporter', function () {
     });
   });
 
+  describe('Diff generation', function () {
+    it('should generate unified diffs if `inlineDiff === false`', function () {
+      var actual = 'a foo unified diff';
+      var expected = 'a bar unified diff';
+
+      var oldInlineDiffs = Base.inlineDiffs;
+      Base.inlineDiffs = false;
+
+      var output = Base.generateDiff(actual, expected);
+
+      Base.inlineDiffs = oldInlineDiffs;
+
+      expect(output).to.equal('\n      + expected - actual\n\n      -a foo unified diff\n      +a bar unified diff\n      ');
+    });
+
+    it('should generate inline diffs if `inlineDiffs === true`', function () {
+      var actual = 'a foo inline diff';
+      var expected = 'a bar inline diff';
+
+      var oldInlineDiffs = Base.inlineDiffs;
+      Base.inlineDiffs = true;
+
+      var output = Base.generateDiff(actual, expected);
+
+      Base.inlineDiffs = oldInlineDiffs;
+
+      expect(output).to.equal('      \n      actual expected\n      \n      a foobar inline diff\n      ');
+    });
+  });
+
   describe('Inline strings diff', function () {
     it('should show single line diff if property set to `true`', function () {
       var err = new Error('test');


### PR DESCRIPTION
#### Second attempt at solution for #3011, improves on PR #3201.

PR based on suggestion by @segrey in https://github.com/mochajs/mocha/pull/3201#issuecomment-358933824. Exposed function `generateDiff(expected, actual)` as a static member of `Base`.

The value of `Base.inlineDiffs` is used to determine the form of the diff.

### Alternate Designs

#3201

### Why should this be in core?

Allows IDE's to produce nice output when integrated with mocha.

### Benefits

See #3011.
