### PR TITLE
extract checking AMD bundle as own test command

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -40,7 +40,7 @@ module.exports = {
     test: {
       default: 'nps test.all',
       all: {
-        script: 'nps lint.code test.node test.browser',
+        script: 'nps lint.code test.node test.browser test.bundle',
         description: 'Lint code and runs node / browser environment tests'
       },
       node: {
@@ -204,6 +204,17 @@ module.exports = {
         spec: {
           script: test('non-tty-dot', '--reporter spec test/interfaces/bdd.spec 2>&1 > /tmp/spec.out && echo "spec:" && cat /tmp/spec.out'),
           description: 'Test non-TTY spec reporter'
+        }
+      },
+      bundle: {
+        default: 'nps test.bundle.all',
+        all: {
+          script: 'nps clean build.mochajs test.bundle.amd',
+          description: 'Compile Mocha and run all tests for bundle files'
+        },
+        amd: {
+          script: test('amd', 'test/bundle/amd.spec'),
+          description: 'Test bundle files for AMD'
         }
       }
     },

--- a/scripts/travis-before-script.sh
+++ b/scripts/travis-before-script.sh
@@ -2,6 +2,3 @@
 
 # bundle artifacts to AWS go here
 mkdir -p .karma
-
-# ensure we are building a non-broken bundle for AMD
-npm start build.mochajs && [[ -z "$(grep 'define.amd' mocha.js)" ]] || exit 1

--- a/test/bundle/amd.spec.js
+++ b/test/bundle/amd.spec.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+it('should build a non-broken bundle for AMD', function (done) {
+  var bundle = path.join(process.cwd(), 'mocha.js');
+  fs.readFile(bundle, 'utf8', function (err, content) {
+    if (err) { return done(err); }
+
+    expect(content).not.to.match(/define.amd/);
+    done();
+  });
+});


### PR DESCRIPTION
### Description of the Change
As #3208 , I moved checking AMD bundle into `package-script.js`.
I'm not sure the name which is`test.browser.amd` is properly.

### Alternate Designs
I considered between `nps lint.amd` and `npm test.browser.amd`.
I thought it is a kind of testing rather than linting.

### Why should this be in core?
See #3208

### Benefits
Developers can run it locally.

### Possible Drawbacks
N/A

### Applicable issues
Fix #3208 

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)? N
* Is it an enhancement (minor release)? N
* Is it a bug fix, or does it not impact production code (patch release)? N
-->
