### PR TITLE
fix: When using --delay, .only() no longer works. Issue  #1838

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -810,11 +810,6 @@ Runner.prototype.run = function (fn) {
   var self = this;
   var rootSuite = this.suite;
 
-  // If there is an `only` filter
-  if (hasOnly(rootSuite)) {
-    filterOnly(rootSuite);
-  }
-
   fn = fn || function () {};
 
   function uncaught (err) {
@@ -822,6 +817,10 @@ Runner.prototype.run = function (fn) {
   }
 
   function start () {
+    // If there is an `only` filter
+    if (hasOnly(rootSuite)) {
+      filterOnly(rootSuite);
+    }
     self.started = true;
     self.emit('start');
     self.runSuite(rootSuite, function () {

--- a/test/integration/fixtures/options/delay-only.fixture.js
+++ b/test/integration/fixtures/options/delay-only.fixture.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var assert = require('assert');
+var delay = 200;
+
+setTimeout(function () {
+  describe('delayed execution should execute exclusive tests only', function () {
+    it('should not run this test', function () {
+      (true).should.equal(false);
+    });
+
+    it.only('should run this', function () {});
+
+    it('should not run this test, neither', function () {
+      (true).should.equal(false);
+    });
+
+    it.only('should run this, too', function () {});
+  });
+
+  run();
+}, delay);
+
+

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -162,6 +162,25 @@ describe('options', function () {
       });
     });
 
+    it('should execute exclusive tests only', function (done) {
+      run('options/delay-only.fixture.js', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.equal(res.stats.tests, 2);
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 2);
+        assert.equal(res.stats.failures, 0);
+
+        assert.equal(res.passes[0].title, 'should run this');
+        assert.equal(res.passes[1].title, 'should run this, too');
+        assert.equal(res.code, 0);
+        done();
+      });
+    });
+
     it('should throw an error if the test suite failed to run', function (done) {
       run('options/delay-fail.fixture.js', args, function (err, res) {
         if (err) {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Fix the issue #1838 

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

It applies to issue #1838 
It is bug fix

