### PR TITLE
Issue/2819 - Fix / Clarify this.skip behavior in before hooks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -635,6 +635,30 @@ before(function() {
 });
 ```
 
+This will skip all `it`, `beforeEach/afterEach`, and `describe` blocks within the suite. `before/after` hooks are skipped unless they are defined at the same level as the hook containing `this.skip()`.
+
+```js
+describe('outer', function () {
+  before(function () {
+    this.skip();
+  });
+
+  after(function () {
+    // will be executed
+  });
+
+  describe('inner', function () {
+    before(function () {
+      // will be skipped
+    });
+
+    after(function () {
+      // will be skipped
+    });
+  });
+});
+```
+
 > Before Mocha v3.0.0, `this.skip()` was not supported in asynchronous tests and hooks.
 
 ## Retry Tests

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -317,6 +317,9 @@ Runner.prototype.hook = function(name, fn) {
             suite.tests.forEach(function(test) {
               test.pending = true;
             });
+            suite.suites.forEach(function(suite) {
+              suite.pending = true;
+            });
             // a pending hook won't be executed twice.
             hook.pending = true;
           }

--- a/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
@@ -20,15 +20,15 @@ describe('outer suite', function () {
     });
 
     beforeEach(function () {
-      throw new Error('never thrown');
+      throw new Error('beforeEach should not run');
     });
 
     afterEach(function () {
-      throw new Error('never thrown');
+      throw new Error('afterEach should not run');
     });
 
     it('should not run this test', function () {
-      throw new Error('never thrown');
+      throw new Error('inner suite test should not run');
     });
 
     after(function () {
@@ -41,7 +41,7 @@ describe('outer suite', function () {
       });
 
       it('should not run this test', function () {
-        throw new Error('never thrown');
+        throw new Error('skipped suite test should not run');
       });
 
       after(function () {

--- a/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
@@ -1,0 +1,60 @@
+'use string';
+
+describe('outer suite', function () {
+
+  before(function () {
+    console.log('outer before');
+  });
+
+  it('should run this test', function () {});
+
+  describe('inner suite', function () {
+
+    before(function (done) {
+      console.log('inner before');
+      var self = this;
+      setTimeout(function () {
+        self.skip();
+        done();
+      });
+    });
+
+    beforeEach(function () {
+      throw new Error('never thrown');
+    });
+
+    afterEach(function () {
+      throw new Error('never thrown');
+    });
+
+    it('should not run this test', function () {
+      throw new Error('never thrown');
+    });
+
+    after(function () {
+      console.log('inner after');
+    });
+
+    describe('skipped suite', function () {
+      before(function () {
+        console.log('skipped before');
+      });
+
+      it('should not run this test', function () {
+        throw new Error('never thrown');
+      });
+
+      after(function () {
+        console.log('skipped after');
+      });
+    });
+
+  });
+
+  it('should run this test', function () {});
+
+  after(function () {
+    console.log('outer after');
+  });
+
+});

--- a/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
@@ -16,7 +16,7 @@ describe('outer suite', function () {
       setTimeout(function () {
         self.skip();
         done();
-      });
+      }, 0);
     });
 
     beforeEach(function () {

--- a/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
@@ -1,4 +1,4 @@
-'use string';
+'use strict';
 
 describe('outer suite', function () {
 
@@ -6,7 +6,7 @@ describe('outer suite', function () {
     console.log('outer before');
   });
 
-  it('should run this test', function () {});
+  it('should run this test', function () { });
 
   describe('inner suite', function () {
 
@@ -51,7 +51,7 @@ describe('outer suite', function () {
 
   });
 
-  it('should run this test', function () {});
+  it('should run this test', function () { });
 
   after(function () {
     console.log('outer after');

--- a/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
@@ -1,0 +1,35 @@
+describe('skip in before with nested describes', function () {
+  before(function (done) {
+    var self = this;
+    setTimeout(function () {
+      self.skip();
+      done();
+    }, 50);
+  });
+
+  it('should never run this test', function () {});
+
+  describe('nested describe', function () {
+    before(function () {
+      throw new Error('should not run');
+    });
+
+    it('should never run this test', function () {});
+
+    after(function () {
+      throw new Error('should not run');
+    });
+
+    describe('nested again', function () {
+      before(function () {
+        throw new Error('should not run');
+      });
+
+      it('should never run this test', function () {});
+
+      after(function () {
+        throw new Error('should not run');
+      });
+    });
+  });
+});

--- a/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
@@ -4,7 +4,7 @@ describe('skip in before with nested describes', function () {
     setTimeout(function () {
       self.skip();
       done();
-    }, 50);
+    }, 0);
   });
 
   it('should never run this test', function () { });

--- a/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
@@ -7,28 +7,28 @@ describe('skip in before with nested describes', function () {
     }, 50);
   });
 
-  it('should never run this test', function () {});
+  it('should never run this test', function () { });
 
   describe('nested describe', function () {
     before(function () {
-      throw new Error('should not run');
+      throw new Error('first level before should not run');
     });
 
-    it('should never run this test', function () {});
+    it('should never run this test', function () { });
 
     after(function () {
-      throw new Error('should not run');
+      throw new Error('first level after should not run');
     });
 
     describe('nested again', function () {
       before(function () {
-        throw new Error('should not run');
+        throw new Error('second level before should not run');
       });
 
-      it('should never run this test', function () {});
+      it('should never run this test', function () { });
 
       after(function () {
-        throw new Error('should not run');
+        throw new Error('second level after should not run');
       });
     });
   });

--- a/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
@@ -7,14 +7,18 @@ describe('skip in before with nested describes', function () {
     }, 0);
   });
 
-  it('should never run this test', function () { });
+  it('should never run this test', function () {
+    throw new Error('never run this test');
+  });
 
   describe('nested describe', function () {
     before(function () {
       throw new Error('first level before should not run');
     });
 
-    it('should never run this test', function () { });
+    it('should never run this test', function () {
+      throw new Error('never run this test');
+    });
 
     after(function () {
       throw new Error('first level after should not run');
@@ -25,7 +29,9 @@ describe('skip in before with nested describes', function () {
         throw new Error('second level before should not run');
       });
 
-      it('should never run this test', function () { });
+      it('should never run this test', function () {
+        throw new Error('never run this test');
+      });
 
       after(function () {
         throw new Error('second level after should not run');

--- a/test/integration/fixtures/pending/skip-async-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before.fixture.js
@@ -1,18 +1,21 @@
 'use strict';
 
-describe('skip in before', function () {
-  before(function (done) {
-    var self = this;
-    setTimeout(function () {
-      self.skip();
-    }, 50);
+describe('outer describe', function () {
+
+  it('should run this test', function () {});
+
+  describe('skip in before', function () {
+    before(function (done) {
+      var self = this;
+      setTimeout(function () {
+        self.skip();
+      }, 50);
+    });
+
+    it('should never run this test', function () {});
+    it('should never run this test', function () {});
   });
 
-  it('should never run this test', function () {
-    throw new Error('never thrown');
-  });
+  it('should run this test', function () {});
 
-  it('should never run this test', function () {
-    throw new Error('never thrown');
-  });
 });

--- a/test/integration/fixtures/pending/skip-async-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before.fixture.js
@@ -1,7 +1,6 @@
 'use strict';
 
 describe('outer describe', function () {
-
   it('should run this test', function () {});
 
   describe('skip in before', function () {
@@ -12,10 +11,13 @@ describe('outer describe', function () {
       }, 0);
     });
 
-    it('should never run this test', function () {});
-    it('should never run this test', function () {});
+    it('should never run this test', function () {
+      throw new Error('never run this test');
+    });
+    it('should never run this test', function () {
+      throw new Error('never run this test');
+    });
   });
 
   it('should run this test', function () {});
-
 });

--- a/test/integration/fixtures/pending/skip-async-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before.fixture.js
@@ -9,7 +9,7 @@ describe('outer describe', function () {
       var self = this;
       setTimeout(function () {
         self.skip();
-      }, 50);
+      }, 0);
     });
 
     it('should never run this test', function () {});

--- a/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
@@ -5,14 +5,11 @@ describe('skip in beforeEach', function () {
     var self = this;
     setTimeout(function () {
       self.skip();
+      done();
     }, 50);
   });
 
-  it('should never run this test', function () {
-    throw new Error('never thrown');
-  });
-
-  it('should never run this test', function () {
-    throw new Error('never thrown');
-  });
+  it('should skip this test', function () {});
+  it('should error before reaching this test', function () {});
+  it('should error before reaching this test', function () {});
 });

--- a/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
@@ -6,7 +6,7 @@ describe('skip in beforeEach', function () {
     setTimeout(function () {
       self.skip();
       done();
-    }, 50);
+    }, 0);
   });
 
   it('should skip this test', function () {});

--- a/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
@@ -9,7 +9,13 @@ describe('skip in beforeEach', function () {
     }, 0);
   });
 
-  it('should skip this test', function () {});
-  it('should error before reaching this test', function () {});
-  it('should error before reaching this test', function () {});
+  it('should skip this test', function () {
+    throw new Error('never run this test');
+  });
+  it('should not reach this test', function () {
+    throw new Error('never run this test');
+  });
+  it('should not reach this test', function () {
+    throw new Error('never run this test');
+  });
 });

--- a/test/integration/fixtures/pending/skip-async-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-spec.fixture.js
@@ -5,7 +5,7 @@ describe('skip in test', function () {
     var self = this;
     setTimeout(function () {
       self.skip();
-    }, 50);
+    }, 0);
   });
 
   it('should run other tests in the suite', function () {

--- a/test/integration/fixtures/pending/skip-async-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-spec.fixture.js
@@ -8,7 +8,5 @@ describe('skip in test', function () {
     }, 0);
   });
 
-  it('should run other tests in the suite', function () {
-    // Do nothing
-  });
+  it('should run other tests in the suite', function () {});
 });

--- a/test/integration/fixtures/pending/skip-sync-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before-hooks.fixture.js
@@ -39,7 +39,7 @@ describe('outer suite', function () {
       });
 
       it('should never run this test', function () {
-        throw new Error('skipped suie test should not run');
+        throw new Error('skipped suite test should not run');
       });
 
       after(function () {

--- a/test/integration/fixtures/pending/skip-sync-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before-hooks.fixture.js
@@ -1,0 +1,57 @@
+'use strict';
+
+describe('outer suite', function () {
+
+  before(function () {
+    console.log('outer before');
+  });
+
+  it('should run this test', function () {});
+
+  describe('inner suite', function () {
+    before(function () {
+      this.skip();
+    });
+
+    before(function () {
+      console.log('inner before');
+    });
+
+    beforeEach(function () {
+      throw new Error('never thrown');
+    });
+
+    afterEach(function () {
+      throw new Error('never thrown');
+    });
+
+    after(function () {
+      console.log('inner after');
+    });
+
+    it('should never run this test', function () {
+      throw new Error('never thrown');
+    });
+
+    describe('skipped suite', function () {
+      before(function () {
+        console.log('skipped before');
+      });
+
+      it('should never run this test', function () {
+        throw new Error('never thrown');
+      });
+
+      after(function () {
+        console.log('skipped after');
+      });
+    });
+  });
+
+  it('should run this test', function () {});
+
+  after(function () {
+    console.log('outer after');
+  })
+
+});

--- a/test/integration/fixtures/pending/skip-sync-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before-hooks.fixture.js
@@ -6,7 +6,7 @@ describe('outer suite', function () {
     console.log('outer before');
   });
 
-  it('should run this test', function () {});
+  it('should run this test', function () { });
 
   describe('inner suite', function () {
     before(function () {
@@ -18,11 +18,11 @@ describe('outer suite', function () {
     });
 
     beforeEach(function () {
-      throw new Error('never thrown');
+      throw new Error('beforeEach should not run');
     });
 
     afterEach(function () {
-      throw new Error('never thrown');
+      throw new Error('afterEach should not run');
     });
 
     after(function () {
@@ -30,7 +30,7 @@ describe('outer suite', function () {
     });
 
     it('should never run this test', function () {
-      throw new Error('never thrown');
+      throw new Error('inner suite test should not run');
     });
 
     describe('skipped suite', function () {
@@ -39,7 +39,7 @@ describe('outer suite', function () {
       });
 
       it('should never run this test', function () {
-        throw new Error('never thrown');
+        throw new Error('skipped suie test should not run');
       });
 
       after(function () {
@@ -48,7 +48,7 @@ describe('outer suite', function () {
     });
   });
 
-  it('should run this test', function () {});
+  it('should run this test', function () { });
 
   after(function () {
     console.log('outer after');

--- a/test/integration/fixtures/pending/skip-sync-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before-nested.fixture.js
@@ -5,28 +5,28 @@ describe('skip in before with nested describes', function () {
     this.skip();
   });
 
-  it('should never run this test', function () {});
+  it('should never run this test', function () { });
 
   describe('nested describe', function () {
     before(function () {
-      throw new Error('should not run');
+      throw new Error('first level before should not run');
     });
 
-    it('should never run this test', function () {});
+    it('should never run this test', function () { });
 
     after(function () {
-      throw new Error('should not run');
+      throw new Error('first level after should not run');
     });
 
     describe('nested again', function () {
       before(function () {
-        throw new Error('should not run');
+        throw new Error('second level before should not run');
       });
 
-      it('should never run this test', function () {});
+      it('should never run this test', function () { });
 
       after(function () {
-        throw new Error('should not run');
+        throw new Error('second level after should not run');
       });
     });
   });

--- a/test/integration/fixtures/pending/skip-sync-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before-nested.fixture.js
@@ -5,14 +5,18 @@ describe('skip in before with nested describes', function () {
     this.skip();
   });
 
-  it('should never run this test', function () { });
+  it('should never run this test', function () {
+    throw new Error('never run this test');
+  });
 
   describe('nested describe', function () {
     before(function () {
       throw new Error('first level before should not run');
     });
 
-    it('should never run this test', function () { });
+    it('should never run this test', function () {
+      throw new Error('never run this test');
+    });
 
     after(function () {
       throw new Error('first level after should not run');
@@ -23,7 +27,9 @@ describe('skip in before with nested describes', function () {
         throw new Error('second level before should not run');
       });
 
-      it('should never run this test', function () { });
+      it('should never run this test', function () {
+        throw new Error('never run this test');
+      });
 
       after(function () {
         throw new Error('second level after should not run');

--- a/test/integration/fixtures/pending/skip-sync-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before-nested.fixture.js
@@ -1,0 +1,33 @@
+'use strict';
+
+describe('skip in before with nested describes', function () {
+  before(function () {
+    this.skip();
+  });
+
+  it('should never run this test', function () {});
+
+  describe('nested describe', function () {
+    before(function () {
+      throw new Error('should not run');
+    });
+
+    it('should never run this test', function () {});
+
+    after(function () {
+      throw new Error('should not run');
+    });
+
+    describe('nested again', function () {
+      before(function () {
+        throw new Error('should not run');
+      });
+
+      it('should never run this test', function () {});
+
+      after(function () {
+        throw new Error('should not run');
+      });
+    });
+  });
+});

--- a/test/integration/fixtures/pending/skip-sync-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before.fixture.js
@@ -1,15 +1,18 @@
 'use strict';
 
-describe('skip in before', function () {
-  before(function () {
-    this.skip();
+describe('outer describe', function () {
+
+  it('should run this test', function () {});
+
+  describe('skip in before', function () {
+    before(function () {
+      this.skip();
+    });
+
+    it('should never run this test', function () {});
+    it('should never run this test', function () {});
   });
 
-  it('should never run this test', function () {
-    throw new Error('never thrown');
-  });
+  it('should run this test', function () {});
 
-  it('should never run this test', function () {
-    throw new Error('never thrown');
-  });
 });

--- a/test/integration/fixtures/pending/skip-sync-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-before.fixture.js
@@ -1,7 +1,6 @@
 'use strict';
 
 describe('outer describe', function () {
-
   it('should run this test', function () {});
 
   describe('skip in before', function () {
@@ -9,10 +8,13 @@ describe('outer describe', function () {
       this.skip();
     });
 
-    it('should never run this test', function () {});
-    it('should never run this test', function () {});
+    it('should never run this test', function () {
+      throw new Error('never run this test');
+    });
+    it('should never run this test', function () {
+      throw new Error('never run this test');
+    });
   });
 
   it('should run this test', function () {});
-
 });

--- a/test/integration/fixtures/pending/skip-sync-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-beforeEach.fixture.js
@@ -6,10 +6,10 @@ describe('skip in beforeEach', function () {
   });
 
   it('should never run this test', function () {
-    throw new Error('never thrown');
+    throw new Error('never run this test');
   });
 
   it('should never run this test', function () {
-    throw new Error('never thrown');
+    throw new Error('never run this test');
   });
 });

--- a/test/integration/fixtures/pending/skip-sync-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-spec.fixture.js
@@ -3,10 +3,8 @@
 describe('skip in test', function () {
   it('should skip immediately', function () {
     this.skip();
-    throw new Error('never thrown');
+    throw new Error('never run this test');
   });
 
-  it('should run other tests in the suite', function () {
-    // Do nothing
-  });
+  it('should run other tests in the suite', function () {});
 });

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -2,6 +2,8 @@
 
 var assert = require('assert');
 var run = require('./helpers').runMochaJSON;
+var runMocha = require('./helpers').runMocha;
+var splitRegExp = require('./helpers').splitRegExp;
 var args = [];
 
 describe('pending', function() {
@@ -74,6 +76,78 @@ describe('pending', function() {
             return;
           }
           assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.passes, 2);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0);
+          done();
+        });
+      });
+      it('should run before and after hooks', function(done) {
+        runMocha('pending/skip-sync-before-hooks.fixture.js', args, function(
+          err,
+          res
+        ) {
+          if (err) {
+            done(err);
+            return;
+          }
+          var output = res.output.split(splitRegExp);
+          assert.equal(res.pending, 2);
+          assert.equal(res.passing, 2);
+          assert.equal(res.failing, 0);
+          assert.equal(res.code, 0);
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'outer before';
+            }).length
+          );
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'outer after';
+            }).length
+          );
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'inner before';
+            }).length
+          );
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'inner after';
+            }).length
+          );
+          assert.equal(
+            0,
+            output.filter(function(txt) {
+              return txt === 'skipped before';
+            }).length
+          );
+          assert.equal(
+            0,
+            output.filter(function(txt) {
+              return txt === 'skipped after';
+            }).length
+          );
+          done();
+        });
+      });
+    });
+
+    describe('in before with nested describe', function() {
+      it('should skip all suite specs, even if nested', function(done) {
+        run('pending/skip-sync-before-nested.fixture.js', args, function(
+          err,
+          res
+        ) {
+          if (err) {
+            done(err);
+            return;
+          }
+          assert.equal(res.stats.pending, 3);
           assert.equal(res.stats.passes, 0);
           assert.equal(res.stats.failures, 0);
           assert.equal(res.code, 0);
@@ -127,6 +201,78 @@ describe('pending', function() {
             return;
           }
           assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.passes, 2);
+          assert.equal(res.stats.failures, 0);
+          assert.equal(res.code, 0, 'code');
+          done();
+        });
+      });
+      it('should run before and after hooks', function(done) {
+        runMocha('pending/skip-async-before-hooks.fixture.js', args, function(
+          err,
+          res
+        ) {
+          if (err) {
+            done(err);
+            return;
+          }
+          var output = res.output.split(splitRegExp);
+          assert.equal(res.pending, 2);
+          assert.equal(res.passing, 2);
+          assert.equal(res.failing, 0);
+          assert.equal(res.code, 0);
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'outer before';
+            }).length
+          );
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'outer after';
+            }).length
+          );
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'inner before';
+            }).length
+          );
+          assert.equal(
+            1,
+            output.filter(function(txt) {
+              return txt === 'inner after';
+            }).length
+          );
+          assert.equal(
+            0,
+            output.filter(function(txt) {
+              return txt === 'skipped before';
+            }).length
+          );
+          assert.equal(
+            0,
+            output.filter(function(txt) {
+              return txt === 'skipped after';
+            }).length
+          );
+          done();
+        });
+      });
+    });
+
+    describe('in before with nested describe', function() {
+      it('should skip all suite specs, even if nested', function(done) {
+        run('pending/skip-async-before-nested.fixture.js', args, function(
+          err,
+          res
+        ) {
+          if (err) {
+            done(err);
+            return;
+          }
+          assert.equal(res.stats.pending, 3);
           assert.equal(res.stats.passes, 0);
           assert.equal(res.stats.failures, 0);
           assert.equal(res.code, 0);
@@ -137,7 +283,7 @@ describe('pending', function() {
 
     describe('in beforeEach', function() {
       it('should skip all suite specs', function(done) {
-        run('pending/skip-sync-beforeEach.fixture.js', args, function(
+        run('pending/skip-async-beforeEach.fixture.js', args, function(
           err,
           res
         ) {
@@ -145,10 +291,10 @@ describe('pending', function() {
             done(err);
             return;
           }
-          assert.equal(res.stats.pending, 2);
+          assert.equal(res.stats.pending, 1);
           assert.equal(res.stats.passes, 0);
-          assert.equal(res.stats.failures, 0);
-          assert.equal(res.code, 0);
+          assert.equal(res.stats.failures, 1);
+          assert.equal(res.code, 1);
           done();
         });
       });

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -189,7 +189,7 @@ describe('pending', function() {
           assert.equal(res.stats.pending, 2);
           assert.equal(res.stats.passes, 2);
           assert.equal(res.stats.failures, 0);
-          assert.equal(res.code, 0, 'code');
+          assert.equal(res.code, 0);
           done();
         });
       });

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -83,57 +83,43 @@ describe('pending', function() {
         });
       });
       it('should run before and after hooks', function(done) {
-        runMocha('pending/skip-sync-before-hooks.fixture.js', args, function(
-          err,
-          res
-        ) {
-          if (err) {
-            done(err);
-            return;
+        runMocha(
+          'pending/skip-sync-before-hooks.fixture.js',
+          args.concat(['--reporter', 'dot']),
+          function(err, res) {
+            if (err) {
+              done(err);
+              return;
+            }
+
+            var lines = res.output
+              .split(splitRegExp)
+              .map(function(line) {
+                return line.trim();
+              })
+              .filter(function(line) {
+                return line.length;
+              })
+              .slice(0, -1);
+
+            var expected = [
+              'outer before',
+              'inner before',
+              'inner after',
+              'outer after'
+            ];
+
+            assert.equal(res.pending, 2);
+            assert.equal(res.passing, 2);
+            assert.equal(res.failing, 0);
+            assert.equal(res.code, 0);
+            expected.forEach(function(line, i) {
+              assert.equal(true, lines[i].includes(line));
+            });
+
+            done();
           }
-          var output = res.output.split(splitRegExp);
-          assert.equal(res.pending, 2);
-          assert.equal(res.passing, 2);
-          assert.equal(res.failing, 0);
-          assert.equal(res.code, 0);
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'outer before';
-            }).length
-          );
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'outer after';
-            }).length
-          );
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'inner before';
-            }).length
-          );
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'inner after';
-            }).length
-          );
-          assert.equal(
-            0,
-            output.filter(function(txt) {
-              return txt === 'skipped before';
-            }).length
-          );
-          assert.equal(
-            0,
-            output.filter(function(txt) {
-              return txt === 'skipped after';
-            }).length
-          );
-          done();
-        });
+        );
       });
     });
 
@@ -208,57 +194,43 @@ describe('pending', function() {
         });
       });
       it('should run before and after hooks', function(done) {
-        runMocha('pending/skip-async-before-hooks.fixture.js', args, function(
-          err,
-          res
-        ) {
-          if (err) {
-            done(err);
-            return;
+        runMocha(
+          'pending/skip-async-before-hooks.fixture.js',
+          args.concat(['--reporter', 'dot']),
+          function(err, res) {
+            if (err) {
+              done(err);
+              return;
+            }
+
+            var lines = res.output
+              .split(splitRegExp)
+              .map(function(line) {
+                return line.trim();
+              })
+              .filter(function(line) {
+                return line.length;
+              })
+              .slice(0, -1);
+
+            var expected = [
+              'outer before',
+              'inner before',
+              'inner after',
+              'outer after'
+            ];
+
+            assert.equal(res.pending, 2);
+            assert.equal(res.passing, 2);
+            assert.equal(res.failing, 0);
+            assert.equal(res.code, 0);
+            expected.forEach(function(line, i) {
+              assert.equal(true, lines[i].includes(line));
+            });
+
+            done();
           }
-          var output = res.output.split(splitRegExp);
-          assert.equal(res.pending, 2);
-          assert.equal(res.passing, 2);
-          assert.equal(res.failing, 0);
-          assert.equal(res.code, 0);
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'outer before';
-            }).length
-          );
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'outer after';
-            }).length
-          );
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'inner before';
-            }).length
-          );
-          assert.equal(
-            1,
-            output.filter(function(txt) {
-              return txt === 'inner after';
-            }).length
-          );
-          assert.equal(
-            0,
-            output.filter(function(txt) {
-              return txt === 'skipped before';
-            }).length
-          );
-          assert.equal(
-            0,
-            output.filter(function(txt) {
-              return txt === 'skipped after';
-            }).length
-          );
-          done();
-        });
+        );
       });
     });
 


### PR DESCRIPTION
This PR contains a possible fix for [Issue 2819](https://github.com/mochajs/mocha/issues/2819).

### Description of the Change

Let me preface this by saying I'm new to open source contributing, so if I messed something up please let me know. I assure you in advance that it was an unintentional mistake rather than deliberate violation of the rules. :)

I adapted this change from [Elergy's PR](https://github.com/mochajs/mocha/pull/2836/files), since it seemed to be stuck in a limbo. I also referred to [this discussion](https://github.com/mochajs/mocha/pull/2571) regarding skip and hooks. It seems like all the discussions have been inactive for a while, so I'm interested to know if there's been a resolution.

Changes:
- Added integration tests for `this.skip` in `before` that verify hooks don't execute and nested describes are skipped.
  - Modified existing `this.skip` / `before` tests to show that subsequent hooks aren't executed.
- Modified `runner.js` to set this.suite.pending instead of just the tests.
- Added a proposed doc change for the interaction of this.skip and nested describes (I'm fine dropping this commit if needed, but it'd be nice if the docs spoke to this situation).

This PR's primary goal is to get a consensus on what the expected behavior is regarding `this.skip` in non-trivial cases involving hooks and describe. At the very least, it'd be helpful for the documentation / tests to address these cases one way or the other. If this fix works, so much the better.

Here are the behaviors I'm concerned about (my first commit contains the failing tests). I've lumped the two issues together since they seem to stem from the same root cause; namely, that the suite itself is not marked as pending when skipped in a before.
- When `this.skip` is called in a `before` block, subsequent before blocks are still executed.
  - Expected: Subsequent hooks are not executed if the suite is skipped.
- When `this.skip` is called in a `before` block, tests in nested describes are not skipped (issue 2819).
  - Expected: All tests in a block are skipped, even if nested.

### Alternate Designs

If these behaviors are NOT bugs, then perhaps we can make that clear in the docs.

### Why should this be in core?

This issue speaks to the behavior of this.skip, which is in core.

### Benefits

At a minimum, I'd like to reach a point where the documentation addresses these cases. This will help address potential user confusion in the future. I'm happy to collaborate on the documentation itself. :)

### Possible Drawbacks

I'm not sure, but I'm hoping someone else has feedback.

### Applicable issues

[Issue 2819](https://github.com/mochajs/mocha/issues/2819)
