### PR TITLE
refactor(reporters/base): extract and export formatTestFailure function

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -166,6 +166,67 @@ function stringifyDiffObjs (err) {
   }
 }
 
+
+exports.formatTestFailure = function (test) {
+  // msg
+  var msg;
+  var err = test.err;
+  var message;
+  if (err.message && typeof err.message.toString === 'function') {
+    message = err.message + '';
+  } else if (typeof err.inspect === 'function') {
+    message = err.inspect() + '';
+  } else {
+    message = '';
+  }
+  var stack = err.stack || message;
+  var index = message ? stack.indexOf(message) : -1;
+
+  if (index === -1) {
+    msg = message;
+  } else {
+    index += message.length;
+    msg = stack.slice(0, index);
+    // remove msg from stack
+    stack = stack.slice(index + 1);
+  }
+
+  // uncaught
+  if (err.uncaught) {
+    msg = 'Uncaught ' + msg;
+  }
+  // explicitly show diff
+  if (!exports.hideDiff && showDiff(err)) {
+    stringifyDiffObjs(err);
+    fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
+    var match = message.match(/^([^:]+): expected/);
+    msg = '\n      ' + color('error message', match ? match[1] : msg);
+
+    if (exports.inlineDiffs) {
+      msg += inlineDiff(err);
+    } else {
+      msg += unifiedDiff(err);
+    }
+  }
+
+  // indent stack trace
+  stack = stack.replace(/^/gm, '  ');
+  
+  // indented test title
+  var testTitle = '';
+  test.titlePath().forEach(function (str, index) {
+    if (index !== 0) {
+      testTitle += '\n     ';
+    }
+    for (var i = 0; i < index; i++) {
+      testTitle += '  ';
+    }
+    testTitle += str;
+  });
+
+  return {testTitle: testTitle, msg: msg, stack: stack}
+}
+
 /**
  * Output the given `failures` as a list.
  *
@@ -176,68 +237,8 @@ function stringifyDiffObjs (err) {
 exports.list = function (failures) {
   console.log();
   failures.forEach(function (test, i) {
-    // format
-    var fmt = color('error title', '  %s) %s:\n') +
-      color('error message', '     %s') +
-      color('error stack', '\n%s\n');
-
-    // msg
-    var msg;
-    var err = test.err;
-    var message;
-    if (err.message && typeof err.message.toString === 'function') {
-      message = err.message + '';
-    } else if (typeof err.inspect === 'function') {
-      message = err.inspect() + '';
-    } else {
-      message = '';
-    }
-    var stack = err.stack || message;
-    var index = message ? stack.indexOf(message) : -1;
-
-    if (index === -1) {
-      msg = message;
-    } else {
-      index += message.length;
-      msg = stack.slice(0, index);
-      // remove msg from stack
-      stack = stack.slice(index + 1);
-    }
-
-    // uncaught
-    if (err.uncaught) {
-      msg = 'Uncaught ' + msg;
-    }
-    // explicitly show diff
-    if (!exports.hideDiff && showDiff(err)) {
-      stringifyDiffObjs(err);
-      fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
-      var match = message.match(/^([^:]+): expected/);
-      msg = '\n      ' + color('error message', match ? match[1] : msg);
-
-      if (exports.inlineDiffs) {
-        msg += inlineDiff(err);
-      } else {
-        msg += unifiedDiff(err);
-      }
-    }
-
-    // indent stack trace
-    stack = stack.replace(/^/gm, '  ');
-
-    // indented test title
-    var testTitle = '';
-    test.titlePath().forEach(function (str, index) {
-      if (index !== 0) {
-        testTitle += '\n     ';
-      }
-      for (var i = 0; i < index; i++) {
-        testTitle += '  ';
-      }
-      testTitle += str;
-    });
-
-    console.log(fmt, (i + 1), testTitle, msg, stack);
+    var formatted = Base.formatTestFailure(test)
+    console.log(fmt, (i + 1), formatted.testTitle, formatted.msg, formatted.stack);
   });
 };
 


### PR DESCRIPTION
I want to create a reporter that immediately displays the error message and stack when a test fails, and I would like to be able to use the same code that the base reporter does to format the error.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
