### PR TITLE
Removes trailing spaces in changelog to fix CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ...your garden-variety patch release.
 
-Special thanks to [Wallaby.js](https://wallabyjs.com) for their continued support! :heart: 
+Special thanks to [Wallaby.js](https://wallabyjs.com) for their continued support! :heart:
 
 ## :bug: Fixes
- 
+
 - [#1838]: `--delay` now works with `.only()` ([@silviom])
 - [#3119]: Plug memory leak present in v8 ([@boneskull])
 


### PR DESCRIPTION
Will fix the failing CI.

Trailing spaces in CHANGELOG.md are causing travis to fail, this PR removes the trailing spaces.