### PR TITLE
Give a deprecation warning if a suite callback returns a value.

### DIFF
--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Suite = require('../suite');
+var utils = require('../utils');
 
 /**
  * Functions common to more than one interface.
@@ -110,8 +111,8 @@ module.exports = function (suites, context, mocha) {
         }
         if (typeof opts.fn === 'function') {
           var result = opts.fn.call(suite);
-          if (result && typeof result.then === 'function') {
-            throw new Error('Suite "' + suite.fullTitle() + '" was given an async callback. This will not behave as you expect.');
+          if (typeof result !== 'undefined') {
+            utils.deprecate('Returning a value from a Suite is deprecated; this will throw an exception in the next major version of Mocha');
           }
           suites.shift();
         } else if (typeof opts.fn === 'undefined' && !suite.pending) {

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -111,7 +111,7 @@ module.exports = function (suites, context, mocha) {
         }
         if (typeof opts.fn === 'function') {
           var result = opts.fn.call(suite);
-          if (result) {
+          if (typeof result !== 'undefined') {
             utils.deprecate('Returning a value from a Suite is deprecated; this will throw an exception in the next major version of Mocha');
           }
           suites.shift();

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -112,7 +112,7 @@ module.exports = function (suites, context, mocha) {
         if (typeof opts.fn === 'function') {
           var result = opts.fn.call(suite);
           if (typeof result !== 'undefined') {
-            utils.deprecate('Returning a value from a Suite is deprecated; this will throw an exception in the next major version of Mocha');
+            utils.deprecate('Deprecation Warning: Suites do not support a return value;' + opts.title + ' returned :' + result);
           }
           suites.shift();
         } else if (typeof opts.fn === 'undefined' && !suite.pending) {

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -109,7 +109,10 @@ module.exports = function (suites, context, mocha) {
           suite.parent._onlySuites = suite.parent._onlySuites.concat(suite);
         }
         if (typeof opts.fn === 'function') {
-          opts.fn.call(suite);
+          var result = opts.fn.call(suite);
+          if (result && typeof result.then === 'function') {
+            throw new Error('Suite "' + suite.fullTitle() + '" was given an async callback. This will not behave as you expect.');
+          }
           suites.shift();
         } else if (typeof opts.fn === 'undefined' && !suite.pending) {
           throw new Error('Suite "' + suite.fullTitle() + '" was defined but no callback was supplied. Supply a callback or explicitly skip the suite.');

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -111,7 +111,7 @@ module.exports = function (suites, context, mocha) {
         }
         if (typeof opts.fn === 'function') {
           var result = opts.fn.call(suite);
-          if (typeof result !== 'undefined') {
+          if (result) {
             utils.deprecate('Returning a value from a Suite is deprecated; this will throw an exception in the next major version of Mocha');
           }
           suites.shift();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -544,15 +544,30 @@ exports.getError = function (err) {
 };
 
 /**
- * Show a deprecation warning
+ * Show a deprecation warning. Each distinct message is only displayed once.
  *
  * @param {string} msg
  */
-exports.deprecate = process.emitWarning
+exports.deprecate = function (msg) {
+  msg = String(msg);
+  if (seenDeprecationMsg.hasOwnProperty(msg)) {
+    return;
+  }
+  seenDeprecationMsg[msg] = true;
+  doDeprecationWarning(msg);
+};
+
+var seenDeprecationMsg = {};
+
+var doDeprecationWarning = process.emitWarning
   // Node.js v6+
   ? function (msg) { process.emitWarning(msg, 'DeprecationWarning'); }
+  // Node.js v4+
+  // process.emitWarning emits on the next tick; emulate that.
+  : process.nextTick ?
+  function (msg) { process.nextTick(() => console.warn(msg)); }
   // Everything else
-  : function (msg) { console.warn(msg); };
+  : function (msg) { Promise.resolve().then(() => console.warn(msg)); };
 
 /**
  * @summary

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -564,10 +564,10 @@ var doDeprecationWarning = process.emitWarning
   ? function (msg) { process.emitWarning(msg, 'DeprecationWarning'); }
   // Node.js v4+
   // process.emitWarning emits on the next tick; emulate that.
-  : process.nextTick ?
-  function (msg) { process.nextTick(() => console.warn(msg)); }
-  // Everything else
-  : function (msg) { Promise.resolve().then(() => console.warn(msg)); };
+  : process.nextTick
+    ? function (msg) { process.nextTick(() => console.warn(msg)); }
+    // Everything else
+    : function (msg) { Promise.resolve().then(() => console.warn(msg)); };
 
 /**
  * @summary

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -563,7 +563,7 @@ var doDeprecationWarning = process.emitWarning
   // Node.js v6+
   ? function (msg) { process.emitWarning(msg, 'DeprecationWarning'); }
   // Everything else
-  :  function (msg) { process.nextTick(() => console.warn(msg)); }
+  : function (msg) { process.nextTick(() => console.warn(msg)); };
 
 /**
  * @summary

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -544,6 +544,17 @@ exports.getError = function (err) {
 };
 
 /**
+ * Show a deprecation warning
+ *
+ * @param {string} msg
+ */
+exports.deprecate = process.emitWarning
+  // Node.js v6+
+  ? function (msg) { process.emitWarning(msg, 'DeprecationWarning'); }
+  // Everything else
+  : function (msg) { console.warn(msg); };
+
+/**
  * @summary
  * This Filter based on `mocha-clean` module.(see: `github.com/rstacruz/mocha-clean`)
  * @description

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -562,12 +562,8 @@ var seenDeprecationMsg = {};
 var doDeprecationWarning = process.emitWarning
   // Node.js v6+
   ? function (msg) { process.emitWarning(msg, 'DeprecationWarning'); }
-  // Node.js v4+
-  // process.emitWarning emits on the next tick; emulate that.
-  : process.nextTick
-    ? function (msg) { process.nextTick(() => console.warn(msg)); }
-    // Everything else
-    : function (msg) { Promise.resolve().then(() => console.warn(msg)); };
+  // Everything else
+  :  function (msg) { process.nextTick(() => console.warn(msg)); }
 
 /**
  * @summary

--- a/test/integration/deprecate.spec.js
+++ b/test/integration/deprecate.spec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var assert = require('assert');
+var run = require('./helpers').runMocha;
+var args = [];
+
+describe.only('utils.deprecate test', function () {
+  it('should print unique deprecation only once', function (done) {
+    run('deprecate.fixture.js', args, function (err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+      console.trace(res);
+      var result = res.output.match(/deprecated thing/g) || [];
+      assert.equal(result.length, 2);
+      done();
+    });
+  });
+});

--- a/test/integration/fixtures/deprecate.fixture.js
+++ b/test/integration/fixtures/deprecate.fixture.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var utils = require("../../../lib/utils");
+
+it('consolidates identical calls to deprecate', function() {
+  utils.deprecate("suite foo did a deprecated thing");
+  utils.deprecate("suite foo did a deprecated thing");
+  utils.deprecate("suite bar did a deprecated thing");
+});

--- a/test/integration/fixtures/suite/suite-async-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-async-callback.fixture.js
@@ -1,0 +1,3 @@
+'use strict';
+
+describe('a suite with an async callback', async function () {});

--- a/test/integration/fixtures/suite/suite-async-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-async-callback.fixture.js
@@ -1,5 +1,0 @@
-'use strict';
-
-describe('a suite with an async callback', function () {
-  return Promise.resolve();
-});

--- a/test/integration/fixtures/suite/suite-async-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-async-callback.fixture.js
@@ -1,3 +1,5 @@
 'use strict';
 
-describe('a suite with an async callback', async function () {});
+describe('a suite with an async callback', function () {
+  return Promise.resolve();
+});

--- a/test/integration/fixtures/suite/suite-returning-value.fixture.js
+++ b/test/integration/fixtures/suite/suite-returning-value.fixture.js
@@ -1,0 +1,5 @@
+'use strict';
+
+describe('a suite returning a value', function () {
+  return Promise.resolve();
+});

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -59,7 +59,7 @@ describe('suite returning a value', function () {
         done(err);
         return;
       }
-      var pattern = new RegExp('deprecated', 'g');
+      var pattern = new RegExp('Deprecation Warning', 'g');
       var result = res.output.match(pattern) || [];
       assert.equal(result.length, 1);
       done();

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -51,17 +51,17 @@ describe('skipped suite w/ callback', function () {
   });
 });
 
-describe('suite with erroneous async callback', function () {
+describe('suite returning a value', function () {
   this.timeout(2000);
-  it('should throw an error for suite callback returning promise', function (done) {
-    run('suite/suite-async-callback.fixture.js', args, function (err, res) {
+  it('should give a deprecation warning for suite callback returning a value', function (done) {
+    run('suite/suite-returning-value.fixture.js', args, function (err, res) {
       if (err) {
         done(err);
         return;
       }
-      var pattern = new RegExp('Error', 'g');
+      var pattern = new RegExp('DeprecationWarning', 'g');
       var result = res.output.match(pattern) || [];
-      assert.equal(result.length, 2);
+      assert.equal(result.length, 1);
       done();
     });
   });

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -50,3 +50,19 @@ describe('skipped suite w/ callback', function () {
     });
   });
 });
+
+describe('suite with erroneous async callback', function () {
+  this.timeout(2000);
+  it('should throw an error for suite callback returning promise', function (done) {
+    run('suite/suite-async-callback.fixture.js', args, function (err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+      var pattern = new RegExp('Error', 'g');
+      var result = res.output.match(pattern) || [];
+      assert.equal(result.length, 2);
+      done();
+    });
+  });
+});

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -59,7 +59,7 @@ describe('suite returning a value', function () {
         done(err);
         return;
       }
-      var pattern = new RegExp('DeprecationWarning', 'g');
+      var pattern = new RegExp('deprecated', 'g');
       var result = res.output.match(pattern) || [];
       assert.equal(result.length, 1);
       done();


### PR DESCRIPTION
### Description of the Change

As long as this is not supported, the behavior is confusing. It can produce a suite that is not properly initialized. Turning this into a hard error will make it clear that this is not supported.

In short, the test suite below currently does nothing; this change will make it into an error.

```javascript
describe("my suite", async function() {
  await Promise.resolve();
  it("does a thing", function() {
    assert(false);
  });
});
```

Other usage could possibly produce a partially-initialized test suite that fails for unknown reasons; this will make it fail obviously.

### Alternate Designs

Original proposal was to throw, but settled for a deprecation warning in the accepted version.
This would need be revisited in future to throw an Error instead.

### Why should this be in core?

N/A

### Benefits

Reduction in user confusion/expectations attempting to use `describe` function as anything but a namespace.

### Possible Drawbacks

Users will get deprecation warning for unsupported behavior.
No _real_ downside to knowledge.

### Applicable issues

Fixes #2975
semver-patch