### PR TITLE
Persist paths in stack trace which have cwd as infix

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -597,7 +597,7 @@ exports.stackTraceFilter = function () {
 
       // Clean up cwd(absolute)
       if (/\(?.+:\d+:\d+\)?$/.test(line)) {
-        line = line.replace(cwd, '');
+        line = line.replace('(' + cwd, '(');
       }
 
       list.push(line);

--- a/test/node-unit/stack-trace-filter.spec.js
+++ b/test/node-unit/stack-trace-filter.spec.js
@@ -88,6 +88,23 @@ describe('stackTraceFilter()', function () {
         expect(filter(stack.join('\n')))
           .to.equal(expected.join('\n'));
       });
+
+      it('should not replace absolute path which has cwd as infix', function () {
+        var stack = [
+          'Error: /www' + process.cwd() + '/bla.js has a problem',
+          'at foo (/www' + process.cwd() + '/foo/index.js:13:226)',
+          'at bar (/usr/local/dev/own/tmp/node_modules/bluebird/js/main/promise.js:11:26)'
+        ];
+
+        var expected = [
+          'Error: /www' + process.cwd() + '/bla.js has a problem',
+          'at foo (/www' + process.cwd() + '/foo/index.js:13:226)',
+          'at bar (/usr/local/dev/own/tmp/node_modules/bluebird/js/main/promise.js:11:26)'
+        ];
+
+        expect(filter(stack.join('\n')))
+          .to.equal(expected.join('\n'));
+      });
     });
 
     describe('on Windows', function () {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change
As #3093 ,  when paths in stack trace messages have a current working directory as infix, it should not be replaced.  So, I added `(` in front of `cwd` to replace only in a case of the paths started with `cwd`. I assumed `(` is always be there.
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs
@ScottFreeCode suggested `'escape-string-regexp'` package. However, I don't understand how it fixes this issue.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
It is related with display stack trace in mocah.
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
This is an edge case, so the most of users don't experience the issue. Some users like in docker can see correct path in a stack trace.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
If a case of `(` is in front of a path can exist, the paths in a stack trace are not replaced with a current working directory.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
#3093

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
