### PR TITLE
add FOSSA check to CI; closes #3263

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-# trust dist provides a modern build chain (as opposed to 'precise' dist)
-# which absolves us from having to install compilers and stuff
 dist: trusty
 
 language: node_js
 
 env:
   global:
-    # phantomjs hosts binaries @ bitbucket, which has fairly restrictive
-    # rate-limiting.  pull it from this sketchy site in China instead.
-    - PHANTOMJS_CDNURL='https://cnpmjs.org/downloads'
+    # for FOSSA API
+    - secure: lfYXsrvBnlPILCVwFY0p+5GLf3tMmFIsfwAqFFS/tNWsLsPHkckMWiZ5Rgfk5O29t4GOpyJBqgs7RbrR/ee69BSjqzKZTKiNS9frgPtzTFBTCfkp0PpNq/lh8EGWIzaNA/Ar1KdU2jZZvs0voSs1QpiF99Og/EE8bLKCN7Xm7nE=
 
 matrix:
   fast_finish: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,11 +1022,6 @@
         }
       }
     },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-    },
     "browserify": {
       "version": "14.4.0",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
@@ -1496,6 +1491,12 @@
       "requires": {
         "restore-cursor": "2.0.0"
       }
+    },
+    "cli-spinners": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
@@ -6490,6 +6491,30 @@
         "astw": "2.2.0"
       }
     },
+    "license-cli": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/license-cli/-/license-cli-1.1.6.tgz",
+      "integrity": "sha512-FTRRkNo55ypT07hDwFhb5M5VbmHEH7x1AtBj+FP+qQCT3adTo5gSe70SpGaHV8V4iFN2aOZn2vKtGzYCGERXWA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "colors": "1.1.2",
+        "commander": "2.11.0",
+        "moment": "2.21.0",
+        "ora": "1.4.0",
+        "request": "2.83.0",
+        "request-promise": "4.2.2",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
     "linkify-it": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
@@ -7307,6 +7332,12 @@
         "through2": "2.0.3",
         "xtend": "4.0.1"
       }
+    },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -9780,6 +9811,18 @@
         "bin-build": "2.2.0",
         "bin-wrapper": "3.0.2",
         "logalot": "2.1.0"
+      }
+    },
+    "ora": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
+      "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "log-symbols": "2.1.0"
       }
     },
     "ordered-read-streams": {
@@ -12650,6 +12693,27 @@
         "uuid": "3.1.0"
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13389,6 +13453,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-browserify": {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -221,6 +221,16 @@ module.exports = {
     watchDocs: {
       script: 'nps prewatchDocs && bundle exec jekyll serve --source ./docs --destination ./docs/_site --config ./docs/_config.yml --safe --drafts --watch',
       description: 'Watch documentation for changes'
+    },
+    license: {
+      auth: {
+        script: `license-cli auth "${process.env.FOSSA_API_KEY}"`,
+        description: 'Authorize with FOSSA'
+      },
+      check: {
+        script: `license-cli scan -r "${process.env.TRAVIS_COMMIT}"`,
+        description: 'Perform FOSSA license check'
+      }
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -339,6 +339,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.4",
     "karma-sauce-launcher": "^1.2.0",
+    "license-cli": "^1.1.6",
     "markdown-toc": "^1.2.0",
     "markdownlint-cli": "^0.6.0",
     "nps": "^5.7.1",

--- a/scripts/travis-before-script.sh
+++ b/scripts/travis-before-script.sh
@@ -5,3 +5,5 @@ mkdir -p .karma
 
 # ensure we are building a non-broken bundle for AMD
 npm start build.mochajs && [[ -z "$(grep 'define.amd' mocha.js)" ]] || exit 1
+
+npm start license.auth && npm start license.check


### PR DESCRIPTION
- add auth and check with [FOSSA](https://fossa.io) to `before_script` script via `nps`
- add `license-cli` dev dep
- remove crufty PhantomJS-related stuff from `.travis.yml`

I'm not sure that's where we want the check to run, but that's what the [example on FOSSA's site has](https://app.fossa.io/docs/integrating-tools/travisci).