### PR TITLE
fix: ReDoS vuln in mocha@5.0.2 › diff@3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha",
-  "version": "5.0.3",
+  "version": "5.0.2",
   "description": "simple, flexible, fun test framework",
   "keywords": [
     "mocha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "simple, flexible, fun test framework",
   "keywords": [
     "mocha",
@@ -309,7 +309,7 @@
     "browser-stdout": "1.3.1",
     "commander": "2.11.0",
     "debug": "3.1.0",
-    "diff": "3.3.1",
+    "diff": "3.5.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.2",
     "growl": "1.10.3",


### PR DESCRIPTION
### Description of the Change
* Bump dep "diff" to 3.5.0

### Alternate Designs
N/A

### Why should this be in core?

diff@3.3.1 has ReDoS vuln: https://snyk.io/test/npm/mocha/5.0.2?severity=high&severity=medium&severity=low

### Benefits

https://snyk.io/vuln/npm:diff:20180305

### Possible Drawbacks


### Applicable issues

