### PR TITLE
chore(ci): Remove PHANTOMJS_CDNURL, nit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
-# trust dist provides a modern build chain (as opposed to 'precise' dist)
+# trusty dist provides a modern build chain (as opposed to 'precise' dist)
 # which absolves us from having to install compilers and stuff
 dist: trusty
 
 language: node_js
-
-env:
-  global:
-    # phantomjs hosts binaries @ bitbucket, which has fairly restrictive
-    # rate-limiting.  pull it from this sketchy site in China instead.
-    - PHANTOMJS_CDNURL='https://cnpmjs.org/downloads'
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Seems like `PHANTOMJS_CDNURL` is not needed anymore now that PhantomJS support is [depracated](https://github.com/mochajs/mocha/blob/6a796cbbcd6c9f805e482c424327c82ed0398dbf/CHANGELOG.md#compatibility).

Please ignore if I am wrong.

### Description of the Change
* Remove `PHANTOMJS_CDNURL` from `.travis.yml` because it is not used anymore.
* Minor edit to comment

### Alternate Designs

### Why should this be in core?

### Benefits

* Remove cruft

### Possible Drawbacks


### Applicable issues
