### PR TITLE
Refactor Reporter tests

### DIFF
--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// comment to commit
+
 var assert = require('assert');
 
 var Base = require('../../lib/reporters/base');

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -1,33 +1,20 @@
 'use strict';
 
-// comment to commit
-
 var assert = require('assert');
 
 var Base = require('../../lib/reporters/base');
 var Assert = require('assert').AssertionError;
 
-function makeTest (err) {
-  return {
-    err: err,
-    titlePath: function () {
-      return ['test title'];
-    }
-  };
-}
-
-function createElements (argObj) {
-  var res = [];
-  for (var i = argObj.from; i <= argObj.to; i += 1) {
-    res.push('element ' + i);
-  }
-  return res;
-}
+var makeTest = require('./helpers').makeTest;
+var createElements = require('./helpers').createElements;
 
 describe('Base reporter', function () {
   var stdout;
   var stdoutWrite;
   var useColors;
+  var err;
+  var errOut;
+  var test;
 
   beforeEach(function () {
     stdout = [];
@@ -45,11 +32,12 @@ describe('Base reporter', function () {
   });
 
   describe('showDiff', function () {
-    it('should show diffs by default', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' });
-      var errOut;
+    beforeEach(function () {
+      err = new Assert({ actual: 'foo', expected: 'bar' });
+    });
 
-      var test = makeTest(err);
+    it('should show diffs by default', function () {
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -59,11 +47,8 @@ describe('Base reporter', function () {
     });
 
     it('should show diffs if property set to `true`', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' });
-      var errOut;
-
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -73,11 +58,8 @@ describe('Base reporter', function () {
     });
 
     it('should not show diffs when showDiff property set to `false`', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' });
-      var errOut;
-
       err.showDiff = false;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -87,10 +69,9 @@ describe('Base reporter', function () {
     });
 
     it('should not show diffs when expected is not defined', function () {
-      var err = new Error('ouch');
-      var errOut;
+      err = new Error('ouch');
 
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -100,10 +81,7 @@ describe('Base reporter', function () {
     });
 
     it('should not show diffs when hideDiff is set', function () {
-      var err = new Assert({ actual: 'foo', expected: 'bar' });
-      var errOut;
-
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.hideDiff = true;
       Base.list([test]);
@@ -118,13 +96,12 @@ describe('Base reporter', function () {
   describe('Getting two strings', function () {
     // Fix regression V1.2.1(see: issue #1241)
     it('should show strings diff as is', function () {
-      var err = new Error('test');
-      var errOut;
+      err = new Error('test');
 
       err.actual = 'foo\nbar';
       err.expected = 'foo\nbaz';
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -140,6 +117,9 @@ describe('Base reporter', function () {
 
   describe('Diff generation', function () {
     var oldInlineDiffs;
+    var actual;
+    var expected;
+    var output;
 
     beforeEach(function () {
       oldInlineDiffs = Base.inlineDiffs;
@@ -150,21 +130,21 @@ describe('Base reporter', function () {
     });
 
     it('should generate unified diffs if `inlineDiff === false`', function () {
-      var actual = 'a foo unified diff';
-      var expected = 'a bar unified diff';
+      actual = 'a foo unified diff';
+      expected = 'a bar unified diff';
 
       Base.inlineDiffs = false;
-      var output = Base.generateDiff(actual, expected);
+      output = Base.generateDiff(actual, expected);
 
       expect(output).to.equal('\n      + expected - actual\n\n      -a foo unified diff\n      +a bar unified diff\n      ');
     });
 
     it('should generate inline diffs if `inlineDiffs === true`', function () {
-      var actual = 'a foo inline diff';
-      var expected = 'a bar inline diff';
+      actual = 'a foo inline diff';
+      expected = 'a bar inline diff';
 
       Base.inlineDiffs = true;
-      var output = Base.generateDiff(actual, expected);
+      output = Base.generateDiff(actual, expected);
 
       expect(output).to.equal('      \n      actual expected\n      \n      a foobar inline diff\n      ');
     });
@@ -172,13 +152,12 @@ describe('Base reporter', function () {
 
   describe('Inline strings diff', function () {
     it('should show single line diff if property set to `true`', function () {
-      var err = new Error('test');
-      var errOut;
+      err = new Error('test');
 
       err.actual = 'a foo inline diff';
       err.expected = 'a bar inline diff';
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.inlineDiffs = true;
       Base.list([test]);
@@ -192,13 +171,12 @@ describe('Base reporter', function () {
     });
 
     it('should split lines when string has more than 4 line breaks', function () {
-      var err = new Error('test');
-      var errOut;
+      err = new Error('test');
 
       err.actual = 'a\nfoo\ninline\ndiff\nwith\nmultiple lines';
       err.expected = 'a\nbar\ninline\ndiff\nwith\nmultiple lines';
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.inlineDiffs = true;
       Base.list([test]);
@@ -218,14 +196,15 @@ describe('Base reporter', function () {
   });
 
   describe('unified diff reporter', function () {
-    it('should separate diff hunks by two dashes', function () {
-      var err = new Error('test');
-      var errOut;
+    beforeEach(function () {
+      err = new Error('test');
+    });
 
+    it('should separate diff hunks by two dashes', function () {
       err.actual = createElements({ from: 2, to: 11 });
       err.expected = createElements({ from: 1, to: 10 });
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.inlineDiffs = false;
       Base.list([test]);
@@ -258,13 +237,12 @@ describe('Base reporter', function () {
   });
 
   it('should stringify objects', function () {
-    var err = new Error('test');
-    var errOut;
+    err = new Error('test');
 
     err.actual = {key: 'a1'};
     err.expected = {key: 'e1'};
     err.showDiff = true;
-    var test = makeTest(err);
+    test = makeTest(err);
 
     Base.list([test]);
 
@@ -276,15 +254,14 @@ describe('Base reporter', function () {
   });
 
   it('should stringify Object.create(null)', function () {
-    var err = new Error('test');
-    var errOut;
+    err = new Error('test');
 
     err.actual = Object.create(null);
     err.actual.hasOwnProperty = 1;
     err.expected = Object.create(null);
     err.expected.hasOwnProperty = 2;
     err.showDiff = true;
-    var test = makeTest(err);
+    test = makeTest(err);
 
     Base.list([test]);
 
@@ -296,15 +273,13 @@ describe('Base reporter', function () {
   });
 
   it('should handle error messages that are not strings', function () {
-    var errOut;
-
     try {
       assert(false, true);
     } catch (err) {
       err.actual = false;
       err.expected = true;
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -317,8 +292,6 @@ describe('Base reporter', function () {
   });
 
   it('should interpret chaijs custom error messages', function () {
-    var errOut;
-
     try {
       // expect(43, 'custom error message').to.equal(42);
       // AssertionError: custom error message: expected 43 to equal 42.
@@ -327,7 +300,7 @@ describe('Base reporter', function () {
       err.actual = 43;
       err.expected = 42;
       err.showDiff = true;
-      var test = makeTest(err);
+      test = makeTest(err);
 
       Base.list([test]);
 
@@ -341,51 +314,51 @@ describe('Base reporter', function () {
   });
 
   it('should remove message from stack', function () {
-    var err = {
+    err = {
       message: 'Error',
       stack: 'Error\nfoo\nbar',
       showDiff: false
     };
-    var test = makeTest(err);
+    test = makeTest(err);
 
     Base.list([test]);
 
-    var errOut = stdout.join('\n').trim();
+    errOut = stdout.join('\n').trim();
     expect(errOut).to.equal('1) test title:\n     Error\n  foo\n  bar');
   });
 
   it('should use the inspect() property if `message` is not set', function () {
-    var err = {
+    err = {
       showDiff: false,
       inspect: function () { return 'an error happened'; }
     };
-    var test = makeTest(err);
+    test = makeTest(err);
     Base.list([test]);
-    var errOut = stdout.join('\n').trim();
+    errOut = stdout.join('\n').trim();
     expect(errOut).to.equal('1) test title:\n     an error happened');
   });
 
   it('should set an empty message if `message` and `inspect()` are not set', function () {
-    var err = {
+    err = {
       showDiff: false
     };
-    var test = makeTest(err);
+    test = makeTest(err);
     Base.list([test]);
-    var errOut = stdout.join('\n').trim();
+    errOut = stdout.join('\n').trim();
     expect(errOut).to.equal('1) test title:');
   });
 
   it('should not modify stack if it does not contain message', function () {
-    var err = {
+    err = {
       message: 'Error',
       stack: 'foo\nbar',
       showDiff: false
     };
-    var test = makeTest(err);
+    test = makeTest(err);
 
     Base.list([test]);
 
-    var errOut = stdout.join('\n').trim();
+    errOut = stdout.join('\n').trim();
     expect(errOut).to.equal('1) test title:\n     Error\n  foo\n  bar');
   });
 });

--- a/test/reporters/doc.spec.js
+++ b/test/reporters/doc.spec.js
@@ -3,7 +3,7 @@
 var reporters = require('../../').reporters;
 var Doc = reporters.Doc;
 
-var runnerEvent = require('./helpers.js').runnerEvent;
+var createMockRunner = require('./helpers.js').createMockRunner;
 
 describe('Doc reporter', function () {
   var stdout;
@@ -11,7 +11,6 @@ describe('Doc reporter', function () {
   var runner;
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -27,7 +26,7 @@ describe('Doc reporter', function () {
         title: expectedTitle
       };
       it('should log html with indents and expected title', function () {
-        runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
+        runner = createMockRunner('suite', 'suite', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -43,7 +42,7 @@ describe('Doc reporter', function () {
           title: unescapedTitle
         };
         expectedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
-        runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
+        runner = createMockRunner('suite', 'suite', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -59,7 +58,7 @@ describe('Doc reporter', function () {
         root: true
       };
       it('should not log any html', function () {
-        runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
+        runner = createMockRunner('suite', 'suite', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         expect(stdout).to.be.empty();
@@ -73,7 +72,7 @@ describe('Doc reporter', function () {
         root: false
       };
       it('should log expected html with indents', function () {
-        runner.on = runner.once = runnerEvent('suite end', 'suite end', null, null, suite);
+        runner = createMockRunner('suite end', 'suite end', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -87,7 +86,7 @@ describe('Doc reporter', function () {
         root: true
       };
       it('should not log any html', function () {
-        runner.on = runner.once = runnerEvent('suite end', 'suite end', null, null, suite);
+        runner = createMockRunner('suite end', 'suite end', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         expect(stdout).to.be.empty();
@@ -106,7 +105,7 @@ describe('Doc reporter', function () {
       }
     };
     it('should log html with indents and expected title and body', function () {
-      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+      runner = createMockRunner('pass', 'pass', null, null, test);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -123,7 +122,7 @@ describe('Doc reporter', function () {
 
       var expectedEscapedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
       var expectedEscapedBody = '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
-      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+      runner = createMockRunner('pass', 'pass', null, null, test);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -146,7 +145,7 @@ describe('Doc reporter', function () {
       }
     };
     it('should log html with indents and expected title, body and error', function () {
-      runner.on = runner.once = runnerEvent('fail two args', 'fail', null, null, test, expectedError);
+      runner = createMockRunner('fail two args', 'fail', null, null, test, expectedError);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -166,7 +165,7 @@ describe('Doc reporter', function () {
       var expectedEscapedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
       var expectedEscapedBody = '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
       var expectedEscapedError = '&#x3C;div&#x3E;' + expectedError + '&#x3C;/div&#x3E;';
-      runner.on = runner.once = runnerEvent('fail two args', 'fail', null, null, test, unescapedError);
+      runner = createMockRunner('fail two args', 'fail', null, null, test, unescapedError);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [

--- a/test/reporters/doc.spec.js
+++ b/test/reporters/doc.spec.js
@@ -3,6 +3,8 @@
 var reporters = require('../../').reporters;
 var Doc = reporters.Doc;
 
+var runnerEvent = require('./helpers.js').runnerEvent;
+
 describe('Doc reporter', function () {
   var stdout;
   var stdoutWrite;
@@ -25,11 +27,7 @@ describe('Doc reporter', function () {
         title: expectedTitle
       };
       it('should log html with indents and expected title', function () {
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'suite') {
-            callback(suite);
-          }
-        };
+        runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -45,11 +43,7 @@ describe('Doc reporter', function () {
           title: unescapedTitle
         };
         expectedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'suite') {
-            callback(suite);
-          }
-        };
+        runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -65,11 +59,7 @@ describe('Doc reporter', function () {
         root: true
       };
       it('should not log any html', function () {
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'suite') {
-            callback(suite);
-          }
-        };
+        runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         expect(stdout).to.be.empty();
@@ -83,11 +73,7 @@ describe('Doc reporter', function () {
         root: false
       };
       it('should log expected html with indents', function () {
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'suite end') {
-            callback(suite);
-          }
-        };
+        runner.on = runner.once = runnerEvent('suite end', 'suite end', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -101,11 +87,7 @@ describe('Doc reporter', function () {
         root: true
       };
       it('should not log any html', function () {
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'suite end') {
-            callback(suite);
-          }
-        };
+        runner.on = runner.once = runnerEvent('suite end', 'suite end', null, null, suite);
         Doc.call(this, runner);
         process.stdout.write = stdoutWrite;
         expect(stdout).to.be.empty();
@@ -124,11 +106,7 @@ describe('Doc reporter', function () {
       }
     };
     it('should log html with indents and expected title and body', function () {
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pass') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -145,11 +123,7 @@ describe('Doc reporter', function () {
 
       var expectedEscapedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
       var expectedEscapedBody = '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pass') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -172,11 +146,7 @@ describe('Doc reporter', function () {
       }
     };
     it('should log html with indents and expected title, body and error', function () {
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'fail') {
-          callback(test, expectedError);
-        }
-      };
+      runner.on = runner.once = runnerEvent('fail two args', 'fail', null, null, test, expectedError);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -196,11 +166,7 @@ describe('Doc reporter', function () {
       var expectedEscapedTitle = '&#x3C;div&#x3E;' + expectedTitle + '&#x3C;/div&#x3E;';
       var expectedEscapedBody = '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
       var expectedEscapedError = '&#x3C;div&#x3E;' + expectedError + '&#x3C;/div&#x3E;';
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'fail') {
-          callback(test, unescapedError);
-        }
-      };
+      runner.on = runner.once = runnerEvent('fail two args', 'fail', null, null, test, unescapedError);
       Doc.call(this, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -4,6 +4,8 @@ var reporters = require('../../').reporters;
 var Dot = reporters.Dot;
 var Base = reporters.Base;
 
+var runnerEvent = require('./helpers.js').runnerEvent;
+
 describe('Dot reporter', function () {
   var stdout;
   var stdoutWrite;
@@ -31,11 +33,7 @@ describe('Dot reporter', function () {
 
   describe('on start', function () {
     it('should return a new line', function () {
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('start', 'start');
       Dot.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -50,11 +48,7 @@ describe('Dot reporter', function () {
         Base.window.width = 2;
       });
       it('should return a new line and then a coma', function () {
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'pending') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('pending', 'pending');
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -66,11 +60,7 @@ describe('Dot reporter', function () {
     });
     describe('if window width is equal to or less than 1', function () {
       it('should return a coma', function () {
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'pending') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('pending', 'pending');
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -81,21 +71,17 @@ describe('Dot reporter', function () {
     });
   });
   describe('on pass', function () {
+    var test = {
+      duration: 1,
+      slow: function () { return 2; }
+    };
     describe('if window width is greater than 1', function () {
       beforeEach(function () {
         Base.window.width = 2;
       });
       describe('if test speed is fast', function () {
         it('should return a new line and then a dot', function () {
-          var test = {
-            duration: 1,
-            slow: function () { return 2; }
-          };
-          runner.on = runner.once = function (event, callback) {
-            if (event === 'pass') {
-              callback(test);
-            }
-          };
+          runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
           Dot.call({epilogue: function () {}}, runner);
           process.stdout.write = stdoutWrite;
           var expectedArray = [
@@ -109,15 +95,7 @@ describe('Dot reporter', function () {
     describe('if window width is equal to or less than 1', function () {
       describe('if test speed is fast', function () {
         it('should return a dot', function () {
-          var test = {
-            duration: 1,
-            slow: function () { return 2; }
-          };
-          runner.on = runner.once = function (event, callback) {
-            if (event === 'pass') {
-              callback(test);
-            }
-          };
+          runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
           Dot.call({epilogue: function () {}}, runner);
           process.stdout.write = stdoutWrite;
           var expectedArray = [
@@ -128,15 +106,8 @@ describe('Dot reporter', function () {
       });
       describe('if test speed is slow', function () {
         it('should return a dot', function () {
-          var test = {
-            duration: 2,
-            slow: function () { return 1; }
-          };
-          runner.on = runner.once = function (event, callback) {
-            if (event === 'pass') {
-              callback(test);
-            }
-          };
+          test.duration = 2;
+          runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
           Dot.call({epilogue: function () {}}, runner);
           process.stdout.write = stdoutWrite;
           var expectedArray = [
@@ -148,21 +119,17 @@ describe('Dot reporter', function () {
     });
   });
   describe('on fail', function () {
+    var test = {
+      test: {
+        err: 'some error'
+      }
+    };
     describe('if window width is greater than 1', function () {
       beforeEach(function () {
         Base.window.width = 2;
       });
       it('should return a new line and then an exclamation mark', function () {
-        var test = {
-          test: {
-            err: 'some error'
-          }
-        };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'fail') {
-            callback(test);
-          }
-        };
+        runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -174,16 +141,7 @@ describe('Dot reporter', function () {
     });
     describe('if window width is equal to or less than 1', function () {
       it('should return an exclamation mark', function () {
-        var test = {
-          test: {
-            err: 'some error'
-          }
-        };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'fail') {
-            callback(test);
-          }
-        };
+        runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -195,11 +153,7 @@ describe('Dot reporter', function () {
   });
   describe('on end', function () {
     it('should call the epilogue', function () {
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('end', 'end');
       var epilogueCalled = false;
       var epilogue = function () {
         epilogueCalled = true;

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var Dot = reporters.Dot;
 var Base = reporters.Base;
 
-var runnerEvent = require('./helpers.js').runnerEvent;
+var createMockRunner = require('./helpers.js').createMockRunner;
 
 describe('Dot reporter', function () {
   var stdout;
@@ -15,7 +15,6 @@ describe('Dot reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -33,7 +32,7 @@ describe('Dot reporter', function () {
 
   describe('on start', function () {
     it('should return a new line', function () {
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       Dot.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -48,7 +47,7 @@ describe('Dot reporter', function () {
         Base.window.width = 2;
       });
       it('should return a new line and then a coma', function () {
-        runner.on = runner.once = runnerEvent('pending', 'pending');
+        runner = createMockRunner('pending', 'pending');
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -60,7 +59,7 @@ describe('Dot reporter', function () {
     });
     describe('if window width is equal to or less than 1', function () {
       it('should return a coma', function () {
-        runner.on = runner.once = runnerEvent('pending', 'pending');
+        runner = createMockRunner('pending', 'pending');
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -81,7 +80,7 @@ describe('Dot reporter', function () {
       });
       describe('if test speed is fast', function () {
         it('should return a new line and then a dot', function () {
-          runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+          runner = createMockRunner('pass', 'pass', null, null, test);
           Dot.call({epilogue: function () {}}, runner);
           process.stdout.write = stdoutWrite;
           var expectedArray = [
@@ -95,7 +94,7 @@ describe('Dot reporter', function () {
     describe('if window width is equal to or less than 1', function () {
       describe('if test speed is fast', function () {
         it('should return a dot', function () {
-          runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+          runner = createMockRunner('pass', 'pass', null, null, test);
           Dot.call({epilogue: function () {}}, runner);
           process.stdout.write = stdoutWrite;
           var expectedArray = [
@@ -107,7 +106,7 @@ describe('Dot reporter', function () {
       describe('if test speed is slow', function () {
         it('should return a dot', function () {
           test.duration = 2;
-          runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+          runner = createMockRunner('pass', 'pass', null, null, test);
           Dot.call({epilogue: function () {}}, runner);
           process.stdout.write = stdoutWrite;
           var expectedArray = [
@@ -129,7 +128,7 @@ describe('Dot reporter', function () {
         Base.window.width = 2;
       });
       it('should return a new line and then an exclamation mark', function () {
-        runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
+        runner = createMockRunner('fail', 'fail', null, null, test);
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -141,7 +140,7 @@ describe('Dot reporter', function () {
     });
     describe('if window width is equal to or less than 1', function () {
       it('should return an exclamation mark', function () {
-        runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
+        runner = createMockRunner('fail', 'fail', null, null, test);
         Dot.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedArray = [
@@ -153,7 +152,7 @@ describe('Dot reporter', function () {
   });
   describe('on end', function () {
     it('should call the epilogue', function () {
-      runner.on = runner.once = runnerEvent('end', 'end');
+      runner = createMockRunner('end', 'end');
       var epilogueCalled = false;
       var epilogue = function () {
         epilogueCalled = true;

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -95,7 +95,7 @@ function runnerEvent (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       }
     };
   } else {
-    throw new Error('This function does not support the runner string specified.')
+    throw new Error('This function does not support the runner string specified.');
   }
 }
 

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/*
+  This function prevents the constant use of creating a runnerEvent.
+  runStr is the argument that solely defines the runnerEvent.
+  ifStr1 is one possible reporter argument, as is ifStr2, and ifStr3
+  arg1 and arg2 are the possible variables that need to be put into the scope of this function for the tests to run properly.
+*/
+function runnerEvent (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
+  var test = null;
+  if (runStr === 'start' || runStr === 'pending' || runStr === 'end') {
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback();
+      }
+    };
+  } else if (runStr === 'pending test' || runStr === 'pass' || runStr === 'fail' || runStr === 'end' || runStr === 'suite' || runStr === 'suite end' || runStr === 'test end') {
+    test = arg1;
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback(test);
+      }
+    };
+  } else if (runStr === 'fail two args') {
+    test = arg1;
+    var expectedError = arg2;
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback(test, expectedError);
+      }
+    };
+  } else if (runStr === 'start test') {
+    test = arg1;
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback();
+      }
+      if (event === ifStr2) {
+        callback(test);
+      }
+    };
+  } else if (runStr === 'suite suite end') {
+    var expectedSuite = arg1;
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback(expectedSuite);
+      }
+      if (event === ifStr2) {
+        callback();
+      }
+      if (event === ifStr3) {
+        callback();
+      }
+    };
+  } else if (runStr === 'pass end') {
+    var expectedTest = arg1;
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback(expectedTest);
+      }
+      if (event === ifStr2) {
+        callback();
+      }
+    };
+  }
+}
+
+function makeTest (err) {
+  return {
+    err: err,
+    titlePath: function () {
+      return ['test title'];
+    }
+  };
+}
+
+function createElements (argObj) {
+  var res = [];
+  for (var i = argObj.from; i <= argObj.to; i += 1) {
+    res.push('element ' + i);
+  }
+  return res;
+}
+
+function makeExpectedTest (expectedTitle, expectedFullTitle, expectedDuration, currentRetry) {
+  return {
+    title: expectedTitle,
+    fullTitle: function () { return expectedFullTitle; },
+    duration: expectedDuration,
+    currentRetry: function () { return currentRetry; },
+    slow: function () { }
+  };
+}
+
+module.exports = { runnerEvent, makeTest, createElements, makeExpectedTest };

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -2,100 +2,112 @@
 
 /*
   This function prevents the constant use of creating a runnerEvent.
-  runStr is the argument that solely defines the runnerEvent.
+  runStr is the argument that defines the runnerEvent.
   ifStr1 is one possible reporter argument, as is ifStr2, and ifStr3
-  arg1 and arg2 are the possible variables that need to be put into the scope of this function for the tests to run properly.
+  arg1 and arg2 are the possible variables that need to be put into the 
+  scope of this function for the tests to run properly.
 */
-function runnerEvent (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
+
+function createMockRunner (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
+  var runnerFunction = createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2);
+  return {
+    on: runnerFunction,
+    once: runnerFunction
+  };
+}
+
+function createRunnerFunction (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
   var test = null;
-  if (runStr === 'start' || runStr === 'pending' || runStr === 'end') {
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback();
-      }
-    };
-  } else if (
-    runStr === 'pending test' ||
-    runStr === 'pass' ||
-    runStr === 'fail' ||
-    runStr === 'end' ||
-    runStr === 'suite' ||
-    runStr === 'suite end' ||
-    runStr === 'test end'
-  ) {
-    test = arg1;
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback(test);
-      }
-    };
-  } else if (runStr === 'fail two args') {
-    test = arg1;
-    var expectedError = arg2;
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback(test, expectedError);
-      }
-    };
-  } else if (runStr === 'start test') {
-    test = arg1;
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback();
-      }
-      if (event === ifStr2) {
-        callback(test);
-      }
-    };
-  } else if (runStr === 'suite suite end') {
-    var expectedSuite = arg1;
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback(expectedSuite);
-      }
-      if (event === ifStr2) {
-        callback();
-      }
-      if (event === ifStr3) {
-        callback();
-      }
-    };
-  } else if (runStr === 'pass end') {
-    test = arg1;
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback(test);
-      }
-      if (event === ifStr2) {
-        callback();
-      }
-    };
-  } else if (runStr === 'test end fail') {
-    test = arg1;
-    var error = arg2;
-    return function (event, callback) {
-      if (event === ifStr1) {
-        callback();
-      }
-      if (event === ifStr2) {
-        callback(test, error);
-      }
-    };
-  } else if (runStr === 'fail end pass') {
-    return function (event, callback) {
+  switch (runStr) {
+    case 'start':
+    case 'pending':
+    case 'end':
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback();
+        }
+      };
+    case 'pending test':
+    case 'pass':
+    case 'fail':
+    case 'suite':
+    case 'suite end':
+    case 'test end':
       test = arg1;
-      if (event === ifStr1) {
-        callback(test, {});
-      }
-      if (event === ifStr2) {
-        callback(test);
-      }
-      if (event === ifStr3) {
-        callback(test);
-      }
-    };
-  } else {
-    throw new Error('This function does not support the runner string specified.');
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback(test);
+        }
+      };
+    case 'fail two args':
+      test = arg1;
+      var expectedError = arg2;
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback(test, expectedError);
+        }
+      };
+    case 'start test':
+      test = arg1;
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback();
+        }
+        if (event === ifStr2) {
+          callback(test);
+        }
+      };
+    case 'suite suite end':
+      var expectedSuite = arg1;
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback(expectedSuite);
+        }
+        if (event === ifStr2) {
+          callback();
+        }
+        if (event === ifStr3) {
+          callback();
+        }
+      };
+    case 'pass end':
+      test = arg1;
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback(test);
+        }
+        if (event === ifStr2) {
+          callback();
+        }
+      };
+    case 'test end fail':
+      test = arg1;
+      var error = arg2;
+      return function (event, callback) {
+        if (event === ifStr1) {
+          callback();
+        }
+        if (event === ifStr2) {
+          callback(test, error);
+        }
+      };
+    case 'fail end pass':
+      return function (event, callback) {
+        test = arg1;
+        if (event === ifStr1) {
+          callback(test, {});
+        }
+        if (event === ifStr2) {
+          callback(test);
+        }
+        if (event === ifStr3) {
+          callback(test);
+        }
+      };
+    default:
+      throw new Error(
+        'This function does not support the runner string specified.'
+      );
   }
 }
 
@@ -110,7 +122,7 @@ function makeTest (err) {
 
 function createElements (argObj) {
   var res = [];
-  for (var i = argObj.from; i <= argObj.to; i += 1) {
+  for (var i = argObj.from; i <= argObj.to; i++) {
     res.push('element ' + i);
   }
   return res;
@@ -136,4 +148,9 @@ function makeExpectedTest (
   };
 }
 
-module.exports = { runnerEvent, makeTest, createElements, makeExpectedTest };
+module.exports = {
+  createMockRunner,
+  makeTest,
+  createElements,
+  makeExpectedTest
+};

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -94,6 +94,8 @@ function runnerEvent (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
         callback(test);
       }
     };
+  } else {
+    throw new Error('This function does not support the runner string specified.')
   }
 }
 

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -14,7 +14,15 @@ function runnerEvent (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
         callback();
       }
     };
-  } else if (runStr === 'pending test' || runStr === 'pass' || runStr === 'fail' || runStr === 'end' || runStr === 'suite' || runStr === 'suite end' || runStr === 'test end') {
+  } else if (
+    runStr === 'pending test' ||
+    runStr === 'pass' ||
+    runStr === 'fail' ||
+    runStr === 'end' ||
+    runStr === 'suite' ||
+    runStr === 'suite end' ||
+    runStr === 'test end'
+  ) {
     test = arg1;
     return function (event, callback) {
       if (event === ifStr1) {
@@ -106,13 +114,23 @@ function createElements (argObj) {
   return res;
 }
 
-function makeExpectedTest (expectedTitle, expectedFullTitle, expectedDuration, currentRetry, expectedBody) {
+function makeExpectedTest (
+  expectedTitle,
+  expectedFullTitle,
+  expectedDuration,
+  currentRetry,
+  expectedBody
+) {
   return {
     title: expectedTitle,
-    fullTitle: function () { return expectedFullTitle; },
+    fullTitle: function () {
+      return expectedFullTitle;
+    },
     duration: expectedDuration,
-    currentRetry: function () { return currentRetry; },
-    slow: function () { }
+    currentRetry: function () {
+      return currentRetry;
+    },
+    slow: function () {}
   };
 }
 

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -53,13 +53,37 @@ function runnerEvent (runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       }
     };
   } else if (runStr === 'pass end') {
-    var expectedTest = arg1;
+    test = arg1;
     return function (event, callback) {
       if (event === ifStr1) {
-        callback(expectedTest);
+        callback(test);
       }
       if (event === ifStr2) {
         callback();
+      }
+    };
+  } else if (runStr === 'test end fail') {
+    test = arg1;
+    var error = arg2;
+    return function (event, callback) {
+      if (event === ifStr1) {
+        callback();
+      }
+      if (event === ifStr2) {
+        callback(test, error);
+      }
+    };
+  } else if (runStr === 'fail end pass') {
+    return function (event, callback) {
+      test = arg1;
+      if (event === ifStr1) {
+        callback(test, {});
+      }
+      if (event === ifStr2) {
+        callback(test);
+      }
+      if (event === ifStr3) {
+        callback(test);
       }
     };
   }
@@ -82,7 +106,7 @@ function createElements (argObj) {
   return res;
 }
 
-function makeExpectedTest (expectedTitle, expectedFullTitle, expectedDuration, currentRetry) {
+function makeExpectedTest (expectedTitle, expectedFullTitle, expectedDuration, currentRetry, expectedBody) {
   return {
     title: expectedTitle,
     fullTitle: function () { return expectedFullTitle; },

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -3,7 +3,7 @@
 var reporters = require('../../').reporters;
 var JSONStream = reporters.JSONStream;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 var makeExpectedTest = require('./helpers').makeExpectedTest;
 
 describe('Json Stream reporter', function () {
@@ -11,38 +11,28 @@ describe('Json Stream reporter', function () {
   var stdout;
   var stdoutWrite;
 
-  var expectedTitle;
-  var expectedFullTitle;
-  var expectedDuration;
-  var currentRetry;
-  var expectedTest;
-  var expectedErrorMessage;
-  var expectedErrorStack;
-  var expectedError;
+  var expectedTitle = 'some title';
+  var expectedFullTitle = 'full title';
+  var expectedDuration = 1000;
+  var currentRetry = 1;
+  var expectedTest = makeExpectedTest(expectedTitle, expectedFullTitle, expectedDuration, currentRetry);
+  var expectedErrorMessage = 'error message';
+  var expectedErrorStack = 'error stack';
+  var expectedError = {
+    message: expectedErrorMessage
+  };
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
-    };
-
-    expectedTitle = 'some title';
-    expectedFullTitle = 'full title';
-    expectedDuration = 1000;
-    currentRetry = 1;
-    expectedTest = makeExpectedTest(expectedTitle, expectedFullTitle, expectedDuration, currentRetry);
-    expectedErrorMessage = 'error message';
-    expectedErrorStack = 'error stack';
-    expectedError = {
-      message: expectedErrorMessage
     };
   });
 
   describe('on start', function () {
     it('should write stringified start with expected total', function () {
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       var expectedTotal = 12;
       runner.total = expectedTotal;
       JSONStream.call({}, runner);
@@ -55,7 +45,7 @@ describe('Json Stream reporter', function () {
 
   describe('on pass', function () {
     it('should write stringified test data', function () {
-      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, expectedTest);
+      runner = createMockRunner('pass', 'pass', null, null, expectedTest);
       JSONStream.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -68,7 +58,7 @@ describe('Json Stream reporter', function () {
     describe('if error stack exists', function () {
       it('should write stringified test data with error data', function () {
         expectedError.stack = expectedErrorStack;
-        runner.on = runner.once = runnerEvent('fail two args', 'fail', null, null, expectedTest, expectedError);
+        runner = createMockRunner('fail two args', 'fail', null, null, expectedTest, expectedError);
 
         JSONStream.call({}, runner);
 
@@ -81,7 +71,7 @@ describe('Json Stream reporter', function () {
     describe('if error stack does not exist', function () {
       it('should write stringified test data with error data', function () {
         expectedError.stack = null;
-        runner.on = runner.once = runnerEvent('fail two args', 'fail', null, null, expectedTest, expectedError);
+        runner = createMockRunner('fail two args', 'fail', null, null, expectedTest, expectedError);
 
         JSONStream.call({}, runner);
         process.stdout.write = stdoutWrite;
@@ -93,7 +83,7 @@ describe('Json Stream reporter', function () {
 
   describe('on end', function () {
     it('should write end details', function () {
-      runner.on = runner.once = runnerEvent('end', 'end');
+      runner = createMockRunner('end', 'end');
       JSONStream.call({}, runner);
       process.stdout.write = stdoutWrite;
       expect(stdout[0]).to.match(/end/);

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -7,6 +7,7 @@ var Test = Mocha.Test;
 
 describe('json reporter', function () {
   var suite, runner;
+  var testTitle = 'json test 1';
 
   beforeEach(function () {
     var mocha = new Mocha({
@@ -19,7 +20,6 @@ describe('json reporter', function () {
   });
 
   it('should have 1 test failure', function (done) {
-    var testTitle = 'json test 1';
     var error = { message: 'oh shit' };
 
     suite.addTest(new Test(testTitle, function (done) {
@@ -43,8 +43,6 @@ describe('json reporter', function () {
   });
 
   it('should have 1 test pending', function (done) {
-    var testTitle = 'json test 1';
-
     suite.addTest(new Test(testTitle));
 
     runner.run(function (failureCount) {

--- a/test/reporters/landing.spec.js
+++ b/test/reporters/landing.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var Landing = reporters.Landing;
 var Base = reporters.Base;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('Landing reporter', function () {
   var stdout;
@@ -26,7 +26,6 @@ describe('Landing reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -46,7 +45,7 @@ describe('Landing reporter', function () {
     it('should write new lines', function () {
       var cachedCursor = Base.cursor;
       Base.cursor.hide = function () {};
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       Landing.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -61,7 +60,7 @@ describe('Landing reporter', function () {
       Base.cursor.hide = function () {
         calledCursorHide = true;
       };
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       Landing.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -77,7 +76,7 @@ describe('Landing reporter', function () {
         var test = {
           state: 'failed'
         };
-        runner.on = runner.once = runnerEvent('test end', 'test end', null, null, test);
+        runner = createMockRunner('test end', 'test end', null, null, test);
         runner.total = 12;
         Landing.call({}, runner);
 
@@ -91,7 +90,7 @@ describe('Landing reporter', function () {
         var test = {
           state: 'success'
         };
-        runner.on = runner.once = runnerEvent('test end', 'test end', null, null, test);
+        runner = createMockRunner('test end', 'test end', null, null, test);
 
         Landing.call({}, runner);
 
@@ -108,7 +107,7 @@ describe('Landing reporter', function () {
       Base.cursor.show = function () {
         calledCursorShow = true;
       };
-      runner.on = runner.once = runnerEvent('end', 'end');
+      runner = createMockRunner('end', 'end');
 
       var calledEpilogue = false;
       Landing.call({

--- a/test/reporters/landing.spec.js
+++ b/test/reporters/landing.spec.js
@@ -4,6 +4,8 @@ var reporters = require('../../').reporters;
 var Landing = reporters.Landing;
 var Base = reporters.Base;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('Landing reporter', function () {
   var stdout;
   var stdoutWrite;
@@ -11,6 +13,16 @@ describe('Landing reporter', function () {
   var useColors;
   var windowWidth;
   var resetCode = '\u001b[0m';
+  var expectedArray = [
+    '\u001b[1D\u001b[2A',
+    '  ',
+    '\n  ',
+    '',
+    '✈',
+    '\n',
+    '  ',
+    resetCode
+  ];
 
   beforeEach(function () {
     stdout = [];
@@ -34,11 +46,7 @@ describe('Landing reporter', function () {
     it('should write new lines', function () {
       var cachedCursor = Base.cursor;
       Base.cursor.hide = function () {};
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('start', 'start');
       Landing.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -53,11 +61,7 @@ describe('Landing reporter', function () {
       Base.cursor.hide = function () {
         calledCursorHide = true;
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('start', 'start');
       Landing.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -73,26 +77,12 @@ describe('Landing reporter', function () {
         var test = {
           state: 'failed'
         };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'test end') {
-            callback(test);
-          }
-        };
+        runner.on = runner.once = runnerEvent('test end', 'test end', null, null, test);
         runner.total = 12;
         Landing.call({}, runner);
 
         process.stdout.write = stdoutWrite;
 
-        var expectedArray = [
-          '\u001b[1D\u001b[2A',
-          '  ',
-          '\n  ',
-          '',
-          '✈',
-          '\n',
-          '  ',
-          resetCode
-        ];
         expect(stdout).to.eql(expectedArray);
       });
     });
@@ -101,26 +91,12 @@ describe('Landing reporter', function () {
         var test = {
           state: 'success'
         };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'test end') {
-            callback(test);
-          }
-        };
+        runner.on = runner.once = runnerEvent('test end', 'test end', null, null, test);
 
         Landing.call({}, runner);
 
         process.stdout.write = stdoutWrite;
 
-        var expectedArray = [
-          '\u001b[1D\u001b[2A',
-          '  ',
-          '\n  ',
-          '',
-          '✈',
-          '\n',
-          '  ',
-          resetCode
-        ];
         expect(stdout).to.eql(expectedArray);
       });
     });
@@ -132,11 +108,8 @@ describe('Landing reporter', function () {
       Base.cursor.show = function () {
         calledCursorShow = true;
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('end', 'end');
+
       var calledEpilogue = false;
       Landing.call({
         epilogue: function () {

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var List = reporters.List;
 var Base = reporters.Base;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('List reporter', function () {
   var stdout;
@@ -22,7 +22,6 @@ describe('List reporter', function () {
   };
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -37,7 +36,7 @@ describe('List reporter', function () {
 
   describe('on start and test', function () {
     it('should write expected new line and title to the console', function () {
-      runner.on = runner.once = runnerEvent('start test', 'start', 'test', null, test);
+      runner = createMockRunner('start test', 'start', 'test', null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -52,7 +51,7 @@ describe('List reporter', function () {
   });
   describe('on pending', function () {
     it('should write expected title to the console', function () {
-      runner.on = runner.once = runnerEvent('pending test', 'pending', null, null, test);
+      runner = createMockRunner('pending test', 'pending', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -67,7 +66,7 @@ describe('List reporter', function () {
       Base.cursor.CR = function () {
         calledCursorCR = true;
       };
-      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+      runner = createMockRunner('pass', 'pass', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -82,7 +81,7 @@ describe('List reporter', function () {
       Base.symbols.ok = expectedOkSymbol;
       var cachedCursor = Base.cursor;
       Base.cursor.CR = function () {};
-      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+      runner = createMockRunner('pass', 'pass', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -100,7 +99,7 @@ describe('List reporter', function () {
       Base.cursor.CR = function () {
         calledCursorCR = true;
       };
-      runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
+      runner = createMockRunner('fail', 'fail', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -113,7 +112,7 @@ describe('List reporter', function () {
       var cachedCursor = Base.cursor;
       var expectedErrorCount = 1;
       Base.cursor.CR = function () {};
-      runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
+      runner = createMockRunner('fail', 'fail', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -149,7 +148,7 @@ describe('List reporter', function () {
   describe('on end', function () {
     it('should call epilogue', function () {
       var calledEpilogue = false;
-      runner.on = runner.once = runnerEvent('end', 'end');
+      runner = createMockRunner('end', 'end');
       List.call({
         epilogue: function () {
           calledEpilogue = true;

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -4,11 +4,15 @@ var reporters = require('../../').reporters;
 var List = reporters.List;
 var Base = reporters.Base;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('List reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;
   var useColors;
+  var expectedTitle = 'some title';
+  var expectedDuration = 100;
 
   beforeEach(function () {
     stdout = [];
@@ -27,20 +31,12 @@ describe('List reporter', function () {
 
   describe('on start and test', function () {
     it('should write expected new line and title to the console', function () {
-      var expectedTitle = 'some title';
       var test = {
         fullTitle: function () {
           return expectedTitle;
         }
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-        if (event === 'test') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('start test', 'start', 'test', null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -55,17 +51,12 @@ describe('List reporter', function () {
   });
   describe('on pending', function () {
     it('should write expected title to the console', function () {
-      var expectedTitle = 'some title';
       var test = {
         fullTitle: function () {
           return expectedTitle;
         }
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pending') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('pending test', 'pending', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -80,8 +71,6 @@ describe('List reporter', function () {
       Base.cursor.CR = function () {
         calledCursorCR = true;
       };
-      var expectedTitle = 'some title';
-      var expectedDuration = 100;
       var test = {
         fullTitle: function () {
           return expectedTitle;
@@ -89,11 +78,7 @@ describe('List reporter', function () {
         duration: expectedDuration,
         slow: function () {}
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pass') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -108,8 +93,6 @@ describe('List reporter', function () {
       Base.symbols.ok = expectedOkSymbol;
       var cachedCursor = Base.cursor;
       Base.cursor.CR = function () {};
-      var expectedTitle = 'some title';
-      var expectedDuration = 100;
       var test = {
         fullTitle: function () {
           return expectedTitle;
@@ -117,11 +100,7 @@ describe('List reporter', function () {
         duration: expectedDuration,
         slow: function () {}
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pass') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -139,8 +118,6 @@ describe('List reporter', function () {
       Base.cursor.CR = function () {
         calledCursorCR = true;
       };
-      var expectedTitle = 'some title';
-      var expectedDuration = 100;
       var test = {
         fullTitle: function () {
           return expectedTitle;
@@ -148,11 +125,7 @@ describe('List reporter', function () {
         duration: expectedDuration,
         slow: function () {}
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'fail') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -165,8 +138,6 @@ describe('List reporter', function () {
       var cachedCursor = Base.cursor;
       var expectedErrorCount = 1;
       Base.cursor.CR = function () {};
-      var expectedTitle = 'some title';
-      var expectedDuration = 100;
       var test = {
         fullTitle: function () {
           return expectedTitle;
@@ -174,16 +145,7 @@ describe('List reporter', function () {
         duration: expectedDuration,
         slow: function () {}
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'fail') {
-          callback(test);
-        }
-      };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'fail') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -219,11 +181,7 @@ describe('List reporter', function () {
   describe('on end', function () {
     it('should call epilogue', function () {
       var calledEpilogue = false;
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('end', 'end');
       List.call({
         epilogue: function () {
           calledEpilogue = true;

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -13,7 +13,13 @@ describe('List reporter', function () {
   var useColors;
   var expectedTitle = 'some title';
   var expectedDuration = 100;
-
+  var test = {
+    fullTitle: function () {
+      return expectedTitle;
+    },
+    duration: expectedDuration,
+    slow: function () {}
+  };
   beforeEach(function () {
     stdout = [];
     runner = {};
@@ -31,11 +37,6 @@ describe('List reporter', function () {
 
   describe('on start and test', function () {
     it('should write expected new line and title to the console', function () {
-      var test = {
-        fullTitle: function () {
-          return expectedTitle;
-        }
-      };
       runner.on = runner.once = runnerEvent('start test', 'start', 'test', null, test);
       List.call({epilogue: function () {}}, runner);
 
@@ -51,11 +52,6 @@ describe('List reporter', function () {
   });
   describe('on pending', function () {
     it('should write expected title to the console', function () {
-      var test = {
-        fullTitle: function () {
-          return expectedTitle;
-        }
-      };
       runner.on = runner.once = runnerEvent('pending test', 'pending', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
@@ -70,13 +66,6 @@ describe('List reporter', function () {
       var cachedCursor = Base.cursor;
       Base.cursor.CR = function () {
         calledCursorCR = true;
-      };
-      var test = {
-        fullTitle: function () {
-          return expectedTitle;
-        },
-        duration: expectedDuration,
-        slow: function () {}
       };
       runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
       List.call({epilogue: function () {}}, runner);
@@ -93,13 +82,6 @@ describe('List reporter', function () {
       Base.symbols.ok = expectedOkSymbol;
       var cachedCursor = Base.cursor;
       Base.cursor.CR = function () {};
-      var test = {
-        fullTitle: function () {
-          return expectedTitle;
-        },
-        duration: expectedDuration,
-        slow: function () {}
-      };
       runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
@@ -118,13 +100,6 @@ describe('List reporter', function () {
       Base.cursor.CR = function () {
         calledCursorCR = true;
       };
-      var test = {
-        fullTitle: function () {
-          return expectedTitle;
-        },
-        duration: expectedDuration,
-        slow: function () {}
-      };
       runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
@@ -138,13 +113,6 @@ describe('List reporter', function () {
       var cachedCursor = Base.cursor;
       var expectedErrorCount = 1;
       Base.cursor.CR = function () {};
-      var test = {
-        fullTitle: function () {
-          return expectedTitle;
-        },
-        duration: expectedDuration,
-        slow: function () {}
-      };
       runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
       List.call({epilogue: function () {}}, runner);
 
@@ -157,9 +125,9 @@ describe('List reporter', function () {
     it('should immediately construct fail strings', function () {
       var actual = { a: 'actual' };
       var expected = { a: 'expected' };
-      var test = {};
       var checked = false;
       var err;
+      test = {};
       runner.on = runner.once = function (event, callback) {
         if (!checked && event === 'fail') {
           err = new Error('fake failure object with actual/expected');

--- a/test/reporters/markdown.spec.js
+++ b/test/reporters/markdown.spec.js
@@ -3,10 +3,15 @@
 var reporters = require('../../').reporters;
 var Markdown = reporters.Markdown;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('Markdown reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;
+  var expectedTitle = 'expected title';
+  var expectedFullTitle = 'full title';
+  var sluggedFullTitle = 'full-title';
 
   beforeEach(function () {
     stdout = [];
@@ -19,9 +24,6 @@ describe('Markdown reporter', function () {
 
   describe('on \'suite\'', function () {
     it('should write expected slugged titles on \'end\' event', function () {
-      var expectedTitle = 'expected title';
-      var expectedFullTitle = 'full title';
-      var sluggedFullTitle = 'full-title';
       var expectedSuite = {
         title: expectedTitle,
         fullTitle: function () { return expectedFullTitle; },
@@ -31,17 +33,7 @@ describe('Markdown reporter', function () {
           suites: []
         }]
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'suite') {
-          callback(expectedSuite);
-        }
-        if (event === 'suite end') {
-          callback();
-        }
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('suite suite end', 'suite', 'suite end', 'end', expectedSuite);
       runner.suite = expectedSuite;
       Markdown.call({}, runner);
       process.stdout.write = stdoutWrite;
@@ -57,9 +49,6 @@ describe('Markdown reporter', function () {
   });
   describe('on \'pass\'', function () {
     it('should write test code inside js code block, on \'end\' event', function () {
-      var expectedTitle = 'expected title';
-      var expectedFullTitle = 'full title';
-      var sluggedFullTitle = 'full-title';
       var expectedSuite = {
         title: expectedTitle,
         fullTitle: function () { return expectedFullTitle; },
@@ -76,14 +65,7 @@ describe('Markdown reporter', function () {
         slow: function () {},
         body: expectedBody
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pass') {
-          callback(expectedTest);
-        }
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('pass end', 'pass', 'end', null, expectedTest);
       runner.suite = expectedSuite;
       Markdown.call({}, runner);
       process.stdout.write = stdoutWrite;

--- a/test/reporters/markdown.spec.js
+++ b/test/reporters/markdown.spec.js
@@ -3,7 +3,7 @@
 var reporters = require('../../').reporters;
 var Markdown = reporters.Markdown;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('Markdown reporter', function () {
   var stdout;
@@ -15,7 +15,6 @@ describe('Markdown reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -33,7 +32,7 @@ describe('Markdown reporter', function () {
           suites: []
         }]
       };
-      runner.on = runner.once = runnerEvent('suite suite end', 'suite', 'suite end', 'end', expectedSuite);
+      runner = createMockRunner('suite suite end', 'suite', 'suite end', 'end', expectedSuite);
       runner.suite = expectedSuite;
       Markdown.call({}, runner);
       process.stdout.write = stdoutWrite;
@@ -65,7 +64,7 @@ describe('Markdown reporter', function () {
         slow: function () {},
         body: expectedBody
       };
-      runner.on = runner.once = runnerEvent('pass end', 'pass', 'end', null, expectedTest);
+      runner = createMockRunner('pass end', 'pass', 'end', null, expectedTest);
       runner.suite = expectedSuite;
       Markdown.call({}, runner);
       process.stdout.write = stdoutWrite;

--- a/test/reporters/min.spec.js
+++ b/test/reporters/min.spec.js
@@ -3,7 +3,7 @@
 var reporters = require('../../').reporters;
 var Min = reporters.Min;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('Min reporter', function () {
   var stdout;
@@ -12,7 +12,6 @@ describe('Min reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -21,7 +20,7 @@ describe('Min reporter', function () {
 
   describe('on start', function () {
     it('should clear screen then set cursor position', function () {
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       Min.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -36,7 +35,7 @@ describe('Min reporter', function () {
   describe('on end', function () {
     it('should call epilogue', function () {
       var calledEpilogue = false;
-      runner.on = runner.once = runnerEvent('end', 'end');
+      runner = createMockRunner('end', 'end');
       Min.call({
         epilogue: function () {
           calledEpilogue = true;

--- a/test/reporters/min.spec.js
+++ b/test/reporters/min.spec.js
@@ -3,6 +3,8 @@
 var reporters = require('../../').reporters;
 var Min = reporters.Min;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('Min reporter', function () {
   var stdout;
   var stdoutWrite;
@@ -19,11 +21,7 @@ describe('Min reporter', function () {
 
   describe('on start', function () {
     it('should clear screen then set cursor position', function () {
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('start', 'start');
       Min.call({epilogue: function () {}}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -38,11 +36,7 @@ describe('Min reporter', function () {
   describe('on end', function () {
     it('should call epilogue', function () {
       var calledEpilogue = false;
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('end', 'end');
       Min.call({
         epilogue: function () {
           calledEpilogue = true;

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -4,11 +4,14 @@ var reporters = require('../../').reporters;
 var NyanCat = reporters.Nyan;
 var Base = reporters.Base;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('Nyan reporter', function () {
   describe('events', function () {
     var runner;
     var stdout;
     var stdoutWrite;
+    var calledDraw;
 
     beforeEach(function () {
       stdout = [];
@@ -21,12 +24,8 @@ describe('Nyan reporter', function () {
 
     describe('on start', function () {
       it('should call draw', function () {
-        var calledDraw = false;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'start') {
-            callback();
-          }
-        };
+        calledDraw = false;
+        runner.on = runner.once = runnerEvent('start', 'start');
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -40,12 +39,8 @@ describe('Nyan reporter', function () {
     });
     describe('on pending', function () {
       it('should call draw', function () {
-        var calledDraw = false;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'pending') {
-            callback();
-          }
-        };
+        calledDraw = false;
+        runner.on = runner.once = runnerEvent('pending', 'pending');
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -59,16 +54,12 @@ describe('Nyan reporter', function () {
     });
     describe('on pass', function () {
       it('should call draw', function () {
-        var calledDraw = false;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'pass') {
-            var test = {
-              duration: '',
-              slow: function () {}
-            };
-            callback(test);
-          }
+        calledDraw = false;
+        var test = {
+          duration: '',
+          slow: function () {}
         };
+        runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -82,15 +73,11 @@ describe('Nyan reporter', function () {
     });
     describe('on fail', function () {
       it('should call draw', function () {
-        var calledDraw = false;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'fail') {
-            var test = {
-              err: ''
-            };
-            callback(test);
-          }
+        calledDraw = false;
+        var test = {
+          err: ''
         };
+        runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -105,11 +92,7 @@ describe('Nyan reporter', function () {
     describe('on end', function () {
       it('should call epilogue', function () {
         var calledEpilogue = false;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'end') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('end', 'end');
         NyanCat.call({
           draw: function () {},
           generateColors: function () {},
@@ -123,11 +106,7 @@ describe('Nyan reporter', function () {
       });
       it('should write numberOfLines amount of new lines', function () {
         var expectedNumberOfLines = 4;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'end') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('end', 'end');
         NyanCat.call({
           draw: function () {},
           generateColors: function () {},
@@ -145,11 +124,7 @@ describe('Nyan reporter', function () {
         Base.cursor.show = function () {
           showCalled = true;
         };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'end') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('end', 'end');
         NyanCat.call({
           draw: function () {},
           generateColors: function () {},

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var NyanCat = reporters.Nyan;
 var Base = reporters.Base;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('Nyan reporter', function () {
   describe('events', function () {
@@ -15,7 +15,6 @@ describe('Nyan reporter', function () {
 
     beforeEach(function () {
       stdout = [];
-      runner = {};
       stdoutWrite = process.stdout.write;
       process.stdout.write = function (string) {
         stdout.push(string);
@@ -25,7 +24,7 @@ describe('Nyan reporter', function () {
     describe('on start', function () {
       it('should call draw', function () {
         calledDraw = false;
-        runner.on = runner.once = runnerEvent('start', 'start');
+        runner = createMockRunner('start', 'start');
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -40,7 +39,7 @@ describe('Nyan reporter', function () {
     describe('on pending', function () {
       it('should call draw', function () {
         calledDraw = false;
-        runner.on = runner.once = runnerEvent('pending', 'pending');
+        runner = createMockRunner('pending', 'pending');
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -59,7 +58,7 @@ describe('Nyan reporter', function () {
           duration: '',
           slow: function () {}
         };
-        runner.on = runner.once = runnerEvent('pass', 'pass', null, null, test);
+        runner = createMockRunner('pass', 'pass', null, null, test);
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -77,7 +76,7 @@ describe('Nyan reporter', function () {
         var test = {
           err: ''
         };
-        runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
+        runner = createMockRunner('fail', 'fail', null, null, test);
         NyanCat.call({
           draw: function () {
             calledDraw = true;
@@ -92,7 +91,7 @@ describe('Nyan reporter', function () {
     describe('on end', function () {
       it('should call epilogue', function () {
         var calledEpilogue = false;
-        runner.on = runner.once = runnerEvent('end', 'end');
+        runner = createMockRunner('end', 'end');
         NyanCat.call({
           draw: function () {},
           generateColors: function () {},
@@ -106,7 +105,7 @@ describe('Nyan reporter', function () {
       });
       it('should write numberOfLines amount of new lines', function () {
         var expectedNumberOfLines = 4;
-        runner.on = runner.once = runnerEvent('end', 'end');
+        runner = createMockRunner('end', 'end');
         NyanCat.call({
           draw: function () {},
           generateColors: function () {},
@@ -124,7 +123,7 @@ describe('Nyan reporter', function () {
         Base.cursor.show = function () {
           showCalled = true;
         };
-        runner.on = runner.once = runnerEvent('end', 'end');
+        runner = createMockRunner('end', 'end');
         NyanCat.call({
           draw: function () {},
           generateColors: function () {},

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var Progress = reporters.Progress;
 var Base = reporters.Base;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('Progress reporter', function () {
   var stdout;
@@ -13,7 +13,6 @@ describe('Progress reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -27,7 +26,7 @@ describe('Progress reporter', function () {
       Base.cursor.hide = function () {
         calledCursorHide = true;
       };
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       Progress.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -49,8 +48,8 @@ describe('Progress reporter', function () {
 
         var expectedTotal = 1;
         var expectedOptions = {};
+        runner = createMockRunner('test end', 'test end');
         runner.total = expectedTotal;
-        runner.on = runner.once = runnerEvent('test end', 'test end');
         Progress.call({}, runner, expectedOptions);
 
         process.stdout.write = stdoutWrite;
@@ -87,8 +86,8 @@ describe('Progress reporter', function () {
         var options = {
           reporterOptions: expectedOptions
         };
+        runner = createMockRunner('test end', 'test end');
         runner.total = expectedTotal;
-        runner.on = runner.once = runnerEvent('test end', 'test end');
         Progress.call({}, runner, options);
 
         process.stdout.write = stdoutWrite;
@@ -116,7 +115,7 @@ describe('Progress reporter', function () {
       Base.cursor.show = function () {
         calledCursorShow = true;
       };
-      runner.on = runner.once = runnerEvent('end', 'end');
+      runner = createMockRunner('end', 'end');
       var calledEpilogue = false;
       Progress.call({
         epilogue: function () {

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -4,6 +4,8 @@ var reporters = require('../../').reporters;
 var Progress = reporters.Progress;
 var Base = reporters.Base;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('Progress reporter', function () {
   var stdout;
   var stdoutWrite;
@@ -25,11 +27,7 @@ describe('Progress reporter', function () {
       Base.cursor.hide = function () {
         calledCursorHide = true;
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('start', 'start');
       Progress.call({}, runner);
 
       process.stdout.write = stdoutWrite;
@@ -52,11 +50,7 @@ describe('Progress reporter', function () {
         var expectedTotal = 1;
         var expectedOptions = {};
         runner.total = expectedTotal;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'test end') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('test end', 'test end');
         Progress.call({}, runner, expectedOptions);
 
         process.stdout.write = stdoutWrite;
@@ -94,11 +88,7 @@ describe('Progress reporter', function () {
           reporterOptions: expectedOptions
         };
         runner.total = expectedTotal;
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'test end') {
-            callback();
-          }
-        };
+        runner.on = runner.once = runnerEvent('test end', 'test end');
         Progress.call({}, runner, options);
 
         process.stdout.write = stdoutWrite;
@@ -126,11 +116,7 @@ describe('Progress reporter', function () {
       Base.cursor.show = function () {
         calledCursorShow = true;
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'end') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('end', 'end');
       var calledEpilogue = false;
       Progress.call({
         epilogue: function () {

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -4,11 +4,14 @@ var reporters = require('../../').reporters;
 var Spec = reporters.Spec;
 var Base = reporters.Base;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('Spec reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;
   var useColors;
+  var expectedTitle = 'expectedTitle';
 
   beforeEach(function () {
     stdout = [];
@@ -27,15 +30,10 @@ describe('Spec reporter', function () {
 
   describe('on suite', function () {
     it('should return title', function () {
-      var expectedTitle = 'expectedTitle';
       var suite = {
         title: expectedTitle
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'suite') {
-          callback(suite);
-        }
-      };
+      runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -46,15 +44,10 @@ describe('Spec reporter', function () {
   });
   describe('on pending', function () {
     it('should return title', function () {
-      var expectedTitle = 'expectedTitle';
       var suite = {
         title: expectedTitle
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'pending') {
-          callback(suite);
-        }
-      };
+      runner.on = runner.once = runnerEvent('pending test', 'pending', null, null, suite);
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -66,7 +59,6 @@ describe('Spec reporter', function () {
   describe('on pass', function () {
     describe('if test speed is slow', function () {
       it('should return expected tick, title and duration', function () {
-        var expectedTitle = 'expectedTitle';
         var expectedDuration = 2;
         var test = {
           title: expectedTitle,
@@ -86,7 +78,6 @@ describe('Spec reporter', function () {
     });
     describe('if test speed is fast', function () {
       it('should return expected tick, title and without a duration', function () {
-        var expectedTitle = 'expectedTitle';
         var expectedDuration = 1;
         var test = {
           title: expectedTitle,
@@ -107,16 +98,11 @@ describe('Spec reporter', function () {
   });
   describe('on fail', function () {
     it('should return title and function count', function () {
-      var expectedTitle = 'expectedTitle';
       var functionCount = 1;
       var test = {
         title: expectedTitle
       };
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'fail') {
-          callback(test);
-        }
-      };
+      runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -4,7 +4,7 @@ var reporters = require('../../').reporters;
 var Spec = reporters.Spec;
 var Base = reporters.Base;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('Spec reporter', function () {
   var stdout;
@@ -15,7 +15,6 @@ describe('Spec reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -33,7 +32,7 @@ describe('Spec reporter', function () {
       var suite = {
         title: expectedTitle
       };
-      runner.on = runner.once = runnerEvent('suite', 'suite', null, null, suite);
+      runner = createMockRunner('suite', 'suite', null, null, suite);
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -47,7 +46,7 @@ describe('Spec reporter', function () {
       var suite = {
         title: expectedTitle
       };
-      runner.on = runner.once = runnerEvent('pending test', 'pending', null, null, suite);
+      runner = createMockRunner('pending test', 'pending', null, null, suite);
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [
@@ -65,11 +64,7 @@ describe('Spec reporter', function () {
           duration: expectedDuration,
           slow: function () { return 1; }
         };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'pass') {
-            callback(test);
-          }
-        };
+        runner = createMockRunner('pass', 'pass', null, null, test);
         Spec.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedString = '  ' + Base.symbols.ok + ' ' + expectedTitle + ' (' + expectedDuration + 'ms)' + '\n';
@@ -84,11 +79,7 @@ describe('Spec reporter', function () {
           duration: expectedDuration,
           slow: function () { return 2; }
         };
-        runner.on = runner.once = function (event, callback) {
-          if (event === 'pass') {
-            callback(test);
-          }
-        };
+        runner = createMockRunner('pass', 'pass', null, null, test);
         Spec.call({epilogue: function () {}}, runner);
         process.stdout.write = stdoutWrite;
         var expectedString = '  ' + Base.symbols.ok + ' ' + expectedTitle + '\n';
@@ -102,7 +93,7 @@ describe('Spec reporter', function () {
       var test = {
         title: expectedTitle
       };
-      runner.on = runner.once = runnerEvent('fail', 'fail', null, null, test);
+      runner = createMockRunner('fail', 'fail', null, null, test);
       Spec.call({epilogue: function () {}}, runner);
       process.stdout.write = stdoutWrite;
       var expectedArray = [

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -3,10 +3,14 @@
 var reporters = require('../../').reporters;
 var TAP = reporters.TAP;
 
+var runnerEvent = require('./helpers').runnerEvent;
+
 describe('TAP reporter', function () {
   var stdout;
   var stdoutWrite;
   var runner;
+  var expectedTitle = 'some title';
+  var countAfterTestEnd = 2;
 
   beforeEach(function () {
     stdout = [];
@@ -22,11 +26,7 @@ describe('TAP reporter', function () {
       var expectedSuite = 'some suite';
       var expectedTotal = 10;
       var expectedString;
-      runner.on = runner.once = function (event, callback) {
-        if (event === 'start') {
-          callback();
-        }
-      };
+      runner.on = runner.once = runnerEvent('start', 'start');
       runner.suite = expectedSuite;
       runner.grepTotal = function (string) {
         expectedString = string;
@@ -46,8 +46,6 @@ describe('TAP reporter', function () {
 
   describe('on pending', function () {
     it('should write expected message including count and title', function () {
-      var expectedTitle = 'some title';
-      var countAfterTestEnd = 2;
       var test = {
         fullTitle: function () {
           return expectedTitle;
@@ -74,8 +72,6 @@ describe('TAP reporter', function () {
 
   describe('on pass', function () {
     it('should write expected message including count and title', function () {
-      var expectedTitle = 'some title';
-      var countAfterTestEnd = 2;
       var test = {
         fullTitle: function () {
           return expectedTitle;
@@ -104,8 +100,6 @@ describe('TAP reporter', function () {
   describe('on fail', function () {
     describe('if there is an error stack', function () {
       it('should write expected message and stack', function () {
-        var expectedTitle = 'some title';
-        var countAfterTestEnd = 2;
         var expectedStack = 'some stack';
         var test = {
           fullTitle: function () {
@@ -139,8 +133,6 @@ describe('TAP reporter', function () {
     });
     describe('if there is no error stack', function () {
       it('should write expected message only', function () {
-        var expectedTitle = 'some title';
-        var countAfterTestEnd = 2;
         var test = {
           fullTitle: function () {
             return expectedTitle;
@@ -172,7 +164,6 @@ describe('TAP reporter', function () {
 
   describe('on end', function () {
     it('should write total tests, passes and failures', function () {
-      var expectedTitle = 'some title';
       var numberOfPasses = 1;
       var numberOfFails = 1;
       var test = {

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -3,7 +3,7 @@
 var reporters = require('../../').reporters;
 var TAP = reporters.TAP;
 
-var runnerEvent = require('./helpers').runnerEvent;
+var createMockRunner = require('./helpers').createMockRunner;
 
 describe('TAP reporter', function () {
   var stdout;
@@ -15,7 +15,6 @@ describe('TAP reporter', function () {
 
   beforeEach(function () {
     stdout = [];
-    runner = {};
     stdoutWrite = process.stdout.write;
     process.stdout.write = function (string) {
       stdout.push(string);
@@ -33,7 +32,7 @@ describe('TAP reporter', function () {
       var expectedSuite = 'some suite';
       var expectedTotal = 10;
       var expectedString;
-      runner.on = runner.once = runnerEvent('start', 'start');
+      runner = createMockRunner('start', 'start');
       runner.suite = expectedSuite;
       runner.grepTotal = function (string) {
         expectedString = string;
@@ -53,12 +52,7 @@ describe('TAP reporter', function () {
 
   describe('on pending', function () {
     it('should write expected message including count and title', function () {
-      // var test = {
-      //   fullTitle: function () {
-      //     return expectedTitle;
-      //   }
-      // };
-      runner.on = runner.once = runnerEvent('start test', 'test end', 'pending', null, test);
+      runner = createMockRunner('start test', 'test end', 'pending', null, test);
       runner.suite = '';
       runner.grepTotal = function () { };
       TAP.call({}, runner);
@@ -72,7 +66,7 @@ describe('TAP reporter', function () {
 
   describe('on pass', function () {
     it('should write expected message including count and title', function () {
-      runner.on = runner.once = runnerEvent('start test', 'test end', 'pass', null, test);
+      runner = createMockRunner('start test', 'test end', 'pass', null, test);
 
       runner.suite = '';
       runner.grepTotal = function () { };
@@ -92,7 +86,7 @@ describe('TAP reporter', function () {
         var error = {
           stack: expectedStack
         };
-        runner.on = runner.once = runnerEvent('test end fail', 'test end', 'fail', null, test, error);
+        runner = createMockRunner('test end fail', 'test end', 'fail', null, test, error);
         runner.suite = '';
         runner.grepTotal = function () { };
         TAP.call({}, runner);
@@ -135,7 +129,7 @@ describe('TAP reporter', function () {
     it('should write total tests, passes and failures', function () {
       var numberOfPasses = 1;
       var numberOfFails = 1;
-      runner.on = runner.once = runnerEvent('fail end pass', 'fail', 'end', 'pass', test);
+      runner = createMockRunner('fail end pass', 'fail', 'end', 'pass', test);
       runner.suite = '';
       runner.grepTotal = function () { };
       TAP.call({}, runner);

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -12,12 +12,18 @@ describe('XUnit reporter', function () {
   var stdoutWrite;
   var runner;
 
+  var callbackArgument = null;
+  var expectedFailure = 'some-failures';
+  var expectedLine = 'some-line';
+  var expectedClassName = 'fullTitle';
+  var expectedTitle = 'some title';
+  var expectedMessage = 'some message';
+  var expectedStack = 'some-stack';
+  var expectedWrite = null;
+
   beforeEach(function () {
     stdout = [];
-    runner = {
-      on: function () {},
-      once: function () {}
-    };
+    runner = {on: function () {}, once: function () {}};
   });
 
   describe('if reporter options output is given', function () {
@@ -112,12 +118,10 @@ describe('XUnit reporter', function () {
     describe('if fileStream is truthly', function () {
       it('should run callback with failure inside streams end', function () {
         var xunit = new XUnit({on: function () {}, once: function () {}});
-        var callbackArgument = null;
         var callback = function (failures) {
           callbackArgument = failures;
         };
         var calledEnd = false;
-        var expectedFailure = 'some-failures';
         var fileStream = {
           end: function (callback) {
             calledEnd = true;
@@ -137,11 +141,9 @@ describe('XUnit reporter', function () {
     describe('if fileStream is falsy', function () {
       it('should run callback with failure', function () {
         var xunit = new XUnit({on: function () {}, once: function () {}});
-        var callbackArgument = null;
         var callback = function (failures) {
           callbackArgument = failures;
         };
-        var expectedFailure = 'some-failures';
         xunit.done.call(
           { fileStream: false },
           expectedFailure,
@@ -156,14 +158,12 @@ describe('XUnit reporter', function () {
   describe('write', function () {
     describe('if fileStream is truthly', function () {
       it('should call fileStream write with line and new line', function () {
-        var expectedWrite = null;
         var xunit = new XUnit({on: function () {}, once: function () {}});
         var fileStream = {
           write: function (write) {
             expectedWrite = write;
           }
         };
-        var expectedLine = 'some-line';
         xunit.write.call(
           { fileStream: fileStream },
           expectedLine
@@ -180,7 +180,6 @@ describe('XUnit reporter', function () {
         };
 
         var xunit = new XUnit({on: function () {}, once: function () {}});
-        var expectedLine = 'some-line';
         xunit.write.call(
           { fileStream: false },
           expectedLine
@@ -201,7 +200,6 @@ describe('XUnit reporter', function () {
         };
 
         var xunit = new XUnit({on: function () {}, once: function () {}});
-        var expectedLine = 'some-line';
         xunit.write.call(
           { fileStream: false },
           expectedLine
@@ -218,12 +216,6 @@ describe('XUnit reporter', function () {
     describe('on test failure', function () {
       it('should write expected tag with error details', function () {
         var xunit = new XUnit({on: function () {}, once: function () {}});
-
-        var expectedWrite = null;
-        var expectedClassName = 'fullTitle';
-        var expectedTitle = 'some title';
-        var expectedMessage = 'some message';
-        var expectedStack = 'some-stack';
         var expectedTest = {
           state: 'failed',
           title: expectedTitle,
@@ -256,8 +248,6 @@ describe('XUnit reporter', function () {
       it('should write expected tag', function () {
         var xunit = new XUnit({on: function () {}, once: function () {}});
 
-        var expectedClassName = 'fullTitle';
-        var expectedTitle = 'some title';
         var expectedTest = {
           isPending: function () { return true; },
           title: expectedTitle,
@@ -268,7 +258,6 @@ describe('XUnit reporter', function () {
           },
           duration: 1000
         };
-        var expectedWrite = null;
         xunit.test.call(
           {
             write: function (string) {
@@ -287,8 +276,6 @@ describe('XUnit reporter', function () {
       it('should write expected tag', function () {
         var xunit = new XUnit({on: function () {}, once: function () {}});
 
-        var expectedClassName = 'fullTitle';
-        var expectedTitle = 'some title';
         var expectedTest = {
           isPending: function () { return false; },
           title: expectedTitle,
@@ -299,7 +286,6 @@ describe('XUnit reporter', function () {
           },
           duration: false
         };
-        var expectedWrite = null;
         xunit.test.call(
           {
             write: function (string) {
@@ -319,13 +305,10 @@ describe('XUnit reporter', function () {
   describe('custom suite name', function () {
     // capture the events that the reporter subscribes to
     var events;
-
     // the runner parameter of the reporter
     var runner;
-
     // capture output lines (will contain the resulting XML of the xunit reporter)
     var lines;
-
     // the file stream into which the xunit reporter will write into
     var fileStream;
 


### PR DESCRIPTION
### Description of the Change

In reference to issue: #3260 

I did my best at refactoring the code. Though the part of the test files that was quite obviously capable to become more modular was the runner events. I could make all of those calls from one function, ie:

```javascript
runner.on = runner.once = function...
// into
runner.on = runner.once = runnerEvent(whatevery necessary parameters);
```

Otherwise I tried to make variables that I noticed were repeatedly called throughout singular files to be called only one time rather then the continual `var something = 'something'` over and over.

### Alternate Designs

I believe that it can still be worked on. It is not perfect. The `runnerEvent` function could be more beautiful/intuitive. Some tests can make more sense. BaseReporter tests run but it is not obvious, I have no idea how i'd implement that.

### Why should this be in core?

Quite a bit less lines of code for the same functionality. 

### Benefits

Less intensive use of memory and variable calls, etc. More modular code.

### Possible Drawbacks

I had to alter quite a bit of code that a lot of people put lots of time into. There are no errors atm, and I expect there not to be.

### Applicable issues

Not that I know of

Open to doing more if there is a recommendation.