### PR TITLE
fix to bail option works properly with hooks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -265,10 +265,10 @@ Runner.prototype.failHook = function (hook, err) {
     hook.title = hook.originalTitle + ' for "' + hook.ctx.currentTest.title + '"';
   }
 
-  this.fail(hook, err);
   if (this.suite.bail()) {
     this.emit('end');
   }
+  this.fail(hook, err);
 };
 
 /**

--- a/test/integration/fixtures/options/bail-with-after.fixture.js
+++ b/test/integration/fixtures/options/bail-with-after.fixture.js
@@ -1,0 +1,11 @@
+'use strict';
+
+describe('suite1', function () {
+  it('should only display this error', function () {
+    throw new Error('this should be displayed');
+  });
+
+  after(function () {
+    throw new Error('this hook should not be displayed');
+  });
+});

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -68,6 +68,22 @@ describe('options', function () {
         done();
       });
     });
+
+    it('should stop all hooks after the first error', function (done) {
+      run('options/bail-with-after.fixture.js', args, function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 0);
+        assert.equal(res.stats.failures, 1);
+
+        assert.equal(res.failures[0].title, 'should only display this error');
+        assert.equal(res.code, 1);
+        done();
+      });
+    });
   });
 
   describe('--sort', function () {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change
With bail option, all tests must be stopped after first test failure. However, bail option doesn't stop hooks such as `after` or `afterEach`. 
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs
I have no idea.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
It's a bug. It makes bail works correctly.
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
A user can use bail intentionally.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
No.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
Fix  #3096 .
It is patch release.
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
