### PR TITLE
Ensure all after hooks are executed, even if one of them fail

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -318,6 +318,7 @@ Runnable.prototype.run = function (fn) {
     self.clearTimeout();
     self.duration = new Date() - start;
     finished = true;
+    delete self.callback;
     if (!err && self.duration > ms && self._enableTimeouts) {
       err = new Error('Timeout of ' + ms +
       'ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.');
@@ -325,7 +326,7 @@ Runnable.prototype.run = function (fn) {
     fn(err);
   }
 
-  // for .resetTimeout()
+  // for .resetTimeout() and uncaught errors
   this.callback = done;
 
   // explicit async with `done` argument

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -284,10 +284,10 @@ Runner.prototype.hook = function (name, fn) {
   var hooks = suite['_' + name];
   var self = this;
 
-  function next (i) {
+  function next (i, prevErr) {
     var hook = hooks[i];
     if (!hook) {
-      return fn();
+      return fn(prevErr);
     }
     self.currentRunnable = hook;
 
@@ -320,13 +320,18 @@ Runner.prototype.hook = function (name, fn) {
         } else {
           self.failHook(hook, err);
 
-          // stop executing hooks, notify callee of hook err
-          return fn(err);
+          if (name === 'beforeAll' || name === 'beforeEach') {
+            // stop executing hooks, notify callee of hook err
+            return fn(err);
+          } else {
+            // continue calling all after and afterEach hooks
+            prevErr = err;
+          }
         }
       }
       self.emit('hook end', hook);
       delete hook.ctx.currentTest;
-      next(++i);
+      next(++i, prevErr);
     });
   }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -724,8 +724,6 @@ Runner.prototype.uncaught = function (err) {
     return;
   }
 
-  runnable.clearTimeout();
-
   // Ignore errors if already failed or pending
   // See #3226
   if (runnable.isFailed() || runnable.isPending()) {
@@ -733,33 +731,15 @@ Runner.prototype.uncaught = function (err) {
   }
   // we cannot recover gracefully if a Runnable has already passed
   // then fails asynchronously
-  var alreadyPassed = runnable.isPassed();
-  // this will change the state to "failed" regardless of the current value
-  this.fail(runnable, err);
-  if (!alreadyPassed) {
-    // recover from test
-    if (runnable.type === 'test') {
-      this.emit('test end', runnable);
-      this.hookUp('afterEach', this.next);
-      return;
-    }
+  if (runnable.isPassed() || !runnable.callback) {
+    // this will change the state to "failed" regardless of the current value
+    this.fail(runnable, err);
 
-    // recover from hooks
-    var errSuite = this.suite;
-    // if hook failure is in afterEach block
-    if (runnable.fullTitle().indexOf('after each') > -1) {
-      return this.hookErr(err, errSuite, true);
-    }
-    // if hook failure is in beforeEach block
-    if (runnable.fullTitle().indexOf('before each') > -1) {
-      return this.hookErr(err, errSuite, false);
-    }
-    // if hook failure is in after or before blocks
-    return this.nextSuite(errSuite);
+    // bail
+    this.emit('end');
+  } else {
+    runnable.callback(err);
   }
-
-  // bail
-  this.emit('end');
 };
 
 /**

--- a/test/integration/fixtures/hooks/after-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-hook-async-error.fixture.js
@@ -19,3 +19,18 @@ describe('spec 2', function () {
     console.log('test 3');
   });
 });
+describe('spec 3', function () {
+  after(function (done) {
+    console.log('after 1');
+    process.nextTick(function () {
+      throw new Error('after hook error');
+    });
+  });
+  after(function (done) {
+    console.log('after 2');
+    done();
+  });
+  it('should call all after hooks also if one fails', function () {
+    console.log('test 4');
+  });
+});

--- a/test/integration/fixtures/hooks/after-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-hook-error.fixture.js
@@ -17,3 +17,15 @@ describe('spec 2', function () {
     console.log('test 3');
   });
 });
+describe('spec 3', function () {
+  after(function () {
+    console.log('after 1');
+    throw new Error('after hook error');
+  });
+  after(function () {
+    console.log('after 2');
+  });
+  it('should call all after hooks also if one fails', function () {
+    console.log('test 4');
+  });
+});

--- a/test/integration/fixtures/hooks/afterEach-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/afterEach-hook-async-error.fixture.js
@@ -19,3 +19,18 @@ describe('spec 2', function () {
     console.log('test 3');
   });
 });
+describe('spec 3', function () {
+  afterEach(function (done) {
+    console.log('after each 1');
+    process.nextTick(function () {
+      throw new Error('after each hook error');
+    });
+  });
+  afterEach(function (done) {
+    console.log('after each 2');
+    done();
+  });
+  it('should call all after each hooks also if one fails', function () {
+    console.log('test 4');
+  });
+});

--- a/test/integration/fixtures/hooks/afterEach-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/afterEach-hook-error.fixture.js
@@ -17,3 +17,15 @@ describe('spec 2', function () {
     console.log('test 3');
   });
 });
+describe('spec 3', function () {
+  afterEach(function () {
+    console.log('after each 1');
+    throw new Error('after each hook error');
+  });
+  afterEach(function () {
+    console.log('after each 2');
+  });
+  it('should call all after each hooks also if one fails', function () {
+    console.log('test 4');
+  });
+});

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -43,7 +43,7 @@ describe('hook error handling', function () {
     it('should verify results', function () {
       assert.deepEqual(
         lines,
-        ['test 1', 'test 2', 'after', bang + 'test 3']
+        ['test 1', 'test 2', 'after', bang + 'test 3', 'test 4', 'after 1', bang + 'after 2']
       );
     });
   });
@@ -53,7 +53,7 @@ describe('hook error handling', function () {
     it('should verify results', function () {
       assert.deepEqual(
         lines,
-        ['test 1', 'after', bang + 'test 3']
+        ['test 1', 'after', bang + 'test 3', 'test 4', 'after each 1', bang + 'after each 2']
       );
     });
   });
@@ -131,7 +131,7 @@ describe('hook error handling', function () {
     it('should verify results', function () {
       assert.deepEqual(
         lines,
-        ['test 1', 'test 2', 'after', bang + 'test 3']
+        ['test 1', 'test 2', 'after', bang + 'test 3', 'test 4', 'after 1', bang + 'after 2']
       );
     });
   });
@@ -141,7 +141,7 @@ describe('hook error handling', function () {
     it('should verify results', function () {
       assert.deepEqual(
         lines,
-        ['test 1', 'after', bang + 'test 3']
+        ['test 1', 'after', bang + 'test 3', 'test 4', 'after each 1', bang + 'after each 2']
       );
     });
   });

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -16,7 +16,7 @@ describe('uncaught exceptions', function () {
       assert.equal(res.stats.failures, 1);
 
       assert.equal(res.failures[0].fullTitle,
-        'uncaught "before each" hook');
+        'uncaught "before each" hook for "test"');
       assert.equal(res.code, 1);
       done();
     });


### PR DESCRIPTION
### Description of the Change

If you have tests that require some cleanup, for example to close open files, network connections, processes, or other things, you usually have an `after()` or `afterEach()` hook to do that.

```js
describe('suite A', function () {
  afterEach(function () {
    cleanupItemX();
    cleanupItemY();
  });

  .
  .
  .
});
```

Now, if there is an exception from the first cleanup method, the second one will not be run.

This PR enables you to write cleanup code like this:

```js
describe('suite A', function () {
  afterEach(function () {
    cleanupItemX();
  });

  afterEach(function () {
    cleanupItemY();
  });

  .
  .
  .
});
```

This will make sure that both hooks are always executed, and errors are reported properly if any of them fail.
Before this PR, the second after each hook was not executed if the first one throws an exception. But the fact that hooks in the parent suite are executed leads me to believe that this was simply overlooked, maybe because several after hooks in the same suite is not very common.

### Alternate Designs

It would be possible to fix this by adding a bunch of try/finally blocks. However, there are some problems with that.
 - The code is cluttered with a bunch of try/finally blocks
 - Only one error is reported from the test suite. You want to log all errors that happen.

```js
describe('suite A', function () {
  afterEach(function () {
    try {
      cleanupItemX();
    } finally {
      try {
        cleanupItemY();
      } finally {
        cleanupItemZ();
      }
    }
  });

  .
  .
  .
});
```

### Why should this be in core?

Because there is an inconsistency in how after hooks work. Hooks in the same suite are not run if the first one fails, but hooks in parent suites are run. To be consistent, it should work the same for all hooks.

### Benefits

Consistency in how hooks work, and possibility to write less try/finally clauses in the after hooks.

### Possible Drawbacks

Cannot see any drawbacks

### Applicable issues

I say this is a patch release, because it only affects what is executed when something fails. Also you should not be surprised that your after hook is executed when something fails, because that is the purpose of having it.