### PR TITLE
feature: add classbdd interface style

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -761,7 +761,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     -r, --require <name>                    require the given module
     -s, --slow <ms>                         "slow" test threshold in milliseconds [75]
     -t, --timeout <ms>                      set test-case timeout in milliseconds [2000]
-    -u, --ui <name>                         specify user-interface (bdd|tdd|qunit|exports)
+    -u, --ui <name>                         specify user-interface (bdd|tdd|qunit|exports|classbdd)
     -w, --watch                             watch files for changes
     --check-leaks                           check for global variable leaks
     --full-trace                            display the full stack trace
@@ -917,7 +917,7 @@ describe('app', function() {
 
 ## Interfaces
 
-Mocha's "interface" system allows developers to choose their style of DSL.  Mocha has **BDD**, **TDD**, **Exports**, **QUnit** and **Require**-style interfaces.
+Mocha's "interface" system allows developers to choose their style of DSL.  Mocha has **BDD**, **TDD**, **Exports**, **QUnit**, **Require**, **ClassBDD**-style interfaces.
 
 ### BDD
 
@@ -951,6 +951,40 @@ The **BDD** interface provides `describe()`, `context()`, `it()`, `specify()`, `
       });
     });
   });
+```
+
+### ClassBDD
+
+The **ClassBDD** interface provides a way to implement tests using the same bdd style syntax but in a classed and less verbose fashion.
+
+The class represents the main suite and the methods represent the `itXXX()`, `before()`, `after()`, `beforeEach()`, and `afterEach()` corresponding to the BDD style.
+
+You can also specify `itSkipXXXX()` or `xitXXXXX` in order to skip a test, or `itOnlyXXXX()` to only execute and specific test.
+
+The suite will be named as the class name, or as the file in case of anonymous classes.
+
+```js
+  class ArraySuiteIndexOf {
+    before() {
+      // ...
+    };
+
+    itShouldNotThrowAnErrorWhenNotPresent() {
+      (function() {
+        [1,2,3].indexOf(4);
+      }).should.not.throw();
+    }
+
+    itShouldReturnMinus1WhenNotPresent() {
+      it('should return -1', function() {
+        [1,2,3].indexOf(4).should.equal(-1);
+      });
+    }
+
+    itShouldReturnTheIndexWhereTheElementFirstAppearsWhenPresent() {
+      [1,2,3].indexOf(3).should.equal(2);
+    }
+  }
 ```
 
 ### TDD

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -127,6 +127,7 @@ module.exports = config => {
     case 'bdd':
     case 'tdd':
     case 'qunit':
+    case 'classbdd':
       if (cfg.sauceLabs) {
         cfg.sauceLabs.testName = `Interface "${MOCHA_TEST}" Integration Tests`;
       }

--- a/lib/interfaces/classbdd.js
+++ b/lib/interfaces/classbdd.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var bdd = require('./bdd');
+
+/**
+ * ClassBDD-style interface:
+ *
+ *      class ArrayIndexOf {
+ *
+ *        itShouldReturnMinus1WhenNotPresent() {
+ *          // ...
+ *        }
+ *
+ *        itShouldReturnTheIndexWhenPresent() {
+ *          // ...
+ *        }
+ *
+ *      }
+ *
+ * @param {Suite} suite Root suite.
+ */
+module.exports = function (suite) {
+  bdd(suite);
+
+  suite.on('pre-require', function (context, file, mocha) {
+    suite.on('require', visit);
+
+    var testMapping = [
+      { match: /^itSkip.*$/, fn: context.it.skip },
+      { match: /^xit.*$/, fn: context.it.skip },
+      { match: /^itOnly.*$/, fn: context.it.only },
+      { match: /^it.*$/, fn: context.it },
+      { match: /^beforeEach.*$/, fn: function (_, fn) { context.beforeEach(fn); } },
+      { match: /^afterEach.*$/, fn: function (_, fn) { context.afterEach(fn); } },
+      { match: /^before.*$/, fn: function (_, fn) { context.before(fn); } },
+      { match: /^after.*$/, fn: function (_, fn) { context.after(fn); } }
+    ];
+
+    var suiteMapping = [
+      { match: /^Skip.*$/, fn: context.describe.skip },
+      { match: /^X.*$/, fn: context.describe.skip },
+      { match: /^Only.*$/, fn: context.describe.only },
+      { match: /^.*$/, fn: context.describe }
+    ];
+
+    function visit (Clss, file) {
+      var name = Clss.name || file;
+
+      for (var item of suiteMapping) {
+        if (name.match(item.match)) {
+          item.fn(name, function () {
+            var instance = new Clss(context);
+            Object.getOwnPropertyNames(Object.getPrototypeOf(instance)).forEach(function (method) {
+              for (var item of testMapping) {
+                if (method.match(item.match)) {
+                  item.fn(method, instance[method].bind(instance));
+                  return;
+                }
+              }
+            });
+          });
+          return;
+        }
+      }
+    }
+  });
+};

--- a/lib/interfaces/index.js
+++ b/lib/interfaces/index.js
@@ -3,4 +3,5 @@
 exports.bdd = require('./bdd');
 exports.tdd = require('./tdd');
 exports.qunit = require('./qunit');
+exports.classbdd = require('./classbdd');
 exports.exports = require('./exports');

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -50,6 +50,7 @@ module.exports = {
             'test.node.bdd',
             'test.node.tdd',
             'test.node.qunit',
+            'test.node.classbdd',
             'test.node.exports',
             'test.node.unit',
             'test.node.integration',
@@ -76,6 +77,10 @@ module.exports = {
         exports: {
           script: test('exports', '--ui exports test/interfaces/exports.spec'),
           description: 'Test Node exports interface'
+        },
+        classbdd: {
+          script: test('classbdd', '--ui classbdd test/interfaces/classbdd.spec'),
+          description: 'Test Node ClassBDD interface'
         },
         unit: {
           script: test('unit', '"test/unit/*.spec.js" "test/node-unit/*.spec.js" --growl'),
@@ -138,6 +143,10 @@ module.exports = {
             script: test('only-bdd', '--ui bdd test/only/bdd.spec'),
             description: 'Test .only() with BDD interface'
           },
+          classbdd: {
+            script: test('only-class-bdd', '--ui classbdd test/only/classbdd.spec'),
+            description: 'Test .only() with ClassBDD interface'
+          },
           tdd: {
             script: test('only-tdd', '--ui tdd test/only/tdd.spec'),
             description: 'Test .only() with TDD interface'
@@ -181,6 +190,10 @@ module.exports = {
         qunit: {
           script: 'MOCHA_TEST=qunit nps test.browser.unit',
           description: 'Test QUnit interface in browser'
+        },
+        classbdd: {
+          script: 'MOCHA_TEST=classbdd nps test.browser.classbdd',
+          description: 'Test ClassBDD interface in browser'
         },
         esm: {
           script: 'MOCHA_TEST=esm nps test.browser.unit',

--- a/test/interfaces/classbdd.spec.js
+++ b/test/interfaces/classbdd.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+module.exports = class IntegerPrimitivesArithmetic {
+  before () {
+    this.number1 = 1;
+  }
+
+  beforeEach () {
+    this.number2 = 2;
+  }
+
+  itSkipShouldNotRun () {
+    expect(1).to.equal(2);
+  }
+
+  itShouldAdd () {
+    expect(this.number1 + this.number2).to.equal(3);
+  }
+
+  itShouldSubstract (done) {
+    setTimeout(function () {
+      expect(this.number1 - this.number2).to.equal(-1);
+      done();
+    }.bind(this), 10);
+  }
+
+  after () {
+    this.number1 = 0;
+  }
+
+  afterEach () {
+    this.number2 = 200;
+  }
+};

--- a/test/only/classbdd.spec.js
+++ b/test/only/classbdd.spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = class {
+  before () {
+    this.number1 = 1;
+  }
+
+  beforeEach () {
+    this.number2 = 2;
+  }
+
+  itShouldNotRun () {
+    expect(1).to.equal(2);
+  }
+
+  itOnlyShouldAdd () {
+    expect(this.number1 + this.number2).to.equal(3);
+  }
+
+  after () {
+    this.number1 = 0;
+  }
+
+  afterEach () {
+    this.number2 = 200;
+  }
+};


### PR DESCRIPTION
This change adds a new interface called 'classbdd' which uses bdd interface under-the-hood but accepts class syntax suites as the following:

```js
module.exports = class IntegerPrimitivesArithmetic{

  before() {
    this.number1 = 1;
  }

  beforeEach() {
    this.number2 = 2;
  }

  itShouldFail() {
    expect(1).to.equal(2);
  }

  itShouldAdd() {
    expect(this.number1 + this.number2).to.equal(3);
  }

};
```

### Alternate Designs

I have not taken into account any other design strategies.

### Why should this be in core?

I think there's not a way to include a new interface from a plugin.

### Benefits

Less verbose and more friendly structure

### Possible Drawbacks

- Can't access to test context (right now)
- Test and suite names are methods (possible to clean by changing from camel case to regular text)
- Can't put suites inside others

### Applicable issues

N/A