### PR TITLE
use build stages for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,37 @@ language: node_js
 
 matrix:
   fast_finish: true
-  include:
-    - node_js: '9'
-      env: TARGET=test.node COVERAGE=true
-    - node_js: '8'
-      env: TARGET=test.node
-    - node_js: '6'
-      env: TARGET=test.node
-    - node_js: '4'
-      env: TARGET=test.node
-    - node_js: '8'
-      env: TARGET=lint
-    - node_js: '8'
-      env: TARGET=test.browser
 
 before_install: scripts/travis-before-install.sh
 
 before_script: scripts/travis-before-script.sh
 
-script: npm start $TARGET
+jobs:
+  include:
+    - stage: lint
+      node_js: '8'
+      env: TARGET=lint
+      script: npm start $TARGET
+    - stage: test
+      node_js: '9'
+      env: TARGET=test.node COVERAGE=true
+      script: npm start $TARGET
+    - node_js: '8'
+      env: TARGET=test.node
+      script: npm start $TARGET
+    - node_js: '6'
+      env: TARGET=test.node
+      script: npm start $TARGET
+    - node_js: '4'
+      env: TARGET=test.node
+      script: npm start $TARGET
+    - node_js: '8'
+      env: TARGET=test.browser
+      script: npm start $TARGET
+
+stages:
+  - lint
+  - test
 
 after_success: npm start coveralls
 


### PR DESCRIPTION
### Description of the Change
Introduce TravisCI build stages; it's still beta to make our builds more obviously and easier to understand. It groups our builds as `lint` or `test.`
I run linting first and then run tests because linting is much cheaper than tests.

### Alternate Designs
We can add more stages.
For example, we can use a `build` stage instead `before_script` or a `coverage` stage instead `after_success`.

### Why should this be in core?
IMO, it's more obviously, but it's tiny.
I'm not sure that we should use this yet. It's still beta.

### Benefits
Easy to understand our build status.

### Possible Drawbacks
If there are some bugs in this feature or Travis change something, our build might be broken, or we should update our `.travis.yml`.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
https://github.com/mochajs/mocha/issues/3292
