### PR TITLE
update stages and build matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,15 @@ jobs:
       script: npm start test.node
 
     - <<: *node
+      cache: false
       node_js: '8'
 
     - <<: *node
-      cache:
-        directories:
-          - node_modules
+      cache: false
       node_js: '6'
 
     - <<: *node
-      cache:
-        directories:
-          - node_modules
+      cache: false
       node_js: '4'
 
     - script: npm start test.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,17 @@ jobs:
     - script: npm start test.bundle
     - script: npm start test.browser
       before_script: mkdir -p .karma
+      addons:
+        artifacts:
+          paths:
+            - .karma/
+            - ./mocha.js
+        chrome: stable
     - stage: lint
       script: npm start lint
     - &smoke
       stage: smoke
-      env: BUST_CACHE=1
+      env: SMOKE=1 # just busts the cache
       install: npm install --production
       script: ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
     - <<: *smoke
@@ -43,12 +49,6 @@ notifications:
   on_success: change
   on_failure: always
 
-addons:
-  artifacts:
-    paths:
-      - .karma/
-      - ./mocha.js
-  chrome: stable
 cache:
   directories:
     - ~/.npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: npm start test.node
 
 jobs:
   include:
-    - env: COVERAGE=true
+    - script: COVERAGE=1 npm start test.node
       after_success: npm start coveralls
     - node_js: '8'
     - node_js: '6'
@@ -16,14 +16,22 @@ jobs:
       before_script: mkdir -p .karma
     - stage: lint
       script: npm start lint
-    - stage: smoke # this ensures a "user" install works properly
+    - &smoke
+      stage: smoke
+      env: BUST_CACHE=1
       install: npm install --production
       script: ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
+    - <<: *smoke
+      node_js: '8'
+    - <<: *smoke
+      node_js: '6'
+    - <<: *smoke
+      node_js: '4'
 
 stages:
-  - lint
-  - smoke
-  - test
+  - smoke # this ensures a "user" install works properly
+  - lint # lint code and docs
+  - test # all tests
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,40 @@
-language: node_js
+# these are executed in order.  each must pass for the next to be run
+stages:
+  - smoke # this ensures a "user" install works properly
+  - lint # lint code and docs
+  - test # all tests
 
 # defaults
+language: node_js
 node_js: '9'
-script: npm start test.node
+cache:
+  directories:
+    - ~/.npm
+    - node_modules
 
 jobs:
   include:
     - script: COVERAGE=1 npm start test.node
       after_success: npm start coveralls
-    - node_js: '8'
-    - node_js: '6'
-    - node_js: '4'
+
+    - &node
+      script: npm start test.node
+
+    - <<: *node
+      node_js: '8'
+
+    - <<: *node
+      cache: &cache-old-npm
+        directories:
+          - node_modules
+      node_js: '6'
+
+    - <<: *node
+      cache: *cache-old-npm
+      node_js: '4'
+
     - script: npm start test.bundle
+
     - script: npm start test.browser
       before_script: mkdir -p .karma
       addons:
@@ -20,24 +43,26 @@ jobs:
             - .karma/
             - ./mocha.js
         chrome: stable
+        sauce_connect: true
+
     - stage: lint
       script: npm start lint
+
     - &smoke
       stage: smoke
-      env: SMOKE=1 # just busts the cache
-      install: npm install --production
+      env: NPM_CONFIG_PRODUCTION=1
       script: ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
+
     - <<: *smoke
       node_js: '8'
-    - <<: *smoke
-      node_js: '6'
-    - <<: *smoke
-      node_js: '4'
 
-stages:
-  - smoke # this ensures a "user" install works properly
-  - lint # lint code and docs
-  - test # all tests
+    - <<: *smoke
+      cache: *cache-old-npm
+      node_js: '6'
+
+    - <<: *smoke
+      cache: *cache-old-npm
+      node_js: '4'
 
 notifications:
   email: false
@@ -48,8 +73,3 @@ notifications:
     - secure: rGMGYWBaZgEa9i997jJHKzjI8WxECqLi6BqsMhvstDq9EeTeXkZFVfz4r6G3Xugsk3tFwb/pDpiYo1OK36kA5arUJTCia51u4Wn+c7lHKcpef/vXztoyucvw6/jXdVm/FQz1jztYYbqdyAOWC2BV8gYvg5F8TpK05UGCe5R0bRA=
   on_success: change
   on_failure: always
-
-cache:
-  directories:
-    - ~/.npm
-    - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,21 @@ language: node_js
 
 # defaults
 node_js: '9'
-script: npm start $TARGET
-env: TARGET=test.node
+script: npm start test.node
 
 jobs:
   include:
-    - env: TARGET=test.node COVERAGE=true
+    - env: COVERAGE=true
       after_success: npm start coveralls
     - node_js: '8'
     - node_js: '6'
     - node_js: '4'
-    - env: TARGET=test.browser
+    - script: npm start test.bundle
+    - script: npm start test.browser
       before_script: mkdir -p .karma
     - stage: lint
-      env: TARGET=lint
-    - stage: smoke
+      script: npm start lint
+    - stage: smoke # this ensures a "user" install works properly
       install: npm install --production
       script: ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,22 +19,16 @@ jobs:
 
     - &node
       script: npm start test.node
-
-    - <<: *node
-      cache: false
       node_js: '8'
+      cache: false
 
     - <<: *node
-      cache: false
       node_js: '6'
 
     - <<: *node
-      cache: false
       node_js: '4'
 
-    - script: npm start test.bundle
-
-    - script: npm start test.browser
+    - script: npm start test.bundle test.browser
       before_script: mkdir -p .karma
       addons:
         artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,15 @@ jobs:
       node_js: '8'
 
     - <<: *node
-      cache: &cache-old-npm
+      cache:
         directories:
           - node_modules
       node_js: '6'
 
     - <<: *node
-      cache: *cache-old-npm
+      cache:
+        directories:
+          - node_modules
       node_js: '4'
 
     - script: npm start test.bundle
@@ -52,16 +54,15 @@ jobs:
       stage: smoke
       env: NPM_CONFIG_PRODUCTION=1
       script: ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
+      cache: false
 
     - <<: *smoke
       node_js: '8'
 
     - <<: *smoke
-      cache: *cache-old-npm
       node_js: '6'
 
     - <<: *smoke
-      cache: *cache-old-npm
       node_js: '4'
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,29 @@
-# trusty dist provides a modern build chain (as opposed to 'precise' dist)
-# which absolves us from having to install compilers and stuff
-dist: trusty
-
 language: node_js
 
-matrix:
-  fast_finish: true
-
-before_install: scripts/travis-before-install.sh
-
-before_script: scripts/travis-before-script.sh
+# defaults
+node_js: '9'
+script: npm start $TARGET
+env: TARGET=test.node
 
 jobs:
   include:
-    - stage: lint
-      node_js: '8'
-      env: TARGET=lint
-      script: npm start $TARGET
-    - stage: test
-      node_js: '9'
-      env: TARGET=test.node COVERAGE=true
-      script: npm start $TARGET
+    - env: TARGET=test.node COVERAGE=true
+      after_success: npm start coveralls
     - node_js: '8'
-      env: TARGET=test.node
-      script: npm start $TARGET
     - node_js: '6'
-      env: TARGET=test.node
-      script: npm start $TARGET
     - node_js: '4'
-      env: TARGET=test.node
-      script: npm start $TARGET
-    - node_js: '8'
-      env: TARGET=test.browser
-      script: npm start $TARGET
+    - env: TARGET=test.browser
+      before_script: mkdir -p .karma
+    - stage: lint
+      env: TARGET=lint
+    - stage: smoke
+      install: npm install --production
+      script: ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
 
 stages:
   - lint
+  - smoke
   - test
-
-after_success: npm start coveralls
 
 notifications:
   email: false
@@ -55,7 +40,6 @@ addons:
     paths:
       - .karma/
       - ./mocha.js
-  sauce_connect: true
   chrome: stable
 cache:
   directories:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -85,7 +85,7 @@ module.exports = config => {
         sauceConfig = {
           build: `TRAVIS #${env.TRAVIS_BUILD_NUMBER} (${env.TRAVIS_BUILD_ID})`,
           tunnelIdentifier: env.TRAVIS_JOB_NUMBER,
-          startConnect: true
+          startConnect: false
         };
         console.error('Configured SauceLabs');
       } else {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -85,7 +85,7 @@ module.exports = config => {
         sauceConfig = {
           build: `TRAVIS #${env.TRAVIS_BUILD_NUMBER} (${env.TRAVIS_BUILD_ID})`,
           tunnelIdentifier: env.TRAVIS_JOB_NUMBER,
-          startConnect: false
+          startConnect: true
         };
         console.error('Configured SauceLabs');
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,7 +1025,7 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
     },
     "browserify": {
       "version": "14.4.0",
@@ -1687,7 +1687,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM="
     },
     "comment-regex": {
       "version": "1.0.0",
@@ -2246,7 +2246,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2622,7 +2622,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -4962,7 +4962,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -5200,7 +5200,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8="
     },
     "gulp-decompress": {
       "version": "1.2.0",
@@ -7281,7 +7281,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -13716,7 +13716,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "requires": {
         "has-flag": "2.0.0"
       }

--- a/scripts/travis-before-install.sh
+++ b/scripts/travis-before-install.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-runSanityTest () {
-  # avoids our mocha.opts (and thus devDependencies) in a roundabout way
-  ./bin/mocha --opts /dev/null --reporter spec test/sanity/sanity.spec.js
-}
-
-npm install --production
-runSanityTest

--- a/scripts/travis-before-script.sh
+++ b/scripts/travis-before-script.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# bundle artifacts to AWS go here
-mkdir -p .karma


### PR DESCRIPTION
- fiddle with caching 
  - don't cache for smoke tests
  - npm@5 comes with node@8 or newer, so cache `~/.npm` as well
  - otherwise, don't.
- smoke test for each node.js version (stage 1)
- lint (stage 2)
- tests for each node.js version and browsers (stage 3)
- addons (artifacts, sauce labs, chrome) are only present for browser tests!

YAML aliases are basically voodoo.
