### PR TITLE
improve caching performance in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,18 @@ jobs:
     - &node
       script: npm start test.node
       node_js: '8'
-      cache: false
 
     - <<: *node
       node_js: '6'
+      cache:
+        directories:
+          - node_modules
 
     - <<: *node
       node_js: '4'
+      cache:
+        directories:
+          - node_modules
 
     - script: npm start test.bundle test.browser
       before_script: mkdir -p .karma

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # these are executed in order.  each must pass for the next to be run
 stages:
   - smoke # this ensures a "user" install works properly
+  - precache # warm up cache for default Node.js version
   - lint # lint code and docs
   - test # all tests
 
@@ -55,6 +56,9 @@ jobs:
 
     - <<: *smoke
       node_js: '4'
+
+    - stage: precache
+      script: true
 
 notifications:
   email: false


### PR DESCRIPTION
This change "warms up"  the npm caches for Node.js 9 jobs, since it will be reused during the build.  It re-enables caching for Node.js 8, 6 and 4, since I RTFM'd more closely. 😬 

From the Travis-CI [docs](https://docs.travis-ci.com/user/caching):

> There is one cache per branch and language version/ compiler version/ JDK version/ Gemfile location/ etc.

1. for the smoke tests, we do a *production only* install per node.js version.  we do NOT want to cache `node_modules` or `~/.npm`, since it should always reflect what a user would get.
1. we warm up the cache; basically this runs a *full* `npm install` for node.js 9 with *no global environment variables*
1. we lint, using the warmed-up cache
1. tests:
  - we run node.js tests in 9 *and* browser tests using the warmed-up cache
  - we run node.js tests in v6 and v4 using a `node_modules`-only cache.  these are *not* reused during the build (unlike the node 9 caches), but may be reused during subsequent builds against the same branch.
