### PR TITLE
#3111 - Added a console warn to let users know they don’t have growl …

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -244,14 +244,22 @@ Mocha.prototype._growl = function (runner, reporter) {
 
   runner.on('end', function () {
     var stats = reporter.stats;
+    var errMsg = 'The prerequisites for Growl support are missing. Please see https://github.com/mochajs/mocha/wiki/Growl-Notifications for details';
+    var msg = '';
+
     if (stats.failures) {
-      var msg = stats.failures + ' of ' + runner.total + ' tests failed';
-      notify(msg, { name: 'mocha', title: 'Failed', image: image('error') });
+      msg = stats.failures + ' of ' + runner.total + ' tests failed';
+      notify(msg, { name: 'mocha', title: 'Failed', image: image('error') }, function (err) {
+        if (err && err.code === 'ENOENT') {
+          console.warn(errMsg);
+        }
+      });
     } else {
-      notify(stats.passes + ' tests passed in ' + stats.duration + 'ms', {
-        name: 'mocha',
-        title: 'Passed',
-        image: image('ok')
+      msg = stats.passes + ' tests passed in ' + stats.duration + 'ms';
+      notify(msg, { name: 'mocha', title: 'Passed', image: image('ok') }, function (err) {
+        if (err && err.code === 'ENOENT') {
+          console.warn(errMsg);
+        }
       });
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5154,9 +5154,9 @@
       }
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
     "gulp-decompress": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "diff": "3.5.0",
     "escape-string-regexp": "1.0.5",
     "glob": "7.1.2",
-    "growl": "1.10.3",
+    "growl": "1.10.5",
     "he": "1.1.1",
     "mkdirp": "0.5.1",
     "supports-color": "4.4.0"


### PR DESCRIPTION
…installed.

Updated the growl dependency to the latest version which returns the appropriate error when growl is not installed on system.

Also updating the logic when Mocha attempts to use a growl notification to log a warning if growl errors.

### Benefits

This will allow users who are attempting to use the growl notifications the ability to know they do not have it installed and provide them a link to find out how to resolve that.

### Possible Drawbacks

Additional messages in the console

### Applicable issues

#3111 
