### PR TITLE
PATH workaround for Travis CI bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ stages:
 # defaults
 language: node_js
 node_js: '9'
-env: PATH=~/npm/node_modules/.bin:$PATH
 # `nvm install` happens before the cache is restored, which means
 # we must install our own npm elsewhere (`~/npm`)
 before_install: |
@@ -17,6 +16,8 @@ before_install: |
     cd ~/npm && npm install npm
     cd -
   } || true
+  # avoids bugs around https://github.com/travis-ci/travis-ci/issues/5092
+  export PATH=~/npm/node_modules/.bin:$PATH
 # this avoids compilation in most cases (where we don't need it)
 install: npm ci --ignore-scripts
 cache:


### PR DESCRIPTION
there's some weird bug on Travis CI where it doesn't respect the `PATH` as set in `env`.  It may have to do with the thing where it adds `./node_modules/.bin` to the `PATH`, which is travis-ci/travis-ci#8813.

Anyway, this works around the problem.