### PR TITLE
#3320 Native types exceptions can crash Mocha runner

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -231,15 +231,7 @@ Runner.prototype.fail = function(test, err) {
   ++this.failures;
   test.state = 'failed';
 
-  if (!(err instanceof Error || (err && typeof err.message === 'string'))) {
-    err = new Error(
-      'the ' +
-        type(err) +
-        ' ' +
-        stringify(err) +
-        ' was thrown, throw an Error :)'
-    );
-  }
+  err = string2Error(err);
 
   try {
     err.stack =
@@ -731,15 +723,7 @@ Runner.prototype.uncaught = function(err) {
     debug('uncaught undefined exception');
     err = undefinedError();
   }
-  if (!(err instanceof Error || (err && typeof err.message === 'string'))) {
-    err = new Error(
-      'the ' +
-        type(err) +
-        ' ' +
-        stringify(err) +
-        ' was thrown, throw an Error :)'
-    );
-  }
+  err = string2Error(err);
   err.uncaught = true;
 
   var runnable = this.currentRunnable;
@@ -1000,6 +984,27 @@ function filterLeaks(ok, globals) {
     });
     return !matched.length && (!global.navigator || key !== 'onerror');
   });
+}
+
+/**
+ *
+ * Check that the given object is an Error, convert it at such on the contrary
+ *
+ * @api private
+ * @param {Object} err
+ * @return {Error}
+ */
+function string2Error(err) {
+  if (!(err instanceof Error || (err && typeof err.message === 'string'))) {
+    err = new Error(
+      'the ' +
+        type(err) +
+        ' ' +
+        stringify(err) +
+        ' was thrown, throw an Error :)'
+    );
+  }
+  return err;
 }
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -731,6 +731,15 @@ Runner.prototype.uncaught = function(err) {
     debug('uncaught undefined exception');
     err = undefinedError();
   }
+  if (!(err instanceof Error || (err && typeof err.message === 'string'))) {
+    err = new Error(
+      'the ' +
+        type(err) +
+        ' ' +
+        stringify(err) +
+        ' was thrown, throw an Error :)'
+    );
+  }
   err.uncaught = true;
 
   var runnable = this.currentRunnable;

--- a/test/unit/throw.spec.js
+++ b/test/unit/throw.spec.js
@@ -26,6 +26,24 @@ describe('a test that throws', function() {
     });
   });
 
+  describe('non-extensible', function() {
+    it('should not crash if throwing non-extensible type', function(done) {
+      var test = new Test('im async and throw string async', function(done2) {
+        process.nextTick(function() {
+          throw 'error';
+        });
+      });
+      suite.addTest(test);
+      runner = new Runner(suite);
+      runner.on('end', function() {
+        expect(runner.failures, 'to be', 1);
+        expect(test.state, 'to be', 'failed');
+        done();
+      });
+      runner.run();
+    });
+  });
+
   describe('undefined', function() {
     it('should not pass if throwing sync and test is sync', function(done) {
       var test = new Test('im sync and throw undefined sync', function() {


### PR DESCRIPTION
Any non-extensible type thrown in an async callback raises an exception in Mocha runner, stopping tests.

See issue #3320 

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

Tests continue and reports errors properly
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
