### PR TITLE
replace deprecated New Buffer() with Buffer.from()

### DIFF
--- a/test/integration/fixtures/diffs/diffs.fixture.js
+++ b/test/integration/fixtures/diffs/diffs.fixture.js
@@ -106,8 +106,8 @@ describe('diffs', function () {
   });
 
   it('should display diff by data and not like an objects', function () {
-    actual = new Buffer([0x01]);
-    expected = new Buffer([0x02]);
+    actual = Buffer.from([0x01]);
+    expected = Buffer.from([0x02]);
     expect(actual).to.eql(expected);
   });
 });


### PR DESCRIPTION
#### Description of Change

`new Buffer()` is set to be run time deprecated in node v10 (see https://github.com/nodejs/node/issues/19079 and https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor).

I swapped out the usage of `new Buffer()` for `Buffer.from()` in mocha's integration tests.

This should be semver patch.