### PR TITLE
Nested before error using wrong test name in error message

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -324,8 +324,8 @@ Runner.prototype.hook = function(name, fn) {
             hook.pending = true;
           }
         } else {
-          // set the current test to the next one to run so the error message is correct
           if (!self.suite.bail()) {
+            // set the current test to the next one to run so the error message is correct
             hook.ctx.currentTest = suite.tests[0];
           }
           self.failHook(hook, err);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -324,6 +324,8 @@ Runner.prototype.hook = function(name, fn) {
             hook.pending = true;
           }
         } else {
+          // set the current test to the next one to run so the error message is correct
+          hook.ctx.currentTest = suite.tests[0];
           self.failHook(hook, err);
 
           // stop executing hooks, notify callee of hook err

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -325,7 +325,9 @@ Runner.prototype.hook = function(name, fn) {
           }
         } else {
           // set the current test to the next one to run so the error message is correct
-          hook.ctx.currentTest = suite.tests[0];
+          if (!self.suite.bail()) {
+            hook.ctx.currentTest = suite.tests[0];
+          }
           self.failHook(hook, err);
 
           // stop executing hooks, notify callee of hook err

--- a/test/integration/fixtures/hooks/after-nested-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-nested-hook-error.fixture.js
@@ -1,0 +1,20 @@
+'use strict';
+
+describe('spec 1', function () {
+  it('should not blame me', function () {
+    console.log('test 1');
+  });
+  describe('nested 1', function () {
+    after(function() {
+      throw new Error('Nested before hook error');
+    });
+    it('blames me', function () {
+      console.log('test 2');
+    });
+  });
+  describe('nested 2', function() {
+    it('should not blame me either', function() {
+      console.log('test 3');
+    });
+  });
+});

--- a/test/integration/fixtures/hooks/before-nested-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/before-nested-hook-error.fixture.js
@@ -1,14 +1,14 @@
 'use strict';
 
 describe('spec 1', function () {
-  it('should pass', function () {
+  it('should not blame me', function () {
     console.log('test 1');
   });
-  describe('nested', function () {
+  describe('nested 1', function () {
     before(function() {
       throw new Error('Nested before hook error');
     });
-    it('should fail because of hook error', function () {
+    it('blames me', function () {
       console.log('test 2');
     });
   });

--- a/test/integration/fixtures/hooks/before-nested-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/before-nested-hook-error.fixture.js
@@ -1,0 +1,15 @@
+'use strict';
+
+describe('spec 1', function () {
+  it('should pass', function () {
+    console.log('test 1');
+  });
+  describe('nested', function () {
+    before(function() {
+      throw new Error('Nested before hook error');
+    });
+    it('should fail because of hook error', function () {
+      console.log('test 2');
+    });
+  });
+});

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -53,6 +53,17 @@ describe('hook error handling', function() {
     });
   });
 
+  describe('nested after hook error', function() {
+    before(run('hooks/after-nested-hook-error.fixture.js', onlyErrorTitle()));
+    it('should verify results', function() {
+      assert.deepEqual(lines, [
+        '1) spec 1',
+        'nested 1',
+        '"after all" hook for "blames me":'
+      ]);
+    });
+  });
+
   describe('after each hook error', function() {
     before(run('hooks/afterEach-hook-error.fixture.js'));
     it('should verify results', function() {

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -3,7 +3,6 @@
 var runMocha = require('./helpers').runMocha;
 var splitRegExp = require('./helpers').splitRegExp;
 var bang = require('../../lib/reporters/base').symbols.bang;
-var assert = require('assert');
 
 describe('hook error handling', function() {
   var lines;
@@ -17,25 +16,26 @@ describe('hook error handling', function() {
 
   describe('before hook error tip', function() {
     before(run('hooks/before-hook-error-tip.fixture.js', onlyErrorTitle()));
-    it('should verify results', function () {
-      assert.deepEqual(
-        lines,
-        ['1) spec 2', '"before all" hook for "skipped":']
-      );
+    it('should verify results', function() {
+      expect(lines, 'to equal', [
+        '1) spec 2',
+        '"before all" hook for "skipped":'
+      ]);
     });
   });
 
-  describe('nested before hook error', function () {
+  describe('nested before hook error', function() {
     before(run('hooks/before-nested-hook-error.fixture.js', onlyErrorTitle()));
-    it('should verify results', function () {
-      assert.deepEqual(
-        lines,
-        ['1) spec 1', 'nested 1', '"before all" hook for "blames me":']
-      );
+    it('should verify results', function() {
+      expect(lines, 'to equal', [
+        '1) spec 1',
+        'nested 1',
+        '"before all" hook for "blames me":'
+      ]);
     });
   });
 
-  describe('before each hook error', function () {
+  describe('before each hook error', function() {
     before(run('hooks/beforeEach-hook-error.fixture.js'));
     it('should verify results', function() {
       expect(lines, 'to equal', ['before', bang + 'test 3']);
@@ -52,7 +52,7 @@ describe('hook error handling', function() {
   describe('nested after hook error', function() {
     before(run('hooks/after-nested-hook-error.fixture.js', onlyErrorTitle()));
     it('should verify results', function() {
-      assert.deepEqual(lines, [
+      expect(lines, 'to equal', [
         '1) spec 1',
         'nested 1',
         '"after all" hook for "blames me":'

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -16,8 +16,16 @@ describe('hook error handling', function() {
 
   describe('before hook error tip', function() {
     before(run('hooks/before-hook-error-tip.fixture.js', onlyErrorTitle()));
+<<<<<<< HEAD
     it('should verify results', function() {
       expect(lines, 'to equal', ['1) spec 2', '"before all" hook:']);
+=======
+    it('should verify results', function () {
+      assert.deepEqual(
+        lines,
+        ['1) spec 2', '"before all" hook for "skipped":']
+      );
+>>>>>>> Update hook error tests so error tip & nested error are consistent
     });
   });
 
@@ -26,7 +34,7 @@ describe('hook error handling', function() {
     it('should verify results', function () {
       assert.deepEqual(
         lines,
-        ['1) spec 1', 'nested', '"before all" hook for "should fail because of hook error":']
+        ['1) spec 1', 'nested 1', '"before all" hook for "blames me":']
       );
     });
   });

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -21,7 +21,17 @@ describe('hook error handling', function() {
     });
   });
 
-  describe('before each hook error', function() {
+  describe('nested before hook error', function () {
+    before(run('hooks/before-nested-hook-error.fixture.js', onlyErrorTitle()));
+    it('should verify results', function () {
+      assert.deepEqual(
+        lines,
+        ['1) spec 1', 'nested', '"before all" hook for "should fail because of hook error":']
+      );
+    });
+  });
+
+  describe('before each hook error', function () {
     before(run('hooks/beforeEach-hook-error.fixture.js'));
     it('should verify results', function() {
       expect(lines, 'to equal', ['before', bang + 'test 3']);

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -3,6 +3,7 @@
 var runMocha = require('./helpers').runMocha;
 var splitRegExp = require('./helpers').splitRegExp;
 var bang = require('../../lib/reporters/base').symbols.bang;
+var assert = require('assert');
 
 describe('hook error handling', function() {
   var lines;
@@ -16,16 +17,11 @@ describe('hook error handling', function() {
 
   describe('before hook error tip', function() {
     before(run('hooks/before-hook-error-tip.fixture.js', onlyErrorTitle()));
-<<<<<<< HEAD
-    it('should verify results', function() {
-      expect(lines, 'to equal', ['1) spec 2', '"before all" hook:']);
-=======
     it('should verify results', function () {
       assert.deepEqual(
         lines,
         ['1) spec 2', '"before all" hook for "skipped":']
       );
->>>>>>> Update hook error tests so error tip & nested error are consistent
     });
   });
 


### PR DESCRIPTION
### Description of the Change

When an error is encountered in a hook, set the current test on `hook.ctx` to the first one in the current suite

### Benefits

The error message shown for a test will use the correct test name
Previously if you had a nested before function which errored, it would use the previous test's name

```
describe('Top-level describe', () => {

  it('Top-level it', () => { });

  describe('Nested describe', () => {
    before(() => {
      throw new Error();
    });

    it('Nested it', () => { });
  });
});
```
would show:
```
Top-level describe
    ✓ Top-level it
    Nested describe
      1) "before all" hook for "Top-level it"
```

### Applicable issues

Fixes #3291
