### PR TITLE
fix ESLint problems and consolidate configuration

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,8 +3,12 @@ extends: semistandard
 env:
   node: yes
   browser: yes
-  es6: no
 parserOptions:
+  ecmaVersion: 5
+  ecmaFeatures:
+    globalReturn: no
+    experimentalObjectRestSpread: no
+    jsx: no
   sourceType: script
 rules:
   strict:
@@ -13,3 +17,26 @@ rules:
   linebreak-style:
     - error
     - unix
+overrides:
+  - files:
+    - scripts/**/*.js
+    - package-scripts.js
+    - karma.conf.js
+    - .wallaby.js
+    - bin/*
+    parserOptions:
+      ecmaVersion: 6
+    env:
+      browser: no
+  - files:
+    - test/**/*.js
+    env:
+      mocha: yes
+    globals:
+      expect: no
+      assert: no
+  - files:
+    - doc/**/*.js
+    env:
+      node: no
+

--- a/bin/.eslintrc.yml
+++ b/bin/.eslintrc.yml
@@ -1,3 +1,0 @@
-env:
-  es6: true
-  browser: false

--- a/docs/.eslintrc.yml
+++ b/docs/.eslintrc.yml
@@ -1,3 +1,0 @@
-env:
-  browser: true
-  node: false

--- a/lib/browser/.eslintrc.yml
+++ b/lib/browser/.eslintrc.yml
@@ -1,4 +1,0 @@
-env:
-  node: false
-  browser: false
-  commonjs: true

--- a/scripts/.eslintrc.yml
+++ b/scripts/.eslintrc.yml
@@ -1,3 +1,0 @@
-env:
-  es6: true
-  browser: false

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,7 +1,0 @@
-env:
-  mocha: true
-globals:
-  expect: false
-  assert: false
-rules:
-  no-unused-expressions: off

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -149,8 +149,8 @@ function makeExpectedTest (
 }
 
 module.exports = {
-  createMockRunner,
-  makeTest,
-  createElements,
-  makeExpectedTest
+  createMockRunner: createMockRunner,
+  makeTest: makeTest,
+  createElements: createElements,
+  makeExpectedTest: makeExpectedTest
 };

--- a/test/unit/grep.spec.js
+++ b/test/unit/grep.spec.js
@@ -61,7 +61,7 @@ describe('Mocha', function () {
   describe('"invert" option', function () {
     it('should add a Boolean to the mocha.options object', function () {
       var mocha = new Mocha({ invert: true });
-      expect(mocha.options.invert).to.be.ok;
+      expect(mocha.options.invert, 'to be', true);
     });
   });
 });


### PR DESCRIPTION
- we weren't being strict enough about disallowing ES6.  even though we
  had `es6: false` in the config, the `parserOptions` were set to use
  `ecmaVersion: 8`.  oops
- linted a couple files
- deleted all `.eslintrc.yml` files except for the root one; use `overrides` instead
