### PR TITLE
tests: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,11 @@ matrix:
     - node_js: '8'
       env: TARGET=test.browser
 
-before_install: scripts/travis-before-install.sh
+before_install:
+  - scripts/travis-before-install.sh
+  - npm install -g npm@latest
+
+install: npm ci
 
 before_script: scripts/travis-before-script.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,9 @@ install:
   - ps: Install-Product node $env:nodejs_version x64
   - set CI=true
   - set PATH=%APPDATA%\npm;c:\MinGW\bin;%PATH%
-  - npm install -g npm
-  - npm install
+  # upgrade npm
+  - npm install -g npm@latest
+  - npm ci
 matrix:
   fast_finish: true
 build: off


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable