### PR TITLE
Update an example for browsers in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,8 @@
 
 1. Run `npm install` from working copy root to get Node.js deps.
 1. Run `bundle install` to install Jekyll and its dependencies.  This may or may not require elevated privileges, depending on your system.
-1. To serve the site and rebuild as changes are made, execute `npm run docs.watch`.
-1. To rebuild the site *once*, execute `npm start docs.build`.
+1. To serve the site and rebuild as changes are made, execute `npm start docs.watch`.
+1. To rebuild the site *once*, execute `npm start docs`.
 
 ### Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1191,14 +1191,14 @@ A typical setup might look something like the following, where we call `mocha.se
 <head>
   <meta charset="utf-8">
   <title>Mocha Tests</title>
-  <link href="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css" rel="stylesheet" />
+  <link href="https://unpkg.com/mocha@5.1.1/mocha.css" rel="stylesheet" />
 </head>
 <body>
   <div id="mocha"></div>
 
-  <script src="https://cdn.rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
-  <script src="https://cdn.rawgit.com/Automattic/expect.js/0.3.1/index.js"></script>
-  <script src="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.js"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+  <script src="https://unpkg.com/chai/chai.js"></script>
+  <script src="https://unpkg.com/mocha@5.1.1/mocha.js"></script>
 
   <script>mocha.setup('bdd')</script>
   <script src="test.array.js"></script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1191,14 +1191,13 @@ A typical setup might look something like the following, where we call `mocha.se
 <head>
   <meta charset="utf-8">
   <title>Mocha Tests</title>
-  <link href="https://unpkg.com/mocha@5.1.1/mocha.css" rel="stylesheet" />
+  <link href="https://unpkg.com/mocha@5.2.0/mocha.css" rel="stylesheet" />
 </head>
 <body>
   <div id="mocha"></div>
 
-  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
   <script src="https://unpkg.com/chai/chai.js"></script>
-  <script src="https://unpkg.com/mocha@5.1.1/mocha.js"></script>
+  <script src="https://unpkg.com/mocha@5.2.0/mocha.js"></script>
 
   <script>mocha.setup('bdd')</script>
   <script src="test.array.js"></script>
@@ -1206,7 +1205,6 @@ A typical setup might look something like the following, where we call `mocha.se
   <script src="test.xhr.js"></script>
   <script>
     mocha.checkLeaks();
-    mocha.globals(['jQuery']);
     mocha.run();
   </script>
 </body>


### PR DESCRIPTION
### Description of the Change
In [mocha homepage](https://mochajs.org/#running-mocha-in-the-browser), the example for browsers is too old. It works but mocha doesn't provide `mocha.js`/`mocha.css` in repo anymore. 
So, beginners are hard to use the example.

Additionally, I found that [docs/README.md](https://github.com/mochajs/mocha/blob/master/docs/README.md) is not updated to use `nps`. I updated the script for users can build the docs on local.
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs
I use [unpkg](https://unpkg.com/#/) as CDN in example. I'm not sure which js CDN is popular in developers. If there is another CDN which developers are familiar, I can update it.

I use [chai.js](http://www.chaijs.com/) in the example. I believe chai.js is more popular than expect.js now.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
The example is helpful to beginners.
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
Developers can use the example and build docs in local.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
close #3329
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
