### PR TITLE
Print warning message for `--opts` argument

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -30,7 +30,9 @@ function getOptions() {
     : 'test/mocha.opts';
 
   if (optPathSpecified && !fs.existsSync(optsPath)) {
-    const noSuchFileError = new Error(`Specified options file does not exist: ${optsPath}`);
+    const noSuchFileError = new Error(
+      `Specified options file does not exist: ${optsPath}`
+    );
     noSuchFileError.code = 'ENOENT';
     throw noSuchFileError;
   }

--- a/bin/options.js
+++ b/bin/options.js
@@ -24,16 +24,17 @@ function getOptions() {
     return;
   }
 
-  const optPathSpecified = (process.argv.indexOf('--opts') > -1);
-  const optsPath = optPathSpecified ?
-      process.argv[process.argv.indexOf('--opts') + 1]
-        : 'test/mocha.opts';
+  const optPathSpecified = process.argv.indexOf('--opts') > -1;
+  const optsPath = optPathSpecified
+    ? process.argv[process.argv.indexOf('--opts') + 1]
+    : 'test/mocha.opts';
 
   if (optPathSpecified && !fs.existsSync(optsPath)) {
     console.error(
       `Warning: Could not find specified options file: ${optsPath}
 Continuing with default configuration.\n`
     );
+    return;
   }
 
   try {

--- a/bin/options.js
+++ b/bin/options.js
@@ -24,10 +24,17 @@ function getOptions() {
     return;
   }
 
-  const optsPath =
-    process.argv.indexOf('--opts') === -1
-      ? 'test/mocha.opts'
-      : process.argv[process.argv.indexOf('--opts') + 1];
+  const optPathSpecified = (process.argv.indexOf('--opts') > -1);
+  const optsPath = optPathSpecified ?
+      process.argv[process.argv.indexOf('--opts') + 1]
+        : 'test/mocha.opts';
+
+  if (optPathSpecified && !fs.existsSync(optsPath)) {
+    console.error(
+      `Warning: Could not find specified options file: ${optsPath}
+Continuing with default configuration.\n`
+    );
+  }
 
   try {
     const opts = fs

--- a/bin/options.js
+++ b/bin/options.js
@@ -52,5 +52,5 @@ function getOptions() {
     // ignore
   }
 
-  process.env.LOADED_MOCHA_OPTS = true;
+  process.env.LOADED_MOCHA_OPTS = 'true';
 }

--- a/bin/options.js
+++ b/bin/options.js
@@ -30,11 +30,9 @@ function getOptions() {
     : 'test/mocha.opts';
 
   if (optPathSpecified && !fs.existsSync(optsPath)) {
-    console.error(
-      `Warning: Could not find specified options file: ${optsPath}
-Continuing with default configuration.\n`
-    );
-    return;
+    const noSuchFileError = new Error(`Specified options file does not exist: ${optsPath}`);
+    noSuchFileError.code = 'ENOENT';
+    throw noSuchFileError;
   }
 
   try {


### PR DESCRIPTION
When specified options file does not exist

(Tackling #2576)

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

* Check if specified options file exists
* If it does not, print a warning message


### Alternate Designs

-

### Why should this be in core?

-


### Benefits

Less headache when your options file is not being loaded.

### Possible Drawbacks

-

### Applicable issues

- This is probably a breaking change since it triggers a non-zero exit of the application.
