### PR TITLE
remove dead code in bin/_mocha

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -367,19 +367,6 @@ if (program.reporterOptions !== undefined) {
 
 mocha.reporter(program.reporter, reporterOptions);
 
-// load reporter
-
-let Reporter = null;
-try {
-  Reporter = require(`../lib/reporters/${program.reporter}`);
-} catch (err) {
-  try {
-    Reporter = require(program.reporter);
-  } catch (err2) {
-    throw new Error(`reporter "${program.reporter}" does not exist`);
-  }
-}
-
 // --no-colors
 
 if (!program.colors) {


### PR DESCRIPTION
As far as I can tell, this is useless, because [this call](https://github.com/mochajs/mocha/compare/dead-reporter-code?expand=1#diff-789b16a197fe1df6ad7686554bb32265R368) actually does all of that already.

(prompted by @plroebuck's [comment](https://github.com/mochajs/mocha/commit/55ebbdbf6bcc1e4b45f497ff68420df33859cb88#commitcomment-28763932))