### PR TITLE
3370: Add support for comment lines in "mocha.opts"

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -32,6 +32,7 @@ function getOptions() {
   try {
     const opts = fs
       .readFileSync(optsPath, 'utf8')
+      .replace(/^#.*$/gm, '')
       .replace(/\\\s/g, '%20')
       .split(/\s/)
       .filter(Boolean)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1257,15 +1257,32 @@ The "HTML" reporter is what you see when running Mocha in the browser.  It looks
 
 ## `mocha.opts`
 
-Back on the server, Mocha will attempt to load `./test/mocha.opts` as a configuration file of sorts. The lines in this file are combined with any command-line arguments.  The command-line arguments take precedence.  For example, suppose you have the following `mocha.opts` file:
+Back on the server, Mocha will attempt to load `"./test/mocha.opts"` as a
+Run-Control file of sorts.
+
+Beginning-of-line comment support is available; any line _starting_ with a
+hash (#) symbol will be considered a comment. Blank lines may also be used.
+Any other line will be treated as a command-line argument (along with any
+associated option value) to be used as a default setting. Settings should be
+specified one per line.
+
+The lines in this file are prepended to any actual command-line arguments.
+As such, actual command-line arguments will take precedence over the defaults.
+
+For example, suppose you have the following `mocha.opts` file:
 
 ```sh
+# mocha.opts
+
   --require should
   --reporter dot
   --ui bdd
 ```
 
-This will default the reporter to `dot`, require the `should` library, and use `bdd` as the interface. With this, you may then invoke `mocha` with additional arguments, here enabling [Growl](http://growl.info) support, and changing the reporter to `list`:
+The settings above will default the reporter to `dot`, require the `should`
+library, and use `bdd` as the interface. With this, you may then invoke `mocha`
+with additional arguments, here enabling [Growl](http://growl.info/) support,
+and changing the reporter to `list`:
 
 ```sh
 $ mocha --reporter list --growl

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -32,6 +32,7 @@ describe('regressions', function() {
     var processArgv = process.argv.join('');
     var mochaOpts = fs
       .readFileSync(path.join(__dirname, '..', 'mocha.opts'), 'utf-8')
+      .replace(/^#.*$/gm, '')
       .split(/[\s]+/)
       .join('');
     assert.notEqual(

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,11 @@
+###
+### mocha.opts
+###
+
 --require ./test/setup
 --ui bdd
 --globals okGlobalA,okGlobalB
 --globals okGlobalC
 --globals callback*
 --timeout 200
+


### PR DESCRIPTION


### Description of the Change

Modified code to strip comment lines [lines beginning with a hash character ('#')] from "mocha.opts" prior to processing its contents. Inline comments are **not** supported.

### Alternate Designs

See related issues in #3370.
One used JS comments '//', but most everyone agreed hash '#' was more fitting.
Others got bogged down attempting to figure out how to support inline comments.

### Why should this be in core?

N/A

### Benefits

* Allows user to document the arguments in the options file.
* An argument can now be commented out, but left in file. (user request)

### Possible Drawbacks

None to knowledge

### Applicable issues

Fixes #3370
(minor/patch release)? yes

This is an enhancement with no impact on production code; could go with either.
