### PR TITLE
3363: Throw error if unable to parse Mocha options file

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -24,10 +24,12 @@ function getOptions() {
     return;
   }
 
-  const optsPath =
-    process.argv.indexOf('--opts') === -1
-      ? 'test/mocha.opts'
-      : process.argv[process.argv.indexOf('--opts') + 1];
+  const optsIndex = process.argv.indexOf('--opts');
+  const optsPathSpecified = optsIndex !== -1;
+  const defaultOptsPath = 'test/mocha.opts';
+  const optsPath = optsPathSpecified
+    ? process.argv[optsIndex + 1]
+    : defaultOptsPath;
 
   try {
     const opts = fs
@@ -37,12 +39,19 @@ function getOptions() {
       .filter(Boolean)
       .map(value => value.replace(/%20/g, ' '));
 
-    process.argv = process.argv
-      .slice(0, 2)
-      .concat(opts.concat(process.argv.slice(2)));
-  } catch (ignore) {
-    // NOTE: should console.error() and throw the error
+    if (opts.length > 0) {
+      process.argv = process.argv
+        .slice(0, 2)
+        .concat(opts.concat(process.argv.slice(2)));
+    }
+  } catch (err) {
+    // Default options file may not exist - rethrow anything else
+    if (optsPathSpecified || err.code !== 'ENOENT') {
+      console.error(`failed to load Mocha options file: ${optsPath}`);
+      throw err;
+    }
+  } finally {
+    // Despite its name, signifies loading was attempted and should not be again
+    process.env.LOADED_MOCHA_OPTS = '1';
   }
-
-  process.env.LOADED_MOCHA_OPTS = true;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1257,15 +1257,32 @@ The "HTML" reporter is what you see when running Mocha in the browser.  It looks
 
 ## `mocha.opts`
 
-Back on the server, Mocha will attempt to load `./test/mocha.opts` as a configuration file of sorts. The lines in this file are combined with any command-line arguments.  The command-line arguments take precedence.  For example, suppose you have the following `mocha.opts` file:
+Back on the server, Mocha will attempt to load `"./test/mocha.opts"` as a
+Run-Control file of sorts.
+
+Beginning-of-line comment support is available; any line _starting_ with a
+hash (#) symbol will be considered a comment. Blank lines may also be used.
+Any other line will be treated as a command-line argument (along with any
+associated option value) to be used as a default setting. Settings should be
+specified one per line.
+
+The lines in this file are prepended to any actual command-line arguments.
+As such, actual command-line arguments will take precedence over the defaults.
+
+For example, suppose you have the following `mocha.opts` file:
 
 ```sh
+# mocha.opts
+
   --require should
   --reporter dot
   --ui bdd
 ```
 
-This will default the reporter to `dot`, require the `should` library, and use `bdd` as the interface. With this, you may then invoke `mocha` with additional arguments, here enabling [Growl](http://growl.info) support, and changing the reporter to `list`:
+The settings above will default the reporter to `dot`, require the `should`
+library, and use `bdd` as the interface. With this, you may then invoke `mocha`
+with additional arguments, here enabling [Growl](http://growl.info/) support,
+and changing the reporter to `list`:
 
 ```sh
 $ mocha --reporter list --growl

--- a/docs/index.md
+++ b/docs/index.md
@@ -1257,32 +1257,15 @@ The "HTML" reporter is what you see when running Mocha in the browser.  It looks
 
 ## `mocha.opts`
 
-Back on the server, Mocha will attempt to load `"./test/mocha.opts"` as a
-Run-Control file of sorts.
-
-Beginning-of-line comment support is available; any line _starting_ with a
-hash (#) symbol will be considered a comment. Blank lines may also be used.
-Any other line will be treated as a command-line argument (along with any
-associated option value) to be used as a default setting. Settings should be
-specified one per line.
-
-The lines in this file are prepended to any actual command-line arguments.
-As such, actual command-line arguments will take precedence over the defaults.
-
-For example, suppose you have the following `mocha.opts` file:
+Back on the server, Mocha will attempt to load `./test/mocha.opts` as a configuration file of sorts. The lines in this file are combined with any command-line arguments.  The command-line arguments take precedence.  For example, suppose you have the following `mocha.opts` file:
 
 ```sh
-# mocha.opts
-
   --require should
   --reporter dot
   --ui bdd
 ```
 
-The settings above will default the reporter to `dot`, require the `should`
-library, and use `bdd` as the interface. With this, you may then invoke `mocha`
-with additional arguments, here enabling [Growl](http://growl.info/) support,
-and changing the reporter to `list`:
+This will default the reporter to `dot`, require the `should` library, and use `bdd` as the interface. With this, you may then invoke `mocha` with additional arguments, here enabling [Growl](http://growl.info) support, and changing the reporter to `list`:
 
 ```sh
 $ mocha --reporter list --growl

--- a/test/integration/fixtures/options/opts.fixture.js
+++ b/test/integration/fixtures/options/opts.fixture.js
@@ -1,0 +1,6 @@
+'use strict';
+  
+describe('opts', function () {
+  it('should display this spec', function () {});
+});
+

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -165,7 +165,7 @@ function invokeMocha(args, fn, cwd) {
 }
 
 function resolveFixturePath(fixture) {
-  return path.join('./test/integration/fixtures', fixture);
+  return path.join('test', 'integration', 'fixtures', fixture);
 }
 
 function getSummary(res) {

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -484,6 +484,42 @@ describe('options', function() {
     });
   });
 
+  describe('--opts', function() {
+    var testFile = path.join('options', 'opts.fixture.js');
+
+    it('works despite nonexistent default options file', function(done) {
+      args = [];
+      run(testFile, args, function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(res.stats.pending, 0);
+        assert.equal(res.stats.passes, 1);
+        assert.equal(res.stats.failures, 0);
+        assert.equal(res.code, 0);
+        return done();
+      });
+    });
+
+    it('should throw an error due to nonexistent options file', function(done) {
+      args = ['--opts', 'nosuchoptionsfile', testFile];
+      directInvoke(
+        args,
+        function(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.output).to.contain('failed to load Mocha options file');
+          expect(res.output).to.contain('ENOENT:');
+          expect(res.code).to.be(1);
+          return done();
+        },
+        path.join(__dirname, 'fixtures')
+      );
+    });
+
+  });
+
   describe('--exclude', function() {
     /*
      * Runs mocha in {path} with the given args.


### PR DESCRIPTION
### Description of the Change

Code now throws an error for any problems loading the Mocha options file (except for nonexistent default "test/mocha.opts").

Builds off of previous discussions and work done in PR #2716 and PR #3352 .

### Why should this be in core?

Silently ignoring problems loading this file is just wrong.

### Benefits

Users will now be told if the file failed to load.

### Possible Drawbacks

Users with invalid Mocha options files (or permissions problems, etc.) will need to correct the problem.

### Applicable issues

Fixes #3363
Fixes #2576 
(server-major) [since Mocha could throw an error when it didn't previously]