### PR TITLE
add a command to initialize node.js tests

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -284,6 +284,48 @@ program
     process.exit(0);
   });
 
+program
+  .command('init-test')
+  .description('initialize a node.js mocha setup at current working directory')
+  .action(() => {
+    let hasTestDir = false;
+    const defaultTestDIr = 'test';
+    try {
+      const testFiles = fs.readdirSync(join(cwd, defaultTestDIr));
+      if (testFiles.length < 1) {
+        hasTestDir = true;
+      }
+    } catch (ignore) {}
+
+    if (!hasTestDir) {
+      const mkdir = require('mkdirp');
+      mkdir.sync(defaultTestDIr);
+      const test = fs.readFileSync(
+        join(__dirname, '..', 'lib/template.js.tmpl')
+      );
+      fs.writeFileSync(join(defaultTestDIr, 'index.js'), test);
+    } else {
+      console.log('test directory is not empty. Skip to create test files');
+    }
+
+    try {
+      const pkg = fs.readFileSync('package.json', 'utf8');
+      const pkgRegExp = /"scripts"\s*:\s*{\n*(.*\n)*?(\s*"test"\s*:\s*"(.*)")(.*\n)?.*}/gm;
+      let testScript = pkgRegExp.exec(pkg);
+      if (testScript && testScript.length > 3) {
+        testScript = testScript[3];
+      }
+      const newPkg = pkg.replace(
+        testScript,
+        `mocha --recursive \\"./${defaultTestDIr}/*.js\\"`
+      );
+      fs.writeFileSync('package.json', newPkg);
+    } catch (ignore) {
+      console.log('There is no package.json. You should run npm init first.');
+    }
+    process.exit(0);
+  });
+
 // --globals
 
 program.on('option:globals', val => {

--- a/lib/template.js.tmpl
+++ b/lib/template.js.tmpl
@@ -1,0 +1,9 @@
+var assert = require('assert');
+
+describe('Array', function() {
+  describe('#indexOf()', function() {
+    it('should return -1 when the value is not present', function() {
+      assert.equal([1,2,3].indexOf(4), -1);
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Change
add `init-test` command to initialize node.js test environments.

1. create `test` directory
    * if `test` directory already exists and it is not empty, skip it.
    * Otherwise, create `test` directory and first test file.
2. replace `npm test` script in `package.json`.
    * If there is no `package.json`, guide `npm init` first.

### Alternate Designs
I named it as `init-test`. `init` is client initialization. So, I don't want to break backward compatibility. I didn't think `server` is not fit for here because it is for node.js tests not only server-side.

The first test file's test is from mocha.org. It is a very simple test so it can be useless. Should we add more tests case as an example like promise?

I change `test` script of `package.json` via RegExp. It is not good readability and could not cover many cases of `package.json`. I don't want to add new dependencies. Is there another solution?

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
Newbies can adopt it more easier than now.
And we do it whenever making new js project with mocha.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
#2989
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
