### PR TITLE
Added unloading files feature from require cache

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -251,8 +251,8 @@ Mocha.prototype.unloadFile = function(filePath) {
  * @api private
  */
 Mocha.prototype.unloadFiles = function() {
-  this.files.forEach(function(file) {
-    delete require.cache[require.resolve(file)];
+  this.files.forEach(file => {
+    this.unloadFile(file);
   });
 };
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -251,9 +251,7 @@ Mocha.prototype.unloadFile = function(filePath) {
  * @api private
  */
 Mocha.prototype.unloadFiles = function() {
-  this.files.forEach(file => {
-    this.unloadFile(file);
-  });
+  this.files.forEach(this.unloadFile);
 };
 
 /**

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -239,7 +239,7 @@ Mocha.prototype.ui = function(name) {
 /**
  * Unload test file.
  *
- * @api private
+ * @api public
  */
 Mocha.prototype.unloadFile = function(filePath) {
   delete require.cache[require.resolve(filePath)];
@@ -248,7 +248,7 @@ Mocha.prototype.unloadFile = function(filePath) {
 /**
  * Unload all test files.
  *
- * @api private
+ * @api public
  */
 Mocha.prototype.unloadFiles = function() {
   this.files.forEach(this.unloadFile);

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -237,6 +237,26 @@ Mocha.prototype.ui = function(name) {
 };
 
 /**
+ * Unload test file.
+ *
+ * @api private
+ */
+Mocha.prototype.unloadFile = function(filePath) {
+  delete require.cache[require.resolve(filePath)];
+};
+
+/**
+ * Unload all test files.
+ *
+ * @api private
+ */
+Mocha.prototype.unloadFiles = function() {
+  this.files.forEach(function(file) {
+    delete require.cache[require.resolve(file)];
+  });
+};
+
+/**
  * Load registered files.
  *
  * @api private

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -1,37 +1,43 @@
 'use strict';
 
 var Mocha = require('../../lib/mocha');
+var Path = require('path');
 
 describe('.unloadFile()', function() {
   it('should load and unload file to/from cache', function() {
     var mocha = new Mocha({});
     var filePath = __filename;
+
     mocha.addFile(filePath);
     mocha.loadFiles();
 
-    expect(
-      require.cache[require.resolve(filePath)] !== undefined,
-      'to be',
-      true
-    );
+    expect(require.cache, 'to have property', require.resolve(filePath));
     mocha.unloadFile(filePath);
-    expect(require.cache[require.resolve(filePath)], 'to be', undefined);
+    expect(require.cache, 'not to have property', require.resolve(filePath));
   });
 });
 
 describe('.unloadFiles()', function() {
   it('should unload all test files from cache', function() {
     var mocha = new Mocha({});
-    var filePath = __filename;
-    mocha.addFile(filePath);
-    mocha.loadFiles();
+    var testFiles = [
+      __filename,
+      Path.join(__dirname, 'fs.spec.js'),
+      Path.join(__dirname, 'color.spec.js')
+    ];
 
-    expect(
-      require.cache[require.resolve(filePath)] !== undefined,
-      'to be',
-      true
-    );
+    testFiles.forEach(function(file) {
+      mocha.addFile(file);
+    });
+
+    mocha.loadFiles();
+    testFiles.forEach(function(file) {
+      expect(require.cache, 'to have property', require.resolve(file));
+    });
+
     mocha.unloadFiles();
-    expect(require.cache[require.resolve(filePath)], 'to be', undefined);
+    testFiles.forEach(function(file) {
+      expect(require.cache, 'not to have property', require.resolve(file));
+    });
   });
 });

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Mocha = require('../../lib/mocha');
 
 describe('.unloadFile()', function() {

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -1,0 +1,35 @@
+var Mocha = require('../../lib/mocha');
+
+describe('.unloadFile()', function() {
+  it('should load and unload file to/from cache', function() {
+    var mocha = new Mocha({});
+    var filePath = __filename;
+    mocha.addFile(filePath);
+    mocha.loadFiles();
+
+    expect(
+      require.cache[require.resolve(filePath)] !== undefined,
+      'to be',
+      true
+    );
+    mocha.unloadFile(filePath);
+    expect(require.cache[require.resolve(filePath)], 'to be', undefined);
+  });
+});
+
+describe('.unloadFiles()', function() {
+  it('should unload all test files from cache', function() {
+    var mocha = new Mocha({});
+    var filePath = __filename;
+    mocha.addFile(filePath);
+    mocha.loadFiles();
+
+    expect(
+      require.cache[require.resolve(filePath)] !== undefined,
+      'to be',
+      true
+    );
+    mocha.unloadFiles();
+    expect(require.cache[require.resolve(filePath)], 'to be', undefined);
+  });
+});

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -45,6 +45,40 @@ describe('Mocha', function() {
     });
   });
 
+  describe('.unloadFile()', function() {
+    it('should load and unload file to/from cache', function() {
+      var mocha = new Mocha(blankOpts);
+      var filePath = __filename;
+      mocha.addFile(filePath);
+      mocha.loadFiles();
+
+      expect(
+        require.cache[require.resolve(filePath)] != undefined,
+        'to be',
+        true
+      );
+      mocha.unloadFile(filePath);
+      expect(require.cache[require.resolve(filePath)], 'to be', undefined);
+    });
+  });
+
+  describe('.unloadFiles()', function() {
+    it('should unload all test files from cache', function() {
+      var mocha = new Mocha(blankOpts);
+      var filePath = __filename;
+      mocha.addFile(filePath);
+      mocha.loadFiles();
+
+      expect(
+        require.cache[require.resolve(filePath)] != undefined,
+        'to be',
+        true
+      );
+      mocha.unloadFiles();
+      expect(require.cache[require.resolve(filePath)], 'to be', undefined);
+    });
+  });
+
   describe('.invert()', function() {
     it('should set the invert option to true', function() {
       var mocha = new Mocha(blankOpts);

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -53,7 +53,7 @@ describe('Mocha', function() {
       mocha.loadFiles();
 
       expect(
-        require.cache[require.resolve(filePath)] != undefined,
+        require.cache[require.resolve(filePath)] !== undefined,
         'to be',
         true
       );
@@ -70,7 +70,7 @@ describe('Mocha', function() {
       mocha.loadFiles();
 
       expect(
-        require.cache[require.resolve(filePath)] != undefined,
+        require.cache[require.resolve(filePath)] !== undefined,
         'to be',
         true
       );

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -45,40 +45,6 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.unloadFile()', function() {
-    it('should load and unload file to/from cache', function() {
-      var mocha = new Mocha(blankOpts);
-      var filePath = __filename;
-      mocha.addFile(filePath);
-      mocha.loadFiles();
-
-      expect(
-        require.cache[require.resolve(filePath)] !== undefined,
-        'to be',
-        true
-      );
-      mocha.unloadFile(filePath);
-      expect(require.cache[require.resolve(filePath)], 'to be', undefined);
-    });
-  });
-
-  describe('.unloadFiles()', function() {
-    it('should unload all test files from cache', function() {
-      var mocha = new Mocha(blankOpts);
-      var filePath = __filename;
-      mocha.addFile(filePath);
-      mocha.loadFiles();
-
-      expect(
-        require.cache[require.resolve(filePath)] !== undefined,
-        'to be',
-        true
-      );
-      mocha.unloadFiles();
-      expect(require.cache[require.resolve(filePath)], 'to be', undefined);
-    });
-  });
-
   describe('.invert()', function() {
     it('should set the invert option to true', function() {
       var mocha = new Mocha(blankOpts);


### PR DESCRIPTION

### Description of the Change

Added a feature which allows unloading test files from `require` cache. 
This feature allows reusing data/objects since there is no need to create a new Mocha process.
(Feature is orientated to those that are accessing Mocha as a module, not CLI)

### Alternate Designs

1. The user would have to implement same logic in his own code
2. The user would have to create a new Mocha process on each dataset modification

### Why should this be in core?

1. Because it allows reuse of objects
2. Because it already has `loadFiles` function, so I would think that there should be a function that does the opposite.

### Benefits

Better reusability, fewer headaches for programmers

### Possible Drawbacks

None as far as I know

### Applicable issues

This is just a small code enhancement, has no impact on current production code.

