### PR TITLE
fix runner to emit start/end event

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -851,10 +851,15 @@ Runner.prototype.run = function(fn) {
       filterOnly(rootSuite);
     }
     self.started = true;
-    self.emit('start');
+    Runner.immediately(function() {
+      self.emit('start');
+    });
+
     self.runSuite(rootSuite, function() {
       debug('finished running');
-      self.emit('end');
+      Runner.immediately(function() {
+        self.emit('end');
+      });
     });
   }
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -34,6 +34,16 @@ describe('Mocha', function() {
         });
       }
     );
+
+    it('should emit start event', function(done) {
+      var mocha = new Mocha(blankOpts);
+      mocha.run().on('start', done);
+    });
+
+    it('should emit end event', function(done) {
+      var mocha = new Mocha(blankOpts);
+      mocha.run().on('end', done);
+    });
   });
 
   describe('.addFile()', function() {


### PR DESCRIPTION
### Description of the Change
Using mocha programmatically, the mocha runner doesn't emit start/end event correctly.
Because both events emitted before event listeners are registered. So, this change is fixed to emit events in event loop.

### Alternate Designs
I have no idea.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
This is a bug.
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
Users can get start/end event correctly.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
close #2753
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
