### PR TITLE
more "npm audit fix" fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -832,9 +832,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-      "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+      "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
       "dev": true,
       "optional": true
     },
@@ -5635,9 +5635,9 @@
       "dev": true
     },
     "get-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.1.tgz",
-      "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.2.tgz",
+      "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9261,9 +9261,9 @@
       }
     },
     "log4js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.7.0.tgz",
-      "integrity": "sha512-FyTwaPJfbfiK2AHc9ct/oFHNN4bJj0IQeqdO/LaDHhfjeBi8fnZU5rPcHOZhkYV0Aes31Ow+St1YTCluPtzs5g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.8.0.tgz",
+      "integrity": "sha512-PjsaE4ElS0e2jWOY14Ef2PrC1Y+fny4AWPPT3xD6+2k2Aa5golhqJ4DSzP+5kXRL5bSw/5j1ocU5A9ceaxZeGA==",
       "dev": true,
       "requires": {
         "amqplib": "^0.5.2",
@@ -9626,13 +9626,13 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "^4.17.10"
           }
         }
       }


### PR DESCRIPTION
fixed 7 of 35 vulnerabilities in 32225 scanned packages