### PR TITLE
Remove bower install instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,8 +94,6 @@ $ npm install --save-dev mocha
 
 > To install Mocha v3.0.0 or newer with `npm`, you will need `npm` v2.14.2 or newer.  Additionally, to run Mocha, you will need Node.js v4 or newer.
 
-Mocha can also be installed via [Bower](https://bower.io) (`bower install mocha`), and is available at [cdnjs](https://cdnjs.com/libraries/mocha).
-
 ## Getting Started
 
 ```sh


### PR DESCRIPTION
Remove installing mocha via bower instruction because mocha no longer supports bower installs.

### Description of the Change

Remove installing mocha via bower instruction because mocha no longer supports bower installs.  See the [comments](https://github.com/mochajs/mocha/pull/3364#discussion_r185073819)

### Alternate Designs

N/A

### Why should this be in core?

Mocha no longer supports bower installs

### Benefits

N/A

### Possible Drawbacks

N/A

### Applicable issues

#3369
