### PR TITLE
Adding support for --ignore-timeout flag

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -223,6 +223,7 @@ program
     'force shutdown of the event loop after test run: mocha will call process.exit'
   )
   .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
+  .option('--ignore-timeouts', 'do not treat timeouts as fails')
   .option('--no-warnings', 'silence all node process warnings')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
   .option('--perf-basic-prof', 'enable perf linux profiler (basic support)')
@@ -409,6 +410,12 @@ if (program.timeout) {
   mocha.suite.timeout(program.timeout);
 }
 
+// --ignore-timeouts
+
+if (program.ignoreTimeouts) {
+  mocha.suite.ignoreTimeouts(program.ignoreTimeouts);
+}
+
 // --bail
 
 mocha.suite.bail(program.bail);
@@ -488,8 +495,8 @@ if (program.forbidPending) mocha.forbidPending();
 // custom compiler support
 
 if (program.compilers.length > 0) {
-  require('util').deprecate(() => {},
-  '"--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info')();
+  require('util').deprecate(() => { },
+    '"--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info')();
 }
 const extensions = ['js'];
 program.compilers.forEach(c => {

--- a/docs/index.md
+++ b/docs/index.md
@@ -729,6 +729,21 @@ Again, use `this.timeout(0)` to disable the timeout for a hook.
 
 > In v3.0.0 or newer, a parameter passed to `this.timeout()` greater than the [maximum delay value](https://developer.mozilla.org/docs/Web/API/WindowTimers/setTimeout#Maximum_delay_value) will cause the timeout to be disabled.
 
+### Ignore Timeouts
+
+You can also treat a timeout as a non-fail for cases where you want a given test to timeout, but it is not critical if it does. This is done using the --ignore-timeouts flag. This can also be done on a per scope basis as shown below:
+
+```js
+describe('a suite of tests', function() {
+  beforeEach(function(done) {
+    this.timeout(3000); // A very long environment setup.
+    this.ignoreTimeout(true);
+    setTimeout(done, 2500);
+  });
+});
+```
+
+
 ## Diffs
 
 Mocha supports the `err.expected` and `err.actual` properties of any thrown `AssertionError`s from an assertion library.  Mocha will attempt to display the difference between what was expected, and what the assertion actually saw.  Here's an example of a "string" diff:

--- a/lib/context.js
+++ b/lib/context.js
@@ -13,7 +13,7 @@ module.exports = Context;
  *
  * @api private
  */
-function Context() {}
+function Context() { }
 
 /**
  * Set or get the context `Runnable` to `runnable`.
@@ -22,7 +22,7 @@ function Context() {}
  * @param {Runnable} runnable
  * @return {Context} context
  */
-Context.prototype.runnable = function(runnable) {
+Context.prototype.runnable = function (runnable) {
   if (!arguments.length) {
     return this._runnable;
   }
@@ -37,7 +37,7 @@ Context.prototype.runnable = function(runnable) {
  * @param {number} ms
  * @return {Context} self
  */
-Context.prototype.timeout = function(ms) {
+Context.prototype.timeout = function (ms) {
   if (!arguments.length) {
     return this.runnable().timeout();
   }
@@ -52,11 +52,26 @@ Context.prototype.timeout = function(ms) {
  * @param {boolean} enabled
  * @return {Context} self
  */
-Context.prototype.enableTimeouts = function(enabled) {
+Context.prototype.enableTimeouts = function (enabled) {
   if (!arguments.length) {
     return this.runnable().enableTimeouts();
   }
   this.runnable().enableTimeouts(enabled);
+  return this;
+};
+
+/**
+ * Set test ignore timeouts `ignore`
+ *
+ * @api private
+ * @param {boolean} ignore
+ * @return {Context} self
+ */
+Context.prototype.ignoreTimeouts = function (ignore) {
+  if (!arguments.length) {
+    return this.runnable().ignoreTimeouts();
+  }
+  this.runnable().ignoreTimeouts(ignore);
   return this;
 };
 
@@ -67,7 +82,7 @@ Context.prototype.enableTimeouts = function(enabled) {
  * @param {number} ms
  * @return {Context} self
  */
-Context.prototype.slow = function(ms) {
+Context.prototype.slow = function (ms) {
   if (!arguments.length) {
     return this.runnable().slow();
   }
@@ -81,7 +96,7 @@ Context.prototype.slow = function(ms) {
  * @api private
  * @throws Pending
  */
-Context.prototype.skip = function() {
+Context.prototype.skip = function () {
   this.runnable().skip();
 };
 
@@ -92,7 +107,7 @@ Context.prototype.skip = function() {
  * @param {number} n
  * @return {Context} self
  */
-Context.prototype.retries = function(n) {
+Context.prototype.retries = function (n) {
   if (!arguments.length) {
     return this.runnable().retries();
   }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -100,6 +100,7 @@ function Mocha(options) {
   if (typeof options.retries !== 'undefined' && options.retries !== null) {
     this.retries(options.retries);
   }
+  this.ignoreTimeouts(options.ignoreTimeouts);
   this.useColors(options.useColors);
   if (options.enableTimeouts !== null) {
     this.enableTimeouts(options.enableTimeouts);
@@ -116,7 +117,7 @@ function Mocha(options) {
  * @api public
  * @param {boolean} [bail]
  */
-Mocha.prototype.bail = function(bail) {
+Mocha.prototype.bail = function (bail) {
   if (!arguments.length) {
     bail = true;
   }
@@ -131,7 +132,7 @@ Mocha.prototype.bail = function(bail) {
  * @api public
  * @param {string} file
  */
-Mocha.prototype.addFile = function(file) {
+Mocha.prototype.addFile = function (file) {
   this.files.push(file);
   return this;
 };
@@ -146,7 +147,7 @@ Mocha.prototype.addFile = function(file) {
  * @param {string|Function} reporter name or constructor
  * @param {Object} reporterOptions optional options
  */
-Mocha.prototype.reporter = function(reporter, reporterOptions) {
+Mocha.prototype.reporter = function (reporter, reporterOptions) {
   if (typeof reporter === 'function') {
     this._reporter = reporter;
   } else {
@@ -169,11 +170,11 @@ Mocha.prototype.reporter = function(reporter, reporterOptions) {
             err.message.indexOf('Cannot find module') !== -1
               ? console.warn('"' + reporter + '" reporter not found')
               : console.warn(
-                  '"' +
-                    reporter +
-                    '" reporter blew up with error:\n' +
-                    err.stack
-                );
+                '"' +
+                reporter +
+                '" reporter blew up with error:\n' +
+                err.stack
+              );
           }
         } else {
           console.warn(
@@ -185,8 +186,8 @@ Mocha.prototype.reporter = function(reporter, reporterOptions) {
     if (!_reporter && reporter === 'teamcity') {
       console.warn(
         'The Teamcity reporter was moved to a package named ' +
-          'mocha-teamcity-reporter ' +
-          '(https://npmjs.org/package/mocha-teamcity-reporter).'
+        'mocha-teamcity-reporter ' +
+        '(https://npmjs.org/package/mocha-teamcity-reporter).'
       );
     }
     if (!_reporter) {
@@ -204,7 +205,7 @@ Mocha.prototype.reporter = function(reporter, reporterOptions) {
  * @api public
  * @param {string} bdd
  */
-Mocha.prototype.ui = function(name) {
+Mocha.prototype.ui = function (name) {
   name = name || 'bdd';
   this._ui = exports.interfaces[name];
   if (!this._ui) {
@@ -216,7 +217,7 @@ Mocha.prototype.ui = function(name) {
   }
   this._ui = this._ui(this.suite);
 
-  this.suite.on('pre-require', function(context) {
+  this.suite.on('pre-require', function (context) {
     exports.afterEach = context.afterEach || context.teardown;
     exports.after = context.after || context.suiteTeardown;
     exports.beforeEach = context.beforeEach || context.setup;
@@ -241,10 +242,10 @@ Mocha.prototype.ui = function(name) {
  *
  * @api private
  */
-Mocha.prototype.loadFiles = function(fn) {
+Mocha.prototype.loadFiles = function (fn) {
   var self = this;
   var suite = this.suite;
-  this.files.forEach(function(file) {
+  this.files.forEach(function (file) {
     file = path.resolve(file);
     suite.emit('pre-require', global, file, self);
     suite.emit('require', require(file), file, self);
@@ -258,14 +259,14 @@ Mocha.prototype.loadFiles = function(fn) {
  *
  * @api private
  */
-Mocha.prototype._growl = function(runner, reporter) {
+Mocha.prototype._growl = function (runner, reporter) {
   var notify = require('growl');
 
-  runner.on('end', function() {
+  runner.on('end', function () {
     var stats = reporter.stats;
     if (stats.failures) {
       var msg = stats.failures + ' of ' + runner.total + ' tests failed';
-      notify(msg, {name: 'mocha', title: 'Failed', image: image('error')});
+      notify(msg, { name: 'mocha', title: 'Failed', image: image('error') });
     } else {
       notify(stats.passes + ' tests passed in ' + stats.duration + 'ms', {
         name: 'mocha',
@@ -284,7 +285,7 @@ Mocha.prototype._growl = function(runner, reporter) {
  * @param str
  * @returns {Mocha}
  */
-Mocha.prototype.fgrep = function(str) {
+Mocha.prototype.fgrep = function (str) {
   return this.grep(new RegExp(escapeRe(str)));
 };
 
@@ -298,7 +299,7 @@ Mocha.prototype.fgrep = function(str) {
  * @param {RegExp|string} re
  * @return {Mocha}
  */
-Mocha.prototype.grep = function(re) {
+Mocha.prototype.grep = function (re) {
   if (utils.isString(re)) {
     // extract args if it's regex-like, i.e: [string, pattern, flag]
     var arg = re.match(/^\/(.*)\/(g|i|)$|.*/);
@@ -315,7 +316,7 @@ Mocha.prototype.grep = function(re) {
  * @return {Mocha}
  * @api public
  */
-Mocha.prototype.invert = function() {
+Mocha.prototype.invert = function () {
   this.options.invert = true;
   return this;
 };
@@ -330,7 +331,7 @@ Mocha.prototype.invert = function() {
  * @param {boolean} ignore
  * @return {Mocha}
  */
-Mocha.prototype.ignoreLeaks = function(ignore) {
+Mocha.prototype.ignoreLeaks = function (ignore) {
   this.options.ignoreLeaks = Boolean(ignore);
   return this;
 };
@@ -342,7 +343,7 @@ Mocha.prototype.ignoreLeaks = function(ignore) {
  * @api public
  * @public
  */
-Mocha.prototype.checkLeaks = function() {
+Mocha.prototype.checkLeaks = function () {
   this.options.ignoreLeaks = false;
   return this;
 };
@@ -354,7 +355,7 @@ Mocha.prototype.checkLeaks = function() {
  * @api public
  * @public
  */
-Mocha.prototype.fullTrace = function() {
+Mocha.prototype.fullTrace = function () {
   this.options.fullStackTrace = true;
   return this;
 };
@@ -366,7 +367,7 @@ Mocha.prototype.fullTrace = function() {
  * @api public
  * @public
  */
-Mocha.prototype.growl = function() {
+Mocha.prototype.growl = function () {
   this.options.growl = true;
   return this;
 };
@@ -381,7 +382,7 @@ Mocha.prototype.growl = function() {
  * @param {Array|string} globals
  * @return {Mocha}
  */
-Mocha.prototype.globals = function(globals) {
+Mocha.prototype.globals = function (globals) {
   this.options.globals = (this.options.globals || []).concat(globals);
   return this;
 };
@@ -396,7 +397,7 @@ Mocha.prototype.globals = function(globals) {
  * @param {boolean} colors
  * @return {Mocha}
  */
-Mocha.prototype.useColors = function(colors) {
+Mocha.prototype.useColors = function (colors) {
   if (colors !== undefined) {
     this.options.useColors = colors;
   }
@@ -413,7 +414,7 @@ Mocha.prototype.useColors = function(colors) {
  * @param {boolean} inlineDiffs
  * @return {Mocha}
  */
-Mocha.prototype.useInlineDiffs = function(inlineDiffs) {
+Mocha.prototype.useInlineDiffs = function (inlineDiffs) {
   this.options.useInlineDiffs = inlineDiffs !== undefined && inlineDiffs;
   return this;
 };
@@ -428,7 +429,7 @@ Mocha.prototype.useInlineDiffs = function(inlineDiffs) {
  * @param {boolean} hideDiff
  * @return {Mocha}
  */
-Mocha.prototype.hideDiff = function(hideDiff) {
+Mocha.prototype.hideDiff = function (hideDiff) {
   this.options.hideDiff = hideDiff !== undefined && hideDiff;
   return this;
 };
@@ -443,8 +444,20 @@ Mocha.prototype.hideDiff = function(hideDiff) {
  * @param {number} timeout
  * @return {Mocha}
  */
-Mocha.prototype.timeout = function(timeout) {
+Mocha.prototype.timeout = function (timeout) {
   this.suite.timeout(timeout);
+  return this;
+};
+
+/**
+ * Set if timeouts are considered errors.
+ *
+ * @param {Boolean} ignore
+ * @return {Mocha}
+ * @api public
+ */
+Mocha.prototype.ignoreTimeouts = function (ignore) {
+  this.suite.ignoreTimeouts(ignore);
   return this;
 };
 
@@ -456,7 +469,7 @@ Mocha.prototype.timeout = function(timeout) {
  * @api public
  * @public
  */
-Mocha.prototype.retries = function(n) {
+Mocha.prototype.retries = function (n) {
   this.suite.retries(n);
   return this;
 };
@@ -471,7 +484,7 @@ Mocha.prototype.retries = function(n) {
  * @param {number} slow
  * @return {Mocha}
  */
-Mocha.prototype.slow = function(slow) {
+Mocha.prototype.slow = function (slow) {
   this.suite.slow(slow);
   return this;
 };
@@ -486,7 +499,7 @@ Mocha.prototype.slow = function(slow) {
  * @param {boolean} enabled
  * @return {Mocha}
  */
-Mocha.prototype.enableTimeouts = function(enabled) {
+Mocha.prototype.enableTimeouts = function (enabled) {
   this.suite.enableTimeouts(
     arguments.length && enabled !== undefined ? enabled : true
   );
@@ -500,7 +513,7 @@ Mocha.prototype.enableTimeouts = function(enabled) {
  * @api public
  * @public
  */
-Mocha.prototype.asyncOnly = function() {
+Mocha.prototype.asyncOnly = function () {
   this.options.asyncOnly = true;
   return this;
 };
@@ -511,7 +524,7 @@ Mocha.prototype.asyncOnly = function() {
  * @api public
  * @public
  */
-Mocha.prototype.noHighlighting = function() {
+Mocha.prototype.noHighlighting = function () {
   this.options.noHighlighting = true;
   return this;
 };
@@ -523,7 +536,7 @@ Mocha.prototype.noHighlighting = function() {
  * @api public
  * @public
  */
-Mocha.prototype.allowUncaught = function() {
+Mocha.prototype.allowUncaught = function () {
   this.options.allowUncaught = true;
   return this;
 };
@@ -541,7 +554,7 @@ Mocha.prototype.delay = function delay() {
  * Tests marked only fail the suite
  * @returns {Mocha}
  */
-Mocha.prototype.forbidOnly = function() {
+Mocha.prototype.forbidOnly = function () {
   this.options.forbidOnly = true;
   return this;
 };
@@ -550,7 +563,7 @@ Mocha.prototype.forbidOnly = function() {
  * Pending tests and tests marked skip fail the suite
  * @returns {Mocha}
  */
-Mocha.prototype.forbidPending = function() {
+Mocha.prototype.forbidPending = function () {
   this.options.forbidPending = true;
   return this;
 };
@@ -571,7 +584,7 @@ Mocha.prototype.forbidPending = function() {
  * @param {Function} fn
  * @return {Runner}
  */
-Mocha.prototype.run = function(fn) {
+Mocha.prototype.run = function (fn) {
   if (this.files.length) {
     this.loadFiles();
   }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -107,7 +107,7 @@ if (process.platform === 'win32') {
  * @return {string}
  * @api private
  */
-var color = (exports.color = function(type, str) {
+var color = (exports.color = function (type, str) {
   if (!exports.useColors) {
     return String(str);
   }
@@ -133,23 +133,23 @@ if (isatty) {
  */
 
 exports.cursor = {
-  hide: function() {
+  hide: function () {
     isatty && process.stdout.write('\u001b[?25l');
   },
 
-  show: function() {
+  show: function () {
     isatty && process.stdout.write('\u001b[?25h');
   },
 
-  deleteLine: function() {
+  deleteLine: function () {
     isatty && process.stdout.write('\u001b[2K');
   },
 
-  beginningOfLine: function() {
+  beginningOfLine: function () {
     isatty && process.stdout.write('\u001b[0G');
   },
 
-  CR: function() {
+  CR: function () {
     if (isatty) {
       exports.cursor.deleteLine();
       exports.cursor.beginningOfLine();
@@ -185,7 +185,7 @@ function stringifyDiffObjs(err) {
  * @param {string} expected
  * @return {string} Diff
  */
-var generateDiff = (exports.generateDiff = function(actual, expected) {
+var generateDiff = (exports.generateDiff = function (actual, expected) {
   return exports.inlineDiffs
     ? inlineDiff(actual, expected)
     : unifiedDiff(actual, expected);
@@ -201,9 +201,9 @@ var generateDiff = (exports.generateDiff = function(actual, expected) {
  * @api public
  */
 
-exports.list = function(failures) {
+exports.list = function (failures) {
   console.log();
-  failures.forEach(function(test, i) {
+  failures.forEach(function (test, i) {
     // format
     var fmt =
       color('error title', '  %s) %s:\n') +
@@ -253,7 +253,7 @@ exports.list = function(failures) {
 
     // indented test title
     var testTitle = '';
-    test.titlePath().forEach(function(str, index) {
+    test.titlePath().forEach(function (str, index) {
       if (index !== 0) {
         testTitle += '\n     ';
       }
@@ -288,9 +288,11 @@ function Base(runner) {
     tests: 0,
     passes: 0,
     pending: 0,
-    failures: 0
+    failures: 0,
+    safeTimeouts: 0,
   });
   var failures = (this.failures = []);
+  var safeTimeouts = (this.safeTimeouts = []);
 
   if (!runner) {
     return;
@@ -299,21 +301,21 @@ function Base(runner) {
 
   runner.stats = stats;
 
-  runner.on('start', function() {
+  runner.on('start', function () {
     stats.start = new Date();
   });
 
-  runner.on('suite', function(suite) {
+  runner.on('suite', function (suite) {
     stats.suites = stats.suites || 0;
     suite.root || stats.suites++;
   });
 
-  runner.on('test end', function() {
+  runner.on('test end', function () {
     stats.tests = stats.tests || 0;
     stats.tests++;
   });
 
-  runner.on('pass', function(test) {
+  runner.on('pass', function (test) {
     stats.passes = stats.passes || 0;
 
     if (test.duration > test.slow()) {
@@ -327,7 +329,7 @@ function Base(runner) {
     stats.passes++;
   });
 
-  runner.on('fail', function(test, err) {
+  runner.on('fail', function (test, err) {
     stats.failures = stats.failures || 0;
     stats.failures++;
     if (showDiff(err)) {
@@ -337,12 +339,19 @@ function Base(runner) {
     failures.push(test);
   });
 
-  runner.once('end', function() {
+  runner.on('safe timeout', function (test, err) {
+    stats.safeTimeouts = stats.safeTimeouts || 0;
+    stats.safeTimeouts++;
+    test.err = err;
+    safeTimeouts.push(test);
+  });
+
+  runner.once('end', function () {
     stats.end = new Date();
     stats.duration = stats.end - stats.start;
   });
 
-  runner.on('pending', function() {
+  runner.on('pending', function () {
     stats.pending++;
   });
 }
@@ -355,7 +364,7 @@ function Base(runner) {
  * @public
  * @api public
  */
-Base.prototype.epilogue = function() {
+Base.prototype.epilogue = function () {
   var stats = this.stats;
   var fmt;
 
@@ -383,6 +392,16 @@ Base.prototype.epilogue = function() {
     console.log(fmt, stats.failures);
 
     Base.list(this.failures);
+    console.log();
+  }
+
+  // safe timeouts
+  if (stats.safeTimeouts) {
+    fmt = color('bright yellow', '  %d ignored timeouts');
+
+    console.log(fmt, stats.safeTimeouts);
+
+    Base.list(this.safeTimeouts);
     console.log();
   }
 
@@ -418,7 +437,7 @@ function inlineDiff(actual, expected) {
   if (lines.length > 4) {
     var width = String(lines.length).length;
     msg = lines
-      .map(function(str, i) {
+      .map(function (str, i) {
         return pad(++i, width) + ' |' + ' ' + str;
       })
       .join('\n');
@@ -493,7 +512,7 @@ function unifiedDiff(actual, expected) {
 function errorDiff(actual, expected) {
   return diff
     .diffWordsWithSpace(actual, expected)
-    .map(function(str) {
+    .map(function (str) {
       if (str.added) {
         return colorLines('diff added', str.value);
       }
@@ -516,7 +535,7 @@ function errorDiff(actual, expected) {
 function colorLines(name, str) {
   return str
     .split('\n')
-    .map(function(str) {
+    .map(function (str) {
       return color(name, str);
     })
     .join('\n');

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -61,6 +61,21 @@ function Doc(runner) {
     console.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 
+  runner.on('safe timeout', function(test, err) {
+    console.log(
+      '%s  <dt class="error">Timeout Ignored: %s</dt>',
+      indent(),
+      utils.escape(test.title)
+    );
+    var code = utils.escape(utils.clean(test.body));
+    console.log(
+      '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
+      indent(),
+      code
+    );
+    console.log('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
+  });
+
   runner.on('fail', function(test, err) {
     console.log(
       '%s  <dt class="error">%s</dt>',

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -62,6 +62,13 @@ function Dot(runner) {
     process.stdout.write(color('fail', Base.symbols.bang));
   });
 
+  runner.on('safe timeout', function() {
+    if (++n % width === 0) {
+      process.stdout.write('\n  ');
+    }
+    process.stdout.write(color('bright yellow', Base.symbols.bang));
+  });
+
   runner.once('end', function() {
     console.log();
     self.epilogue();

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -159,6 +159,62 @@ function HTML(runner) {
     updateStats();
   });
 
+  runner.on('safe timeout', function(test) {
+    var el = fragment(
+      '<li class="test pass"><h2>Timeout Ignored: %e <a href="%e" class="replay">' +
+        playIcon +
+        '</a></h2></li>',
+      test.title,
+      self.testURL(test)
+    );
+    var stackString; // Note: Includes leading newline
+    var message = test.err.toString();
+
+    // <=IE7 stringifies to [Object Error]. Since it can be overloaded, we
+    // check for the result of the stringifying.
+    if (message === '[object Error]') {
+      message = test.err.message;
+    }
+
+    if (test.err.stack) {
+      var indexOfMessage = test.err.stack.indexOf(test.err.message);
+      if (indexOfMessage === -1) {
+        stackString = test.err.stack;
+      } else {
+        stackString = test.err.stack.substr(
+          test.err.message.length + indexOfMessage
+        );
+      }
+    } else if (test.err.sourceURL && test.err.line !== undefined) {
+      // Safari doesn't give you a stack. Let's at least provide a source line.
+      stackString = '\n(' + test.err.sourceURL + ':' + test.err.line + ')';
+    }
+
+    stackString = stackString || '';
+
+    if (test.err.htmlMessage && stackString) {
+      el.appendChild(
+        fragment(
+          '<div class="html-error">%s\n<pre class="error">%e</pre></div>',
+          test.err.htmlMessage,
+          stackString
+        )
+      );
+    } else if (test.err.htmlMessage) {
+      el.appendChild(
+        fragment('<div class="html-error">%s</div>', test.err.htmlMessage)
+      );
+    } else {
+      el.appendChild(
+        fragment('<pre class="error">%e%e</pre>', message, stackString)
+      );
+    }
+
+    self.addCodeToggle(el, test.body);
+    appendToStack(el);
+    updateStats();
+  });
+
   runner.on('fail', function(test) {
     var el = fragment(
       '<li class="test fail"><h2>%e <a href="%e" class="replay">' +

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -39,6 +39,13 @@ function List(runner) {
     console.log(JSON.stringify(['pass', clean(test)]));
   });
 
+  runner.on('safe timeout', function(test, err) {
+    test = clean(test);
+    test.err = err.message;
+    test.stack = err.stack || null;
+    console.log(JSON.stringify(['safeTimeout', test]));
+  });
+
   runner.on('fail', function(test, err) {
     test = clean(test);
     test.err = err.message;

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -32,6 +32,7 @@ function JSONReporter(runner) {
   var pending = [];
   var failures = [];
   var passes = [];
+  var safeTimeouts = [];
 
   runner.on('test end', function(test) {
     tests.push(test);
@@ -45,6 +46,10 @@ function JSONReporter(runner) {
     failures.push(test);
   });
 
+  runner.on('safe timeout', function(test) {
+    safeTimeouts.push(test);
+  });
+
   runner.on('pending', function(test) {
     pending.push(test);
   });
@@ -55,7 +60,8 @@ function JSONReporter(runner) {
       tests: tests.map(clean),
       pending: pending.map(clean),
       failures: failures.map(clean),
-      passes: passes.map(clean)
+      passes: passes.map(clean),
+      safeTimeouts: safeTimeouts.map(clean),
     };
 
     runner.testResults = obj;

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -31,7 +31,8 @@ function List(runner) {
   Base.call(this, runner);
 
   var self = this;
-  var n = 0;
+  var n = 0; // used to track fails
+  var j = 0; // used to track safe timeouts
 
   runner.on('start', function() {
     console.log();
@@ -58,6 +59,11 @@ function List(runner) {
   runner.on('fail', function(test) {
     cursor.CR();
     console.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
+  });
+
+  runner.on('safe timeout', function(test) {
+    cursor.CR();
+    console.log(color('bright yellow', '  %d) %s'), ++j, test.fullTitle());
   });
 
   runner.once('end', self.epilogue.bind(self));

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -34,11 +34,11 @@ function NyanCat(runner) {
   var nyanCatWidth = (this.nyanCatWidth = 11);
 
   this.colorIndex = 0;
-  this.numberOfLines = 4;
+  this.numberOfLines = 5;
   this.rainbowColors = self.generateColors();
   this.scoreboardWidth = 5;
   this.tick = 0;
-  this.trajectories = [[], [], [], []];
+  this.trajectories = [[], [], [], [], []];
   this.trajectoryWidthMax = width - nyanCatWidth;
 
   runner.on('start', function() {
@@ -51,6 +51,10 @@ function NyanCat(runner) {
   });
 
   runner.on('pass', function() {
+    self.draw();
+  });
+
+  runner.on('safe timeout', function() {
     self.draw();
   });
 
@@ -104,6 +108,7 @@ NyanCat.prototype.drawScoreboard = function() {
 
   draw('green', stats.passes);
   draw('fail', stats.failures);
+  draw('bright yellow', stats.safeTimeouts);
   draw('pending', stats.pending);
   write('\n');
 
@@ -158,6 +163,7 @@ NyanCat.prototype.drawNyanCat = function() {
   var dist = '\u001b[' + startWidth + 'C';
   var padding = '';
 
+  write('\n'); // account for extra score board line for safe time outs
   write(dist);
   write('_,------,');
   write('\n');

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -31,34 +31,35 @@ function Spec(runner) {
 
   var self = this;
   var indents = 0;
-  var n = 0;
+  var n = 0; // tracks fails
+  var j = 0; // tracks safe timeouts
 
   function indent() {
     return Array(indents).join('  ');
   }
 
-  runner.on('start', function() {
+  runner.on('start', function () {
     console.log();
   });
 
-  runner.on('suite', function(suite) {
+  runner.on('suite', function (suite) {
     ++indents;
     console.log(color('suite', '%s%s'), indent(), suite.title);
   });
 
-  runner.on('suite end', function() {
+  runner.on('suite end', function () {
     --indents;
     if (indents === 1) {
       console.log();
     }
   });
 
-  runner.on('pending', function(test) {
+  runner.on('pending', function (test) {
     var fmt = indent() + color('pending', '  - %s');
     console.log(fmt, test.title);
   });
 
-  runner.on('pass', function(test) {
+  runner.on('pass', function (test) {
     var fmt;
     if (test.speed === 'fast') {
       fmt =
@@ -76,8 +77,17 @@ function Spec(runner) {
     }
   });
 
-  runner.on('fail', function(test) {
+  runner.on('fail', function (test) {
     console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+  });
+
+  runner.on('safe timeout', function (test) {
+    var fmt =
+      indent() +
+      color('bright yellow', '  %d)') +
+      color('bright yellow', ' %s') + 
+      color('slow', ' (%dms)');
+    console.log(fmt, ++j, test.title, test.timeout());
   });
 
   runner.once('end', self.epilogue.bind(self));

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -30,6 +30,7 @@ function TAP(runner) {
   var n = 1;
   var passes = 0;
   var failures = 0;
+  var safeTimouts = 0;
 
   runner.on('start', function() {
     var total = runner.grepTotal(runner.suite);
@@ -49,6 +50,17 @@ function TAP(runner) {
     console.log('ok %d %s', n, title(test));
   });
 
+  runner.on('safe timeout', function(test, err) {
+    safeTimouts++;
+    console.log('timeout ignored: %d %s', n, title(test));
+    if (err.message) {
+      console.log(err.message.replace(/^/gm, '  '));
+    }
+    if (err.stack) {
+      console.log(err.stack.replace(/^/gm, '  '));
+    }
+  });
+
   runner.on('fail', function(test, err) {
     failures++;
     console.log('not ok %d %s', n, title(test));
@@ -61,9 +73,10 @@ function TAP(runner) {
   });
 
   runner.once('end', function() {
-    console.log('# tests ' + (passes + failures));
+    console.log('# tests ' + (passes + failures + safeTimouts));
     console.log('# pass ' + passes);
     console.log('# fail ' + failures);
+    console.log('# ignored timeouts ' + safeTimouts);
   });
 }
 

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -80,6 +80,10 @@ function XUnit(runner, options) {
     tests.push(test);
   });
 
+  runner.on('safe timeout', function(test) {
+    tests.push(test);
+  });
+
   runner.on('fail', function(test) {
     tests.push(test);
   });
@@ -92,6 +96,7 @@ function XUnit(runner, options) {
           name: suiteName,
           tests: stats.tests,
           failures: stats.failures,
+          safeTimeouts: stats.safeTimeouts,
           errors: stats.failures,
           skipped: stats.tests - stats.failures - stats.passes,
           timestamp: new Date().toUTCString(),

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -38,6 +38,7 @@ function Runnable(title, fn) {
   this._timeout = 2000;
   this._slow = 75;
   this._enableTimeouts = true;
+  this._ignoreTimeouts = false;
   this.timedOut = false;
   this._retries = -1;
   this._currentRetry = 0;
@@ -56,7 +57,7 @@ utils.inherits(Runnable, EventEmitter);
  * @param {number|string} ms
  * @return {Runnable|number} ms or Runnable instance.
  */
-Runnable.prototype.timeout = function(ms) {
+Runnable.prototype.timeout = function (ms) {
   if (!arguments.length) {
     return this._timeout;
   }
@@ -82,7 +83,7 @@ Runnable.prototype.timeout = function(ms) {
  * @param {number|string} ms
  * @return {Runnable|number} ms or Runnable instance.
  */
-Runnable.prototype.slow = function(ms) {
+Runnable.prototype.slow = function (ms) {
   if (!arguments.length || typeof ms === 'undefined') {
     return this._slow;
   }
@@ -101,7 +102,7 @@ Runnable.prototype.slow = function(ms) {
  * @param {boolean} enabled
  * @return {Runnable|boolean} enabled or Runnable instance.
  */
-Runnable.prototype.enableTimeouts = function(enabled) {
+Runnable.prototype.enableTimeouts = function (enabled) {
   if (!arguments.length) {
     return this._enableTimeouts;
   }
@@ -117,7 +118,7 @@ Runnable.prototype.enableTimeouts = function(enabled) {
  * @public
  * @api public
  */
-Runnable.prototype.skip = function() {
+Runnable.prototype.skip = function () {
   throw new Pending('sync skip');
 };
 
@@ -126,7 +127,7 @@ Runnable.prototype.skip = function() {
  *
  * @api private
  */
-Runnable.prototype.isPending = function() {
+Runnable.prototype.isPending = function () {
   return this.pending || (this.parent && this.parent.isPending());
 };
 
@@ -135,7 +136,7 @@ Runnable.prototype.isPending = function() {
  * @return {boolean}
  * @private
  */
-Runnable.prototype.isFailed = function() {
+Runnable.prototype.isFailed = function () {
   return !this.isPending() && this.state === 'failed';
 };
 
@@ -144,7 +145,7 @@ Runnable.prototype.isFailed = function() {
  * @return {boolean}
  * @private
  */
-Runnable.prototype.isPassed = function() {
+Runnable.prototype.isPassed = function () {
   return !this.isPending() && this.state === 'passed';
 };
 
@@ -153,7 +154,7 @@ Runnable.prototype.isPassed = function() {
  *
  * @api private
  */
-Runnable.prototype.retries = function(n) {
+Runnable.prototype.retries = function (n) {
   if (!arguments.length) {
     return this._retries;
   }
@@ -165,7 +166,7 @@ Runnable.prototype.retries = function(n) {
  *
  * @api private
  */
-Runnable.prototype.currentRetry = function(n) {
+Runnable.prototype.currentRetry = function (n) {
   if (!arguments.length) {
     return this._currentRetry;
   }
@@ -181,7 +182,7 @@ Runnable.prototype.currentRetry = function(n) {
  * @api public
  * @return {string}
  */
-Runnable.prototype.fullTitle = function() {
+Runnable.prototype.fullTitle = function () {
   return this.titlePath().join(' ');
 };
 
@@ -193,8 +194,25 @@ Runnable.prototype.fullTitle = function() {
  * @api public
  * @return {string}
  */
-Runnable.prototype.titlePath = function() {
+Runnable.prototype.titlePath = function () {
   return this.parent.titlePath().concat([this.title]);
+};
+
+/**
+ * Set and get whether timeout is considered an error
+ *
+ * @memberof Mocha.Runnable
+ * @public
+ * @param {boolean} isError
+ * @return {Runnable|boolean} enabled or Runnable instance.
+ */
+Runnable.prototype.ignoreTimeouts = function (ignore) {
+  if (!arguments.length) {
+    return this._ignoreTimeouts;
+  }
+  debug('ignoreTimeouts %s', ignore);
+  this._ignoreTimeouts = ignore;
+  return this;
 };
 
 /**
@@ -202,7 +220,7 @@ Runnable.prototype.titlePath = function() {
  *
  * @api private
  */
-Runnable.prototype.clearTimeout = function() {
+Runnable.prototype.clearTimeout = function () {
   clearTimeout(this.timer);
 };
 
@@ -212,10 +230,10 @@ Runnable.prototype.clearTimeout = function() {
  * @api private
  * @return {string}
  */
-Runnable.prototype.inspect = function() {
+Runnable.prototype.inspect = function () {
   return JSON.stringify(
     this,
-    function(key, val) {
+    function (key, val) {
       if (key[0] === '_') {
         return;
       }
@@ -236,7 +254,7 @@ Runnable.prototype.inspect = function() {
  *
  * @api private
  */
-Runnable.prototype.resetTimeout = function() {
+Runnable.prototype.resetTimeout = function () {
   var self = this;
   var ms = this.timeout() || 1e9;
 
@@ -244,12 +262,12 @@ Runnable.prototype.resetTimeout = function() {
     return;
   }
   this.clearTimeout();
-  this.timer = setTimeout(function() {
+  this.timer = setTimeout(function () {
     if (!self._enableTimeouts) {
       return;
     }
-    self.callback(self._timeoutError(ms));
     self.timedOut = true;
+    self.callback(self._timeoutError(ms));    
   }, ms);
 };
 
@@ -259,7 +277,7 @@ Runnable.prototype.resetTimeout = function() {
  * @api private
  * @param {string[]} globals
  */
-Runnable.prototype.globals = function(globals) {
+Runnable.prototype.globals = function (globals) {
   if (!arguments.length) {
     return this._allowedGlobals;
   }
@@ -272,7 +290,7 @@ Runnable.prototype.globals = function(globals) {
  * @param {Function} fn
  * @api private
  */
-Runnable.prototype.run = function(fn) {
+Runnable.prototype.run = function (fn) {
   var self = this;
   var start = new Date();
   var ctx = this.ctx;
@@ -302,7 +320,15 @@ Runnable.prototype.run = function(fn) {
   // finished
   function done(err) {
     var ms = self.timeout();
+
     if (self.timedOut) {
+
+      // handle case where test timed out but we are not treating this as a fail
+      if (self._ignoreTimeouts && !finished) {
+        finished = true;
+        fn(err);
+      }
+
       return;
     }
 
@@ -373,13 +399,13 @@ Runnable.prototype.run = function(fn) {
     if (result && typeof result.then === 'function') {
       self.resetTimeout();
       result.then(
-        function() {
+        function () {
           done();
           // Return null so libraries like bluebird do not warn about
           // subsequently constructed Promises.
           return null;
         },
-        function(reason) {
+        function (reason) {
           done(reason || new Error('Promise rejected with no or falsy reason'));
         }
       );
@@ -397,7 +423,7 @@ Runnable.prototype.run = function(fn) {
   }
 
   function callFnAsync(fn) {
-    var result = fn.call(ctx, function(err) {
+    var result = fn.call(ctx, function (err) {
       if (err instanceof Error || toString.call(err) === '[object Error]') {
         return done(err);
       }
@@ -429,7 +455,7 @@ Runnable.prototype.run = function(fn) {
  * @returns {Error} a "timeout" error
  * @private
  */
-Runnable.prototype._timeoutError = function(ms) {
+Runnable.prototype._timeoutError = function (ms) {
   var msg =
     'Timeout of ' +
     ms +

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -72,10 +72,10 @@ function Runner(suite, delay) {
   this.started = false;
   this.total = suite.total();
   this.failures = 0;
-  this.on('test end', function(test) {
+  this.on('test end', function (test) {
     self.checkGlobals(test);
   });
-  this.on('hook end', function(hook) {
+  this.on('hook end', function (hook) {
     self.checkGlobals(hook);
   });
   this._defaultGrep = /.*/;
@@ -107,7 +107,7 @@ inherits(Runner, EventEmitter);
  * @param {boolean} invert
  * @return {Runner} Runner instance.
  */
-Runner.prototype.grep = function(re, invert) {
+Runner.prototype.grep = function (re, invert) {
   debug('grep %s', re);
   this._grep = re;
   this._invert = invert;
@@ -125,11 +125,11 @@ Runner.prototype.grep = function(re, invert) {
  * @param {Suite} suite
  * @return {number}
  */
-Runner.prototype.grepTotal = function(suite) {
+Runner.prototype.grepTotal = function (suite) {
   var self = this;
   var total = 0;
 
-  suite.eachTest(function(test) {
+  suite.eachTest(function (test) {
     var match = self._grep.test(test.fullTitle());
     if (self._invert) {
       match = !match;
@@ -148,7 +148,7 @@ Runner.prototype.grepTotal = function(suite) {
  * @return {Array}
  * @api private
  */
-Runner.prototype.globalProps = function() {
+Runner.prototype.globalProps = function () {
   var props = Object.keys(global);
 
   // non-enumerables
@@ -171,7 +171,7 @@ Runner.prototype.globalProps = function() {
  * @param {Array} arr
  * @return {Runner} Runner instance.
  */
-Runner.prototype.globals = function(arr) {
+Runner.prototype.globals = function (arr) {
   if (!arguments.length) {
     return this._globals;
   }
@@ -185,7 +185,7 @@ Runner.prototype.globals = function(arr) {
  *
  * @api private
  */
-Runner.prototype.checkGlobals = function(test) {
+Runner.prototype.checkGlobals = function (test) {
   if (this.ignoreLeaks) {
     return;
   }
@@ -223,7 +223,8 @@ Runner.prototype.checkGlobals = function(test) {
  * @param {Test} test
  * @param {Error} err
  */
-Runner.prototype.fail = function(test, err) {
+Runner.prototype.fail = function (test, err) {
+
   if (test.isPending()) {
     return;
   }
@@ -234,10 +235,10 @@ Runner.prototype.fail = function(test, err) {
   if (!(err instanceof Error || (err && typeof err.message === 'string'))) {
     err = new Error(
       'the ' +
-        type(err) +
-        ' ' +
-        stringify(err) +
-        ' was thrown, throw an Error :)'
+      type(err) +
+      ' ' +
+      stringify(err) +
+      ' was thrown, throw an Error :)'
     );
   }
 
@@ -253,6 +254,36 @@ Runner.prototype.fail = function(test, err) {
     this.emit('end');
   }
 };
+
+/**
+ * safely timeout the given `test`.
+ *
+ * @api private
+ * @param {Test} test
+ * @param {Error} err
+ */
+Runner.prototype.safeTimeout = function (test, err) {
+  
+  if (test.isPending()) {
+    return;
+  }
+
+  test.state = 'safe timeout';
+
+  // we know here that err is the Error from the timeout
+
+  try {
+    err.stack =
+      this.fullStackTrace || !err.stack ? err.stack : stackFilter(err.stack);
+  } catch (ignore) {
+    // some environments do not take kindly to monkeying with the stack
+  }
+
+  this.emit('safe timeout', test, err);
+  if (this.suite.bail()) {
+    this.emit('end');
+  }
+}
 
 /**
  * Fail the given `hook` with `err`.
@@ -274,7 +305,7 @@ Runner.prototype.fail = function(test, err) {
  * @param {Hook} hook
  * @param {Error} err
  */
-Runner.prototype.failHook = function(hook, err) {
+Runner.prototype.failHook = function (hook, err) {
   if (hook.ctx && hook.ctx.currentTest) {
     hook.originalTitle = hook.originalTitle || hook.title;
     hook.title =
@@ -292,7 +323,7 @@ Runner.prototype.failHook = function(hook, err) {
  * @param {Function} fn
  */
 
-Runner.prototype.hook = function(name, fn) {
+Runner.prototype.hook = function (name, fn) {
   var suite = this.suite;
   var hooks = suite['_' + name];
   var self = this;
@@ -309,12 +340,12 @@ Runner.prototype.hook = function(name, fn) {
     self.emit('hook', hook);
 
     if (!hook.listeners('error').length) {
-      hook.on('error', function(err) {
+      hook.on('error', function (err) {
         self.failHook(hook, err);
       });
     }
 
-    hook.run(function(err) {
+    hook.run(function (err) {
       var testError = hook.error();
       if (testError) {
         self.fail(self.test, testError);
@@ -324,7 +355,7 @@ Runner.prototype.hook = function(name, fn) {
           if (name === 'beforeEach' || name === 'afterEach') {
             self.test.pending = true;
           } else {
-            suite.tests.forEach(function(test) {
+            suite.tests.forEach(function (test) {
               test.pending = true;
             });
             // a pending hook won't be executed twice.
@@ -343,7 +374,7 @@ Runner.prototype.hook = function(name, fn) {
     });
   }
 
-  Runner.immediately(function() {
+  Runner.immediately(function () {
     next(0);
   });
 };
@@ -357,7 +388,7 @@ Runner.prototype.hook = function(name, fn) {
  * @param {Array} suites
  * @param {Function} fn
  */
-Runner.prototype.hooks = function(name, suites, fn) {
+Runner.prototype.hooks = function (name, suites, fn) {
   var self = this;
   var orig = this.suite;
 
@@ -369,7 +400,7 @@ Runner.prototype.hooks = function(name, suites, fn) {
       return fn();
     }
 
-    self.hook(name, function(err) {
+    self.hook(name, function (err) {
       if (err) {
         var errSuite = self.suite;
         self.suite = orig;
@@ -390,7 +421,7 @@ Runner.prototype.hooks = function(name, suites, fn) {
  * @param {Function} fn
  * @api private
  */
-Runner.prototype.hookUp = function(name, fn) {
+Runner.prototype.hookUp = function (name, fn) {
   var suites = [this.suite].concat(this.parents()).reverse();
   this.hooks(name, suites, fn);
 };
@@ -402,7 +433,7 @@ Runner.prototype.hookUp = function(name, fn) {
  * @param {Function} fn
  * @api private
  */
-Runner.prototype.hookDown = function(name, fn) {
+Runner.prototype.hookDown = function (name, fn) {
   var suites = [this.suite].concat(this.parents());
   this.hooks(name, suites, fn);
 };
@@ -414,7 +445,7 @@ Runner.prototype.hookDown = function(name, fn) {
  * @return {Array}
  * @api private
  */
-Runner.prototype.parents = function() {
+Runner.prototype.parents = function () {
   var suite = this.suite;
   var suites = [];
   while (suite.parent) {
@@ -430,7 +461,7 @@ Runner.prototype.parents = function() {
  * @param {Function} fn
  * @api private
  */
-Runner.prototype.runTest = function(fn) {
+Runner.prototype.runTest = function (fn) {
   var self = this;
   var test = this.test;
 
@@ -444,7 +475,7 @@ Runner.prototype.runTest = function(fn) {
   if (this.asyncOnly) {
     test.asyncOnly = true;
   }
-  test.on('error', function(err) {
+  test.on('error', function (err) {
     self.fail(test, err);
   });
   if (this.allowUncaught) {
@@ -465,7 +496,7 @@ Runner.prototype.runTest = function(fn) {
  * @param {Suite} suite
  * @param {Function} fn
  */
-Runner.prototype.runTests = function(suite, fn) {
+Runner.prototype.runTests = function (suite, fn) {
   var self = this;
   var tests = suite.tests.slice();
   var test;
@@ -480,7 +511,7 @@ Runner.prototype.runTests = function(suite, fn) {
 
     if (self.suite) {
       // call hookUp afterEach
-      self.hookUp('afterEach', function(err2, errSuite2) {
+      self.hookUp('afterEach', function (err2, errSuite2) {
         self.suite = orig;
         // some hooks may fail even now
         if (err2) {
@@ -554,7 +585,7 @@ Runner.prototype.runTests = function(suite, fn) {
 
     // execute test and hook(s)
     self.emit('test', (self.test = test));
-    self.hookDown('beforeEach', function(err, errSuite) {
+    self.hookDown('beforeEach', function (err, errSuite) {
       if (test.isPending()) {
         if (self.forbidPending) {
           test.isPending = alwaysFalse;
@@ -570,7 +601,7 @@ Runner.prototype.runTests = function(suite, fn) {
         return hookErr(err, errSuite, false);
       }
       self.currentRunnable = self.test;
-      self.runTest(function(err) {
+      self.runTest(function (err) {
         test = self.test;
         if (err) {
           var retry = test.currentRetry();
@@ -587,6 +618,9 @@ Runner.prototype.runTests = function(suite, fn) {
             // Early return + hook trigger so that it doesn't
             // increment the count wrong
             return self.hookUp('afterEach', next);
+          } else if (test.timedOut && test.ignoreTimeouts()) {
+            // this is the case where the test has timed out but we are not treating that as an error
+            self.safeTimeout(test, err);
           } else {
             self.fail(test, err);
           }
@@ -623,7 +657,7 @@ function alwaysFalse() {
  * @param {Suite} suite
  * @param {Function} fn
  */
-Runner.prototype.runSuite = function(suite, fn) {
+Runner.prototype.runSuite = function (suite, fn) {
   var i = 0;
   var self = this;
   var total = this.grepTotal(suite);
@@ -663,7 +697,7 @@ Runner.prototype.runSuite = function(suite, fn) {
     // huge recursive loop and thus a maximum call stack error.
     // See comment in `this.runTests()` for more information.
     if (self._grep !== self._defaultGrep) {
-      Runner.immediately(function() {
+      Runner.immediately(function () {
         self.runSuite(curr, next);
       });
     } else {
@@ -685,7 +719,7 @@ Runner.prototype.runSuite = function(suite, fn) {
       // remove reference to test
       delete self.test;
 
-      self.hook('afterAll', function() {
+      self.hook('afterAll', function () {
         self.emit('suite end', suite);
         fn(errSuite);
       });
@@ -694,7 +728,7 @@ Runner.prototype.runSuite = function(suite, fn) {
 
   this.nextSuite = next;
 
-  this.hook('beforeAll', function(err) {
+  this.hook('beforeAll', function (err) {
     if (err) {
       return done();
     }
@@ -708,14 +742,14 @@ Runner.prototype.runSuite = function(suite, fn) {
  * @param {Error} err
  * @api private
  */
-Runner.prototype.uncaught = function(err) {
+Runner.prototype.uncaught = function (err) {
   if (err) {
     debug(
       'uncaught exception %s',
       err ===
-      function() {
-        return this;
-      }.call(err)
+        function () {
+          return this;
+        }.call(err)
         ? err.message || err
         : err
     );
@@ -829,11 +863,11 @@ function cleanSuiteReferences(suite) {
  * @param {Function} fn
  * @return {Runner} Runner instance.
  */
-Runner.prototype.run = function(fn) {
+Runner.prototype.run = function (fn) {
   var self = this;
   var rootSuite = this.suite;
 
-  fn = fn || function() {};
+  fn = fn || function () { };
 
   function uncaught(err) {
     self.uncaught(err);
@@ -846,7 +880,7 @@ Runner.prototype.run = function(fn) {
     }
     self.started = true;
     self.emit('start');
-    self.runSuite(rootSuite, function() {
+    self.runSuite(rootSuite, function () {
       debug('finished running');
       self.emit('end');
     });
@@ -858,7 +892,7 @@ Runner.prototype.run = function(fn) {
   this.on('suite end', cleanSuiteReferences);
 
   // callback
-  this.on('end', function() {
+  this.on('end', function () {
     debug('end');
     process.removeListener('uncaughtException', uncaught);
     fn(self.failures);
@@ -887,7 +921,7 @@ Runner.prototype.run = function(fn) {
  * @api public
  * @return {Runner} Runner instance.
  */
-Runner.prototype.abort = function() {
+Runner.prototype.abort = function () {
   debug('aborting');
   this._abort = true;
 
@@ -909,7 +943,7 @@ function filterOnly(suite) {
   } else {
     // Otherwise, do not run any of the tests in this suite.
     suite.tests = [];
-    suite._onlySuites.forEach(function(onlySuite) {
+    suite._onlySuites.forEach(function (onlySuite) {
       // If there are other `only` tests/suites nested in the current `only` suite, then filter that `only` suite.
       // Otherwise, all of the tests on this `only` suite should be run, so don't filter it.
       if (hasOnly(onlySuite)) {
@@ -917,7 +951,7 @@ function filterOnly(suite) {
       }
     });
     // Run the `only` suites, as well as any other suites that have `only` tests/suites as descendants.
-    suite.suites = suite.suites.filter(function(childSuite) {
+    suite.suites = suite.suites.filter(function (childSuite) {
       return (
         suite._onlySuites.indexOf(childSuite) !== -1 || filterOnly(childSuite)
       );
@@ -951,7 +985,7 @@ function hasOnly(suite) {
  * @return {Array}
  */
 function filterLeaks(ok, globals) {
-  return globals.filter(function(key) {
+  return globals.filter(function (key) {
     // Firefox and Chrome exposes iframes as index inside the window object
     if (/^\d+/.test(key)) {
       return false;
@@ -975,7 +1009,7 @@ function filterLeaks(ok, globals) {
       return false;
     }
 
-    var matched = ok.filter(function(ok) {
+    var matched = ok.filter(function (ok) {
       if (~ok.indexOf('*')) {
         return key.indexOf(ok.split('*')[0]) === 0;
       }
@@ -994,7 +1028,7 @@ function filterLeaks(ok, globals) {
 function extraGlobals() {
   if (typeof process === 'object' && typeof process.version === 'string') {
     var parts = process.version.split('.');
-    var nodeVersion = parts.reduce(function(a, v) {
+    var nodeVersion = parts.reduce(function (a, v) {
       return (a << 8) | v;
     });
 

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -70,6 +70,7 @@ function Suite(title, parentContext) {
   this.root = !title;
   this._timeout = 2000;
   this._enableTimeouts = true;
+  this._ignoreTimeouts = false;
   this._slow = 75;
   this._bail = false;
   this._retries = -1;
@@ -94,6 +95,7 @@ Suite.prototype.clone = function() {
   debug('clone');
   suite.ctx = this.ctx;
   suite.timeout(this.timeout());
+  suite.ignoreTimeouts(this.ignoreTimeouts());
   suite.retries(this.retries());
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
@@ -120,6 +122,22 @@ Suite.prototype.timeout = function(ms) {
   }
   debug('timeout %d', ms);
   this._timeout = parseInt(ms, 10);
+  return this;
+};
+
+/**
+ * Set or get if timeouts are considered errors.
+ *
+ * @api private
+ * @param {Boolean} ignore
+ * @return {Suite|number} for chaining
+ */
+Suite.prototype.ignoreTimeouts = function(ignore) {
+  if (!arguments.length) {
+    return this._ignoreTimeouts;
+  }
+  debug('ignoreTimeouts %d', ignore);
+  this._ignoreTimeouts = ignore;
   return this;
 };
 
@@ -210,6 +228,7 @@ Suite.prototype._createHook = function(title, fn) {
   var hook = new Hook(title, fn);
   hook.parent = this;
   hook.timeout(this.timeout());
+  hook.ignoreTimeouts(this.ignoreTimeouts());
   hook.retries(this.retries());
   hook.enableTimeouts(this.enableTimeouts());
   hook.slow(this.slow());
@@ -324,6 +343,7 @@ Suite.prototype.afterEach = function(title, fn) {
 Suite.prototype.addSuite = function(suite) {
   suite.parent = this;
   suite.timeout(this.timeout());
+  suite.ignoreTimeouts(this.ignoreTimeouts());
   suite.retries(this.retries());
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
@@ -343,6 +363,7 @@ Suite.prototype.addSuite = function(suite) {
 Suite.prototype.addTest = function(test) {
   test.parent = this;
   test.timeout(this.timeout());
+  test.ignoreTimeouts(this.ignoreTimeouts());
   test.retries(this.retries());
   test.enableTimeouts(this.enableTimeouts());
   test.slow(this.slow());

--- a/lib/test.js
+++ b/lib/test.js
@@ -36,6 +36,7 @@ Test.prototype.clone = function() {
   test.timeout(this.timeout());
   test.slow(this.slow());
   test.enableTimeouts(this.enableTimeouts());
+  test.ignoreTimeouts(this.ignoreTimeouts());
   test.retries(this.retries());
   test.currentRetry(this.currentRetry());
   test.globals(this.globals());


### PR DESCRIPTION
### Description of the Change

This change adds support for a new flag, --ignore-timeouts, which when provided will not treat timeouts as fails, but rather as a new category of "safe timeouts". This flag can also be supplied in any of the scopes (hook, test, suite) using the ignoreTimeouts method:

```js
describe('a suite of tests', function() {
  beforeEach(function(done) {
    this.timeout(3000); // A very long environment setup.
    this.ignoreTimeout(true);
    setTimeout(done, 2500);
  });
});
```

When set a different emit event is sent, "safe timeout". This PR also updates all reporters to understand this new emit and behave appropriately for their given usage.

### Alternate Designs

Considered disabling timeouts, but in some cases I have a need for an operation to have a timeout (perhaps it hangs) but can in those cases ignore this to not fail the entire test suite, potentially blocking release. I.e. there are some known long running operations that very occasionally fail in testing and can be safely ignore.

### Why should this be in core?

Functionality was not present, I would like it to be. I believe it can apply to others as well.

### Benefits

New capability to still allow tests/suites/hooks to timeout, but continue testing and not fail an entire build due to one possibly long running test.

### Possible Drawbacks

Could mask a real fail if the timeout is due to a bug. Any reporters not in the core package would not understand the new emit event.

### Applicable issues

Came from me asking a question on gitter and looking through the code and determining the option I wanted was not available.
