### PR TITLE
remove play from bin/_mocha

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -99,26 +99,12 @@ const showCursor = () => {
 };
 
 /**
- * Stop play()ing.
+ * Stop.
  */
 const stop = () => {
   process.stdout.write('\u001b[2K');
-  clearInterval(play.timer);
 };
 
-/**
- * Play the given array of strings.
- */
-const play = (arr, interval) => {
-  const len = arr.length;
-  interval = interval || 100;
-  let i = 0;
-
-  play.timer = setInterval(() => {
-    const str = arr[i++ % len];
-    process.stdout.write(`\u001b[0G${str}`);
-  }, interval);
-};
 
 /**
  * Files.

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -105,7 +105,6 @@ const stop = () => {
   process.stdout.write('\u001b[2K');
 };
 
-
 /**
  * Files.
  */


### PR DESCRIPTION
I dont see this function used anywhere, also stop now just spits `\u001b[2K` to the stdout for the rerun, I am not sure if it is needed as well.