### PR TITLE
Show diff in xunit

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -151,6 +151,8 @@ XUnit.prototype.write = function(line) {
  * @param {Test} test
  */
 XUnit.prototype.test = function(test) {
+  Base.useColors = false;
+
   var attrs = {
     classname: test.parent.fullTitle(),
     name: test.title,
@@ -159,6 +161,10 @@ XUnit.prototype.test = function(test) {
 
   if (test.state === 'failed') {
     var err = test.err;
+    var diff =
+      Base.hideDiff || !err.actual || !err.expected
+        ? ''
+        : '\n' + Base.generateDiff(err.actual, err.expected);
     this.write(
       tag(
         'testcase',
@@ -168,7 +174,7 @@ XUnit.prototype.test = function(test) {
           'failure',
           {},
           false,
-          escape(err.message) + '\n' + escape(err.stack)
+          escape(err.message) + escape(diff) + '\n' + escape(err.stack)
         )
       )
     );

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -18,6 +18,8 @@ describe('XUnit reporter', function() {
   var expectedClassName = 'fullTitle';
   var expectedTitle = 'some title';
   var expectedMessage = 'some message';
+  var expectedDiff =
+    '\n      + expected - actual\n\n      -foo\n      +bar\n      ';
   var expectedStack = 'some-stack';
   var expectedWrite = null;
 
@@ -214,6 +216,8 @@ describe('XUnit reporter', function() {
           },
           duration: 1000,
           err: {
+            actual: 'foo',
+            expected: 'bar',
             message: expectedMessage,
             stack: expectedStack
           }
@@ -234,6 +238,8 @@ describe('XUnit reporter', function() {
           expectedTitle +
           '" time="1"><failure>' +
           expectedMessage +
+          '\n' +
+          expectedDiff +
           '\n' +
           expectedStack +
           '</failure></testcase>';


### PR DESCRIPTION
### Description of the Change
XUnit reporter should show diffs as output

### Why should this be in core?
XUnit reporter was already in core

### Benefits
You can tell actual vs. expected which is very helpful and the default in the default reporter.

### Possible Drawbacks
People wrote parsers.

### Applicable issues
This is an enhancement. 