### PR TITLE
update docs with latest cli options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -740,7 +740,6 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
 ```text
   Usage: mocha [debug] [options] [files]
 
-
   Options:
 
     -V, --version                           output the version number
@@ -749,7 +748,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     -C, --no-colors                         force disabling of colors
     -G, --growl                             enable growl notification support
     -O, --reporter-options <k=v,k2=v2,...>  reporter-specific options
-    -R, --reporter <name>                   specify the reporter to use
+    -R, --reporter <name>                   specify the reporter to use (default: spec)
     -S, --sort                              sort test files
     -b, --bail                              bail after first test failure
     -d, --debug                             enable node's debugger, synonym for node --debug
@@ -760,19 +759,19 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     -r, --require <name>                    require the given module
     -s, --slow <ms>                         "slow" test threshold in milliseconds [75]
     -t, --timeout <ms>                      set test-case timeout in milliseconds [2000]
-    -u, --ui <name>                         specify user-interface (bdd|tdd|qunit|exports)
+    -u, --ui <name>                         specify user-interface (bdd|tdd|qunit|exports) (default: bdd)
     -w, --watch                             watch files for changes
     --check-leaks                           check for global variable leaks
     --full-trace                            display the full stack trace
-    --compilers <ext>:<module>,...          use the given module(s) to compile files
+    --compilers <ext>:<module>,...          use the given module(s) to compile files (default: )
     --debug-brk                             enable node's debugger breaking on the first line
-    --globals <names>                       allow the given comma-delimited global [names]
+    --globals <names>                       allow the given comma-delimited global [names] (default: )
     --es_staging                            enable all staged features
-    --file <file>                           include a file to be ran during the suite [file]
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
     --icu-data-dir                          include ICU data
     --inline-diffs                          display actual/expected differences inline within each string
+    --no-diff                               do not show a diff on failure
     --inspect                               activate devtools in chrome
     --inspect-brk                           activate devtools in chrome and break on the first line
     --interfaces                            display available interfaces
@@ -780,7 +779,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --exit                                  force shutdown of the event loop after test run: mocha will call process.exit
     --no-timeouts                           disables timeouts, given implicitly with --debug
     --no-warnings                           silence all node process warnings
-    --opts <path>                           specify opts path
+    --opts <path>                           specify opts path (default: test/mocha.opts)
     --perf-basic-prof                       enable perf linux profiler (basic support)
     --napi-modules                          enable experimental NAPI modules
     --prof                                  log statistical profiling information
@@ -793,13 +792,14 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --trace-deprecation                     show stack traces on deprecations
     --trace-warnings                        show stack traces on node process warnings
     --use_strict                            enforce strict mode
-    --watch-extensions <ext>,...            additional extensions to monitor with --watch
+    --watch-extensions <ext>,...            specify extensions to monitor with --watch (default: js)
     --delay                                 wait for async suite definition
     --allow-uncaught                        enable uncaught errors to propagate
     --forbid-only                           causes test marked with only to fail the suite
     --forbid-pending                        causes pending tests and test marked with skip to fail the suite
+    --file <file>                           include a file to be ran during the suite (default: )
+    --exclude <file>                        a file or glob pattern to ignore (default: )
     -h, --help                              output usage information
-
 
   Commands:
 


### PR DESCRIPTION
In [docs](https://mochajs.org/#usage), CLI usage is outdated.
I updated them with current CLI options.