### PR TITLE
prevent to set bdd ui always

### DIFF
--- a/lib/interfaces/exports.js
+++ b/lib/interfaces/exports.js
@@ -19,8 +19,98 @@ var Test = require('../test');
  *
  * @param {Suite} suite Root suite.
  */
-module.exports = function(suite) {
+module.exports = function exportsInterface(suite) {
   var suites = [suite];
+
+  suite.on('pre-require', function(context, file, mocha) {
+    var common = require('./common')(suites, context, mocha);
+
+    context.before = common.before;
+    context.after = common.after;
+    context.beforeEach = common.beforeEach;
+    context.afterEach = common.afterEach;
+    context.run = mocha.options.delay && common.runWithSuite(suite);
+    /**
+     * Describe a "suite" with the given `title`
+     * and callback `fn` containing nested suites
+     * and/or tests.
+     */
+
+    context.describe = context.context = function(title, fn) {
+      return common.suite.create({
+        title: title,
+        file: file,
+        fn: fn
+      });
+    };
+
+    /**
+     * Pending describe.
+     */
+
+    context.xdescribe = context.xcontext = context.describe.skip = function(
+      title,
+      fn
+    ) {
+      return common.suite.skip({
+        title: title,
+        file: file,
+        fn: fn
+      });
+    };
+
+    /**
+     * Exclusive suite.
+     */
+
+    context.describe.only = function(title, fn) {
+      return common.suite.only({
+        title: title,
+        file: file,
+        fn: fn
+      });
+    };
+
+    /**
+     * Describe a specification or test-case
+     * with the given `title` and callback `fn`
+     * acting as a thunk.
+     */
+
+    context.it = context.specify = function(title, fn) {
+      var suite = suites[0];
+      if (suite.isPending()) {
+        fn = null;
+      }
+      var test = new Test(title, fn);
+      test.file = file;
+      suite.addTest(test);
+      return test;
+    };
+
+    /**
+     * Exclusive test-case.
+     */
+
+    context.it.only = function(title, fn) {
+      return common.test.only(mocha, context.it(title, fn));
+    };
+
+    /**
+     * Pending test case.
+     */
+
+    context.xit = context.xspecify = context.it.skip = function(title) {
+      return context.it(title);
+    };
+
+    /**
+     * Number of attempts to retry.
+     */
+    context.it.retries = function(n) {
+      context.retries(n);
+    };
+  });
 
   suite.on('require', visit);
 

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -27,7 +27,7 @@ var Test = require('../test');
  *
  * @param {Suite} suite Root suite.
  */
-module.exports = function(suite) {
+module.exports = function tddInterface(suite) {
   var suites = [suite];
 
   suite.on('pre-require', function(context, file, mocha) {

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -91,7 +91,9 @@ function Mocha(options) {
     this.fgrep(options.fgrep);
   }
   this.suite = new exports.Suite('', new exports.Context());
-  this.ui(options.ui);
+  if (options.ui) {
+    this.ui(options.ui);
+  }
   this.bail(options.bail);
   this.reporter(options.reporter, options.reporterOptions);
   if (typeof options.timeout !== 'undefined' && options.timeout !== null) {


### PR DESCRIPTION
### Description of the Change
`bdd` ui is set anyway. So, `bdd` ui called twice if you specified `--ui bdd`. `bdd` and `tdd` uis called if you specified `--ui tdd`. It is because of [new Mocha()](https://github.com/mochajs/mocha/blob/master/bin/_mocha#L22) and [setting ui](https://github.com/mochajs/mocha/blob/master/bin/_mocha#L501).

Thererfore, I fixed to call ui only when `option.ui` specified.(for using `new Mocha()` directly)

Additionally, I named UI function to avoid anonymous function name. BDD and qUnit already has [named function](https://github.com/mochajs/mocha/blob/master/lib/interfaces/bdd.js#L22).

### Alternate Designs
N/A

### Why should this be in core?
As #3421, it is a bug.

### Benefits
Users can specify UI as their intention.

### Possible Drawbacks
If users uses mixed UIs (e.g bdd and tdd), it will be broken.

### Applicable issues
Fix #3421 