### PR TITLE
Prevent to empty default value in CLI options

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -82,7 +82,12 @@ const list = str => str.split(/ *, */);
 /**
  * Parse multiple flag.
  */
-const collect = (val, memo) => memo.concat(val);
+const collect = (val, memo) => {
+  if (!memo) {
+    memo = [];
+  }
+  return memo.concat(val);
+};
 
 /**
  * Hide the cursor.
@@ -171,15 +176,13 @@ program
   .option(
     '--compilers <ext>:<module>,...',
     'use the given module(s) to compile files',
-    list,
-    []
+    list
   )
   .option('--debug-brk', "enable node's debugger breaking on the first line")
   .option(
     '--globals <names>',
     'allow the given comma-delimited global [names]',
-    list,
-    []
+    list
   )
   .option('--es_staging', 'enable all staged features')
   .option(
@@ -241,13 +244,8 @@ program
     '--forbid-pending',
     'causes pending tests and test marked with skip to fail the suite'
   )
-  .option(
-    '--file <file>',
-    'include a file to be ran during the suite',
-    collect,
-    []
-  )
-  .option('--exclude <file>', 'a file or glob pattern to ignore', collect, []);
+  .option('--file <file>', 'include a file to be ran during the suite', collect)
+  .option('--exclude <file>', 'a file or glob pattern to ignore', collect);
 
 program._name = 'mocha';
 
@@ -472,6 +470,9 @@ if (program.forbidPending) mocha.forbidPending();
 
 // custom compiler support
 
+if (!program.compilers) {
+  program.compilers = [];
+}
 if (program.compilers.length > 0) {
   require('util').deprecate(() => {},
   '"--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info')();
@@ -506,6 +507,9 @@ const args = program.args;
 
 // default files to test/*.{js,coffee}
 
+if (!program.exclude) {
+  program.exclude = [];
+}
 if (!args.length) {
   args.push('test');
 }
@@ -543,6 +547,9 @@ if (!files.length) {
 }
 
 // resolve
+if (!program.file) {
+  program.file = [];
+}
 let fileArgs = program.file.map(path => resolve(path));
 files = files.map(path => resolve(path));
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -763,9 +763,9 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     -w, --watch                             watch files for changes
     --check-leaks                           check for global variable leaks
     --full-trace                            display the full stack trace
-    --compilers <ext>:<module>,...          use the given module(s) to compile files (default: )
+    --compilers <ext>:<module>,...          use the given module(s) to compile files
     --debug-brk                             enable node's debugger breaking on the first line
-    --globals <names>                       allow the given comma-delimited global [names] (default: )
+    --globals <names>                       allow the given comma-delimited global [names]
     --es_staging                            enable all staged features
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
@@ -797,8 +797,8 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --allow-uncaught                        enable uncaught errors to propagate
     --forbid-only                           causes test marked with only to fail the suite
     --forbid-pending                        causes pending tests and test marked with skip to fail the suite
-    --file <file>                           include a file to be ran during the suite (default: )
-    --exclude <file>                        a file or glob pattern to ignore (default: )
+    --file <file>                           include a file to be ran during the suite
+    --exclude <file>                        a file or glob pattern to ignore
     -h, --help                              output usage information
 
   Commands:


### PR DESCRIPTION
### Description of the Change
If empty array is default value([]), it displayed as `default: `

With `commander` and a default value is an empty array(`[]`), it shows like this:

```
--globals <names>                       allow the given comma-delimited global [names] (default: )
```

`(default: )` is confusing to users.

So, this PR doesn't use a default value with an empty array. Instead, it set an empty array manually.

### Alternate Designs
Let it as `(default: )` or fix it in [commander.js](https://github.com/tj/commander.js).

### Possible Drawbacks
I'm not sure.

### Applicable issues
Fix #3433 