### PR TITLE
Documented some cli options

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -182,6 +182,7 @@ program
     []
   )
   .option('--es_staging', 'enable all staged features')
+  .option('--experimental-modules', 'experimental ES Module support')
   .option(
     '--harmony<_classes,_generators,...>',
     'all node --harmony* flags are available'

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -231,7 +231,7 @@ program
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--trace-warnings', 'show stack traces on node process warnings')
   .option('--use_strict', 'enforce strict mode')
-  .option('--allow-natives-syntax', 'allow natives syntax')
+  .option('--allow-natives-syntax', 'allow direct calls to V8 native commands')
   .option(
     '--watch-extensions <ext>,...',
     'specify extensions to monitor with --watch',

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -181,6 +181,7 @@ program
     list,
     []
   )
+  .option('--gc-global', 'always perform global GCs')
   .option('--es_staging', 'enable all staged features')
   .option('--experimental-modules', 'experimental ES Module support')
   .option(

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -191,6 +191,7 @@ program
     'Instructs the module loader to preserve symbolic links when resolving and caching modules'
   )
   .option('--icu-data-dir', 'include ICU data')
+  .option('--max-old-space-size', 'max size of the old generation (in Mbytes)')
   .option(
     '--inline-diffs',
     'display actual/expected differences inline within each string'

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -231,6 +231,7 @@ program
   .option('--trace-deprecation', 'show stack traces on deprecations')
   .option('--trace-warnings', 'show stack traces on node process warnings')
   .option('--use_strict', 'enforce strict mode')
+  .option('--allow-natives-syntax', 'allow natives syntax')
   .option(
     '--watch-extensions <ext>,...',
     'specify extensions to monitor with --watch',

--- a/docs/index.md
+++ b/docs/index.md
@@ -767,6 +767,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --debug-brk                             enable node's debugger breaking on the first line
     --globals <names>                       allow the given comma-delimited global [names] (default: )
     --es_staging                            enable all staged features
+    --experimental-modules                  experimental ES Module support
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
     --icu-data-dir                          include ICU data

--- a/docs/index.md
+++ b/docs/index.md
@@ -766,6 +766,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --compilers <ext>:<module>,...          use the given module(s) to compile files (default: )
     --debug-brk                             enable node's debugger breaking on the first line
     --globals <names>                       allow the given comma-delimited global [names] (default: )
+    --gc-global                             always perform global GCs
     --es_staging                            enable all staged features
     --experimental-modules                  experimental ES Module support
     --harmony<_classes,_generators,...>     all node --harmony* flags are available

--- a/docs/index.md
+++ b/docs/index.md
@@ -770,6 +770,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --harmony<_classes,_generators,...>     all node --harmony* flags are available
     --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
     --icu-data-dir                          include ICU data
+    --max-old-space-size                    max size of the old generation (in Mbytes)
     --inline-diffs                          display actual/expected differences inline within each string
     --no-diff                               do not show a diff on failure
     --inspect                               activate devtools in chrome

--- a/docs/index.md
+++ b/docs/index.md
@@ -795,7 +795,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --trace-deprecation                     show stack traces on deprecations
     --trace-warnings                        show stack traces on node process warnings
     --use_strict                            enforce strict mode
-    --allow-natives-syntax                  allow natives syntax
+    --allow-natives-syntax                  allow direct calls to V8 native commands
     --watch-extensions <ext>,...            specify extensions to monitor with --watch (default: js)
     --delay                                 wait for async suite definition
     --allow-uncaught                        enable uncaught errors to propagate

--- a/docs/index.md
+++ b/docs/index.md
@@ -795,6 +795,7 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
     --trace-deprecation                     show stack traces on deprecations
     --trace-warnings                        show stack traces on node process warnings
     --use_strict                            enforce strict mode
+    --allow-natives-syntax                  allow natives syntax
     --watch-extensions <ext>,...            specify extensions to monitor with --watch (default: js)
     --delay                                 wait for async suite definition
     --allow-uncaught                        enable uncaught errors to propagate


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Some options didn't show description after execution `mocha --help`, like `--max-old-space-size`, `--experimental-modules`, `--gc-global`, `--allow-natives-syntax` .

so these commits documented `--max-old-space-size`, `--experimental-modules`, `--gc-global`, `--allow-natives-syntax`  cli options to `_mocha` file and doc `index.md` file.


### Alternate Designs

Do Noting.

### Why should this be in core?
Maybe not.

### Benefits

Show command options help.

### Possible Drawbacks

I'm not sure.

### Applicable issues
Can't not find.
