### PR TITLE
resolves #3450: fixed links to "code of conduct" from MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,7 @@ Anyone involved with Mocha will fall into one of these buckets: **user**, **cont
 
 A "user" for the purpose of this document is any *individual developer* who consumes Mocha to write and/or execute tests.  A user interacts with contributors.  A user interacts with the software, web site, documentation, etc., which these contributors provide.
 
-As a user, you're expected to follow the [code of conduct](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md) when interacting in Mocha's "official" social spaces. This includes:
+As a user, you're expected to follow the [code of conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) when interacting in Mocha's "official" social spaces. This includes:
 
 - Any chatroom under the `mochajs` organization on Gitter
 - Any project under the `mochajs` organization on GitHub
@@ -45,7 +45,7 @@ A "contributor" is any individual who has *given back* in some way to the projec
 1. Recruiting more contributors! Don't spam.
 1. Researching the user base, getting feedback, etc. Don't spam.
 
-A contributor is *usually* a user as well, but this isn't a hard-and-fast rule. A contributor is also expected to adhere to the [code of conduct](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md) as a user would.
+A contributor is *usually* a user as well, but this isn't a hard-and-fast rule. A contributor is also expected to adhere to the [code of conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) as a user would.
 
 As you can see, it's wide open!  Think of it another way: if you are *adding value to Mocha*, then you are a contributor.
 


### PR DESCRIPTION

### Description of the Change

I've changed the links to the code of conduct to lead where I expect them (the code of conduct) and not to the changelog.

### Alternate Designs

There is a larger fix to MAINTAINERS.md by https://github.com/plroebuck/mocha/commit/1d8afbf3dc6a6c110b15f6f25fa3b08edad6814c which utilizes much more fancy reference-style links which would probably be nice but I wanted to make as small a change as needed to fix the issue at hand

### Why should this be in core?

Helping people find the code of conduct improves life for all. :two_hearts: 

### Benefits

Links in documentation lead where you expect them.

### Possible Drawbacks

The element of discovery and exploration amidst hyperlinks between documentation is lost.

### Applicable issues

https://github.com/mochajs/mocha/issues/3450
