### PR TITLE
resolves #2149, #1257: Make TAP reporter conform to TAP13

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -53,7 +53,7 @@ function TAP(runner, options) {
   });
 
   runner.on('pending', function(test) {
-    console.log('ok %d %s # SKIP -', n, title(test));
+    self.producer.writePending(n, test);
   });
 
   runner.on('pass', function(test) {
@@ -104,6 +104,10 @@ TAP12Producer.prototype.writeFail = function(n, test, err) {
   }
 };
 
+TAP12Producer.prototype.writePending = function(n, test) {
+  console.log('ok %d %s # SKIP -', n, title(test));
+};
+
 function TAP13Producer() {}
 
 TAP13Producer.prototype.yamlIndent = function(level) {
@@ -131,4 +135,8 @@ TAP13Producer.prototype.writeFail = function(n, test, err) {
     }
     console.log(this.yamlIndent(1) + '...');
   }
+};
+
+TAP13Producer.prototype.writePending = function(n, test) {
+  console.log('ok %d %s # SKIP -', n, title(test));
 };

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -57,14 +57,12 @@ function TAP(runner) {
     if (emitYamlBlock) {
       console.log('  ---');
       if (err.message) {
-        console.log('    message: ' + err.message);
+        console.log('    message: |-');
+        console.log(err.message.replace(/^/gm, '      '));
       }
-      // stack needs to be last in yaml due to literal style indicator (|)
       if (err.stack) {
         console.log('    stack: |-');
-        if (err.stack) {
-          console.log(err.stack.replace(/^/gm, '      '));
-        }
+        console.log(err.stack.replace(/^/gm, '      '));
       }
       console.log('  ...');
     }

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -32,6 +32,7 @@ function TAP(runner) {
   var failures = 0;
 
   runner.on('start', function() {
+    console.log('TAP version 13');
     var total = runner.grepTotal(runner.suite);
     console.log('%d..%d', 1, total);
   });

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -34,7 +34,7 @@ function TAP(runner, options) {
   var tapSpec = '12';
   if (options && options.reporterOptions) {
     if (options.reporterOptions.spec) {
-      var tapSpec = options.reporterOptions.spec;
+      tapSpec = options.reporterOptions.spec;
     }
   }
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -31,10 +31,6 @@ function TAP(runner, options) {
   var self = this;
   var n = 1;
 
-  function yamlIndent(level) {
-    return Array(level + 1).join('  ');
-  }
-
   var tapSpec = '12';
   if (options && options.reporterOptions) {
     if (options.reporterOptions.spec) {
@@ -65,20 +61,7 @@ function TAP(runner, options) {
   });
 
   runner.on('fail', function(test, err) {
-    console.log('not ok %d %s', n, title(test));
-    var emitYamlBlock = err.message != null || err.stack != null;
-    if (emitYamlBlock) {
-      console.log(yamlIndent(1) + '---');
-      if (err.message) {
-        console.log(yamlIndent(2) + 'message: |-');
-        console.log(err.message.replace(/^/gm, yamlIndent(3)));
-      }
-      if (err.stack) {
-        console.log(yamlIndent(2) + 'stack: |-');
-        console.log(err.stack.replace(/^/gm, yamlIndent(3)));
-      }
-      console.log(yamlIndent(1) + '...');
-    }
+    self.producer.writeFail(n, test, err);
   });
 
   runner.once('end', function() {
@@ -111,10 +94,41 @@ TAP12Producer.prototype.writeStart = function(runner) {
   console.log('%d..%d', 1, total);
 };
 
+TAP12Producer.prototype.writeFail = function(n, test, err) {
+  console.log('not ok %d %s', n, title(test));
+  if (err.message) {
+    console.log(err.message.replace(/^/gm, '  '));
+  }
+  if (err.stack) {
+    console.log(err.stack.replace(/^/gm, '  '));
+  }
+};
+
 function TAP13Producer() {}
+
+TAP13Producer.prototype.yamlIndent = function(level) {
+  return Array(level + 1).join('  ');
+};
 
 TAP13Producer.prototype.writeStart = function(runner) {
   console.log('TAP version 13');
   var total = runner.grepTotal(runner.suite);
   console.log('%d..%d', 1, total);
+};
+
+TAP13Producer.prototype.writeFail = function(n, test, err) {
+  console.log('not ok %d %s', n, title(test));
+  var emitYamlBlock = err.message != null || err.stack != null;
+  if (emitYamlBlock) {
+    console.log(this.yamlIndent(1) + '---');
+    if (err.message) {
+      console.log(this.yamlIndent(2) + 'message: |-');
+      console.log(err.message.replace(/^/gm, this.yamlIndent(3)));
+    }
+    if (err.stack) {
+      console.log(this.yamlIndent(2) + 'stack: |-');
+      console.log(err.stack.replace(/^/gm, this.yamlIndent(3)));
+    }
+    console.log(this.yamlIndent(1) + '...');
+  }
 };

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -31,6 +31,10 @@ function TAP(runner) {
   var passes = 0;
   var failures = 0;
 
+  function yamlIndent(level) {
+    return Array(level + 1).join('  ');
+  }
+
   runner.on('start', function() {
     console.log('TAP version 13');
     var total = runner.grepTotal(runner.suite);
@@ -55,16 +59,16 @@ function TAP(runner) {
     console.log('not ok %d %s', n, title(test));
     var emitYamlBlock = err.message != null || err.stack != null;
     if (emitYamlBlock) {
-      console.log('  ---');
+      console.log(yamlIndent(1), '---');
       if (err.message) {
-        console.log('    message: |-');
-        console.log(err.message.replace(/^/gm, '      '));
+        console.log(yamlIndent(2), 'message: |-');
+        console.log(err.message.replace(/^/gm, yamlIndent(3)));
       }
       if (err.stack) {
-        console.log('    stack: |-');
-        console.log(err.stack.replace(/^/gm, '      '));
+        console.log(yamlIndent(2), 'stack: |-');
+        console.log(err.stack.replace(/^/gm, yamlIndent(3)));
       }
-      console.log('  ...');
+      console.log(yamlIndent(1), '...');
     }
   });
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -59,16 +59,16 @@ function TAP(runner) {
     console.log('not ok %d %s', n, title(test));
     var emitYamlBlock = err.message != null || err.stack != null;
     if (emitYamlBlock) {
-      console.log(yamlIndent(1), '---');
+      console.log(yamlIndent(1) + '---');
       if (err.message) {
-        console.log(yamlIndent(2), 'message: |-');
+        console.log(yamlIndent(2) + 'message: |-');
         console.log(err.message.replace(/^/gm, yamlIndent(3)));
       }
       if (err.stack) {
-        console.log(yamlIndent(2), 'stack: |-');
+        console.log(yamlIndent(2) + 'stack: |-');
         console.log(err.stack.replace(/^/gm, yamlIndent(3)));
       }
-      console.log(yamlIndent(1), '...');
+      console.log(yamlIndent(1) + '...');
     }
   });
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -7,7 +7,6 @@
  */
 
 var Base = require('./base');
-var inherits = require('../utils').inherits;
 
 /**
  * Expose `TAP`.
@@ -28,7 +27,6 @@ exports = module.exports = TAP;
 function TAP(runner) {
   Base.call(this, runner);
 
-  var self = this;
   var n = 1;
   var passes = 0;
   var failures = 0;
@@ -76,11 +74,6 @@ function TAP(runner) {
     console.log('# fail ' + failures);
   });
 }
-
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(TAP, Base);
 
 /**
  * Return a TAP-safe title of `test`

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -7,6 +7,7 @@
  */
 
 var Base = require('./base');
+var inherits = require('../utils').inherits;
 
 /**
  * Expose `TAP`.
@@ -27,6 +28,7 @@ exports = module.exports = TAP;
 function TAP(runner) {
   Base.call(this, runner);
 
+  var self = this;
   var n = 1;
   var passes = 0;
   var failures = 0;
@@ -74,6 +76,11 @@ function TAP(runner) {
     console.log('# fail ' + failures);
   });
 }
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+inherits(TAP, Base);
 
 /**
  * Return a TAP-safe title of `test`

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -53,11 +53,20 @@ function TAP(runner) {
   runner.on('fail', function(test, err) {
     failures++;
     console.log('not ok %d %s', n, title(test));
-    if (err.message) {
-      console.log(err.message.replace(/^/gm, '  '));
-    }
-    if (err.stack) {
-      console.log(err.stack.replace(/^/gm, '  '));
+    var emitYamlBlock = err.message != null || err.stack != null;
+    if (emitYamlBlock) {
+      console.log('  ---');
+      if (err.message) {
+        console.log('    message: ' + err.message);
+      }
+      // stack needs to be last in yaml due to literal style indicator (|)
+      if (err.stack) {
+        console.log('    stack: |-');
+        if (err.stack) {
+          console.log(err.stack.replace(/^/gm, '      '));
+        }
+      }
+      console.log('  ...');
     }
   });
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -7,6 +7,7 @@
  */
 
 var Base = require('./base');
+var inherits = require('../utils').inherits;
 
 /**
  * Expose `TAP`.
@@ -89,3 +90,8 @@ function TAP(runner) {
 function title(test) {
   return test.fullTitle().replace(/#/g, '');
 }
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+inherits(TAP, Base);

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -25,19 +25,31 @@ exports = module.exports = TAP;
  * @api public
  * @param {Runner} runner
  */
-function TAP(runner) {
+function TAP(runner, options) {
   Base.call(this, runner);
 
+  var self = this;
   var n = 1;
 
   function yamlIndent(level) {
     return Array(level + 1).join('  ');
   }
 
+  var tapSpec = '12';
+  if (options && options.reporterOptions) {
+    if (options.reporterOptions.spec) {
+      var tapSpec = options.reporterOptions.spec;
+    }
+  }
+
+  if (tapSpec === '13') {
+    this.producer = new TAP13Producer();
+  } else {
+    this.producer = new TAP12Producer();
+  }
+
   runner.on('start', function() {
-    console.log('TAP version 13');
-    var total = runner.grepTotal(runner.suite);
-    console.log('%d..%d', 1, total);
+    self.producer.writeStart(runner);
   });
 
   runner.on('test end', function() {
@@ -91,3 +103,18 @@ function title(test) {
  * Inherit from `Base.prototype`.
  */
 inherits(TAP, Base);
+
+function TAP12Producer() {}
+
+TAP12Producer.prototype.writeStart = function(runner) {
+  var total = runner.grepTotal(runner.suite);
+  console.log('%d..%d', 1, total);
+};
+
+function TAP13Producer() {}
+
+TAP13Producer.prototype.writeStart = function(runner) {
+  console.log('TAP version 13');
+  var total = runner.grepTotal(runner.suite);
+  console.log('%d..%d', 1, total);
+};

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -65,9 +65,7 @@ function TAP(runner, options) {
   });
 
   runner.once('end', function() {
-    console.log('# tests ' + (runner.stats.passes + runner.stats.failures));
-    console.log('# pass ' + runner.stats.passes);
-    console.log('# fail ' + runner.stats.failures);
+    self.producer.writeEnd(runner);
   });
 }
 
@@ -87,6 +85,36 @@ function title(test) {
  */
 inherits(TAP, Base);
 
+/**
+ * Initialize a new `TAPProducer`. Should only be used as a base class.
+ *
+ * @private
+ * @class
+ * @api private
+ */
+function TAPProducer() {}
+
+TAPProducer.prototype.writePending = function(n, test) {
+  console.log('ok %d %s # SKIP -', n, title(test));
+};
+
+TAPProducer.prototype.writePass = function(n, test) {
+  console.log('ok %d %s', n, title(test));
+};
+
+TAPProducer.prototype.writeEnd = function(runner) {
+  console.log('# tests ' + (runner.stats.passes + runner.stats.failures));
+  console.log('# pass ' + runner.stats.passes);
+  console.log('# fail ' + runner.stats.failures);
+};
+
+/**
+ * Initialize a new `TAP12Producer` which will produce output conforming to the TAP12 spec.
+ *
+ * @private
+ * @class
+ * @api private
+ */
 function TAP12Producer() {}
 
 TAP12Producer.prototype.writeStart = function(runner) {
@@ -104,14 +132,15 @@ TAP12Producer.prototype.writeFail = function(n, test, err) {
   }
 };
 
-TAP12Producer.prototype.writePending = function(n, test) {
-  console.log('ok %d %s # SKIP -', n, title(test));
-};
+inherits(TAP12Producer, TAPProducer);
 
-TAP12Producer.prototype.writePass = function(n, test) {
-  console.log('ok %d %s', n, title(test));
-};
-
+/**
+ * Initialize a new `TAP13Producer` which will produce output conforming to the TAP13 spec.
+ *
+ * @private
+ * @class
+ * @api private
+ */
 function TAP13Producer() {}
 
 TAP13Producer.prototype.yamlIndent = function(level) {
@@ -141,10 +170,4 @@ TAP13Producer.prototype.writeFail = function(n, test, err) {
   }
 };
 
-TAP13Producer.prototype.writePending = function(n, test) {
-  console.log('ok %d %s # SKIP -', n, title(test));
-};
-
-TAP13Producer.prototype.writePass = function(n, test) {
-  console.log('ok %d %s', n, title(test));
-};
+inherits(TAP13Producer, TAPProducer);

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -29,8 +29,6 @@ function TAP(runner) {
   Base.call(this, runner);
 
   var n = 1;
-  var passes = 0;
-  var failures = 0;
 
   function yamlIndent(level) {
     return Array(level + 1).join('  ');
@@ -51,12 +49,10 @@ function TAP(runner) {
   });
 
   runner.on('pass', function(test) {
-    passes++;
     console.log('ok %d %s', n, title(test));
   });
 
   runner.on('fail', function(test, err) {
-    failures++;
     console.log('not ok %d %s', n, title(test));
     var emitYamlBlock = err.message != null || err.stack != null;
     if (emitYamlBlock) {
@@ -74,9 +70,9 @@ function TAP(runner) {
   });
 
   runner.once('end', function() {
-    console.log('# tests ' + (passes + failures));
-    console.log('# pass ' + passes);
-    console.log('# fail ' + failures);
+    console.log('# tests ' + (runner.stats.passes + runner.stats.failures));
+    console.log('# pass ' + runner.stats.passes);
+    console.log('# fail ' + runner.stats.failures);
   });
 }
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -57,7 +57,7 @@ function TAP(runner, options) {
   });
 
   runner.on('pass', function(test) {
-    console.log('ok %d %s', n, title(test));
+    self.producer.writePass(n, test);
   });
 
   runner.on('fail', function(test, err) {
@@ -108,6 +108,10 @@ TAP12Producer.prototype.writePending = function(n, test) {
   console.log('ok %d %s # SKIP -', n, title(test));
 };
 
+TAP12Producer.prototype.writePass = function(n, test) {
+  console.log('ok %d %s', n, title(test));
+};
+
 function TAP13Producer() {}
 
 TAP13Producer.prototype.yamlIndent = function(level) {
@@ -139,4 +143,8 @@ TAP13Producer.prototype.writeFail = function(n, test, err) {
 
 TAP13Producer.prototype.writePending = function(n, test) {
   console.log('ok %d %s # SKIP -', n, title(test));
+};
+
+TAP13Producer.prototype.writePass = function(n, test) {
+  console.log('ok %d %s', n, title(test));
 };

--- a/test/integration/fixtures/reporters.fixture.js
+++ b/test/integration/fixtures/reporters.fixture.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * This file generates a wide range of output to test reporter functionality.
+ */
+
+describe('Animals', function() {
+
+  it('should consume organic material', function(done) { done(); });
+  it('should breathe oxygen', function(done) {
+    // we're a jellyfish
+    var actualBreathe = 'nothing';
+    var expectedBreathe = 'oxygen';
+    expect(actualBreathe, 'to equal', expectedBreathe);
+    done();
+  });
+  it('should be able to move', function(done) { done(); });
+  it('should reproduce sexually', function(done) { done(); });
+  it('should grow from a hollow sphere of cells', function(done) { done(); });
+
+  describe('Vertebrates', function() {
+    describe('Mammals', function() {
+      it('should give birth to live young', function(done) {
+        var expectedMammal = {
+          consumesMaterial: 'organic',
+          breathe: 'oxygen',
+          reproduction: {
+            type: 'sexually',
+            spawnType: 'live',
+          }
+        };
+        var platypus = JSON.parse(JSON.stringify(expectedMammal));
+        platypus['reproduction']['spawnType'] = 'hard-shelled egg';
+
+        expect(platypus, 'to equal', expectedMammal);
+        done();
+      });
+
+      describe('Blue Whale', function() {
+        it('should be the largest of all mammals', function(done) { done(); });
+        it('should have a body in some shade of blue', function(done) {
+          var bodyColor = 'blueish_grey';
+          var shadesOfBlue = ['cyan', 'light_blue', 'blue', 'indigo'];
+          expect(bodyColor, 'to be one of', shadesOfBlue);
+
+          done();
+        });
+      });
+    });
+    describe('Birds', function() {
+      it('should have feathers', function(done) { done(); });
+      it('should lay hard-shelled eggs', function(done) { done(); });
+    });
+  });
+
+  describe('Tardigrades', function() {
+    it('should answer to "water bear"', function(done) { done(); });
+    it('should be able to survive global mass extinction events', function(done) {
+      throw new Error("How do we even test for this without causing one?")
+      done();
+    });
+  });
+});

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -101,8 +101,34 @@ describe('reporters', function() {
   });
 
   describe('tap', function() {
+    var not = function(predicate) {
+      return function() {
+        return !predicate.apply(this, arguments);
+      };
+    };
+    var versionPredicate = function(line) {
+      return line.match(/^TAP version \d+$/) != null;
+    };
+    var planPredicate = function(line) {
+      return line.match(/^1\.\.\d+$/) != null;
+    };
     var testLinePredicate = function(line) {
       return line.match(/^not ok/) != null || line.match(/^ok/) != null;
+    };
+    var diagnosticPredicate = function(line) {
+      return line.match(/^#/) != null;
+    };
+    var bailOutPredicate = function(line) {
+      return line.match(/^Bail out!/) != null;
+    };
+    var anythingElsePredicate = function(line) {
+      return (
+        versionPredicate(line) === false &&
+        planPredicate(line) === false &&
+        testLinePredicate(line) === false &&
+        diagnosticPredicate(line) === false &&
+        bailOutPredicate(line) === false
+      );
     };
 
     describe('produces valid TAP v13 output', function() {
@@ -177,22 +203,20 @@ describe('reporters', function() {
 
         var outputLines = res.output.split('\n');
         for (var i = 0; i + 1 < outputLines.length; i++) {
-          console.log('>', outputLines[i]);
-          console.log('\t', testLinePredicate(outputLines[i]));
-          console.log('\t', testLinePredicate(outputLines[i + 1]));
           if (
             testLinePredicate(outputLines[i]) &&
             testLinePredicate(outputLines[i + 1]) === false
           ) {
             var blockLinesStart = i + 1;
             var blockLinesEnd =
-              i + 1 + outputLines.slice(i + 1).findIndex(anythingElsePredicate);
+              i +
+              1 +
+              outputLines.slice(i + 1).findIndex(not(anythingElsePredicate));
             var blockLines =
               blockLinesEnd > blockLinesStart
                 ? outputLines.slice(blockLinesStart, blockLinesEnd)
                 : outputLines.slice(blockLinesStart);
-            console.log(i);
-            console.log(blockLines);
+
             i += blockLines.length;
           }
         }

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -99,4 +99,30 @@ describe('reporters', function() {
       });
     });
   });
+
+  describe('tap', function() {
+    describe('produces valid TAP v13 output', function() {
+      var runFixtureAndValidateOutput = function(fixture) {
+        it('for ' + fixture, function(done) {
+          var args = ['--reporter=tap'];
+          run(fixture, args, function(err, res) {
+            if (err) {
+              done(err);
+              return;
+            }
+
+            // see https://testanything.org/tap-version-13-specification.html
+
+            // first line must be `TAP version 13`
+            var firstLine = res.output.split('\n', 1)[0];
+            expect(firstLine, 'to equal', 'TAP version 13');
+            done();
+          });
+        });
+      };
+
+      runFixtureAndValidateOutput('passing.fixture.js');
+      runFixtureAndValidateOutput('uncaught.fixture.js');
+    });
+  });
 });

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -190,14 +190,14 @@ describe('reporters', function() {
       runFixtureAndValidateOutput('passing.fixture.js', {
         numTests: 2
       });
-      runFixtureAndValidateOutput('uncaught.fixture.js', {
-        numTests: 2
+      runFixtureAndValidateOutput('reporters.fixture.js', {
+        numTests: 12
       });
     });
 
     it('places exceptions correctly in YAML blocks', function(done) {
       var args = ['--reporter=tap'];
-      run('uncaught.fixture.js', args, function(err, res) {
+      run('reporters.fixture.js', args, function(err, res) {
         if (err) {
           done(err);
           return;

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -156,7 +156,9 @@ describe('reporters', function() {
             // plan must appear once
             expect(outputLines, 'to contain', expectedPlan);
             expect(
-              outputLines.filter(l => l === expectedPlan),
+              outputLines.filter(function(l) {
+                return l === expectedPlan;
+              }),
               'to have length',
               1
             );

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -202,6 +202,7 @@ describe('reporters', function() {
         }
 
         var outputLines = res.output.split('\n');
+
         for (var i = 0; i + 1 < outputLines.length; i++) {
           if (
             testLinePredicate(outputLines[i]) &&
@@ -216,8 +217,10 @@ describe('reporters', function() {
               blockLinesEnd > blockLinesStart
                 ? outputLines.slice(blockLinesStart, blockLinesEnd)
                 : outputLines.slice(blockLinesStart);
-
             i += blockLines.length;
+
+            expect(blockLines[0], 'to match', /^\s+\-\-\-/);
+            expect(blockLines[blockLines.length - 1], 'to match', /^\s+\.\.\./);
           }
         }
 

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -111,12 +111,11 @@ describe('reporters', function() {
               return;
             }
 
+            var expectedVersion = 13;
+            var expectedPlan = '1..' + expected.numTests;
+
             var outputLines = res.output.split('\n');
 
-            // see https://testanything.org/tap-version-13-specification.html
-
-            // Version
-            var expectedVersion = 13;
             // first line must be version line
             expect(
               outputLines[0],
@@ -124,8 +123,6 @@ describe('reporters', function() {
               'TAP version ' + expectedVersion
             );
 
-            // Plan
-            var expectedPlan = '1..' + expected.numTests;
             // plan must appear once
             expect(outputLines, 'to contain', expectedPlan);
             expect(
@@ -138,6 +135,7 @@ describe('reporters', function() {
               return line.match(/^not ok/) || line.match(/^ok/);
             };
             var firstTestLine = outputLines.findIndex(testLineMatcher);
+            // there must be at least one test line
             expect(firstTestLine, 'to be greater than', -1);
             var lastTestLine =
               outputLines.length -

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -134,7 +134,7 @@ describe('reporters', function() {
     describe('produces valid TAP v13 output', function() {
       var runFixtureAndValidateOutput = function(fixture, expected) {
         it('for ' + fixture, function(done) {
-          var args = ['--reporter=tap'];
+          var args = ['--reporter=tap', '--reporter-options', 'spec=13'];
           run(fixture, args, function(err, res) {
             if (err) {
               done(err);
@@ -196,7 +196,7 @@ describe('reporters', function() {
     });
 
     it('places exceptions correctly in YAML blocks', function(done) {
-      var args = ['--reporter=tap'];
+      var args = ['--reporter=tap', '--reporter-options', 'spec=13'];
       run('reporters.fixture.js', args, function(err, res) {
         if (err) {
           done(err);

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -221,7 +221,7 @@ describe('reporters', function() {
                 : outputLines.slice(blockLinesStart);
             i += blockLines.length;
 
-            expect(blockLines[0], 'to match', /^\s+\-\-\-/);
+            expect(blockLines[0], 'to match', /^\s+---/);
             expect(blockLines[blockLines.length - 1], 'to match', /^\s+\.\.\./);
           }
         }

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -32,116 +32,60 @@ describe('TAP reporter', function() {
     process.stdout.write = stdoutWrite;
   });
 
-  describe('on start', function() {
-    it('should hand runners suite into grepTotal and log the total', function() {
-      var expectedSuite = 'some suite';
-      var expectedTotal = 10;
-      var expectedString;
-      runner = createMockRunner('start', 'start');
-      runner.suite = expectedSuite;
-      runner.grepTotal = function(string) {
-        expectedString = string;
-        return expectedTotal;
-      };
-      TAP.call({}, runner);
-
-      var expectedSecondLine = '1..' + expectedTotal + '\n';
-      process.stdout.write = stdoutWrite;
-
-      expect(stdout[1], 'to equal', expectedSecondLine);
-      expect(expectedString, 'to be', expectedSuite);
-    });
-  });
-
-  describe('on pending', function() {
-    it('should write expected message including count and title', function() {
-      runner = createMockRunner(
-        'start test',
-        'test end',
-        'pending',
-        null,
-        test
-      );
-      runner.suite = '';
-      runner.grepTotal = function() {};
-      TAP.call({}, runner);
-
-      process.stdout.write = stdoutWrite;
-
-      var expectedMessage =
-        'ok ' + countAfterTestEnd + ' ' + expectedTitle + ' # SKIP -\n';
-      expect(stdout[0], 'to equal', expectedMessage);
-    });
-  });
-
-  describe('on pass', function() {
-    it('should write expected message including count and title', function() {
-      runner = createMockRunner('start test', 'test end', 'pass', null, test);
-
-      runner.suite = '';
-      runner.grepTotal = function() {};
-      TAP.call({}, runner);
-
-      process.stdout.write = stdoutWrite;
-
-      var expectedMessage =
-        'ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n';
-      expect(stdout[0], 'to equal', expectedMessage);
-    });
-  });
-
-  describe('on fail', function() {
-    describe('if there is an error message', function() {
-      it('should write expected message and error message', function() {
-        var expectedTitle = 'some title';
-        var countAfterTestEnd = 2;
-        var expectedErrorMessage = 'some error';
-        var test = {
-          fullTitle: function() {
-            return expectedTitle;
-          },
-          slow: function() {}
+  describe('TAP12 spec', function() {
+    describe('on start', function() {
+      it('should hand runners suite into grepTotal and log the total', function() {
+        var expectedSuite = 'some suite';
+        var expectedTotal = 10;
+        var expectedString;
+        runner = createMockRunner('start', 'start');
+        runner.suite = expectedSuite;
+        runner.grepTotal = function(string) {
+          expectedString = string;
+          return expectedTotal;
         };
-        var error = {
-          message: expectedErrorMessage
-        };
-        runner.on = function(event, callback) {
-          if (event === 'test end') {
-            callback();
-          }
-          if (event === 'fail') {
-            callback(test, error);
-          }
-        };
-        runner.suite = '';
-        runner.grepTotal = function() {};
         TAP.call({}, runner);
 
+        var expectedArray = ['1..' + expectedTotal + '\n'];
         process.stdout.write = stdoutWrite;
 
-        var expectedArray = [
-          'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
-          '  ---\n',
-          '    message: |-\n',
-          '      ' + expectedErrorMessage + '\n',
-          '  ...\n'
-        ];
         expect(stdout, 'to equal', expectedArray);
+        expect(expectedString, 'to be', expectedSuite);
       });
     });
-    describe('if there is an error stack', function() {
-      it('should write expected message and stack', function() {
-        var expectedStack = 'some stack';
-        var error = {
-          stack: expectedStack
+  });
+
+  describe('TAP13 spec', function() {
+    var options = {reporterOptions: {spec: '13'}};
+    describe('on start', function() {
+      it('should hand runners suite into grepTotal and log the total', function() {
+        var expectedSuite = 'some suite';
+        var expectedTotal = 10;
+        var expectedString;
+        runner = createMockRunner('start', 'start');
+        runner.suite = expectedSuite;
+        runner.grepTotal = function(string) {
+          expectedString = string;
+          return expectedTotal;
         };
+        TAP.call({}, runner, options);
+
+        var expectedSecondLine = '1..' + expectedTotal + '\n';
+        process.stdout.write = stdoutWrite;
+
+        expect(stdout[1], 'to equal', expectedSecondLine);
+        expect(expectedString, 'to be', expectedSuite);
+      });
+    });
+
+    describe('on pending', function() {
+      it('should write expected message including count and title', function() {
         runner = createMockRunner(
-          'test end fail',
+          'start test',
           'test end',
-          'fail',
+          'pending',
           null,
-          test,
-          error
+          test
         );
         runner.suite = '';
         runner.grepTotal = function() {};
@@ -149,103 +93,185 @@ describe('TAP reporter', function() {
 
         process.stdout.write = stdoutWrite;
 
-        var expectedArray = [
-          'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
-          '  ---\n',
-          '    stack: |-\n',
-          '      ' + expectedStack + '\n',
-          '  ...\n'
-        ];
-        expect(stdout, 'to equal', expectedArray);
+        var expectedMessage =
+          'ok ' + countAfterTestEnd + ' ' + expectedTitle + ' # SKIP -\n';
+        expect(stdout[0], 'to equal', expectedMessage);
       });
     });
-    describe('if there is an error stack and error message', function() {
-      it('should write expected message and stack', function() {
-        var expectedTitle = 'some title';
-        var countAfterTestEnd = 2;
-        var expectedStack = 'some stack';
-        var expectedErrorMessage = 'some error';
-        var test = {
-          fullTitle: function() {
-            return expectedTitle;
-          },
-          slow: function() {}
-        };
-        var error = {
-          stack: expectedStack,
-          message: expectedErrorMessage
-        };
-        runner.on = function(event, callback) {
-          if (event === 'test end') {
-            callback();
-          }
-          if (event === 'fail') {
-            callback(test, error);
-          }
-        };
+
+    describe('on pass', function() {
+      it('should write expected message including count and title', function() {
+        runner = createMockRunner('start test', 'test end', 'pass', null, test);
+
         runner.suite = '';
         runner.grepTotal = function() {};
         TAP.call({}, runner);
 
         process.stdout.write = stdoutWrite;
 
-        var expectedArray = [
-          'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
-          '  ---\n',
-          '    message: |-\n',
-          '      ' + expectedErrorMessage + '\n',
-          '    stack: |-\n',
-          '      ' + expectedStack + '\n',
-          '  ...\n'
-        ];
-        expect(stdout, 'to equal', expectedArray);
+        var expectedMessage =
+          'ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n';
+        expect(stdout[0], 'to equal', expectedMessage);
       });
     });
-    describe('if there is no error stack or error message', function() {
-      it('should write expected message only', function() {
-        var error = {};
-        runner.on = runner.once = function(event, callback) {
-          if (event === 'test end') {
-            callback();
-          }
-          if (event === 'fail') {
-            callback(test, error);
-          }
-        };
+
+    describe('on fail', function() {
+      describe('if there is an error message', function() {
+        it('should write expected message and error message', function() {
+          var expectedTitle = 'some title';
+          var countAfterTestEnd = 2;
+          var expectedErrorMessage = 'some error';
+          var test = {
+            fullTitle: function() {
+              return expectedTitle;
+            },
+            slow: function() {}
+          };
+          var error = {
+            message: expectedErrorMessage
+          };
+          runner.on = function(event, callback) {
+            if (event === 'test end') {
+              callback();
+            }
+            if (event === 'fail') {
+              callback(test, error);
+            }
+          };
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+            '  ---\n',
+            '    message: |-\n',
+            '      ' + expectedErrorMessage + '\n',
+            '  ...\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+      describe('if there is an error stack', function() {
+        it('should write expected message and stack', function() {
+          var expectedStack = 'some stack';
+          var error = {
+            stack: expectedStack
+          };
+          runner = createMockRunner(
+            'test end fail',
+            'test end',
+            'fail',
+            null,
+            test,
+            error
+          );
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+            '  ---\n',
+            '    stack: |-\n',
+            '      ' + expectedStack + '\n',
+            '  ...\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+      describe('if there is an error stack and error message', function() {
+        it('should write expected message and stack', function() {
+          var expectedTitle = 'some title';
+          var countAfterTestEnd = 2;
+          var expectedStack = 'some stack';
+          var expectedErrorMessage = 'some error';
+          var test = {
+            fullTitle: function() {
+              return expectedTitle;
+            },
+            slow: function() {}
+          };
+          var error = {
+            stack: expectedStack,
+            message: expectedErrorMessage
+          };
+          runner.on = function(event, callback) {
+            if (event === 'test end') {
+              callback();
+            }
+            if (event === 'fail') {
+              callback(test, error);
+            }
+          };
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+            '  ---\n',
+            '    message: |-\n',
+            '      ' + expectedErrorMessage + '\n',
+            '    stack: |-\n',
+            '      ' + expectedStack + '\n',
+            '  ...\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+      describe('if there is no error stack or error message', function() {
+        it('should write expected message only', function() {
+          var error = {};
+          runner.on = runner.once = function(event, callback) {
+            if (event === 'test end') {
+              callback();
+            }
+            if (event === 'fail') {
+              callback(test, error);
+            }
+          };
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+    });
+
+    describe('on end', function() {
+      it('should write total tests, passes and failures', function() {
+        var numberOfPasses = 1;
+        var numberOfFails = 1;
+        runner = createMockRunner('fail end pass', 'fail', 'end', 'pass', test);
         runner.suite = '';
         runner.grepTotal = function() {};
         TAP.call({}, runner);
 
         process.stdout.write = stdoutWrite;
 
+        var totalTests = numberOfPasses + numberOfFails;
         var expectedArray = [
-          'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n'
+          'ok ' + numberOfPasses + ' ' + expectedTitle + '\n',
+          'not ok ' + numberOfFails + ' ' + expectedTitle + '\n',
+          '# tests ' + totalTests + '\n',
+          '# pass ' + numberOfPasses + '\n',
+          '# fail ' + numberOfFails + '\n'
         ];
         expect(stdout, 'to equal', expectedArray);
       });
-    });
-  });
-
-  describe('on end', function() {
-    it('should write total tests, passes and failures', function() {
-      var numberOfPasses = 1;
-      var numberOfFails = 1;
-      runner = createMockRunner('fail end pass', 'fail', 'end', 'pass', test);
-      runner.suite = '';
-      runner.grepTotal = function() {};
-      TAP.call({}, runner);
-
-      process.stdout.write = stdoutWrite;
-
-      var totalTests = numberOfPasses + numberOfFails;
-      var expectedArray = [
-        'ok ' + numberOfPasses + ' ' + expectedTitle + '\n',
-        'not ok ' + numberOfFails + ' ' + expectedTitle + '\n',
-        '# tests ' + totalTests + '\n',
-        '# pass ' + numberOfPasses + '\n',
-        '# fail ' + numberOfFails + '\n'
-      ];
-      expect(stdout, 'to equal', expectedArray);
     });
   });
 });

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -122,7 +122,8 @@ describe('TAP reporter', function() {
         var expectedArray = [
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
           '  ---\n',
-          '    message: ' + expectedErrorMessage + '\n',
+          '    message: |-\n',
+          '      ' + expectedErrorMessage + '\n',
           '  ...\n'
         ];
         expect(stdout, 'to equal', expectedArray);
@@ -191,7 +192,8 @@ describe('TAP reporter', function() {
         var expectedArray = [
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
           '  ---\n',
-          '    message: ' + expectedErrorMessage + '\n',
+          '    message: |-\n',
+          '      ' + expectedErrorMessage + '\n',
           '    stack: |-\n',
           '      ' + expectedStack + '\n',
           '  ...\n'

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -56,10 +56,10 @@ describe('TAP reporter', function() {
       };
       TAP.call({}, runner);
 
-      var expectedArray = ['1..' + expectedTotal + '\n'];
+      var expectedSecondLine = '1..' + expectedTotal + '\n';
       process.stdout.write = stdoutWrite;
 
-      expect(stdout, 'to equal', expectedArray);
+      expect(stdout[1], 'to equal', expectedSecondLine);
       expect(expectedString, 'to be', expectedSuite);
     });
   });

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -121,7 +121,9 @@ describe('TAP reporter', function() {
 
         var expectedArray = [
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
-          '  ' + expectedErrorMessage + '\n'
+          '  ---\n',
+          '    message: ' + expectedErrorMessage + '\n',
+          '  ...\n'
         ];
         expect(stdout, 'to equal', expectedArray);
       });
@@ -148,7 +150,10 @@ describe('TAP reporter', function() {
 
         var expectedArray = [
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
-          '  ' + expectedStack + '\n'
+          '  ---\n',
+          '    stack: |-\n',
+          '      ' + expectedStack + '\n',
+          '  ...\n'
         ];
         expect(stdout, 'to equal', expectedArray);
       });
@@ -185,8 +190,11 @@ describe('TAP reporter', function() {
 
         var expectedArray = [
           'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
-          '  ' + expectedErrorMessage + '\n',
-          '  ' + expectedStack + '\n'
+          '  ---\n',
+          '    message: ' + expectedErrorMessage + '\n',
+          '    stack: |-\n',
+          '      ' + expectedStack + '\n',
+          '  ...\n'
         ];
         expect(stdout, 'to equal', expectedArray);
       });

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -33,6 +33,17 @@ describe('TAP reporter', function() {
   });
 
   describe('on start', function() {
+    it('should write expected version on first line', function() {
+      runner = createMockRunner('start', 'start');
+      runner.grepTotal = function(string) {};
+      TAP.call({}, runner);
+
+      var expectedFirstLine = 'TAP version 13\n';
+      process.stdout.write = stdoutWrite;
+
+      expect(stdout[0], 'to equal', expectedFirstLine);
+    });
+
     it('should hand runners suite into grepTotal and log the total', function() {
       var expectedSuite = 'some suite';
       var expectedTotal = 10;

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -33,17 +33,6 @@ describe('TAP reporter', function() {
   });
 
   describe('on start', function() {
-    it('should write expected version on first line', function() {
-      runner = createMockRunner('start', 'start');
-      runner.grepTotal = function(string) {};
-      TAP.call({}, runner);
-
-      var expectedFirstLine = 'TAP version 13\n';
-      process.stdout.write = stdoutWrite;
-
-      expect(stdout[0], 'to equal', expectedFirstLine);
-    });
-
     it('should hand runners suite into grepTotal and log the total', function() {
       var expectedSuite = 'some suite';
       var expectedTotal = 10;

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -53,6 +53,109 @@ describe('TAP reporter', function() {
         expect(expectedString, 'to be', expectedSuite);
       });
     });
+
+    describe('on fail', function() {
+      describe('if there is an error message', function() {
+        it('should write expected message and error message', function() {
+          var expectedTitle = 'some title';
+          var countAfterTestEnd = 2;
+          var expectedErrorMessage = 'some error';
+          var test = {
+            fullTitle: function() {
+              return expectedTitle;
+            },
+            slow: function() {}
+          };
+          var error = {
+            message: expectedErrorMessage
+          };
+          runner.on = function(event, callback) {
+            if (event === 'test end') {
+              callback();
+            }
+            if (event === 'fail') {
+              callback(test, error);
+            }
+          };
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+            '  ' + expectedErrorMessage + '\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+      describe('if there is an error stack', function() {
+        it('should write expected message and stack', function() {
+          var expectedStack = 'some stack';
+          var error = {
+            stack: expectedStack
+          };
+          runner = createMockRunner(
+            'test end fail',
+            'test end',
+            'fail',
+            null,
+            test,
+            error
+          );
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+            '  ' + expectedStack + '\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+      describe('if there is an error stack and error message', function() {
+        it('should write expected message and stack', function() {
+          var expectedTitle = 'some title';
+          var countAfterTestEnd = 2;
+          var expectedStack = 'some stack';
+          var expectedErrorMessage = 'some error';
+          var test = {
+            fullTitle: function() {
+              return expectedTitle;
+            },
+            slow: function() {}
+          };
+          var error = {
+            stack: expectedStack,
+            message: expectedErrorMessage
+          };
+          runner.on = function(event, callback) {
+            if (event === 'test end') {
+              callback();
+            }
+            if (event === 'fail') {
+              callback(test, error);
+            }
+          };
+          runner.suite = '';
+          runner.grepTotal = function() {};
+          TAP.call({}, runner);
+
+          process.stdout.write = stdoutWrite;
+
+          var expectedArray = [
+            'not ok ' + countAfterTestEnd + ' ' + expectedTitle + '\n',
+            '  ' + expectedErrorMessage + '\n',
+            '  ' + expectedStack + '\n'
+          ];
+          expect(stdout, 'to equal', expectedArray);
+        });
+      });
+    });
   });
 
   describe('TAP13 spec', function() {
@@ -89,7 +192,7 @@ describe('TAP reporter', function() {
         );
         runner.suite = '';
         runner.grepTotal = function() {};
-        TAP.call({}, runner);
+        TAP.call({}, runner, options);
 
         process.stdout.write = stdoutWrite;
 
@@ -105,7 +208,7 @@ describe('TAP reporter', function() {
 
         runner.suite = '';
         runner.grepTotal = function() {};
-        TAP.call({}, runner);
+        TAP.call({}, runner, options);
 
         process.stdout.write = stdoutWrite;
 
@@ -140,7 +243,7 @@ describe('TAP reporter', function() {
           };
           runner.suite = '';
           runner.grepTotal = function() {};
-          TAP.call({}, runner);
+          TAP.call({}, runner, options);
 
           process.stdout.write = stdoutWrite;
 
@@ -170,7 +273,7 @@ describe('TAP reporter', function() {
           );
           runner.suite = '';
           runner.grepTotal = function() {};
-          TAP.call({}, runner);
+          TAP.call({}, runner, options);
 
           process.stdout.write = stdoutWrite;
 
@@ -210,7 +313,7 @@ describe('TAP reporter', function() {
           };
           runner.suite = '';
           runner.grepTotal = function() {};
-          TAP.call({}, runner);
+          TAP.call({}, runner, options);
 
           process.stdout.write = stdoutWrite;
 
@@ -239,7 +342,7 @@ describe('TAP reporter', function() {
           };
           runner.suite = '';
           runner.grepTotal = function() {};
-          TAP.call({}, runner);
+          TAP.call({}, runner, options);
 
           process.stdout.write = stdoutWrite;
 
@@ -258,7 +361,7 @@ describe('TAP reporter', function() {
         runner = createMockRunner('fail end pass', 'fail', 'end', 'pass', test);
         runner.suite = '';
         runner.grepTotal = function() {};
-        TAP.call({}, runner);
+        TAP.call({}, runner, options);
 
         process.stdout.write = stdoutWrite;
 


### PR DESCRIPTION
### Description of the Change

The TAP reporter has been made to conform with [TAP13](https://testanything.org/tap-version-13-specification.html).

Changes to the actual reporter are small: a version string is emitted as the first line, and error `message` and `stack` are both emitted inside a YAML block to be parsed by any TAP Consumer.

A quite large integration test has been added that encodes the expectations of the TAP13 spec, and the existing TAP reporter unit tests have been updated to be compatible with the new spec.

Finally 'reporters.fixture.js' was added to have something to run that generates test results with varying properties.

### Alternate Designs

It was considered to add either a new reporter (e.g. `tap13`) or hide the new spec under a reporter option but since there are no breaking changes in TAP13 this was deemed unnecessary.

### Why should this be in core?

Mocha relies on a default selection of usable reporters. A bunch of TAP Consumers that I've surveyed are poorly written and _expect_ TAP13 or will otherwise break thus rendering the current TAP reporter in mocha less useful.

### Benefits

A larger ecosystem of tools that are only compatible with TAP13 are made available to use together with mocha. Taking a step back, benefits in the TAP13 spec vs v12 are inherited, such as being able to encode richer error information in the now allowed YAML block in the TAP report is a Good Thing.

### Possible Drawbacks

Many TAP Consumers I've encountered are not as flexible as one might wish so it is possible they don't fully conform to the old v12 spec, thus not being compatible with the TAP13 spec resulting in undefined behaviour. For example, currently in mocha the error stack is simply inserted into the report following the failed test, something that is allowed by the v12 spec as an "unknown" line that shouldn't be an error and may be handled by the test harness in any way. If a test harness handles mocha's stacks by e.g. using regex it will probably break now that the stack is wrapped in what TAP13 calls a "YAML block".

### Applicable issues

https://github.com/mochajs/mocha/issues/2149
https://github.com/mochajs/mocha/issues/1257

#### Note

I've decided to not address issue https://github.com/mochajs/mocha/issues/2410 with this PR as it involves communicating with third party tools (e.g. tap-spec) over TAP13 in a new way which I feel is outside the scope of simply bringing the TAP reporter up to spec, whereas 2410 is more about establishing a new spec regarding the structure of the YAML blocks (unspecified by TAP13).
