### PR TITLE
#3320 Native types exceptions can crash Mocha runner

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -231,14 +231,8 @@ Runner.prototype.fail = function(test, err) {
   ++this.failures;
   test.state = 'failed';
 
-  if (!(err instanceof Error || (err && typeof err.message === 'string'))) {
-    err = new Error(
-      'the ' +
-        type(err) +
-        ' ' +
-        stringify(err) +
-        ' was thrown, throw an Error :)'
-    );
+  if (!isError(err)) {
+    err = thrown2Error(err);
   }
 
   try {
@@ -731,6 +725,10 @@ Runner.prototype.uncaught = function(err) {
     debug('uncaught undefined exception');
     err = undefinedError();
   }
+
+  if (!isError(err)) {
+    err = thrown2Error(err);
+  }
   err.uncaught = true;
 
   var runnable = this.currentRunnable;
@@ -991,6 +989,32 @@ function filterLeaks(ok, globals) {
     });
     return !matched.length && (!global.navigator || key !== 'onerror');
   });
+}
+
+/**
+ * Check if argument is an instance of Error object or a duck-typed equivalent.
+ *
+ * @private
+ * @param {Object} err - object to check
+ * @param {string} err.message - error message
+ * @returns {boolean}
+ */
+function isError(err) {
+  return err instanceof Error || (err && typeof err.message === 'string');
+}
+
+/**
+ *
+ * Converts thrown non-extensible type into proper Error.
+ *
+ * @private
+ * @param {*} thrown - Non-extensible type thrown by code
+ * @return {Error}
+ */
+function thrown2Error(err) {
+  return new Error(
+    'the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)'
+  );
 }
 
 /**

--- a/test/unit/throw.spec.js
+++ b/test/unit/throw.spec.js
@@ -26,6 +26,52 @@ describe('a test that throws', function() {
     });
   });
 
+  describe('non-extensible', function() {
+    it('should not pass if throwing sync and test is sync', function(done) {
+      var test = new Test('im sync and throw string sync', function() {
+        throw 'non-extensible';
+      });
+      suite.addTest(test);
+      runner = new Runner(suite);
+      runner.on('end', function() {
+        expect(runner.failures, 'to be', 1);
+        expect(test.state, 'to be', 'failed');
+        done();
+      });
+      runner.run();
+    });
+
+    it('should not pass if throwing sync and test is async', function(done) {
+      var test = new Test('im async and throw string sync', function(done2) {
+        throw 'non-extensible';
+      });
+      suite.addTest(test);
+      runner = new Runner(suite);
+      runner.on('end', function() {
+        expect(runner.failures, 'to be', 1);
+        expect(test.state, 'to be', 'failed');
+        done();
+      });
+      runner.run();
+    });
+
+    it('should not pass if throwing async and test is async', function(done) {
+      var test = new Test('im async and throw string async', function(done2) {
+        process.nextTick(function() {
+          throw 'non-extensible';
+        });
+      });
+      suite.addTest(test);
+      runner = new Runner(suite);
+      runner.on('end', function() {
+        expect(runner.failures, 'to be', 1);
+        expect(test.state, 'to be', 'failed');
+        done();
+      });
+      runner.run();
+    });
+  });
+
   describe('undefined', function() {
     it('should not pass if throwing sync and test is sync', function(done) {
       var test = new Test('im sync and throw undefined sync', function() {


### PR DESCRIPTION
Any non-extensible type thrown in an async callback raises an exception in Mocha runner, stopping tests.

See issue #3320

See PR #3321 for additional discussion.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

Tests continue and reports errors properly
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

Fixes #3320

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
