### PR TITLE
Remove stdout: prefix from browser reporter logs

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -7,7 +7,7 @@
  * Shim process.stdout.
  */
 
-process.stdout = require('browser-stdout')({level: false});
+process.stdout = require('browser-stdout')({label: false});
 
 var Mocha = require('./lib/mocha');
 


### PR DESCRIPTION
As noted by @plroebuck `level` is not used, should be `label` instead.

https://github.com/mochajs/mocha/commit/37193a432119be643b9476f97da557a6f60b7d0f#commitcomment-30530038