### PR TITLE
fix slow test for dot reporter

### DIFF
--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -8,7 +8,6 @@
 
 var Base = require('./base');
 var inherits = require('../utils').inherits;
-var color = Base.color;
 
 /**
  * Expose `Dot`.
@@ -41,7 +40,7 @@ function Dot(runner) {
     if (++n % width === 0) {
       process.stdout.write('\n  ');
     }
-    process.stdout.write(color('pending', Base.symbols.comma));
+    process.stdout.write(Base.color('pending', Base.symbols.comma));
   });
 
   runner.on('pass', function(test) {
@@ -49,9 +48,9 @@ function Dot(runner) {
       process.stdout.write('\n  ');
     }
     if (test.speed === 'slow') {
-      process.stdout.write(color('bright yellow', Base.symbols.dot));
+      process.stdout.write(Base.color('bright yellow', Base.symbols.dot));
     } else {
-      process.stdout.write(color(test.speed, Base.symbols.dot));
+      process.stdout.write(Base.color(test.speed, Base.symbols.dot));
     }
   });
 
@@ -59,7 +58,7 @@ function Dot(runner) {
     if (++n % width === 0) {
       process.stdout.write('\n  ');
     }
-    process.stdout.write(color('fail', Base.symbols.bang));
+    process.stdout.write(Base.color('fail', Base.symbols.bang));
   });
 
   runner.once('end', function() {


### PR DESCRIPTION
### Description of the Change
Although there is [a slow test case](https://github.com/mochajs/mocha/blob/master/test/reporters/dot.spec.js#L98-L107) for dot reporter, 
[coverage](https://coveralls.io/builds/19145852/source?filename=lib/reporters/dot.js#L51) is missed.
Since slow duration is 2(`slow: function() { return 2; }`) and test duration is 2 (`test.duration = 2;`), 
this test is not check slow test actually.

### Alternate Designs
N/A

### Why should this be in core?
Tests should be run as intended.