### PR TITLE
Support for nested options in reporterOptions

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -149,6 +149,12 @@ program
   .option('-C, --no-colors', 'force disabling of colors')
   .option('-G, --growl', 'enable growl notification support')
   .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
+  .option(
+    '-o, --reporter-option <k=v>',
+    'reporter-specific option',
+    collect,
+    []
+  )
   .option('-R, --reporter <name>', 'specify the reporter to use', 'spec')
   .option('-S, --sort', 'sort test files')
   .option('-b, --bail', 'bail after first test failure')
@@ -347,8 +353,9 @@ function addReporterOption(object, name, value) {
   }
 }
 
-if (program.reporterOptions !== undefined) {
-  program.reporterOptions.split(',').forEach(opt => {
+program.reporterOption
+  .concat(program.reporterOptions ? program.reporterOptions.split(',') : [])
+  .forEach(opt => {
     const L = opt.split('=');
     if (L.length > 2 || L.length === 0) {
       throw new Error(`invalid reporter option '${opt}'`);
@@ -358,7 +365,6 @@ if (program.reporterOptions !== undefined) {
       addReporterOption(reporterOptions, L[0].split('.'), true);
     }
   });
-}
 
 // reporter
 

--- a/bin/_mocha
+++ b/bin/_mocha
@@ -335,15 +335,27 @@ Error.stackTraceLimit = Infinity; // TODO: config
 // reporter options
 
 const reporterOptions = {};
+
+function addReporterOption(object, name, value) {
+  if (name.length === 1) {
+    object[name[0]] = value;
+  } else {
+    if (!object[name[0]]) {
+      object[name[0]] = {};
+    }
+    addReporterOption(object[name[0]], name.slice(1), value);
+  }
+}
+
 if (program.reporterOptions !== undefined) {
   program.reporterOptions.split(',').forEach(opt => {
     const L = opt.split('=');
     if (L.length > 2 || L.length === 0) {
       throw new Error(`invalid reporter option '${opt}'`);
     } else if (L.length === 2) {
-      reporterOptions[L[0]] = L[1];
+      addReporterOption(reporterOptions, L[0].split('.'), L[1]);
     } else {
-      reporterOptions[L[0]] = true;
+      addReporterOption(reporterOptions, L[0].split('.'), true);
     }
   });
 }

--- a/test/integration/fixtures/options-reporter.js
+++ b/test/integration/fixtures/options-reporter.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var baseReporter = require('../../../lib/reporters/base');
+module.exports = optionsreporter;
+
+function optionsreporter(runner, options) {
+  baseReporter.call(this, runner, options);
+
+  console.log(JSON.stringify(options.reporterOptions));
+}

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -540,6 +540,48 @@ describe('options', function() {
         done
       );
     });
+
+    it('should accept multiple --reporter-option arguments', function(done) {
+      runMochaTest(
+        [
+          '--reporter',
+          'test/integration/fixtures/options-reporter.js',
+          '--reporter-option',
+          'value1=a',
+          '--reporter-option',
+          'value2=b'
+        ],
+        function(res) {
+          expect(res, 'to equal', {
+            value1: 'a',
+            value2: 'b'
+          });
+        },
+        done
+      );
+    });
+
+    it('should accept nested options to --reporter-option', function(done) {
+      runMochaTest(
+        [
+          '--reporter',
+          'test/integration/fixtures/options-reporter.js',
+          '--reporter-option',
+          'nested.value1=a',
+          '--reporter-option',
+          'nested.value2=b'
+        ],
+        function(res) {
+          expect(res, 'to equal', {
+            nested: {
+              value1: 'a',
+              value2: 'b'
+            }
+          });
+        },
+        done
+      );
+    });
   });
 
   if (process.platform !== 'win32') {

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -505,6 +505,43 @@ describe('options', function() {
     });
   });
 
+  describe('--reporter-options', function() {
+    /*
+     * Runs mocha in {path} with the given args.
+     * Calls handleResult with the result.
+     */
+    function runMochaTest(args, handleResult, done) {
+      helpers.runMocha('passing.fixture.js', args, function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        handleResult(JSON.parse(res.output));
+        done();
+      });
+    }
+
+    it('should accept nested options to --reporter-options', function(done) {
+      runMochaTest(
+        [
+          '--reporter',
+          'test/integration/fixtures/options-reporter.js',
+          '--reporter-options',
+          'nested.value1=a,nested.value2=b'
+        ],
+        function(res) {
+          expect(res, 'to equal', {
+            nested: {
+              value1: 'a',
+              value2: 'b'
+            }
+          });
+        },
+        done
+      );
+    });
+  });
+
   if (process.platform !== 'win32') {
     // Windows: Feature works but SIMULATING the signal (ctr+c), via child process, does not work
     // due to lack of *nix signal compliance.


### PR DESCRIPTION
### Description of the Change

Supporting nested reporter options to be passed on the command line. Example:

```bash
mocha --reporter mocha-multi --reporter-options xunit.stdout=-,xunit.options.suiteName=MySuiteName
```

This is useful when using the mocha-multi reporter, to be able to specify multiple reporters and pass options to each of them.

### Alternate Designs

No other designs considered

### Why should this be in core?

Since mocha owns the reporter-options argument, it also has to own the parsing of it.

### Benefits

It will be possible to pass options to reporters, when using the mocha-multi reporter.

### Possible Drawbacks

None that I can think of

### Applicable issues

This should be a minor release
