### PR TITLE
Updated assetgraph-builder version for libvips in arm architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -474,7 +474,7 @@
   },
   "devDependencies": {
     "@mocha/docdash": "^1.0.1",
-    "assetgraph-builder": "^5.9.1",
+    "assetgraph-builder": "^6.4.2",
     "browserify": "^16.2.2",
     "chai": "^4.1.2",
     "coffee-script": "^1.10.0",


### PR DESCRIPTION
**Modification:**
assetgraph-builder version from 5.9.1 to 6.4.2 in package.json

**Before Modification:**
Was facing libvips download error while installing assetgraph-builder(sub-dependency sharp) dependency. Please look at below error logs for same:
**> sharp@0.17.3 install /mocha/node_modules/sharp
> node-gyp rebuild

ERROR: Download of https://dl.bintray.com/lovell/sharp/libvips-8.4.2-linux-arm64.tar.gz failed: Response code 404 (Not Found)**

**After Modification**
libvips is getting downloaded with tar file **libvips-8.6.1-linux-armv8.tar.gz**

**System Details:**
  uname -a
Linux e7fac9d4ba1c 4.10.0-38-generic #42~16.04.1-Ubuntu SMP Tue Oct 10 16:33:57 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux
node -v
v10.9.0

Update is required to run mocha in arm architecture.