### PR TITLE
3483: Squelch CI Growl-related spawn errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+###
+### .travis.yml
+###
+
 # these are executed in order.  each must pass for the next to be run
 stages:
   - smoke # this ensures a "user" install works properly
@@ -8,6 +12,10 @@ stages:
 # defaults
 language: node_js
 node_js: '10'
+addons:
+  apt:
+    packages:
+    - libnotify-bin
 # `nvm install` happens before the cache is restored, which means
 # we must install our own npm elsewhere (`~/npm`)
 before_install: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,72 @@
-platform:
-  - x64
+###
+### appveyor.yml
+###
+
+## General configuration
+version: '{build}'
+skip_commits:
+  message: /\[ci\s+skip\]/
+
+## Environment configuration
+shallow_clone: true
+clone_depth: 1
 environment:
   matrix:
     - nodejs_version: '10'
     - nodejs_version: '9'
     - nodejs_version: '8'
     - nodejs_version: '6'
-install:
-  - ps: Install-Product node $env:nodejs_version x64
-  - set CI=true
-  - set PATH=%APPDATA%\npm;c:\MinGW\bin;%PATH%
-  - npm install -g npm@^5
-  - npm ci --ignore-scripts
 matrix:
   fast_finish: true
-build: off
-version: '{build}'
-shallow_clone: true
-clone_depth: 1
+install:
+  ## Manual Growl install
+  - ps: Add-AppveyorMessage "Installing Growl..."
+  - ps: $exePath = "$($env:USERPROFILE)\GrowlInstaller.exe"
+  - ps: (New-Object Net.WebClient).DownloadFile('http://www.growlforwindows.com/gfw/downloads/GrowlInstaller.exe', $exePath)
+  - ps: mkdir C:\GrowlInstaller | out-null
+  - ps: 7z x $exePath -oC:\GrowlInstaller | out-null
+  - ps: cmd /c start /wait msiexec /i C:\GrowlInstaller\Growl_v2.0.msi /quiet
+  - ps: $env:path = "C:\Program Files (x86)\Growl for Windows;$env:path"
+  ## Node-related installs
+  - ps: Add-AppveyorMessage "Installing Node..."
+  - set PATH=%APPDATA%\npm;C:\MinGW\bin;%PATH%
+  - ps: Install-Product node $env:nodejs_version x64
+  - ps: Add-AppveyorMessage "Installing npm..."
+  - npm install -g npm@^5
+  ## Mocha-related package installs
+  - ps: Add-AppveyorMessage "Installing Mocha dependencies..."
+  - npm ci --ignore-scripts
+
+## Build configuration
+platform:
+  - x64
+build: script
+before_build:
+  ## Growl requires some time before it's ready to handle notifications
+  - ps: Start-Process -NoNewWindow Growl
+  - ps: Add-AppveyorMessage "Started Growl service..."
+  - ps: Start-Sleep -Milliseconds 2000
+build_script:
+  ## Placeholder command
+  - ps: Start-Sleep -Milliseconds 0
+  #- ps: Add-AppveyorMessage "Verify Growl responding..."
+  #- ps: growlnotify test
+
+## Test configuration
+before_test:
+  - set CI=true
 test_script:
+  - ps: Add-AppveyorMessage "Displaying version information"
   - node --version
   - npm --version
+  - ps: Add-AppveyorMessage "Running tests..."
   - npm start test.node
-skip_commits:
-  message: /\[ci\s+skip\]/
+  - ps: Add-AppveyorMessage "Done"
+
+## Notifications
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
 


### PR DESCRIPTION
### Description of the Change

Installed binary needed for Linux desktop notification support as part of TravisCI job setup.
Installed binary needed for Windows desktop notification support as part of Appveyor job setup.

### Alternate Designs

N/A

### Why should this be in core?

N/A

### Benefits

Misleading Growl-related spawn errors (unrelated to what is being tested) will no longer appear
in TravisCI nor Appveyor job output.

### Possible Drawbacks

Tests will take slightly longer (<10s) to complete due to APT package install on TravisCI.
Timing not provided for Appveyor.

### Applicable issues

Fixes #3483
semver-patch
