### PR TITLE
make isPromise support null as a parameter

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -688,7 +688,7 @@ exports.stackTraceFilter = function() {
  * @returns {boolean} Whether or not `value` is a Promise
  */
 exports.isPromise = function isPromise(value) {
-  return typeof value === 'object' && typeof value.then === 'function';
+  return typeof value === 'object' && value && typeof value.then === 'function';
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -688,7 +688,11 @@ exports.stackTraceFilter = function() {
  * @returns {boolean} Whether or not `value` is a Promise
  */
 exports.isPromise = function isPromise(value) {
-  return typeof value === 'object' && value && typeof value.then === 'function';
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.then === 'function'
+  );
 };
 
 /**

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -591,6 +591,10 @@ describe('lib/utils', function() {
     it('should return false if the value is an object w/o a "then" function', function() {
       expect(utils.isPromise({}), 'to be', false);
     });
+
+    it('should return false if the object is null', function() {
+      expect(utils.isPromise(null), 'to be', false);
+    });
   });
 
   describe('escape', function() {


### PR DESCRIPTION

### Description of the Change

isPromise would crash if given `null`, so I made it check for null too.

---
This is an enhancement.
