### PR TITLE
test(base.spec.js): Fix Base reporter test failure due to timeout

### DIFF
--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -312,6 +312,7 @@ describe('Base reporter', function() {
   });
 
   it('should interpret Chai custom error messages', function() {
+    this.timeout(1000);
     var chaiExpect = require('chai').expect;
     try {
       chaiExpect(43, 'custom error message').to.equal(42);


### PR DESCRIPTION
### Description of the Change

The `Base` reporter's specification verifies reporter can interpret Chai custom error messages.
This test takes ~480ms on my somewhat memory-starved computer, which is _way_ too close to the 500ms timeout.
Change doubles this timeout.

### Alternate Designs

* Could move the Chai require (which is likely culprit), but its scope would expand.
* Could increase timeout, but retain the existing Chai require's test scope.

### Benefits

Prevention of random test failure due to timing issue.
Failure strikes often on Appveyor (for me anyway).

### Possible Drawbacks

None to knowledge.

### Applicable issues

Fixes #3524
semver-patch