### PR TITLE
update commander to show empty array as default value

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -157,9 +157,17 @@ program
   .option('-f, --fgrep <string>', 'only run tests containing <string>')
   .option('-gc, --expose-gc', 'expose gc extension')
   .option('-i, --invert', 'inverts --grep and --fgrep matches')
-  .option('-r, --require <name>', 'require the given module')
-  .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
-  .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
+  .option('-r, --require <name>', 'require the given module', [])
+  .option(
+    '-s, --slow <ms>',
+    'specify "slow" test threshold in milliseconds',
+    75
+  )
+  .option(
+    '-t, --timeout <ms>',
+    'specify test timeout threshold in milliseconds',
+    2000
+  )
   .option(
     '-u, --ui <name>',
     `specify user-interface (${interfaceNames.join('|')})`,
@@ -204,7 +212,7 @@ program
     '--inspect-brk',
     'activate devtools in chrome and break on the first line'
   )
-  .option('--interfaces', 'display available interfaces')
+  .option('--interfaces', 'output provided interfaces and exit')
   .option('--no-deprecation', 'silence deprecation warnings')
   .option(
     '--exit',
@@ -218,10 +226,11 @@ program
   .option('--prof', 'log statistical profiling information')
   .option('--log-timer-events', 'Time events including external callbacks')
   .option('--recursive', 'include sub directories')
-  .option('--reporters', 'display available reporters')
+  .option('--reporters', 'output provided reporters and exit')
   .option(
     '--retries <times>',
-    'set numbers of time to retry a failed test case'
+    'specify number of times to retry a failed test case',
+    0
   )
   .option(
     '--throw-deprecation',
@@ -246,11 +255,16 @@ program
   )
   .option(
     '--file <file>',
-    'include a file to be ran during the suite',
+    'adds file be loaded prior to suite execution',
     collect,
     []
   )
-  .option('--exclude <file>', 'a file or glob pattern to ignore', collect, []);
+  .option(
+    '--exclude <file>',
+    'adds file or glob pattern to ignore',
+    collect,
+    []
+  );
 
 program._name = 'mocha';
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -779,73 +779,71 @@ Mocha supports the `err.expected` and `err.actual` properties of any thrown `Ass
 
 ## Usage
 
-```text
-  Usage: mocha [debug] [options] [files]
+```console
+Usage: mocha [debug] [options] [files]
 
-  Options:
+Options:
+  -V, --version                           output the version number
+  -A, --async-only                        force all tests to take a callback (async) or return a promise
+  -c, --colors                            force enabling of colors
+  -C, --no-colors                         force disabling of colors
+  -G, --growl                             enable growl notification support
+  -O, --reporter-options <k=v,k2=v2,...>  reporter-specific options
+  -R, --reporter <name>                   specify the reporter to use (default: "spec")
+  -S, --sort                              sort test files
+  -b, --bail                              bail after first test failure
+  -d, --debug                             enable node's debugger, synonym for node --debug
+  -g, --grep <pattern>                    only run tests matching <pattern>
+  -f, --fgrep <string>                    only run tests containing <string>
+  -gc, --expose-gc                        expose gc extension
+  -i, --invert                            inverts --grep and --fgrep matches
+  -r, --require <name>                    require the given module (default: [])
+  -s, --slow <ms>                         specify "slow" test threshold in milliseconds (default: 75)
+  -t, --timeout <ms>                      specify test timeout threshold in milliseconds (default: 2000)
+  -u, --ui <name>                         specify user-interface (bdd|tdd|qunit|exports) (default: "bdd")
+  -w, --watch                             watch files in the current working directory for changes
+  --check-leaks                           check for global variable leaks
+  --full-trace                            display the full stack trace
+  --compilers <ext>:<module>,...          use the given module(s) to compile files (default: [])
+  --debug-brk                             enable node's debugger breaking on the first line
+  --globals <names>                       allow the given comma-delimited global [names] (default: [])
+  --es_staging                            enable all staged features
+  --harmony<_classes,_generators,...>     all node --harmony* flags are available
+  --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
+  --icu-data-dir                          include ICU data
+  --inline-diffs                          display actual/expected differences inline within each string
+  --no-diff                               do not show a diff on failure
+  --inspect                               activate devtools in chrome
+  --inspect-brk                           activate devtools in chrome and break on the first line
+  --interfaces                            output provided interfaces and exit
+  --no-deprecation                        silence deprecation warnings
+  --exit                                  force shutdown of the event loop after test run: mocha will call process.exit
+  --no-timeouts                           disables timeouts, given implicitly with --debug
+  --no-warnings                           silence all node process warnings
+  --opts <path>                           specify opts path (default: "test/mocha.opts")
+  --perf-basic-prof                       enable perf linux profiler (basic support)
+  --napi-modules                          enable experimental NAPI modules
+  --prof                                  log statistical profiling information
+  --log-timer-events                      Time events including external callbacks
+  --recursive                             include sub directories
+  --reporters                             output provided reporters and exit
+  --retries <times>                       specify number of times to retry a failed test case (default: 0)
+  --throw-deprecation                     throw an exception anytime a deprecated function is used
+  --trace                                 trace function calls
+  --trace-deprecation                     show stack traces on deprecations
+  --trace-warnings                        show stack traces on node process warnings
+  --use_strict                            enforce strict mode
+  --watch-extensions <ext>,...            specify extensions to monitor with --watch (default: ["js"])
+  --delay                                 wait for async suite definition
+  --allow-uncaught                        enable uncaught errors to propagate
+  --forbid-only                           causes test marked with only to fail the suite
+  --forbid-pending                        causes pending tests and test marked with skip to fail the suite
+  --file <file>                           adds file be loaded prior to suite execution (default: [])
+  --exclude <file>                        adds file or glob pattern to ignore (default: [])
+  -h, --help                              output usage information
 
-    -V, --version                           output the version number
-    -A, --async-only                        force all tests to take a callback (async) or return a promise
-    -c, --colors                            force enabling of colors
-    -C, --no-colors                         force disabling of colors
-    -G, --growl                             enable growl notification support
-    -O, --reporter-options <k=v,k2=v2,...>  reporter-specific options
-    -R, --reporter <name>                   specify the reporter to use (default: spec)
-    -S, --sort                              sort test files
-    -b, --bail                              bail after first test failure
-    -d, --debug                             enable node's debugger, synonym for node --debug
-    -g, --grep <pattern>                    only run tests matching <pattern>
-    -f, --fgrep <string>                    only run tests containing <string>
-    -gc, --expose-gc                        expose gc extension
-    -i, --invert                            inverts --grep and --fgrep matches
-    -r, --require <name>                    require the given module
-    -s, --slow <ms>                         "slow" test threshold in milliseconds [75]
-    -t, --timeout <ms>                      set test-case timeout in milliseconds [2000]
-    -u, --ui <name>                         specify user-interface (bdd|tdd|qunit|exports) (default: bdd)
-    -w, --watch                             watch files in the current working directory for changes
-    --check-leaks                           check for global variable leaks
-    --full-trace                            display the full stack trace
-    --compilers <ext>:<module>,...          use the given module(s) to compile files (default: )
-    --debug-brk                             enable node's debugger breaking on the first line
-    --globals <names>                       allow the given comma-delimited global [names] (default: )
-    --es_staging                            enable all staged features
-    --harmony<_classes,_generators,...>     all node --harmony* flags are available
-    --preserve-symlinks                     Instructs the module loader to preserve symbolic links when resolving and caching modules
-    --icu-data-dir                          include ICU data
-    --inline-diffs                          display actual/expected differences inline within each string
-    --no-diff                               do not show a diff on failure
-    --inspect                               activate devtools in chrome
-    --inspect-brk                           activate devtools in chrome and break on the first line
-    --interfaces                            display available interfaces
-    --no-deprecation                        silence deprecation warnings
-    --exit                                  force shutdown of the event loop after test run: mocha will call process.exit
-    --no-timeouts                           disables timeouts, given implicitly with --debug
-    --no-warnings                           silence all node process warnings
-    --opts <path>                           specify opts path (default: test/mocha.opts)
-    --perf-basic-prof                       enable perf linux profiler (basic support)
-    --napi-modules                          enable experimental NAPI modules
-    --prof                                  log statistical profiling information
-    --log-timer-events                      Time events including external callbacks
-    --recursive                             include sub directories
-    --reporters                             display available reporters
-    --retries <times>                       set numbers of time to retry a failed test case
-    --throw-deprecation                     throw an exception anytime a deprecated function is used
-    --trace                                 trace function calls
-    --trace-deprecation                     show stack traces on deprecations
-    --trace-warnings                        show stack traces on node process warnings
-    --use_strict                            enforce strict mode
-    --watch-extensions <ext>,...            specify extensions to monitor with --watch (default: js)
-    --delay                                 wait for async suite definition
-    --allow-uncaught                        enable uncaught errors to propagate
-    --forbid-only                           causes test marked with only to fail the suite
-    --forbid-pending                        causes pending tests and test marked with skip to fail the suite
-    --file <file>                           include a file to be ran during the suite (default: )
-    --exclude <file>                        a file or glob pattern to ignore (default: )
-    -h, --help                              output usage information
-
-  Commands:
-
-    init <path>  initialize a client-side mocha setup at <path>
+Commands:
+  init <path>                             initialize a client-side mocha setup at <path>
 ```
 
 ### `-w, --watch`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2026,9 +2026,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
     "comment-regex": {
       "version": "1.0.1",
@@ -5939,6 +5939,12 @@
         "uglify-js": "3.3.x"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -17954,6 +17960,12 @@
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -461,7 +461,7 @@
   },
   "dependencies": {
     "browser-stdout": "1.3.1",
-    "commander": "2.15.1",
+    "commander": "2.19.0",
     "debug": "3.1.0",
     "diff": "3.5.0",
     "escape-string-regexp": "1.0.5",


### PR DESCRIPTION
### Description of the Change
In `mocha`'s help, it shows nothing if the default value is an empty array. It is confusing for users.
```console
--globals <names>                       allow the given comma-delimited global [names] (default: )
```

[commander v2.19.0](https://github.com/tj/commander.js/releases/tag/v2.19.0) fixed the display of falsy default values in its `--help` output.

This change updates our package dependency to this version of `tj/commander.js`.

### Alternate Designs
N/A

### Why should this be in core?
`default: ` without a value is rather meaningless.

### Benefits
Now, it will show:
```console
--globals <names>                       allow the given comma-delimited global [names] (default: [])
```

### Applicable issues
Fixes #3433
See [tj/commander.js/#855](https://github.com/tj/commander.js/issues/855)