### PR TITLE
refactor(json-stream.js): Consistent output stream usage

### DIFF
--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -51,7 +51,7 @@ function JSONStream(runner) {
 
 /**
  * Mocha event to be written to the output stream.
- * @typedef {*[]} JSONStream~MochaEvent
+ * @typedef {Array} JSONStream~MochaEvent
  */
 
 /**

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -9,55 +9,68 @@
 var Base = require('./base');
 
 /**
- * Expose `List`.
+ * Expose `JSONStream`.
  */
 
-exports = module.exports = List;
+exports = module.exports = JSONStream;
 
 /**
- * Initialize a new `JSONStream` test reporter.
+ * Constructs a new `JSONStream` reporter instance.
  *
  * @public
- * @name JSONStream
- * @class JSONStream
- * @memberof Mocha.reporters
+ * @class
  * @extends Mocha.reporters.Base
- * @api public
- * @param {Runner} runner
+ * @memberof Mocha.reporters
+ * @param {Runner} runner - Instance triggers reporter actions.
  */
-function List(runner) {
+function JSONStream(runner) {
   Base.call(this, runner);
 
   var self = this;
   var total = runner.total;
 
-  runner.on('start', function() {
-    console.log(JSON.stringify(['start', {total: total}]));
+  runner.once('start', function() {
+    writeEvent(['start', {total: total}]);
   });
 
   runner.on('pass', function(test) {
-    console.log(JSON.stringify(['pass', clean(test)]));
+    writeEvent(['pass', clean(test)]);
   });
 
   runner.on('fail', function(test, err) {
     test = clean(test);
     test.err = err.message;
     test.stack = err.stack || null;
-    console.log(JSON.stringify(['fail', test]));
+    writeEvent(['fail', test]);
   });
 
   runner.once('end', function() {
-    process.stdout.write(JSON.stringify(['end', self.stats]));
+    writeEvent(['end', self.stats]);
   });
 }
 
 /**
- * Return a plain-object representation of `test`
- * free of cyclic properties etc.
+ * Mocha event to be written to the output stream.
+ * @typedef {*[]} JSONStream~MochaEvent
+ */
+
+/**
+ * Writes Mocha event to reporter output stream.
  *
- * @api private
- * @param {Object} test
- * @return {Object}
+ * @private
+ * @param {JSONStream~MochaEvent} event - Mocha event to be output.
+ */
+function writeEvent(event) {
+  process.stdout.write(JSON.stringify(event) + '\n');
+}
+
+/**
+ * Returns an object literal representation of `test`
+ * free of cyclic properties, etc.
+ *
+ * @private
+ * @param {Test} test - Instance used as data source.
+ * @return {Object} object containing pared-down test instance data
  */
 function clean(test) {
   return {


### PR DESCRIPTION
### Description of the Change

* Made all output directly use `process.stdout`. 
  * `process.stdout` and `console.log` take different routes to get to same place
* Corrected ctor name.
* Updated documentation.

### Alternate Designs

N/A

### Benefits

Consistency. [Don't cross the streams](https://www.youtube.com/watch?v=wyKQe_i9yyo)!

### Possible Drawbacks

N/A

### Applicable issues

Fixes #3526
Fixes #3521
semver-patch
