### PR TITLE
Prevent timeout value from skirting limit check

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -47,7 +47,15 @@ function Runnable(title, fn) {
 /**
  * Inherit from `EventEmitter.prototype`.
  */
-utils.inherits(Runnable, EventEmitter); /**
+utils.inherits(Runnable, EventEmitter);
+
+/**
+ * Get current timeout value in msecs.
+ *
+ * @private
+ * @returns {number} current timeout threshold value
+ */
+/**
  * @summary
  * Set timeout threshold value (msecs).
  *
@@ -60,13 +68,7 @@ utils.inherits(Runnable, EventEmitter); /**
  * @returns {Runnable} this
  * @chainable
  */
-
-/**
- * Get current timeout value in msecs.
- *
- * @private
- * @returns {number} current timeout threshold value
- */ Runnable.prototype.timeout = function(ms) {
+Runnable.prototype.timeout = function(ms) {
   if (!arguments.length) {
     return this._timeout;
   }

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -60,10 +60,12 @@ utils.inherits(Runnable, EventEmitter);
  * Set timeout threshold value (msecs).
  *
  * @description
- * A string argument can use shorthand (such as "2s") and will be converted.
- * If value is `0` or exceeds `2^<sup>31</sup>-1`, timeouts will be disabled.
+ * A string argument can use shorthand (e.g., "2s") and will be converted.
+ * The value will be clamped to range [<code>0</code>, <code>2^<sup>31</sup>-1</code>].
+ * If clamped value matches either range endpoint, timeouts will be disabled.
  *
  * @private
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Maximum_delay_value}
  * @param {number|string} ms - Timeout threshold value.
  * @returns {Runnable} this
  * @chainable
@@ -75,8 +77,14 @@ Runnable.prototype.timeout = function(ms) {
   if (typeof ms === 'string') {
     ms = milliseconds(ms);
   }
+
+  // Clamp to range
+  var INT_MAX = Math.pow(2, 31) - 1;
+  var range = [0, INT_MAX];
+  ms = utils.clamp(ms, range);
+
   // see #1652 for reasoning
-  if (ms === 0 || ms > Math.pow(2, 31) - 1) {
+  if (ms === range[0] || ms === range[1]) {
     this._enableTimeouts = false;
   }
   debug('timeout %d', ms);

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -61,7 +61,7 @@ utils.inherits(Runnable, EventEmitter);
  *
  * @description
  * A string argument can use shorthand (such as "2s") and will be converted.
- * If the value is `0` or exceeds `2^<sup>31</sup>`, timeouts will be disabled.
+ * If value is `0` or exceeds `2^<sup>31</sup>-1`, timeouts will be disabled.
  *
  * @private
  * @param {number|string} ms - Timeout threshold value.
@@ -76,7 +76,7 @@ Runnable.prototype.timeout = function(ms) {
     ms = milliseconds(ms);
   }
   // see #1652 for reasoning
-  if (ms === 0 || ms > Math.pow(2, 31)) {
+  if (ms === 0 || ms > Math.pow(2, 31) - 1) {
     this._enableTimeouts = false;
   }
   debug('timeout %d', ms);

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -47,25 +47,35 @@ function Runnable(title, fn) {
 /**
  * Inherit from `EventEmitter.prototype`.
  */
-utils.inherits(Runnable, EventEmitter);
+utils.inherits(Runnable, EventEmitter); /**
+ * @summary
+ * Set timeout threshold value (msecs).
+ *
+ * @description
+ * A string argument can use shorthand (such as "2s") and will be converted.
+ * If the value is `0` or exceeds `2^<sup>31</sup>`, timeouts will be disabled.
+ *
+ * @private
+ * @param {number|string} ms - Timeout threshold value.
+ * @returns {Runnable} this
+ * @chainable
+ */
 
 /**
- * Set & get timeout `ms`.
+ * Get current timeout value in msecs.
  *
- * @api private
- * @param {number|string} ms
- * @return {Runnable|number} ms or Runnable instance.
- */
-Runnable.prototype.timeout = function(ms) {
+ * @private
+ * @returns {number} current timeout threshold value
+ */ Runnable.prototype.timeout = function(ms) {
   if (!arguments.length) {
     return this._timeout;
+  }
+  if (typeof ms === 'string') {
+    ms = milliseconds(ms);
   }
   // see #1652 for reasoning
   if (ms === 0 || ms > Math.pow(2, 31)) {
     this._enableTimeouts = false;
-  }
-  if (typeof ms === 'string') {
-    ms = milliseconds(ms);
   }
   debug('timeout %d', ms);
   this._timeout = ms;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -664,6 +664,17 @@ exports.isPromise = function isPromise(value) {
 };
 
 /**
+ * Clamps a numeric value to an inclusive range.
+ *
+ * @param {number} value - Value to be clamped.
+ * @param {numer[]} range - Two element array specifying [min, max] range.
+ * @returns {number} clamped value
+ */
+exports.clamp = function clamp(value, range) {
+  return Math.min(Math.max(value, range[0]), range[1]);
+};
+
+/**
  * It's a noop.
  * @api
  */

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -46,18 +46,51 @@ describe('Runnable(title, fn)', function() {
   });
 
   describe('#timeout(ms)', function() {
-    it('should set the timeout', function() {
-      var run = new Runnable();
-      run.timeout(1000);
-      assert(run.timeout() === 1000);
-    });
-  });
+    var INT_MAX = 2147483647; // (32-bit signed integer)
 
-  describe('#timeout(ms) when ms>2^31', function() {
-    it('should set disabled', function() {
-      var run = new Runnable();
-      run.timeout(1e10);
-      assert(run.enableTimeouts() === false);
+    describe('when value is less than `setTimeout` limit', function() {
+      var oneSecond = 1000;
+
+      it('should set the timeout given numeric', function() {
+        var run = new Runnable();
+        run.timeout(oneSecond);
+        assert(run.timeout() === oneSecond);
+        assert(run.enableTimeouts() === true);
+      });
+      it('should set the timeout given timestamp', function() {
+        var run = new Runnable();
+        run.timeout('1s');
+        assert(run.timeout() === oneSecond);
+        assert(run.enableTimeouts() === true);
+      });
+    });
+
+    describe('when value is equal to `setTimeout` limit', function() {
+      it('should set the timeout given numeric', function() {
+        var run = new Runnable();
+        run.timeout(INT_MAX);
+        assert(run.timeout() === INT_MAX);
+        assert(run.enableTimeouts() === true);
+      });
+      it('should set the timeout given timestamp', function() {
+        var run = new Runnable();
+        run.timeout(INT_MAX + 'ms');
+        assert(run.timeout() === INT_MAX);
+        assert(run.enableTimeouts() === true);
+      });
+    });
+
+    describe('when value is greater than `setTimeout` limit', function() {
+      it('should disable timeouts given numeric', function() {
+        var run = new Runnable();
+        run.timeout(INT_MAX + 1);
+        assert(run.enableTimeouts() === false);
+      });
+      it('should disable timeouts given timestamp', function() {
+        var run = new Runnable();
+        run.timeout('24.9d'); // 2151360000ms
+        assert(run.enableTimeouts() === false);
+      });
     });
   });
 

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -46,9 +46,40 @@ describe('Runnable(title, fn)', function() {
   });
 
   describe('#timeout(ms)', function() {
-    var INT_MAX = 2147483647; // (32-bit signed integer)
+    var MIN_TIMEOUT = 0;
+    var MAX_TIMEOUT = 2147483647; // INT_MAX (32-bit signed integer)
 
-    describe('when value is less than `setTimeout` limit', function() {
+    describe('when value is less than lower bound', function() {
+      it('should clamp to lower bound given numeric', function() {
+        var run = new Runnable();
+        run.timeout(-1);
+        assert(run.timeout() === MIN_TIMEOUT);
+      });
+      // :TODO: Our internal version of `ms` can't handle negative time,
+      // but package version can. Skip this check until that change is merged.
+      it.skip('should clamp to lower bound given timestamp', function() {
+        var run = new Runnable();
+        run.timeout('-1 ms');
+        assert(run.timeout() === MIN_TIMEOUT);
+      });
+    });
+
+    describe('when value is equal to lower bound', function() {
+      it('should set the value and disable timeouts given numeric', function() {
+        var run = new Runnable();
+        run.timeout(MIN_TIMEOUT);
+        assert(run.timeout() === MIN_TIMEOUT);
+        assert(run.enableTimeouts() === false);
+      });
+      it('should set the value and disable timeouts given timestamp', function() {
+        var run = new Runnable();
+        run.timeout(MIN_TIMEOUT + 'ms');
+        assert(run.timeout() === MIN_TIMEOUT);
+        assert(run.enableTimeouts() === false);
+      });
+    });
+
+    describe('when value is within `setTimeout` bounds', function() {
       var oneSecond = 1000;
 
       it('should set the timeout given numeric', function() {
@@ -65,30 +96,32 @@ describe('Runnable(title, fn)', function() {
       });
     });
 
-    describe('when value is equal to `setTimeout` limit', function() {
-      it('should set the timeout given numeric', function() {
+    describe('when value is equal to upper bound', function() {
+      it('should set the value and disable timeout given numeric', function() {
         var run = new Runnable();
-        run.timeout(INT_MAX);
-        assert(run.timeout() === INT_MAX);
-        assert(run.enableTimeouts() === true);
+        run.timeout(MAX_TIMEOUT);
+        assert(run.timeout() === MAX_TIMEOUT);
+        assert(run.enableTimeouts() === false);
       });
-      it('should set the timeout given timestamp', function() {
+      it('should set the value and disable timeout given timestamp', function() {
         var run = new Runnable();
-        run.timeout(INT_MAX + 'ms');
-        assert(run.timeout() === INT_MAX);
-        assert(run.enableTimeouts() === true);
+        run.timeout(MAX_TIMEOUT + 'ms');
+        assert(run.timeout() === MAX_TIMEOUT);
+        assert(run.enableTimeouts() === false);
       });
     });
 
     describe('when value is greater than `setTimeout` limit', function() {
-      it('should disable timeouts given numeric', function() {
+      it('should clamp to upper bound given numeric', function() {
         var run = new Runnable();
-        run.timeout(INT_MAX + 1);
+        run.timeout(MAX_TIMEOUT + 1);
+        assert(run.timeout() === MAX_TIMEOUT);
         assert(run.enableTimeouts() === false);
       });
-      it('should disable timeouts given timestamp', function() {
+      it('should clamp to upper bound given timestamp', function() {
         var run = new Runnable();
         run.timeout('24.9d'); // 2151360000ms
+        assert(run.timeout() === MAX_TIMEOUT);
         assert(run.enableTimeouts() === false);
       });
     });


### PR DESCRIPTION
### Description of the Change

Original PR _partially_ fixed the problem of specifying a timeout value that was too large;
unfortunately, it did not account for string-based timestamp translation.
This corrects that, and updates the function documentation.

### Alternate Designs

N/A

### Why should this be in core?

N/A

### Benefits

All timeout values are now range limited, as originally intended.

### Possible Drawbacks

None.

### Applicable issues

Fixes #1652
Fixes #2951 
semver-patch