### PR TITLE
Normalize Mocha tests to have realistic timings

### DIFF
--- a/test/integration/compiler-globbing.spec.js
+++ b/test/integration/compiler-globbing.spec.js
@@ -5,6 +5,7 @@ var path = require('path');
 
 describe('globbing like --compilers', function() {
   it('should find a file of each type', function(done) {
+    this.slow(900);
     exec(
       '"' +
         process.execPath +

--- a/test/integration/glob.spec.js
+++ b/test/integration/glob.spec.js
@@ -6,6 +6,7 @@ var path = require('path');
 var node = '"' + process.execPath + '"';
 
 describe('globbing', function() {
+  this.slow(600);
   describe('by the shell', function() {
     it('should find the first level test', function(done) {
       testGlob.shouldSucceed(

--- a/test/integration/hooks.spec.js
+++ b/test/integration/hooks.spec.js
@@ -7,6 +7,7 @@ var splitRegExp = require('./helpers').splitRegExp;
 var args = ['--reporter', 'dot'];
 
 describe('hooks', function() {
+  this.slow(900);
   it('are ran in correct order', function(done) {
     runMocha('cascade.fixture.js', args, function(err, res) {
       var lines, expected;

--- a/test/integration/no-diff.spec.js
+++ b/test/integration/no-diff.spec.js
@@ -4,6 +4,7 @@ var helpers = require('./helpers');
 var run = helpers.runMocha;
 
 describe('no-diff', function() {
+  this.slow(900);
   describe('when enabled', function() {
     it('should not display a diff', function(done) {
       run('no-diff.fixture.js', ['--no-diff'], function(err, res) {

--- a/test/integration/only.spec.js
+++ b/test/integration/only.spec.js
@@ -4,6 +4,7 @@ var run = require('./helpers').runMochaJSON;
 var assert = require('assert');
 
 describe('.only()', function() {
+  this.slow(900);
   describe('bdd', function() {
     it('should run only tests that marked as `only`', function(done) {
       run('options/only/bdd.fixture.js', ['--ui', 'bdd'], function(err, res) {

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -7,6 +7,7 @@ var splitRegExp = require('./helpers').splitRegExp;
 var args = [];
 
 describe('pending', function() {
+  this.slow(900);
   describe('pending specs', function() {
     it('should be created by omitting a function', function(done) {
       run('pending/spec.fixture.js', args, function(err, res) {

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -4,6 +4,7 @@ var run = require('./helpers').runMocha;
 var runJSON = require('./helpers').runMochaJSON;
 
 describe('regressions', function() {
+  this.slow(900);
   it('issue-1327: should run all 3 specs exactly once', function(done) {
     var args = [];
     run('regression/issue-1327.fixture.js', args, function(err, res) {

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -35,6 +35,7 @@ describe('reporters', function() {
 
   describe('xunit', function() {
     it('prints test cases with --reporter-options output (issue: 1864)', function(done) {
+      this.slow(900);
       var randomStr = crypto.randomBytes(8).toString('hex');
       var tmpDir = os.tmpdir().replace(new RegExp(path.sep + '$'), '');
       var tmpFile = tmpDir + path.sep + 'test-issue-1864-' + randomStr + '.xml';
@@ -66,6 +67,7 @@ describe('reporters', function() {
   });
 
   describe('loader', function() {
+    this.slow(950);
     it('loads a reporter from a path relative to the current working directory', function(done) {
       var reporterAtARelativePath =
         'test/integration/fixtures/simple-reporter.js';

--- a/test/integration/retries.spec.js
+++ b/test/integration/retries.spec.js
@@ -6,6 +6,7 @@ var args = [];
 var bang = require('../../lib/reporters/base').symbols.bang;
 
 describe('retries', function() {
+  this.slow(950);
   it('are ran in correct order', function(done) {
     helpers.runMocha(
       'retries/hooks.fixture.js',

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -6,6 +6,7 @@ var args = [];
 
 describe('this.timeout()', function() {
   it('is respected by sync and async suites', function(done) {
+    this.slow(900);
     run('timeout.fixture.js', args, function(err, res) {
       if (err) {
         done(err);

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -5,6 +5,7 @@ var run = require('./helpers').runMochaJSON;
 var args = [];
 
 describe('uncaught exceptions', function() {
+  this.slow(900);
   it('handles uncaught exceptions from hooks', function(done) {
     run('uncaught-hook.fixture.js', args, function(err, res) {
       if (err) {

--- a/test/unit/timeout.spec.js
+++ b/test/unit/timeout.spec.js
@@ -15,6 +15,7 @@ describe('timeouts', function() {
 
   it('should allow overriding per-test', function(done) {
     this.timeout(200);
+    this.slow(200);
     setTimeout(function() {
       done();
     }, 50);


### PR DESCRIPTION
### Description of the Change

Add `.slow()` to tests which are normally taking longer time.

### Benefits

More clear view of actual slow tests.

### Possible Drawbacks

Should keep an eye on these test for later -- if they are getting even slower, then something's 🐟 !

### Applicable issues
Fixes #2597
semver-patch

See also #2837
