### PR TITLE
ci(Travis/Appveyor): Update Node versions in CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
           - node_modules # npm install, unlike npm ci, doesn't wipe node_modules
 
     - <<: *smoke
-      node_js: '9'
+      node_js: '10'
 
     - <<: *smoke
       node_js: '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ stages:
 
 # defaults
 language: node_js
-node_js: '10'
+node_js: '11'
 addons:
   apt:
     packages:
@@ -40,7 +40,7 @@ jobs:
 
     - &node
       script: npm start test.node
-      node_js: '9'
+      node_js: '10'
 
     - <<: *node
       node_js: '8'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,4 +69,3 @@ notifications:
     on_build_success: false
     on_build_failure: false
     on_build_status_changed: false
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ shallow_clone: true
 clone_depth: 1
 environment:
   matrix:
+    - nodejs_version: '11'
     - nodejs_version: '10'
-    - nodejs_version: '9'
     - nodejs_version: '8'
     - nodejs_version: '6'
 matrix:


### PR DESCRIPTION
### Description of the Change
Node-11 is [freshmeat](https://medium.com/@nodejs/october-brings-node-js-10-x-to-lts-and-node-js-11-to-current-ae19f8f12b51). Node-9 is officially dead -- technically, it reached its sell-by date at the end of June, but it took a while for us to figure out where the smell in the refrigerator was coming from.

As such, CI-wise:
* Node-11 becomes the _new_ default version of Node for build matrix.
* Node-9 removed from build matrix.

Changeover went smoothly -- everything working without issue. 

### Alternate Designs
N/A

### Why should this be in core?
N/A

### Benefits
Testing Mocha against all _officially_ supported versions of Node.

### Possible Drawbacks
None. Trivially reverted

### Applicable issues
Node.js Foundation RWG - [Release Schedule](https://github.com/nodejs/Release)
