### PR TITLE
build(ESLint/Git): Ignore JSDoc output directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,5 @@ coverage/
 mocha.js
 *.fixture.js
 docs/
+out/
 !lib/mocha.js

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ yarn.lock
 docs/_site
 docs/_dist
 docs/api
+out/
 .vscode/


### PR DESCRIPTION
### Description of the Change
Prettier-ESLint keeps busying itself with the JSDoc output directory, spewing hundreds of errors.
This tells both ESLint and Git to ignore the directory.

### Benefits

Allows local use of JSDoc without it affecting any potential commit.

### Possible Drawbacks

None

### Applicable issues

semver-patch
