### PR TITLE
Update '--no-timeouts' argument description

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -218,7 +218,10 @@ program
     '--exit',
     'force shutdown of the event loop after test run: mocha will call process.exit'
   )
-  .option('--no-timeouts', 'disables timeouts, given implicitly with --debug')
+  .option(
+    '--no-timeouts',
+    'disables timeouts, given implicitly with --debug/--inspect'
+  )
   .option('--no-warnings', 'silence all node process warnings')
   .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
   .option('--perf-basic-prof', 'enable perf linux profiler (basic support)')

--- a/docs/index.md
+++ b/docs/index.md
@@ -818,7 +818,7 @@ Options:
   --interfaces                            output provided interfaces and exit
   --no-deprecation                        silence deprecation warnings
   --exit                                  force shutdown of the event loop after test run: mocha will call process.exit
-  --no-timeouts                           disables timeouts, given implicitly with --debug
+  --no-timeouts                           disables timeouts, given implicitly with --debug/--inspect
   --no-warnings                           silence all node process warnings
   --opts <path>                           specify opts path (default: "test/mocha.opts")
   --perf-basic-prof                       enable perf linux profiler (basic support)


### PR DESCRIPTION
### Description of the Change
Previously undocumented that use of `--inspect` would disable timeouts.

### Alternate Designs
N/A

### Why should this be in core?
N/A

### Benefits
YA aspect of previously undocumented Mocha is no more.

### Possible Drawbacks
None.

### Applicable issues
Fixes #3519
semver-patch