### PR TITLE
ci(.travis.yml,appveyor.yml): Use current npm version in CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 before_install: |
   [[ ! -x ~/npm/node_modules/.bin/npm ]] && {
     # caching feature creates `~/npm` for us
-    cd ~/npm && npm install npm@^5
+    cd ~/npm && npm install npm
     cd -
   } || true
   # avoids bugs around https://github.com/travis-ci/travis-ci/issues/5092

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   - set PATH=%APPDATA%\npm;C:\MinGW\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version x64
   - ps: Add-AppveyorMessage "Installing npm..."
-  - npm install -g npm@^5
+  - npm install -g npm
   ## Mocha-related package installs
   - ps: Add-AppveyorMessage "Installing Mocha dependencies..."
   - npm ci --ignore-scripts


### PR DESCRIPTION
### Description of the Change
Mocha's requirement for using `npm-5` in CI scripts was due to `npm-6` dropping support for `Node-4`. As we have since dropped `Node-4` support, we should use the current version of `npm`. This _should_ have been done as part of PR 3364.

### Benefits
Eliminate `npm-5` "Unsupported Node version" warnings when run against current version of Node.

### Possible Drawbacks
None to knowledge.

### Applicable issues
See <https://github.com/mochajs/mocha/pull/3350#issuecomment-384703961>

Blocked by #3364 (merge after) 
semver-patch
