### PR TITLE
modified SIGINT handling #3570

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -196,19 +196,15 @@ exports.singleRun = (mocha, {files = [], exit = false} = {}) => {
   mocha.files = files;
   const runner = mocha.run(exit ? exitMocha : exitMochaLater);
 
-  process.on('SIGINT', function forceStop() {
-    if (forceStop.lock === undefined) {
-      forceStop.lock = true;
-      debug('aborting runner');
-      runner.abort();
+  process.once('SIGINT', () => {
+    debug('aborting runner');
+    runner.abort();
 
-      // This is a hack:
-      // Instead of `process.exit(130)`, set runner.failures to 130 (exit code for SIGINT)
-      // The amount of failures will be emitted as error code later
-      runner.failures = 130;
-      // Reraising the signal
-      setImmediate(() => process.kill(process.pid, 'SIGINT'));
-    }
+    // This is a hack:
+    // Instead of `process.exit(130)`, set runner.failures to 130 (exit code for SIGINT)
+    // The amount of failures will be emitted as error code later
+    runner.failures = 130;
+    setImmediate(() => process.kill(process.pid, 'SIGINT'));
   });
 };
 

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -196,14 +196,19 @@ exports.singleRun = (mocha, {files = [], exit = false} = {}) => {
   mocha.files = files;
   const runner = mocha.run(exit ? exitMocha : exitMochaLater);
 
-  process.on('SIGINT', () => {
-    debug('aborting runner');
-    runner.abort();
+  process.on('SIGINT', function forceStop() {
+    if (forceStop.lock === undefined) {
+      forceStop.lock = true;
+      debug('aborting runner');
+      runner.abort();
 
-    // This is a hack:
-    // Instead of `process.exit(130)`, set runner.failures to 130 (exit code for SIGINT)
-    // The amount of failures will be emitted as error code later
-    runner.failures = 130;
+      // This is a hack:
+      // Instead of `process.exit(130)`, set runner.failures to 130 (exit code for SIGINT)
+      // The amount of failures will be emitted as error code later
+      runner.failures = 130;
+      // Reraising the signal
+      setImmediate(() => process.kill(process.pid, 'SIGINT'));
+    }
   });
 };
 


### PR DESCRIPTION
### Requirements
* Fix for 'Unable to terminate tests manually, e.g via Ctrl+C when running tests in a terminal.'
* refer issue #3570 

### Description of the Change
* Updated the SIGINT handler.
* A function property set to check if 'SIGINT' was called first time.
* if 'SIGINT" is called first time,keep the current behavior. 
* invoke 'SIGINT' again after 2 seconds which will kill the current process if still running. 

### Applicable issues
see #3570 
