### PR TITLE
make lib/stats-collector a private API

### DIFF
--- a/lib/stats-collector.js
+++ b/lib/stats-collector.js
@@ -1,8 +1,15 @@
 'use strict';
 
 /**
+ * Provides a factory function for a {@link StatsCollector} object.
+ * @private
+ * @module
+ */
+
+/**
  * Test statistics collector.
  *
+ * @private
  * @typedef {Object} StatsCollector
  * @property {number} suites - integer count of suites run.
  * @property {number} tests - integer count of tests run.
@@ -15,14 +22,16 @@
  */
 
 /**
- * Provides stats such as test duration,
- * number of tests passed / failed etc.
+ * Provides stats such as test duration, number of tests passed / failed etc., by listening for events emitted by `runner`.
  *
- * @public
- * @memberof Mocha
- * @param {Runner} runner
+ * @private
+ * @param {Runner} runner - Runner instance
+ * @throws {TypeError} If falsy `runner`
  */
 function createStatsCollector(runner) {
+  /**
+   * @type StatsCollector
+   */
   var stats = {
     suites: 0,
     tests: 0,


### PR DESCRIPTION
Unless we have a good reason to do so, I think new APIs should default to private.

@craigtaub what are your thoughts?  Is there any valid use case for this (outside of how we're using it) that you can think of?

`semver-minor` since it's new stuff anyway, but doesn't really matter.