### PR TITLE
Behavior of after/afterEach hooks with --bail flag

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -907,7 +907,7 @@ Enforce a rule that tests must be written in "async" style, meaning each test pr
 
 ### `--bail, -b`
 
-Causes Mocha to stop running tests after the first test failure it encounters.
+Causes Mocha to stop running tests after the first test failure it encounters. Corresponding `after()` and `afterEach()` hooks are executed for potential cleanup.
 
 `--bail` does *not* imply `--exit`.
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -241,16 +241,14 @@ Runner.prototype.fail = function(test, err) {
   }
 
   this.emit('fail', test, err);
-  // if (this.suite.bail()) {
-  //   this.emit('end');
-  // }
 };
 
 /**
  * Fail the given `hook` with `err`.
  *
  * Hook failures work in the following pattern:
- * - If bail, then exit
+ * - If bail, run corresponding `after each` and `after` hooks,
+ *   then exit
  * - Failed `before` hook skips all tests in a suite and subsuites,
  *   but jumps to corresponding `after` hook
  * - Failed `before each` hook skips remaining tests in a
@@ -494,7 +492,7 @@ Runner.prototype.runTests = function(suite, fn) {
   function next(err, errSuite) {
     // if we bail after first err
     if (self.failures && suite._bail) {
-      return fn();
+      tests = [];
     }
 
     if (self._abort) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -241,9 +241,9 @@ Runner.prototype.fail = function(test, err) {
   }
 
   this.emit('fail', test, err);
-  if (this.suite.bail()) {
-    this.emit('end');
-  }
+  // if (this.suite.bail()) {
+  //   this.emit('end');
+  // }
 };
 
 /**

--- a/test/integration/fixtures/options/bail-async.fixture.js
+++ b/test/integration/fixtures/options/bail-async.fixture.js
@@ -3,21 +3,21 @@
 describe('suite1', function () {
   it('should display this spec', function () {});
 
-  it('should only display this error', function () {
+  it('should only display this error', function (done) {
     throw new Error('this should be displayed');
   });
 
-  it('should not display this error', function () {
+  it('should not display this error', function (done) {
     throw new Error('this should not be displayed');
   });
 });
 
 describe('suite2', function () {
-  before(function () {
+  before(function (done) {
     throw new Error('this hook should not be displayed');
   });
 
-  it('should not display this error', function () {
+  it('should not display this error', function (done) {
     throw new Error('this should not be displayed');
   });
 });

--- a/test/integration/fixtures/options/bail-with-afterEach.fixture.js
+++ b/test/integration/fixtures/options/bail-with-afterEach.fixture.js
@@ -25,10 +25,10 @@ describe('suite1', function () {
     });
     afterEach('afterEach suite1A', function () {
       runOrder.push('afterEach suite1A');
+      throw new Error('afterEach suite1A error');
     });
     after('after suite1A', function () {
       runOrder.push('after suite1A');
-      throw new Error('after suite1A error');
     });
   });
 

--- a/test/integration/fixtures/options/bail-with-before.fixture.js
+++ b/test/integration/fixtures/options/bail-with-before.fixture.js
@@ -1,11 +1,44 @@
 'use strict';
+var assert = require('assert');
 
 describe('suite1', function () {
-  before(function () {
-    throw new Error('this hook should be only displayed');
+  var runOrder = [];
+  before('before suite1', function () {
+    runOrder.push('before suite1');
+    throw new Error('before suite1 error');
+  });
+  beforeEach('beforeEach suite1', function () {
+    runOrder.push('beforeEach suite1 - should not run');
+  });
+  it('test suite1', function () {
+    runOrder.push('test suite1 - should not run');
   });
 
-  it('should not display this error', function () {
-    throw new Error('this should not be displayed');
+  describe('suite1A', function () {
+    before('before suite1A', function () {});
+    beforeEach('beforeEach suite1A', function () {}); 
+    it('test suite1A', function () {
+      runOrder.push('test suite1A - should not run');
+    });
+    afterEach('afterEach suite1A', function () {});
+    after('after suite1A', function () {});
   });
+
+  afterEach('afterEach suite1', function () {
+    runOrder.push('afterEach suite1 - should not run');
+  });
+  after('after suite1', function () {
+    runOrder.push('after suite1');
+    assert.deepStrictEqual(runOrder, ['before suite1', 'after suite1']);
+  });
+});
+
+describe('suite2', function () {
+  before('before suite2', function () {});
+  beforeEach('beforeEach suite2', function () {});
+  it('test suite2', function () {
+    runOrder.push('test suite2 - should not run');
+  });
+  afterEach('afterEach suite2', function () {});
+  after('after suite2', function () {});
 });

--- a/test/integration/fixtures/options/bail-with-beforeEach.fixture.js
+++ b/test/integration/fixtures/options/bail-with-beforeEach.fixture.js
@@ -8,28 +8,20 @@ describe('suite1', function () {
   });
   beforeEach('beforeEach suite1', function () {
     runOrder.push('beforeEach suite1');
+    throw new Error('beforeEach suite1 error');
   });
   it('test suite1', function () {
-    runOrder.push('test suite1');
+    runOrder.push('test suite1 - should not run');
   });
 
   describe('suite1A', function () {
-    before('before suite1A', function () {
-      runOrder.push('before suite1A');
-    });
-    beforeEach('beforeEach suite1A', function () {
-      runOrder.push('beforeEach suite1A');
-    }); 
+    before('before suite1A', function () {});
+    beforeEach('beforeEach suite1A', function () {}); 
     it('test suite1A', function () {
-      runOrder.push('test suite1A');
+      runOrder.push('test suite1A - should not run');
     });
-    afterEach('afterEach suite1A', function () {
-      runOrder.push('afterEach suite1A');
-    });
-    after('after suite1A', function () {
-      runOrder.push('after suite1A');
-      throw new Error('after suite1A error');
-    });
+    afterEach('afterEach suite1A', function () {});
+    after('after suite1A', function () {});
   });
 
   afterEach('afterEach suite1', function () {
@@ -38,10 +30,7 @@ describe('suite1', function () {
   after('after suite1', function () {
     runOrder.push('after suite1');
     assert.deepStrictEqual(runOrder, [
-      'before suite1', 'beforeEach suite1', 'test suite1',
-      'afterEach suite1', 'before suite1A', 'beforeEach suite1',
-      'beforeEach suite1A', 'test suite1A', 'afterEach suite1A',
-      'afterEach suite1', 'after suite1A', 'after suite1'
+      'before suite1', 'beforeEach suite1', 'afterEach suite1', 'after suite1'
     ]);
   });
 });

--- a/test/integration/fixtures/options/bail-with-test.fixture.js
+++ b/test/integration/fixtures/options/bail-with-test.fixture.js
@@ -11,25 +11,17 @@ describe('suite1', function () {
   });
   it('test suite1', function () {
     runOrder.push('test suite1');
+    throw new Error('test suite1 error');
   });
 
   describe('suite1A', function () {
-    before('before suite1A', function () {
-      runOrder.push('before suite1A');
-    });
-    beforeEach('beforeEach suite1A', function () {
-      runOrder.push('beforeEach suite1A');
-    }); 
+    before('before suite1A', function () {});
+    beforeEach('beforeEach suite1A', function () {}); 
     it('test suite1A', function () {
-      runOrder.push('test suite1A');
+      runOrder.push('test suite1A - should not run');
     });
-    afterEach('afterEach suite1A', function () {
-      runOrder.push('afterEach suite1A');
-    });
-    after('after suite1A', function () {
-      runOrder.push('after suite1A');
-      throw new Error('after suite1A error');
-    });
+    afterEach('afterEach suite1A', function () {});
+    after('after suite1A', function () {});
   });
 
   afterEach('afterEach suite1', function () {
@@ -39,9 +31,7 @@ describe('suite1', function () {
     runOrder.push('after suite1');
     assert.deepStrictEqual(runOrder, [
       'before suite1', 'beforeEach suite1', 'test suite1',
-      'afterEach suite1', 'before suite1A', 'beforeEach suite1',
-      'beforeEach suite1A', 'test suite1A', 'afterEach suite1A',
-      'afterEach suite1', 'after suite1A', 'after suite1'
+      'afterEach suite1', 'after suite1'
     ]);
   });
 });

--- a/test/integration/fixtures/options/bail.fixture.js
+++ b/test/integration/fixtures/options/bail.fixture.js
@@ -13,11 +13,11 @@ describe('suite1', function () {
 });
 
 describe('suite2', function () {
-  before(function (done) {
+  before(function () {
     throw new Error('this hook should not be displayed');
   });
 
-  it('should not display this error', function (done) {
+  it('should not display this error', function () {
     throw new Error('this should not be displayed');
   });
 });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -60,12 +60,13 @@ describe('options', function() {
         expect(res, 'to have failed')
           .and('to have passed test', 'should display this spec')
           .and('to have failed test', 'should only display this error')
-          .and('to have passed test count', 1);
+          .and('to have passed test count', 1)
+          .and('to have failed test count', 1);
         done();
       });
     });
 
-    it('should stop all tests after the first error in before hook', function(done) {
+    it('should stop all tests after failing "before" hook', function(done) {
       runMochaJSON('options/bail-with-before.fixture.js', args, function(
         err,
         res
@@ -76,12 +77,50 @@ describe('options', function() {
         }
         expect(res, 'to have failed')
           .and('to have failed test count', 1)
-          .and('to have failed test', '"before all" hook');
+          .and('to have failed test', '"before all" hook: before suite1')
+          .and('to have passed test count', 0);
         done();
       });
     });
 
-    it('should stop all hooks after the first error', function(done) {
+    it('should stop all tests after failing "beforeEach" hook', function(done) {
+      runMochaJSON('options/bail-with-beforeEach.fixture.js', args, function(
+        err,
+        res
+      ) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, 'to have failed')
+          .and('to have failed test count', 1)
+          .and(
+            'to have failed test',
+            '"before each" hook: beforeEach suite1 for "test suite1"'
+          )
+          .and('to have passed test count', 0);
+        done();
+      });
+    });
+
+    it('should stop all tests after failing test', function(done) {
+      runMochaJSON('options/bail-with-test.fixture.js', args, function(
+        err,
+        res
+      ) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, 'to have failed')
+          .and('to have failed test count', 1)
+          .and('to have failed test', 'test suite1')
+          .and('to have passed test count', 0);
+        done();
+      });
+    });
+
+    it('should stop all tests after failing "after" hook', function(done) {
       runMochaJSON('options/bail-with-after.fixture.js', args, function(
         err,
         res
@@ -92,7 +131,30 @@ describe('options', function() {
         }
         expect(res, 'to have failed')
           .and('to have failed test count', 1)
-          .and('to have run test', 'should only display this error');
+          .and('to have failed test', '"after all" hook: after suite1A')
+          .and('to have passed test count', 2)
+          .and('to have passed test order', 'test suite1', 'test suite1A');
+        done();
+      });
+    });
+
+    it('should stop all tests after failing "afterEach" hook', function(done) {
+      runMochaJSON('options/bail-with-afterEach.fixture.js', args, function(
+        err,
+        res
+      ) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, 'to have failed')
+          .and('to have failed test count', 1)
+          .and(
+            'to have failed test',
+            '"after each" hook: afterEach suite1A for "test suite1A"'
+          )
+          .and('to have passed test count', 2)
+          .and('to have passed test order', 'test suite1', 'test suite1A');
         done();
       });
     });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -66,6 +66,22 @@ describe('options', function() {
       });
     });
 
+    it('should stop after the first error - async', function(done) {
+      runMochaJSON('options/bail-async.fixture.js', args, function(err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(res, 'to have failed')
+          .and('to have passed test', 'should display this spec')
+          .and('to have failed test', 'should only display this error')
+          .and('to have passed test count', 1)
+          .and('to have failed test count', 1);
+        done();
+      });
+    });
+
     it('should stop all tests after failing "before" hook', function(done) {
       runMochaJSON('options/bail-with-before.fixture.js', args, function(
         err,

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -373,14 +373,6 @@ describe('Runner', function() {
       runner.failHook(hook, err);
     });
 
-    it('should emit "end" if suite bail is true', function(done) {
-      var hook = new Hook();
-      var err = {};
-      suite.bail(true);
-      runner.on('end', done);
-      runner.failHook(hook, err);
-    });
-
     it('should not emit "end" if suite bail is not true', function(done) {
       var hook = new Hook();
       var err = {};


### PR DESCRIPTION
### Description

It hasn't been clearly defined yet wether `after`/`afterEach` hooks should run after a failing test. Since merging issue #3278 `after`/`afterEach` hooks are not beeing executed anymore.
This was a big change in event behavior and quite a few users complained about.
Reading many posts (of maintainers also) I dare to claim that those hooks should run in order to guarantee a correct cleanup.

current pattern with failing test:
- --bail: the `end` event is triggered twice (which is bug). The first time `after`/`afterEach` hooks are not executed, with the second `end` event they are actually called.
- --bail and --exit: none of the `after`/`afterEach` hooks is called.

proposed pattern: (required changes are marked **bold**)
- `before` hook:
  - `bail: false`: failed `before` hook skips all tests in current suite/subsuites, and jumps to corresponding `after` hook. Subsequent suites/tests are executed.
  - `bail: true`: **as above**, but all subsequent suites/tests are skipped.
- `before each` hook: 
  - `bail: false`: failed `before each` hook skips remaining tests in current suite/subsuites, and jumps to corresponding `after each` hook, then `after`hook. Subsequent suites/tests are executed.
  - `bail: true`: **as above**, but all subsequent suites/tests are skipped.
- `test`: 
  - `bail: false`: failed `test` does not alter execution order.
  - `bail: true`: failed `test` **jumps to corresponding `after each` hook, then `after`hook**. All remaining tests in current suite, subsuites  and subsequent suites are skipped.
- `after` hook:
  - `bail: false`: failed `after` hook does not alter execution order.
  - `bail: true`:  failed `after` hook executes remaining `after` hooks, then all subsequent suites are skipped.
- `after each` hook:
  - `bail: false`: failed `after each` hook executes remaining `after each` and `after` hooks, but skips remaining tests in current suite/subsuites. Subsequent suites/tests are executed.
  - `bail: true`: **as above**, but all subsequent suites/tests are skipped.


### Description of the Change
#### 1. remove added `end` event: 
Emitting an `end` event just somewhere in a test tree doesn't work correctly. The runner is not aborted and keeps going, until a second `end` event (the real one) is emitted.
```
describe('level A', () => {
    beforeEach(() => {
      console.log('beforeEach A');
    });  
    it('test A should fail', () => {
      throw new Error();
    });
    describe('level A2', () => {
        it('should log "test A2', () => {
            console.log('test A2');
        });
    });
    afterEach(() => {
        console.log('afterEach A');
      });
});
```
with --bail flag and "debug":
```
mocha:runner start +1ms
  mocha:runner run suite  +1ms
  mocha:runner run suite level A +4ms
  level A
beforeEach A
    1) test A should fail

  0 passing (7ms)
  1 failing
  1) level A
       test A should fail:
  Error
      at Context.it [...]

  mocha:runner end +10ms                      <<<<<< first end: runner doesn't abort

afterEach A
  mocha:runner run suite level A level A2 +1ms
  mocha:runner finished running +2ms
  mocha:runner end +0ms                       <<<<<< second end
```
#### 2. Correct hook pattern after failing `after each` and `after` hooks:
All remainig `after each` and `after` hooks - the entire suite tree upwards - have to be executed.


### Applicable issues

#3398 
#3598 
#3457 

