### PR TITLE
add more tests for utils.deprecate

### DIFF
--- a/.wallaby.js
+++ b/.wallaby.js
@@ -17,7 +17,8 @@ module.exports = () => {
       },
       'package.json',
       'test/opts/mocha.opts',
-      'mocharc.yml'
+      'mocharc.yml',
+      '!lib/browser/**/*.js',
     ],
     filesWithNoCoverageCalculated: [
       'test/**/*.fixture.js',
@@ -52,7 +53,6 @@ module.exports = () => {
         return execFile.apply(this, arguments);
       };
       require('./test/setup');
-    },
-    debug: true
+    }
   };
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -588,28 +588,20 @@ exports.getError = function(err) {
  *
  * @param {string} msg
  */
-exports.deprecate = function(msg) {
+exports.deprecate = function deprecate(msg) {
   msg = String(msg);
-  if (seenDeprecationMsg.hasOwnProperty(msg)) {
-    return;
-  }
-  seenDeprecationMsg[msg] = true;
-  doDeprecationWarning(msg);
-};
-
-var seenDeprecationMsg = {};
-
-var doDeprecationWarning = process.emitWarning
-  ? function(msg) {
-      // Node.js v6+
+  if (msg && !deprecate.cache[msg]) {
+    deprecate.cache[msg] = true;
+    if (process.emitWarning) {
       process.emitWarning(msg, 'DeprecationWarning');
-    }
-  : function(msg) {
-      // Everything else
+    } else {
       process.nextTick(function() {
         console.warn(msg);
       });
-    };
+    }
+  }
+};
+exports.deprecate.cache = {};
 
 /**
  * @summary

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -69,7 +69,7 @@ module.exports = {
       },
       node: {
         default: {
-          script: `nps ${[
+          script: `rimraf .nyc_output && nps ${[
             'build',
             'test.node.bdd',
             'test.node.tdd',


### PR DESCRIPTION
Mainly trying to get coverage up.

Also a tweak to Wallaby config, and one to coverage computation which will zap `.nyc_output/` between `npm test` runs to ensure the data isn't stale.