### PR TITLE
execute test after "before each" hook asynchronously; closes #3009

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -332,7 +332,9 @@ Runner.prototype.hook = function(name, fn) {
       }
       self.emit('hook end', hook);
       delete hook.ctx.currentTest;
-      next(++i);
+      Runner.immediately(function() {
+        next(++i);
+      });
     });
   }
 

--- a/test/integration/fixtures/hooks/before-hook-promise-rejection.fixture.js
+++ b/test/integration/fixtures/hooks/before-hook-promise-rejection.fixture.js
@@ -1,0 +1,13 @@
+'use strict';
+
+describe('mySuite', function() {
+  var promise;
+
+  before(function() {
+    promise = Promise.reject(new Error());
+  });
+
+  it('myTest', function() {
+    promise.catch(function() {});
+  });
+});

--- a/test/integration/fixtures/hooks/beforeEach-hook-promise-rejection.fixture.js
+++ b/test/integration/fixtures/hooks/beforeEach-hook-promise-rejection.fixture.js
@@ -1,0 +1,13 @@
+'use strict';
+
+describe('mySuite', function() {
+  var promise;
+
+  beforeEach(function() {
+    promise = Promise.reject(new Error());
+  });
+
+  it('myTest', function() {
+    promise.catch(function() {});
+  });
+});

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -30,6 +30,12 @@ module.exports = {
    * @param {Object} [opts] - Options for `spawn()`
    */
   runMocha: function(fixturePath, args, fn, opts) {
+    if (typeof args === 'function') {
+      opts = fn;
+      fn = args;
+      args = [];
+    }
+
     var path;
 
     path = resolveFixturePath(fixturePath);
@@ -61,6 +67,12 @@ module.exports = {
    * @returns {*} Parsed object
    */
   runMochaJSON: function(fixturePath, args, fn, opts) {
+    if (typeof args === 'function') {
+      opts = fn;
+      fn = args;
+      args = [];
+    }
+
     var path;
 
     path = resolveFixturePath(fixturePath);
@@ -208,6 +220,9 @@ function _spawnMochaWithListeners(args, fn, opts) {
 }
 
 function resolveFixturePath(fixture) {
+  if (path.extname(fixture) !== '.js') {
+    fixture += '.fixture.js';
+  }
   return path.join('test', 'integration', 'fixtures', fixture);
 }
 

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var runMocha = require('./helpers').runMocha;
-var splitRegExp = require('./helpers').splitRegExp;
+var helpers = require('./helpers');
+var runMocha = helpers.runMocha;
+var splitRegExp = helpers.splitRegExp;
 var bang = require('../../lib/reporters/base').symbols.bang;
 
 describe('hook error handling', function() {
@@ -165,6 +166,47 @@ describe('hook error handling', function() {
       });
     };
   }
+
+  describe('unhandled Promise rejections', function() {
+    describe('asynchronously caught in "before" hook', function() {
+      beforeEach(function() {});
+      it('should result in an unhandled Promise rejection', function(done) {
+        runMocha(
+          'hooks/before-hook-promise-rejection',
+          function(err, result) {
+            if (err) {
+              return done(err);
+            }
+            expect(result, 'to have passed').and('to satisfy', {
+              output: /UnhandledPromiseRejectionWarning/
+            });
+
+            done();
+          },
+          {stdio: 'pipe'}
+        );
+      });
+    });
+
+    describe('in "before each" hook', function() {
+      it('asynchronously caught in "beforeEach" hook', function(done) {
+        runMocha(
+          'hooks/beforeEach-hook-promise-rejection',
+          function(err, result) {
+            if (err) {
+              return done(err);
+            }
+
+            expect(result, 'to have passed').and('to satisfy', {
+              output: /UnhandledPromiseRejectionWarning/
+            });
+            done();
+          },
+          {stdio: 'pipe'}
+        );
+      });
+    });
+  });
 });
 
 function onlyConsoleOutput() {


### PR DESCRIPTION
This provides consistent, though not necessarily ideal, behavior when a
`Promise` is rejected within a "before" or "before each" hook and *not*
caught synchronously or within a `process.nextTick()` callback.

Previously, the `Promise` would be considered handled if it was rejected
in a "before each" hook and caught within the test, because the test
would be executed synchronously.  This is not the same case for a
"before" hook, which would consider the `Promise` unhandled.  Now, both
result in an unhandled rejection warning from node.

An alternative implementation would be to execute tests within a
`process.nextTick()` callback (not sure what happens in a browser).
This would mean rejected `Promise`s in both cases would be considered
handled, because `process.nextTick()` would execute *before* whatever considers the `Promise` rejection to be unhandled.

Mocha executes tests recursively, and needs to do so
asynchronously in order to avoid exceeding the maximum call stack.  As
per the Node.js documentation [here](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/),
this is *not* a valid use case of `process.nextTick()`.

Yet another alternative implementation which may avoid a decision
entirely would be to execute tests using a generator.  This could only
be *simulated* in an environment such as IE11, and thus would
potentially result in inconsistent or undefined behavior when running
the same tests in different browsers (that being said, generators are
probably a Good Idea for Mocha to consume in the long run).
