### PR TITLE
Set "root" property on Suite correctly

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -92,7 +92,7 @@ function Mocha(options) {
   this.files = [];
   this.options = options;
   // root suite
-  this.suite = new exports.Suite('', new exports.Context());
+  this.suite = new exports.Suite('', new exports.Context(), true);
 
   if ('useColors' in options) {
     utils.deprecate(

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -41,16 +41,18 @@ exports.create = function(parent, title) {
 };
 
 /**
- * Initialize a new `Suite` with the given `title`, `ctx` and `root`. Derived from [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+ * Constructs a new `Suite` instance with the given `title`, `ctx`, and `isRoot`.
  *
- * @memberof Mocha
  * @public
  * @class
- * @param {string} title
- * @param {Context} parentContext
- * @param {boolean} root
+ * @extends EventEmitter
+ * @memberof Mocha
+ * @see {@link https://nodejs.org/api/events.html#events_class_eventemitter|EventEmitter}
+ * @param {string} title - Suite title.
+ * @param {Context} parentContext - Parent context instance.
+ * @param {boolean} [isRoot=false] - Whether this is the root suite.
  */
-function Suite(title, parentContext, root) {
+function Suite(title, parentContext, isRoot) {
   if (!utils.isString(title)) {
     throw createInvalidArgumentTypeError(
       'Suite argument "title" must be a string. Received type "' +
@@ -71,7 +73,7 @@ function Suite(title, parentContext, root) {
   this._beforeAll = [];
   this._afterEach = [];
   this._afterAll = [];
-  this.root = root || false;
+  this.root = isRoot === true;
   this._timeout = 2000;
   this._enableTimeouts = true;
   this._slow = 75;
@@ -327,6 +329,7 @@ Suite.prototype.afterEach = function(title, fn) {
  */
 Suite.prototype.addSuite = function(suite) {
   suite.parent = this;
+  suite.root = false;
   suite.timeout(this.timeout());
   suite.retries(this.retries());
   suite.enableTimeouts(this.enableTimeouts());

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -41,15 +41,16 @@ exports.create = function(parent, title) {
 };
 
 /**
- * Initialize a new `Suite` with the given `title` and `ctx`. Derived from [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+ * Initialize a new `Suite` with the given `title`, `ctx` and `root`. Derived from [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
  *
  * @memberof Mocha
  * @public
  * @class
  * @param {string} title
  * @param {Context} parentContext
+ * @param {boolean} root
  */
-function Suite(title, parentContext) {
+function Suite(title, parentContext, root) {
   if (!utils.isString(title)) {
     throw createInvalidArgumentTypeError(
       'Suite argument "title" must be a string. Received type "' +
@@ -70,7 +71,7 @@ function Suite(title, parentContext) {
   this._beforeAll = [];
   this._afterEach = [];
   this._afterAll = [];
-  this.root = !title;
+  this.root = root || false;
   this._timeout = 2000;
   this._enableTimeouts = true;
   this._slow = 75;

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -390,7 +390,7 @@ describe('Suite', function() {
     describe('when there is a parent', function() {
       describe('the parent is the root suite', function() {
         it('returns the suite title', function() {
-          var parentSuite = new Suite('');
+          var parentSuite = new Suite('', {}, true);
           parentSuite.addSuite(this.suite);
           expect(this.suite.titlePath(), 'to equal', ['A Suite']);
         });
@@ -492,6 +492,16 @@ describe('Suite', function() {
       expect(function() {
         new Suite('Bdd suite', 'root');
       }, 'not to throw');
+    });
+
+    it('should be root suite', function() {
+      var rootSuite = new Suite('', {}, true);
+      expect(rootSuite.root, 'to be', true);
+    });
+
+    it('should not be root suite', function() {
+      var suite = new Suite('');
+      expect(suite.root, 'to be', false);
     });
   });
 

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -302,6 +302,27 @@ describe('Suite', function() {
     });
   });
 
+  describe('.create()', function() {
+    before(function() {
+      this.first = new Suite('Root suite', {}, true);
+      this.second = new Suite('RottenRoot suite', {}, true);
+      this.first.addSuite(this.second);
+    });
+
+    it('does not create a second root suite', function() {
+      expect(this.second.parent, 'to be', this.first);
+      expect(this.first.root, 'to be', true);
+      expect(this.second.root, 'to be', false);
+    });
+
+    it('does not denote the root suite by being titleless', function() {
+      var emptyTitleSuite = Suite.create(this.second, '');
+      expect(emptyTitleSuite.parent, 'to be', this.second);
+      expect(emptyTitleSuite.root, 'to be', false);
+      expect(this.second.root, 'to be', false);
+    });
+  });
+
   describe('.addSuite()', function() {
     beforeEach(function() {
       this.first = new Suite('First suite');
@@ -390,8 +411,8 @@ describe('Suite', function() {
     describe('when there is a parent', function() {
       describe('the parent is the root suite', function() {
         it('returns the suite title', function() {
-          var parentSuite = new Suite('', {}, true);
-          parentSuite.addSuite(this.suite);
+          var rootSuite = new Suite('', {}, true);
+          rootSuite.addSuite(this.suite);
           expect(this.suite.titlePath(), 'to equal', ['A Suite']);
         });
       });
@@ -492,16 +513,6 @@ describe('Suite', function() {
       expect(function() {
         new Suite('Bdd suite', 'root');
       }, 'not to throw');
-    });
-
-    it('should be root suite', function() {
-      var rootSuite = new Suite('', {}, true);
-      expect(rootSuite.root, 'to be', true);
-    });
-
-    it('should not be root suite', function() {
-      var suite = new Suite('');
-      expect(suite.root, 'to be', false);
     });
   });
 


### PR DESCRIPTION
Currently every suite with an empty string title "" has set its property `suite.root === true`, see [here](https://github.com/mochajs/mocha/blob/master/lib/suite.js#L69). This is a bug since there can be only one root suite and a deficient test tree would be the result.
```js
'use strict';
var emptyTitleSuite1;

describe('suite1', function() {
  var rootSuite = this.parent;
  console.log('title rootSuite: %s, root: %s', rootSuite.title || '""', rootSuite.root);
  console.log('title suite1: %s, root: %s', this.title, this.root);

  describe('', function() {                 <<<<< empty title
    emptyTitleSuite1 = this;
    console.log('title emptyTitleSuite1: %s, root: %s', this.title || '""', this.root);
    console.log('rootSuite === emptyTitleSuite1:', rootSuite === this);
  });
});

describe('', function() {                   <<<<< empty title
  var rootSuite = this.parent;
  console.log('title emptyTitleSuite2: %s, root: %s', this.title || '""', this.root);
  console.log('rootSuite === emptyTitleSuite2:', rootSuite === this);
  console.log('emptyTitleSuite1 === emptyTitleSuite2:', emptyTitleSuite1 === this);
});
```
Above we have four different suites (incl. root), three of them with `suite.root === true`. 
```
title rootSuite: "", root: true                <<<< 1. root
title suite1: suite1, root: false
title emptyTitleSuite1: "", root: true         <<<< 2. root
rootSuite === emptyTitleSuite1: false

title emptyTitleSuite2: "", root: true         <<<< 3. root
rootSuite === emptyTitleSuite2: false
emptyTitleSuite1 === emptyTitleSuite2: false
```

### Description of the Change

Add an optional parameter "root" with default value `false` to the Suite constructor function. 


### Alternative

Don't allow empty string suite title, except for root suite.

### Applicable issues

closes #2755
