### PR TITLE
 Remove clear and cursor move in min reporter 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1405,7 +1405,7 @@ The "JSON stream" reporter outputs newline-delimited JSON "events" as they occur
 
 ### Min
 
-The "min" reporter displays the summary only, while still outputting errors on failure. This reporter works great with `--watch` as it clears the terminal in order to keep your test summary at the top.
+The "min" reporter displays the summary only, while still outputting errors on failure. This reporter works great with `--watch` as it only outputs the test summary.
 
 ![min reporter](images/reporter-min.png?withoutEnlargement&resize=920,9999){:class="screenshot"}
 

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -26,14 +26,6 @@ exports = module.exports = Min;
  */
 function Min(runner) {
   Base.call(this, runner);
-
-  runner.on('start', function() {
-    // clear screen
-    process.stdout.write('\u001b[2J');
-    // set cursor position
-    process.stdout.write('\u001b[1;3H');
-  });
-
   runner.once('end', this.epilogue.bind(this));
 }
 

--- a/test/reporters/min.spec.js
+++ b/test/reporters/min.spec.js
@@ -16,11 +16,11 @@ describe('Min reporter', function() {
   });
 
   describe('on start', function() {
-    it('should clear screen then set cursor position', function() {
+    it('should not clear screen or set cursor position', function() {
       runner = createMockRunner('start', 'start');
       var stdout = runReporter({epilogue: function() {}}, runner, options);
 
-      var expectedArray = ['\u001b[2J', '\u001b[1;3H'];
+      var expectedArray = [];
       expect(stdout, 'to equal', expectedArray);
     });
   });


### PR DESCRIPTION
### Description of the Change

Affecting the entire view of the console is not minimal and it prevents this from being used in conjunction with other watch scripts running in parallel in the same process, such as linters and nodemon, docker, etc.

Its not appropriate to do this in a reporter and a separate `--clearscreen` feature should be added if anyone wants that feature specifically.

### Alternate Designs

- Adding a new reporter called `even-more-min` which was identical to `min` but just didn't clear screen or move the cursor.
- Adding a `--clearscreen false` option which has been [rejected](https://github.com/mochajs/mocha/issues/2312#issuecomment-318923995) by mocha devs as being too complex in an already complicated feature.

### Why should this be in core?

It is a reduction in features. It removes functionality already in core that negatively impacts some scenarios, especially running in docker or in conjunction with other watch scripts.

### Benefits

It will allow the min reporter to be able to be used in the same process as other "watch" scripts. This is really important for being able to be run in docker, for example. When running in docker many processes are emitting output and being displayed into the console of a single shell, if any of those processes does a "clear screen" or a move of a cursor it can wipeout the output of other processes. It's not polite to do this and should be an opt-in only feature.

### Possible Drawbacks

The draw back is that upon success during `--watch -R min` the minimal reporter will append the epilogue rather than controlling the entire console window. Over time you will accumulate messages such as `300 passing (400ms)`.

This is necessary in a multi-child process terminal but may not be as pretty in 5 minute demos.

### Applicable issues

Relates to #2312
Fixes #2761

This is technically a breaking change but I don't think it actually warrants a major version bump. I would recommend a minor version bump.
