### PR TITLE
Fixed wrong use of to throw that will fail with unexpected v11

### DIFF
--- a/test/node-unit/cli/run-helpers.spec.js
+++ b/test/node-unit/cli/run-helpers.spec.js
@@ -19,7 +19,7 @@ describe('cli "run" command', function() {
       it('should disallow an array of module names', function() {
         expect(
           () => validatePlugin({foo: ['bar']}, 'foo'),
-          'to throw',
+          'to throw a',
           TypeError
         );
       });


### PR DESCRIPTION
### Description of the Change

I was testing Mocha's compatibility with the upcoming version of Unexpected. For that version we remove support for satisfying against a function as that has confused people. 

I found one test that will fail with the next version as it was using `to throw` to satisfy against an error. This test will actually just call `TypeError` with the throw error, so it wont really check anything. This PR fixes the test to assert that the throw error is a `TypeError`.

### Benefits

Bugfix.

### Possible Drawbacks

None