### PR TITLE
remove teamcity reporter warning (#3634)

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -238,13 +238,6 @@ Mocha.prototype.reporter = function(reporter, reporterOptions) {
         }
       }
     }
-    if (!_reporter && reporter === 'teamcity') {
-      console.warn(
-        'The Teamcity reporter was moved to a package named ' +
-          'mocha-teamcity-reporter ' +
-          '(https://npmjs.org/package/mocha-teamcity-reporter).'
-      );
-    }
     if (!_reporter) {
       throw createInvalidReporterError(
         'invalid reporter "' + reporter + '"',


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

#3634 suggests removing this warning because this warning has been around for 5 years (see https://github.com/mochajs/mocha/commit/1a4ab63f55b0af7305361396a520058e3779203d) so it is unlikely anyone still depends on it.

### Alternate Designs

N/A

### Why should this be in core?

N/A

### Benefits

Fewer branches to cover and less unnecessary code.

### Possible Drawbacks

Someone upgrading directly from 1.x to 6.x may be confused where their reporter went.

### Applicable issues

#3634, patch release