### PR TITLE
Fix messages for file lookup issues - error scenario

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -167,7 +167,7 @@ exports.handleFiles = ({
     // give full message details when only 1 file is missing
     const noneFoundMsg =
       unmatched.length === 1
-        ? `Error: No test files found: ${unmatched[0].pattern}`
+        ? `Error: No test files found: ${JSON.stringify(unmatched[0].pattern)}` // stringify to print escaped characters raw
         : 'Error: No test files found';
     console.error(ansi.red(noneFoundMsg));
     process.exit(1);

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -137,14 +137,14 @@ exports.handleFiles = ({
   spec = []
 } = {}) => {
   let files = [];
-  const errors = [];
+  const missingMessages = [];
   spec.forEach(arg => {
     let newFiles;
     try {
       newFiles = utils.lookupFiles(arg, extension, recursive);
     } catch (err) {
       if (err.code === 'ERR_MOCHA_NO_FILES_MATCH_PATTERN') {
-        errors.push(err.message);
+        missingMessages.push(err.message);
         return;
       }
 
@@ -164,14 +164,11 @@ exports.handleFiles = ({
   });
 
   if (!files.length) {
-    // print messages as an error
-    errors.forEach(message => {
-      console.error(ansi.red(`Error: ${message}`));
-    });
+    console.error(ansi.red('Error: No test files found'));
     process.exit(1);
   } else {
     // print messages as an warning
-    errors.forEach(message => {
+    missingMessages.forEach(message => {
       console.warn(ansi.yellow(`Warning: ${message}`));
     });
   }

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -137,14 +137,14 @@ exports.handleFiles = ({
   spec = []
 } = {}) => {
   let files = [];
-  const missingMessages = [];
+  const unmatched = [];
   spec.forEach(arg => {
     let newFiles;
     try {
       newFiles = utils.lookupFiles(arg, extension, recursive);
     } catch (err) {
       if (err.code === 'ERR_MOCHA_NO_FILES_MATCH_PATTERN') {
-        missingMessages.push(err.message);
+        unmatched.push({message: err.message, pattern: err.pattern});
         return;
       }
 
@@ -164,17 +164,17 @@ exports.handleFiles = ({
   });
 
   if (!files.length) {
-    if (missingMessages.length === 1) {
-      // give full message details when only 1 file is missing
-      console.error(ansi.red(`Error: ${missingMessages[0]}`));
-    } else {
-      console.error(ansi.red('Error: No test files found'));
-    }
+    // give full message details when only 1 file is missing
+    const noneFoundMsg =
+      unmatched.length === 1
+        ? `Error: No test files found: ${unmatched[0].pattern}`
+        : 'Error: No test files found';
+    console.error(ansi.red(noneFoundMsg));
     process.exit(1);
   } else {
     // print messages as an warning
-    missingMessages.forEach(message => {
-      console.warn(ansi.yellow(`Warning: ${message}`));
+    unmatched.forEach(warning => {
+      console.warn(ansi.yellow(`Warning: ${warning.message}`));
     });
   }
 

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -164,7 +164,12 @@ exports.handleFiles = ({
   });
 
   if (!files.length) {
-    console.error(ansi.red('Error: No test files found'));
+    if (missingMessages.length === 1) {
+      // give message details when only 1 missing file
+      console.error(ansi.red(`Error: ${missingMessages[0]}`));
+    } else {
+      console.error(ansi.red('Error: No test files found'));
+    }
     process.exit(1);
   } else {
     // print messages as an warning

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -165,7 +165,7 @@ exports.handleFiles = ({
 
   if (!files.length) {
     if (missingMessages.length === 1) {
-      // give message details when only 1 missing file
+      // give full message details when only 1 file is missing
       console.error(ansi.red(`Error: ${missingMessages[0]}`));
     } else {
       console.error(ansi.red('Error: No test files found'));

--- a/test/integration/glob.spec.js
+++ b/test/integration/glob.spec.js
@@ -25,7 +25,11 @@ describe('globbing', function() {
       testGlob.shouldFail(
         './*-none.js',
         function(results) {
-          expect(results.stderr, 'to contain', 'Error: No test files found:');
+          expect(
+            results.stderr,
+            'to contain',
+            'Error: No test files found: ./*-none.js'
+          );
         },
         done
       );
@@ -80,7 +84,11 @@ describe('globbing', function() {
       testGlob.shouldFail(
         '"./*-none.js"',
         function(results) {
-          expect(results.stderr, 'to contain', 'Error: No test files found:');
+          expect(
+            results.stderr,
+            'to contain',
+            'Error: No test files found: ./*-none.js'
+          );
         },
         done
       );
@@ -134,7 +142,11 @@ describe('globbing', function() {
         testGlob.shouldFail(
           '"./**/*-none.js"',
           function(results) {
-            expect(results.stderr, 'to contain', 'Error: No test files found:');
+            expect(
+              results.stderr,
+              'to contain',
+              'Error: No test files found: ./**/*-none.js'
+            );
           },
           done
         );

--- a/test/integration/glob.spec.js
+++ b/test/integration/glob.spec.js
@@ -28,7 +28,7 @@ describe('globbing', function() {
           expect(
             results.stderr,
             'to contain',
-            'Error: No test files found: ./*-none.js'
+            'Error: No test files found: "./*-none.js"'
           );
         },
         done
@@ -40,6 +40,7 @@ describe('globbing', function() {
         './*-none.js ./*-none-twice.js',
         function(results) {
           expect(results.stderr, 'to contain', 'Error: No test files found');
+          expect(results.stderr, 'not to contain', '*-none');
         },
         done
       );
@@ -87,7 +88,7 @@ describe('globbing', function() {
           expect(
             results.stderr,
             'to contain',
-            'Error: No test files found: ./*-none.js'
+            'Error: No test files found: "./*-none.js"'
           );
         },
         done
@@ -145,7 +146,7 @@ describe('globbing', function() {
             expect(
               results.stderr,
               'to contain',
-              'Error: No test files found: ./**/*-none.js'
+              'Error: No test files found: "./**/*-none.js"'
             );
           },
           done

--- a/test/integration/glob.spec.js
+++ b/test/integration/glob.spec.js
@@ -25,6 +25,20 @@ describe('globbing', function() {
       testGlob.shouldFail(
         './*-none.js',
         function(results) {
+          expect(
+            results.stderr,
+            'to contain',
+            'Error: Cannot find any files matching pattern'
+          );
+        },
+        done
+      );
+    });
+
+    it('should handle multiple non-matching patterns', function(done) {
+      testGlob.shouldFail(
+        './*-none.js ./*-none-twice.js',
+        function(results) {
           expect(results.stderr, 'to contain', 'Error: No test files found');
         },
         done
@@ -70,6 +84,20 @@ describe('globbing', function() {
       testGlob.shouldFail(
         '"./*-none.js"',
         function(results) {
+          expect(
+            results.stderr,
+            'to contain',
+            'Error: Cannot find any files matching pattern'
+          );
+        },
+        done
+      );
+    });
+
+    it('should handle multiple non-matching patterns', function(done) {
+      testGlob.shouldFail(
+        '"./*-none.js" "./*-none-twice.js"',
+        function(results) {
           expect(results.stderr, 'to contain', 'Error: No test files found');
         },
         done
@@ -114,7 +142,11 @@ describe('globbing', function() {
         testGlob.shouldFail(
           '"./**/*-none.js"',
           function(results) {
-            expect(results.stderr, 'to contain', 'Error: No test files found');
+            expect(
+              results.stderr,
+              'to contain',
+              'Error: Cannot find any files matching pattern'
+            );
           },
           done
         );

--- a/test/integration/glob.spec.js
+++ b/test/integration/glob.spec.js
@@ -25,11 +25,7 @@ describe('globbing', function() {
       testGlob.shouldFail(
         './*-none.js',
         function(results) {
-          expect(
-            results.stderr,
-            'to contain',
-            'Error: Cannot find any files matching pattern "./*-none.js"'
-          );
+          expect(results.stderr, 'to contain', 'Error: No test files found');
         },
         done
       );
@@ -74,11 +70,7 @@ describe('globbing', function() {
       testGlob.shouldFail(
         '"./*-none.js"',
         function(results) {
-          expect(
-            results.stderr,
-            'to contain',
-            'Error: Cannot find any files matching pattern "./*-none.js"'
-          );
+          expect(results.stderr, 'to contain', 'Error: No test files found');
         },
         done
       );
@@ -122,11 +114,7 @@ describe('globbing', function() {
         testGlob.shouldFail(
           '"./**/*-none.js"',
           function(results) {
-            expect(
-              results.stderr,
-              'to contain',
-              'Error: Cannot find any files matching pattern "./**/*-none.js"'
-            );
+            expect(results.stderr, 'to contain', 'Error: No test files found');
           },
           done
         );

--- a/test/integration/glob.spec.js
+++ b/test/integration/glob.spec.js
@@ -25,11 +25,7 @@ describe('globbing', function() {
       testGlob.shouldFail(
         './*-none.js',
         function(results) {
-          expect(
-            results.stderr,
-            'to contain',
-            'Error: Cannot find any files matching pattern'
-          );
+          expect(results.stderr, 'to contain', 'Error: No test files found:');
         },
         done
       );
@@ -84,11 +80,7 @@ describe('globbing', function() {
       testGlob.shouldFail(
         '"./*-none.js"',
         function(results) {
-          expect(
-            results.stderr,
-            'to contain',
-            'Error: Cannot find any files matching pattern'
-          );
+          expect(results.stderr, 'to contain', 'Error: No test files found:');
         },
         done
       );
@@ -142,11 +134,7 @@ describe('globbing', function() {
         testGlob.shouldFail(
           '"./**/*-none.js"',
           function(results) {
-            expect(
-              results.stderr,
-              'to contain',
-              'Error: Cannot find any files matching pattern'
-            );
+            expect(results.stderr, 'to contain', 'Error: No test files found:');
           },
           done
         );


### PR DESCRIPTION
Scenario where multiple files (all) are not found only show a single message.
I feel its useful for debugging to keep the message if only 1 file is not found. Happy to remove if others don't agree.

No changes where at least 1 is found (still prints msg).

See PR https://github.com/mochajs/mocha/pull/3650 for full details

## Scenarios

### Nothing given
Command: `mocha`
Output:
```
Error: No test files found: "test/"
```

### Nothing found
Command: `mocha -R json-stream --no-config "test/integration/fixtures/glob/**/*-none.js"`
Output:
```
Error: No test files found: "test/integration/fixtures/glob/**/*-none.js"
```

### Multiple not found
Command: `mocha -R json-stream --no-config "test/integration/fixtures/glob/**/*-none.js" "test/integration/fixtures/glob/**/*-none-again.js"`
New output
```
Error: No test files found
```
Previous output
```
Error: Cannot find any files matching pattern "test/integration/fixtures/glob/**/*-none.js"
Error: Cannot find any files matching pattern "test/integration/fixtures/glob/**/*-none-again.js"
```

## Applicable issues
(semver-patch)
