### PR TITLE
Fix: listen to 'start' and 'end' events when using Mocha programmatically

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -939,7 +939,9 @@ Runner.prototype.run = function(fn) {
     this.emit(constants.EVENT_DELAY_BEGIN, rootSuite);
     rootSuite.once(EVENT_ROOT_SUITE_RUN, start);
   } else {
-    start();
+    Runner.immediately(function() {
+      start();
+    });
   }
 
   return this;

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -487,6 +487,16 @@ describe('Mocha', function() {
       }, 'not to throw');
     });
 
+    it('should catch the `start` event if no tests are provided', function(done) {
+      var mocha = new Mocha(opts);
+      mocha.run().on('start', done);
+    });
+
+    it('should catch the `end` event if no tests are provided', function(done) {
+      var mocha = new Mocha(opts);
+      mocha.run().on('end', done);
+    });
+
     describe('#reporter("xunit")#run(fn)', function() {
       // :TBD: Why does specifying reporter differentiate this test from preceding one
       it('should not raise errors if callback was not provided', function() {


### PR DESCRIPTION
### Description

`mocha.run()` returns a `runner` instance. Since the `EVENT_RUN_BEGIN` (`start`) event is emitted synchronously, it's impossible to register an `EVENT_RUN_BEGIN` listener in time. The event is emitted, but never catched.

When no tests are provided - eg. by a too restrictive `grep` expression - then neither `EVENT_RUN_BEGIN` nor `EVENT_RUN_END` (`end`) events can be listened to.

```js
var mocha = new Mocha();

mocha.addFile("../eventStart.js");

mocha.run()
  .on(EVENT_RUN_BEGIN, () => console.log('start'))    // never runs
  .on(EVENT_RUN_END, () => console.log('end'));       // never runs when no tests are provided
```

### Description of Change

We delay the start of the root Suite by `Runner.immediately`. The order of the event emissions remains unchanged.

### Applicable issues

#3395 (backed out)
#3331 
#3065
closes #2753 