### PR TITLE
Removed MOCHA_COLORS environment variable

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -17,6 +17,7 @@ const {loadOptions} = require('./options');
 const commands = require('./commands');
 const ansi = require('ansi-colors');
 const {repository, homepage, version, gitter} = require('../../package.json');
+const {deprecate} = require('../utils');
 
 /**
  * - Accepts an `Array` of arguments
@@ -31,6 +32,16 @@ exports.main = (argv = process.argv.slice(2)) => {
   module.paths.push(process.cwd(), path.resolve('node_modules'));
 
   Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
+
+  if (process.env.MOCHA_COLORS) {
+    deprecate(
+      'Support for deprecated "MOCHA_COLORS" environment variable was removed from Mocha. Use "FORCE_COLOR" instead.'
+    );
+    if (argv.indexOf('--colors') < 0 && argv.indexOf('-c') < 0) {
+      argv.push('--colors');
+    }
+    delete process.env.MOCHA_COLORS;
+  }
 
   yargs
     .scriptName('mocha')

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -28,9 +28,7 @@ var isatty = tty.isatty(1) && tty.isatty(2);
  * Enable coloring by default, except in the browser interface.
  */
 
-exports.useColors =
-  !process.browser &&
-  (supportsColor.stdout || process.env.MOCHA_COLORS !== undefined);
+exports.useColors = !process.browser && supportsColor.stdout;
 
 /**
  * Inline diffs instead of +/-

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -27,7 +27,13 @@ var isatty = tty.isatty(1) && tty.isatty(2);
 /**
  * Enable coloring by default, except in the browser interface.
  */
-
+if (process.env.MOCHA_COLORS) {
+  utils.deprecate(
+    '"MOCHA_COLORS" is deprecated and will be removed from a future version of Mocha. Use "FORCE_COLOR" instead.'
+  );
+  delete process.env.MOCHA_COLORS;
+  process.env.FORCE_COLOR = 1;
+}
 exports.useColors = !process.browser && supportsColor.stdout;
 
 /**

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -27,13 +27,6 @@ var isatty = tty.isatty(1) && tty.isatty(2);
 /**
  * Enable coloring by default, except in the browser interface.
  */
-if (process.env.MOCHA_COLORS) {
-  utils.deprecate(
-    '"MOCHA_COLORS" is deprecated and will be removed from a future version of Mocha. Use "FORCE_COLOR" instead.'
-  );
-  delete process.env.MOCHA_COLORS;
-  process.env.FORCE_COLOR = 1;
-}
 exports.useColors = !process.browser && supportsColor.stdout;
 
 /**


### PR DESCRIPTION
### Description of the Change

Remove MOCHA_COLORS environment variable

### Why should this be in core?

The [supports-color](https://github.com/chalk/supports-color/) module's environment variable `FORCE_COLOR` provides the same functionality.

### Benefits

Redundant. One less thing to maintain.

### Applicable issues

Fixes #3641
patch release