### PR TITLE
Fix couple errors missing codes

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -11,6 +11,7 @@ const Mocha = require('../mocha');
 const ansi = require('ansi-colors');
 const errors = require('../errors');
 const createInvalidArgumentValueError = errors.createInvalidArgumentValueError;
+const createMissingArgumentError = errors.createMissingArgumentError;
 
 const {
   list,
@@ -258,15 +259,19 @@ exports.builder = yargs =>
 
       // yargs.implies() isn't flexible enough to handle this
       if (argv.invert && !('fgrep' in argv || 'grep' in argv)) {
-        throw new Error(
-          '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"'
+        throw createMissingArgumentError(
+          '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
+          '--invert',
+          argv.invert
         );
       }
 
       if (argv.compilers) {
-        throw new Error(
+        throw createInvalidArgumentValueError(
           `--compilers is DEPRECATED and no longer supported.
-          See ${ansi.cyan('https://git.io/vdcSr')} for migration information.`
+          See ${ansi.cyan('https://git.io/vdcSr')} for migration information.`,
+          '--compilers',
+          argv.compilers
         );
       }
 

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -9,9 +9,10 @@
 
 const Mocha = require('../mocha');
 const ansi = require('ansi-colors');
-const errors = require('../errors');
-const createInvalidArgumentValueError = errors.createInvalidArgumentValueError;
-const createMissingArgumentError = errors.createMissingArgumentError;
+const {
+  createInvalidArgumentValueError,
+  createMissingArgumentError
+} = require('../errors');
 
 const {
   list,
@@ -261,17 +262,15 @@ exports.builder = yargs =>
       if (argv.invert && !('fgrep' in argv || 'grep' in argv)) {
         throw createMissingArgumentError(
           '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
-          '--invert',
-          argv.invert
+          '--fgrep|--grep',
+          'string|regexp'
         );
       }
 
       if (argv.compilers) {
         throw createInvalidArgumentValueError(
           `--compilers is DEPRECATED and no longer supported.
-          See ${ansi.cyan('https://git.io/vdcSr')} for migration information.`,
-          '--compilers',
-          argv.compilers
+          See ${ansi.cyan('https://git.io/vdcSr')} for migration information.`
         );
       }
 

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -347,7 +347,7 @@ describe('options', function() {
         });
       });
 
-      it('fails if no --grep', function(done) {
+      it('should throw an error when `--invert` used in isolation', function(done) {
         args = ['--invert'];
         runMocha(
           'options/grep.fixture.js',
@@ -359,7 +359,7 @@ describe('options', function() {
             }
             expect(res, 'to satisfy', {
               code: 1,
-              output: /fgrep/
+              output: /--invert.*--grep <regexp>/
             });
             done();
           },

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -346,6 +346,26 @@ describe('options', function() {
           done();
         });
       });
+
+      it('fails if no --grep', function(done) {
+        args = ['--invert'];
+        runMocha(
+          'options/grep.fixture.js',
+          args,
+          function(err, res) {
+            if (err) {
+              done(err);
+              return;
+            }
+            expect(res, 'to satisfy', {
+              code: 1,
+              output: /fgrep/
+            });
+            done();
+          },
+          {stdio: 'pipe'}
+        );
+      });
     });
   });
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

#3656 added a couple utils for setting `code` on errors. I fixed a couple here and wanted to make sure I was on the right track before making more changes.

### Alternate Designs

N/A

### Why should this be in core?

Codes help identify errors as mocha errors at a glance without using custom error types, and better DX is always good.

### Benefits

:point_up: 

### Possible Drawbacks

None that I can see

### Applicable issues

#3656, #3125. semver-patch
