### PR TITLE
bug fix: concat(undefined) returns [undefined]

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -505,7 +505,9 @@ Mocha.prototype._growl = growl.notify;
  * mocha.globals(['jQuery', 'MyLib']);
  */
 Mocha.prototype.globals = function(globals) {
-  this.options.globals = (this.options.globals || []).concat(globals);
+  this.options.globals = this.options.globals || [];
+  globals = globals || [];
+  this.options.globals = this.options.globals.concat(globals);
   return this;
 };
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -240,4 +240,11 @@ describe('Mocha', function() {
       });
     });
   });
+
+  describe('globals', function() {
+    it('should return an empty array when globals is undefined', function() {
+      var mocha = new Mocha();
+      expect(mocha.options.globals.length, 'to be', 0);
+    });
+  });
 });


### PR DESCRIPTION
### Requirements

### Description of the Change

This line: `this.options.globals = (this.options.globals || []).concat(globals);` has the potential to produce arrays that contain the `undefined` element.

The result of `concat(undefined)` is `[undefined]`, an array of length 1 that contains `undefined`.

Later in `lib/runner` there is a filter that iterates on the globals list and raises an error when trying to reference `undefined`.

### Alternate Designs

There is different syntax that could be used to achieve the same validation and fallback. If there is a preferred style I'm happy to adjust to it.

### Why should this be in core?

It is fixing an edge case within the core libs.

### Benefits

Protects users from an edge case where `globals` is has falsy value.

### Possible Drawbacks

The impact is trivial, it increases the set up overhead by a little bit (if at all).

### Applicable issues

patch release
