### PR TITLE
set allowUncaught on hooks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -371,6 +371,8 @@ Runner.prototype.hook = function(name, fn) {
       hook.ctx.currentTest = self.test;
     }
 
+    hook.allowUncaught = self.allowUncaught;
+
     self.emit(constants.EVENT_HOOK_BEGIN, hook);
 
     if (!hook.listeners('error').length) {

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -468,6 +468,19 @@ describe('Runner', function() {
       expect(fail, 'to throw', 'allow unhandled errors');
     });
 
+    it('should not allow unhandled errors in hooks to propagate through', function() {
+      suite.beforeEach(function() {
+        throw new Error('this error will not propagate');
+      });
+      var runner = new Runner(suite);
+      try {
+        runner.hook('beforeEach', function() {});
+        expect(true, 'to be', true);
+      } catch (err) {
+        expect(false, 'to be', true);
+      }
+    });
+
     it('should allow unhandled errors in sync hooks to propagate through', function() {
       suite.beforeEach(function() {
         throw new Error('allow unhandled errors in sync hooks');
@@ -481,8 +494,8 @@ describe('Runner', function() {
     });
 
     it('async - should allow unhandled errors in hooks to propagate through', function() {
+      // having `done` triggers the async path
       suite.beforeEach(function(done) {
-        // having `done` triggers the async path
         throw new Error('allow unhandled errors in async hooks');
       });
       var runner = new Runner(suite);


### PR DESCRIPTION
### Requirements

### Description of the Change

When passing `--allow-uncaught`, uncaught exceptions thrown inside hooks are not surfaced. This PR enables that. Original issue: https://github.com/mochajs/mocha/issues/2302

### Alternate Designs

The hook-runner is the best place to set this flag, since it has to be read from the parent context (Runner). I can't see any other way of doing given that strong dependency.

### Why should this be in core?

It is a missing feature, already marked as a confirmed bug (#2302 )

### Benefits

Tests authors can be more strict about not accepting code that throws errors as side effects. Debugging failing hooks becomes easier.

### Possible Drawbacks

There shouldn't be drawbacks. Tests that throw errors within their hooks are most likely not setting `allowUncaught`, otherwise the browser would hang. So it remains an opt-in feature.

### Applicable issues

closes #2302 , patch release
