### PR TITLE
WIP: predictable "setImmediate" between hooks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -336,9 +336,14 @@ Runner.prototype.hook = function(name, fn) {
     });
   }
 
-  Runner.immediately(function() {
+  // nearest 'beforeEach' + 'it' + nearest 'afterEach' run synchronously
+  if (name === 'afterEach' && suite === this.synchSuite && hooks.length) {
     next(0);
-  });
+  } else {
+    Runner.immediately(function() {
+      next(0);
+    });
+  }
 };
 
 /**
@@ -385,6 +390,7 @@ Runner.prototype.hooks = function(name, suites, fn) {
  */
 Runner.prototype.hookUp = function(name, fn) {
   var suites = [this.suite].concat(this.parents()).reverse();
+  this.synchSuite = this.suite;
   this.hooks(name, suites, fn);
 };
 


### PR DESCRIPTION
### Description

see #3009 

Currently between every hook there is a `setImmediate` call, actually there is even one for non-existing hooks. The following simple test without any hook causes eight `setImmediate` calls, two suites each with four possible hooks:
```js
describe("synchSuite", function () {
    it("myTest", function () { });
  });
```
My first efforts to eliminate all `setImmediate` between hooks and insert instead one between each test failed with many "timeout" errors and huge error stacks with hundreds of lines. I decided therefore to take small steps.

### Description of the Change

The smallest synchronous unit should be:
[nearest `beforeEach` hook + `test` + nearest `afterEach` hook]

The following example should run without `PromiseRejectionHandledWarning`.
```js
describe("synchSuite", function () {
    beforeEach(function () {
      promise = Promise.reject(new Error());
    });
    it("myTest", function () {
      // return promise.catch(function () {console.log('catched it()')});
    });
    afterEach(function () {
      return promise.catch(function () {console.log('catched after() nested')});
    });
  });
```

required changes:
- `beforeEach`: no changes required, since [nearest `beforeEach` hook + `test`] do run synchronously.
- `afterEach`: [`test` + nearest `afterEach` hook] change from asynch to synch call.


### Alternate Designs

- `setImmediate` calls only for existing hooks
- eliminate all `setImmediate` between hooks and insert instead one between each test.


### Why should this be in core?

Behavior is more predictable when testing with promises.


### Benefits

### Possible Drawbacks

### Applicable issues
