### PR TITLE
Tests: Avoid the 'was called with' assertion

### DIFF
--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -114,7 +114,7 @@ describe('options', function() {
               try {
                 loadOptions(`--opts ${opts}`);
               } catch (ignored) {}
-              expect(readFileSync, 'was called with', opts, 'utf8');
+              expect(readFileSync, 'to have a call satisfying', [opts, 'utf8']);
             });
 
             it('should throw', function() {
@@ -151,7 +151,10 @@ describe('options', function() {
             });
 
             it('should attempt to load default mocha.opts', function() {
-              expect(readFileSync, 'was called with', defaults.opts, 'utf8');
+              expect(readFileSync, 'to have a call satisfying', [
+                defaults.opts,
+                'utf8'
+              ]);
             });
 
             it('should set opts = false', function() {
@@ -514,7 +517,7 @@ describe('options', function() {
             try {
               loadOptions(`--config ${config}`);
             } catch (ignored) {}
-            expect(loadConfig, 'was called with', config);
+            expect(loadConfig, 'to have a call satisfying', [config]);
           });
 
           it('should throw to warn the user', function() {
@@ -555,7 +558,9 @@ describe('options', function() {
             });
 
             it('should attempt to load file at found path', function() {
-              expect(loadConfig, 'was called with', '/some/.mocharc.json');
+              expect(loadConfig, 'to have a call satisfying', [
+                '/some/.mocharc.json'
+              ]);
             });
 
             it('should set config = false', function() {

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -24,13 +24,13 @@ describe('Mocha', function() {
     it('should prefer "color" over "useColors"', function() {
       // eslint-disable-next-line no-new
       new Mocha({useColors: true, color: false});
-      expect(Mocha.prototype.useColors, 'was called with', false);
+      expect(Mocha.prototype.useColors, 'to have a call satisfying', [false]);
     });
 
     it('should assign "useColors" to "color"', function() {
       // eslint-disable-next-line no-new
       new Mocha({useColors: true});
-      expect(Mocha.prototype.useColors, 'was called with', true);
+      expect(Mocha.prototype.useColors, 'to have a call satisfying', [true]);
     });
 
     it('should call utils.deprecate()', function() {


### PR DESCRIPTION
### Description of the Change

Avoid the use of the `was called with` assertion from unexpected-sinon. It has been deprecated for two years and will soon display warnings or even be removed.

See discussion here: https://github.com/unexpectedjs/unexpected-sinon/issues/32

### Alternate Designs

Not relevant.

### Why should this be in core?

Not applicable, this is just a change to the test suite.

### Benefits

Due diligence so we don't have to deal with this later when upgrading unexpected-sinon.

### Possible Drawbacks

None.

### Applicable issues

None.