### PR TITLE
do not recursively call `process.exit()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ stages:
 
 # defaults
 language: node_js
-node_js: '11.6'
+node_js: '11'
 addons:
   apt:
     packages:

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -25,7 +25,7 @@ const cwd = (exports.cwd = process.cwd());
  */
 const exitMochaLater = code => {
   process.on('exit', () => {
-    process.exit(Math.min(code, 255));
+    process.exitCode = Math.min(code, 255);
   });
 };
 


### PR DESCRIPTION
### Description of the Change

When inside `process.on('exit')`, calling `process.exit()`
stops other `exit` event listeners from being invoked.

This has lead to issues with coverage generation with `nyc`
because a fallback exit detection mechanism in it that relies
on internal Node.js APIs was accidentally disabled in Node v11.7.0,
leaving `nyc` with no way to detect process exit.

### Alternate Designs

No alternatives were considered.

### Benefits

`process.on('exit')` handlers are run even if `exitMochaLater` is used. At least `nyc` relies on this behaviour.

### Possible Drawbacks

I guess running extra code while exiting could have drawbacks.

### Applicable issues

This fixes https://github.com/nodejs/node/issues/25650 (which is already closed, but because Node.js is (possibly temporarily) reintroducing monkey-patching for the internal method in question, not because the underlying cause was addressed).