### PR TITLE
fix regex in utils.stackTraceFilter to prevent ReDoS #3416

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -671,8 +671,6 @@ exports.stackTraceFilter = function() {
   function isMochaInternal(line) {
     return (
       ~line.indexOf('node_modules' + slash + 'mocha' + slash) ||
-      ~line.indexOf('node_modules' + slash + 'mocha.js') ||
-      ~line.indexOf('bower_components' + slash + 'mocha.js') ||
       ~line.indexOf(slash + 'mocha.js')
     );
   }
@@ -701,7 +699,7 @@ exports.stackTraceFilter = function() {
       }
 
       // Clean up cwd(absolute)
-      if (/\(?.+:\d+:\d+\)?$/.test(line)) {
+      if (/:\d+:\d+\)?$/.test(line)) {
         line = line.replace('(' + cwd, '(');
       }
 


### PR DESCRIPTION
if the stack trace begins with a large error message (>= 20k charactors), and user leaves `--full-trace` disabled, `utils.stackTraceFilter()` takes ages to finish. Large error messages is quite possible when user makes containment assertions such as `expect(content).to.contain(word)`.

### Description of the Change

simplified the regex used in `utils.stackTraceFilter()` to boost performance therefore prevent ReDoS if the stack contains large error message.

### Alternate Designs

It's possible to skip check error message in stack by skipping the first line but the regex fix won't change any behavior hence it is chosen.

### Why should this be in core?

well, it's a bug introduced by the stack filtering feature.

### Benefits

mocha won't hang even if users make assertions with large error messages, which is quite possible because containment check is used a lot.

### Possible Drawbacks

None

### Applicable issues

#3416 looks like one but it was because of an external library (still quite possible if chai makes large error message and `assert.deepEqual` don't, didn't check).
