### PR TITLE
ensure invalid arguments are not ignored when using bin/mocha; closes #3687

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -17,6 +17,7 @@ const {loadConfig, findConfig} = require('./config');
 const findup = require('findup-sync');
 const {deprecate} = require('../utils');
 const debug = require('debug')('mocha:cli:options');
+const {createMissingArgumentError} = require('../errors');
 
 /**
  * The `yargs-parser` namespace
@@ -73,8 +74,8 @@ const nargOpts = types.array
  * @private
  * @ignore
  */
-const parse = (args = [], ...configObjects) =>
-  yargsParser(
+const parse = (args = [], ...configObjects) => {
+  const result = yargsParser.detailed(
     args,
     Object.assign(
       {
@@ -87,6 +88,11 @@ const parse = (args = [], ...configObjects) =>
       types
     )
   );
+  if (result.error) {
+    throw createMissingArgumentError(result.error.message);
+  }
+  return result.argv;
+};
 
 /**
  * - Replaces comments with empty strings

--- a/test/integration/invalid-arguments.spec.js
+++ b/test/integration/invalid-arguments.spec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var invokeMocha = require('./helpers').invokeMocha;
+
+describe('invalid arguments', function() {
+  it('should exit with failure if arguments are invalid', function(done) {
+    invokeMocha(
+      ['--ui'],
+      function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, 'to have failed');
+        expect(result.output, 'to match', /not enough arguments/i);
+        done();
+      },
+      {stdio: 'pipe'}
+    );
+  });
+});


### PR DESCRIPTION
What was happening here was that yargs-parser's default command does error checking *but does not return the errors*.  instead, it would act like *no such argument was provided*.  this means that if you used `--ui`, it would act as if you passed nothing, then go and grab whatever the default is (in this case, `bdd`).

using the `detailed()` function of yargs-parser solves this problem.

added a test