### PR TITLE
add zero-config support for loading ES modules in Node

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 
+const esmRequire = require('esm')(module);
+
 /**
  * This file remains for backwards compatibility only.
  * Don't put stuff in this file.
  * @see module:lib/cli
  */
 
-require('../lib/cli').main();
+esmRequire('../lib/cli').main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4813,6 +4813,11 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.1.4.tgz",
+      "integrity": "sha512-GScwIz0110RTNzBmAQEdqaAYkD9zVhj2Jo+jeizjIcdyTw+C6S0Zv/dlPYgfF41hRTu2f1vQYliubzIkusx2gA=="
+    },
     "espree": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -489,6 +489,7 @@
     "debug": "3.2.6",
     "diff": "3.5.0",
     "escape-string-regexp": "1.0.5",
+    "esm": "3.1.4",
     "findup-sync": "2.0.0",
     "glob": "7.1.3",
     "growl": "1.10.5",

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -774,7 +774,7 @@ describe('options', function() {
           setTimeout(function() {
             // kill the child process
             mocha.kill('SIGINT');
-          }, 1000);
+          }, 1500);
         });
       });
     });


### PR DESCRIPTION
This PR adds zero-config support for loading ES modules in Node. This PR just replaces the entry `require` with `esmRequire`. Now `--require` modules, configs, and others files can have ESM syntax. The caveat is that `.mjs` files are not supported since under the hood mocha is still using `require()` to load files. See the following `esm` doc note:
> 💡 By Node’s rules, builtin `require` cannot sideload `.mjs` files. However, with `esm`, ES modules can be sideloaded as `.js` files or `.mjs` files may be loaded with dynamic `import`.

@boneskull Feel free to push tests to this PR.