### PR TITLE
Show total test cases correctly in growl

### DIFF
--- a/lib/browser/growl.js
+++ b/lib/browser/growl.js
@@ -129,7 +129,7 @@ function display(runner) {
   var title;
 
   if (stats.failures) {
-    _message = stats.failures + ' of ' + runner.total + ' tests failed';
+    _message = stats.failures + ' of ' + stats.tests + ' tests failed';
     message = symbol.cross + ' ' + _message;
     title = 'Failed';
   } else {

--- a/lib/growl.js
+++ b/lib/growl.js
@@ -64,7 +64,7 @@ const display = runner => {
   let title;
 
   if (stats.failures) {
-    _message = `${stats.failures} of ${runner.total} tests failed`;
+    _message = `${stats.failures} of ${stats.tests} tests failed`;
     message = `${symbol.cross} ${_message}`;
     title = 'Failed';
   } else {


### PR DESCRIPTION
### Description of the Change
When I run exclusive tests with like `only`, growl notification show total tests count instead test count which I ran.

![2019-01-30 04 21 16](https://user-images.githubusercontent.com/390146/51934484-0b289e00-2447-11e9-9c9f-2301de52888b.png)

IMO, it should be test's count which I ran.

### Alternate Designs
N/A

### Why should this be in core?
Growl notification show total test cases which users ran.

### Benefits
![2019-01-30 04 21 43](https://user-images.githubusercontent.com/390146/51934748-ac175900-2447-11e9-8c6f-151d78891c32.png)

### Possible Drawbacks
N/A