### PR TITLE
Deprecate this.skip() for "after all" hooks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -626,7 +626,7 @@ Because this test _does nothing_, it will be reported as _passing_.
 
 > _Best practice_: Don't do nothing! A test should make an assertion or use `this.skip()`.
 
-To skip _multiple_ tests in this manner, use `this.skip()` in a "before" hook:
+To skip _multiple_ tests in this manner, use `this.skip()` in a "before all" hook:
 
 ```js
 before(function() {
@@ -661,6 +661,8 @@ describe('outer', function() {
   });
 });
 ```
+
+Skipping a test within an "after all" hook is deprecated and will throw an exception in a future version of Mocha. Use a return statement or other means to abort hook execution.
 
 > Before Mocha v3.0.0, `this.skip()` was not supported in asynchronous tests and hooks.
 
@@ -910,7 +912,7 @@ Enforce a rule that tests must be written in "async" style, meaning each test pr
 
 ### `--bail, -b`
 
-Causes Mocha to stop running tests after the first test failure it encounters. Corresponding `after()` and `afterEach()` hooks are executed for potential cleanup.
+Causes Mocha to stop running tests after the first test failure it encounters. Corresponding "after each" and "after all" hooks are executed for potential cleanup.
 
 `--bail` does _not_ imply `--exit`.
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -363,9 +363,9 @@ Runner.prototype.hook = function(name, fn) {
     }
     self.currentRunnable = hook;
 
-    if (name === 'beforeAll') {
+    if (name === HOOK_TYPE_BEFORE_ALL) {
       hook.ctx.currentTest = hook.parent.tests[0];
-    } else if (name === 'afterAll') {
+    } else if (name === HOOK_TYPE_AFTER_ALL) {
       hook.ctx.currentTest = hook.parent.tests[hook.parent.tests.length - 1];
     } else {
       hook.ctx.currentTest = self.test;
@@ -388,6 +388,12 @@ Runner.prototype.hook = function(name, fn) {
       }
       if (err) {
         if (err instanceof Pending) {
+          if (name === HOOK_TYPE_AFTER_ALL) {
+            utils.deprecate(
+              'Skipping a test within an "after all" hook is DEPRECATED and will throw an exception in a future version of Mocha. ' +
+                'Use a return statement or other means to abort hook execution.'
+            );
+          }
           if (name === HOOK_TYPE_BEFORE_EACH || name === HOOK_TYPE_AFTER_EACH) {
             self.test.pending = true;
           } else {

--- a/test/integration/fixtures/pending/skip-sync-after.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-after.fixture.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('skip in after', function () {
+  it('should run this test-1', function () {});
+
+  after('should print DeprecationWarning', function () {
+    this.skip();
+    throw new Error('never throws this error');
+  });
+
+  describe('inner suite', function () {
+    it('should run this test-2', function () {});
+  });
+});
+
+describe('second suite', function () {
+  it('should run this test-3', function () {});
+});

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -71,6 +71,28 @@ describe('pending', function() {
       });
     });
 
+    describe('in after', function() {
+      it('should run all tests', function(done) {
+        runMocha(
+          'pending/skip-sync-after.fixture.js',
+          args,
+          function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            expect(res, 'to have passed').and('to satisfy', {
+              passing: 3,
+              failing: 0,
+              pending: 0,
+              output: expect.it('to contain', '"after all" hook is DEPRECATED')
+            });
+            done();
+          },
+          'pipe'
+        );
+      });
+    });
+
     describe('in before', function() {
       it('should skip all suite specs', function(done) {
         run('pending/skip-sync-before.fixture.js', args, function(err, res) {


### PR DESCRIPTION
### Description

There have been long discussions about the behavior of `this.skip()` in hooks. The `before` hooks have already been clarified and fixed in #3225. The purpose of this PR is to make a decision about the behavior of `after` and `afterEach` hooks.

https://github.com/mochajs/mocha/pull/2571#issuecomment-265416756

> Skipping a test/suite after running it is a bit counter logical. The only purpose would be marking it as pending. Which is not very clean because you've already emitted `pass`/`fail` events for such test. Not sure there's value in changing the test state/outcome post-mortem.

I propose to emit a DeprecationWarning when `this.skip()` is used in `after` and `afterEach` hooks and to remove it in a future release. Besides marking an already passed/failed test as pending, there are actually no obvious effects of calling `this.skip()` in mentioned hooks.
```js
 describe('outer', function () {
    beforeEach(function () {
        console.log("A");
    });
    describe('inner', function () {
        beforeEach(function () {
            console.log("B");
        });
        it('test case', function () {
            console.log("C");
        });
        it('test case', function () {
            console.log("C2");
        });
        afterEach(function () {          // or after()
            console.log("Y");
            this.skip();                 // has no effect
            console.log("Y2");           // indeed there is an effect, this line is skipped.
        });
    });
    afterEach(function () {
        console.log("Z");
    });
    after(function () {
        console.log("ZZ");
    });
});
```
```
  outer
      inner
A
B
C
        √ test case
Y
Z
A
B
C2
        √ test case
Y
Z
ZZ

  2 passing (13ms)
```

### Description of the Change

~~Print a DeprecationWarning when `this.skip()` is used in `after`/`afterEach` hooks~~
Print a DeprecationWarning when `this.skip()` is used in `after` hooks.
