### PR TITLE
fix --reporter-option to allow comma-separated options; closes #3706

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -190,7 +190,7 @@ exports.builder = yargs =>
       },
       'reporter-option': {
         coerce: opts =>
-          opts.reduce((acc, opt) => {
+          list(opts).reduce((acc, opt) => {
             const pair = opt.split('=');
 
             if (pair.length > 2 || !pair.length) {

--- a/test/integration/fixtures/options/reporter-with-options.fixture.js
+++ b/test/integration/fixtures/options/reporter-with-options.fixture.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function ReporterWithOptions(runner, options) {
+  console.log(JSON.stringify(options.reporterOption));
+}
+
+module.exports = ReporterWithOptions;

--- a/test/integration/options/reporter-option.spec.js
+++ b/test/integration/options/reporter-option.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var runMocha = require('../helpers').runMocha;
+var path = require('path');
 
 describe('--reporter-option', function() {
   describe('when given options w/ invalid format', function() {
@@ -15,6 +16,66 @@ describe('--reporter-option', function() {
           expect(res, 'to have failed').and(
             'to contain output',
             /invalid reporter option/i
+          );
+          done();
+        },
+        'pipe'
+      );
+    });
+
+    it('should allow comma-separated values', function(done) {
+      runMocha(
+        'passing.fixture.js',
+        [
+          '--reporter',
+          path.join(
+            __dirname,
+            '..',
+            'fixtures',
+            'options',
+            'reporter-with-options.fixture.js'
+          ),
+          '--reporter-option',
+          'foo=bar,baz=quux'
+        ],
+        function(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have passed').and(
+            'to contain output',
+            /{"foo":"bar","baz":"quux"}/
+          );
+          done();
+        },
+        'pipe'
+      );
+    });
+
+    it('should allow repeated options', function(done) {
+      runMocha(
+        'passing.fixture.js',
+        [
+          '--reporter',
+          path.join(
+            __dirname,
+            '..',
+            'fixtures',
+            'options',
+            'reporter-with-options.fixture.js'
+          ),
+          '--reporter-option',
+          'foo=bar',
+          '--reporter-option',
+          'baz=quux'
+        ],
+        function(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have passed').and(
+            'to contain output',
+            /{"foo":"bar","baz":"quux"}/
           );
           done();
         },


### PR DESCRIPTION
adds tests for comma-separated k/v pairs and repeated `--reporter-option` usage
