### PR TITLE
Base reporter store ref to console.log

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -79,3 +79,12 @@ overrides:
     parserOptions:
       ecmaVersion: 6
       sourceType: module
+
+  - files:
+      - lib/reporters/*.js
+    rules:
+      no-restricted-syntax:
+        - error
+        # disallow Reporters using `console.log()`
+        - selector: 'CallExpression[callee.object.name=console][callee.property.name=log]'
+          message: &GH-3604 See https://github.com/mochajs/mocha/issues/3604

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -313,7 +313,7 @@ Base.prototype.epilogue = function() {
   var stats = this.stats;
   var fmt;
 
-  println();
+  this.println();
 
   // passes
   fmt =
@@ -321,26 +321,26 @@ Base.prototype.epilogue = function() {
     color('green', ' %d passing') +
     color('light', ' (%s)');
 
-  println(fmt, stats.passes || 0, milliseconds(stats.duration));
+  this.println(fmt, stats.passes || 0, milliseconds(stats.duration));
 
   // pending
   if (stats.pending) {
     fmt = color('pending', ' ') + color('pending', ' %d pending');
 
-    println(fmt, stats.pending);
+    this.println(fmt, stats.pending);
   }
 
   // failures
   if (stats.failures) {
     fmt = color('fail', '  %d failing');
 
-    println(fmt, stats.failures);
+    this.println(fmt, stats.failures);
 
     Base.list(this.failures);
-    println();
+    this.println();
   }
 
-  println();
+  this.println();
 };
 
 /**

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -313,7 +313,7 @@ Base.prototype.epilogue = function() {
   var stats = this.stats;
   var fmt;
 
-  this.println();
+  Base.println();
 
   // passes
   fmt =
@@ -321,26 +321,26 @@ Base.prototype.epilogue = function() {
     color('green', ' %d passing') +
     color('light', ' (%s)');
 
-  this.println(fmt, stats.passes || 0, milliseconds(stats.duration));
+  Base.println(fmt, stats.passes || 0, milliseconds(stats.duration));
 
   // pending
   if (stats.pending) {
     fmt = color('pending', ' ') + color('pending', ' %d pending');
 
-    this.println(fmt, stats.pending);
+    Base.println(fmt, stats.pending);
   }
 
   // failures
   if (stats.failures) {
     fmt = color('fail', '  %d failing');
 
-    this.println(fmt, stats.failures);
+    Base.println(fmt, stats.failures);
 
     Base.list(this.failures);
-    this.println();
+    Base.println();
   }
 
-  this.println();
+  Base.println();
 };
 
 /**
@@ -492,5 +492,7 @@ var objToString = Object.prototype.toString;
 function sameType(a, b) {
   return objToString.call(a) === objToString.call(b);
 }
+
+Base.println = println;
 
 Base.abstract = true;

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -28,6 +28,11 @@ exports = module.exports = Base;
 var isatty = tty.isatty(1) && tty.isatty(2);
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * Enable coloring by default, except in the browser interface.
  */
 
@@ -192,7 +197,7 @@ var generateDiff = (exports.generateDiff = function(actual, expected) {
  *     Error property
  */
 exports.list = function(failures) {
-  console.log();
+  println();
   failures.forEach(function(test, i) {
     // format
     var fmt =
@@ -253,7 +258,7 @@ exports.list = function(failures) {
       testTitle += str;
     });
 
-    console.log(fmt, i + 1, testTitle, msg, stack);
+    println(fmt, i + 1, testTitle, msg, stack);
   });
 };
 
@@ -308,7 +313,7 @@ Base.prototype.epilogue = function() {
   var stats = this.stats;
   var fmt;
 
-  console.log();
+  println();
 
   // passes
   fmt =
@@ -316,26 +321,26 @@ Base.prototype.epilogue = function() {
     color('green', ' %d passing') +
     color('light', ' (%s)');
 
-  console.log(fmt, stats.passes || 0, milliseconds(stats.duration));
+  println(fmt, stats.passes || 0, milliseconds(stats.duration));
 
   // pending
   if (stats.pending) {
     fmt = color('pending', ' ') + color('pending', ' %d pending');
 
-    console.log(fmt, stats.pending);
+    println(fmt, stats.pending);
   }
 
   // failures
   if (stats.failures) {
     fmt = color('fail', '  %d failing');
 
-    console.log(fmt, stats.failures);
+    println(fmt, stats.failures);
 
     Base.list(this.failures);
-    console.log();
+    println();
   }
 
-  console.log();
+  println();
 };
 
 /**

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -197,7 +197,7 @@ var generateDiff = (exports.generateDiff = function(actual, expected) {
  *     Error property
  */
 exports.list = function(failures) {
-  println();
+  Base.log();
   failures.forEach(function(test, i) {
     // format
     var fmt =
@@ -258,7 +258,7 @@ exports.list = function(failures) {
       testTitle += str;
     });
 
-    println(fmt, i + 1, testTitle, msg, stack);
+    Base.log(fmt, i + 1, testTitle, msg, stack);
   });
 };
 

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -30,7 +30,7 @@ var isatty = tty.isatty(1) && tty.isatty(2);
 /**
  * Save log references to avoid tests interfering (see GH-3604).
  */
-var println = console.log;
+var consoleLog = console.log;
 
 /**
  * Enable coloring by default, except in the browser interface.
@@ -197,7 +197,7 @@ var generateDiff = (exports.generateDiff = function(actual, expected) {
  *     Error property
  */
 exports.list = function(failures) {
-  Base.log();
+  Base.consoleLog();
   failures.forEach(function(test, i) {
     // format
     var fmt =
@@ -258,7 +258,7 @@ exports.list = function(failures) {
       testTitle += str;
     });
 
-    Base.log(fmt, i + 1, testTitle, msg, stack);
+    Base.consoleLog(fmt, i + 1, testTitle, msg, stack);
   });
 };
 
@@ -313,7 +313,7 @@ Base.prototype.epilogue = function() {
   var stats = this.stats;
   var fmt;
 
-  Base.println();
+  Base.consoleLog();
 
   // passes
   fmt =
@@ -321,26 +321,26 @@ Base.prototype.epilogue = function() {
     color('green', ' %d passing') +
     color('light', ' (%s)');
 
-  Base.println(fmt, stats.passes || 0, milliseconds(stats.duration));
+  Base.consoleLog(fmt, stats.passes || 0, milliseconds(stats.duration));
 
   // pending
   if (stats.pending) {
     fmt = color('pending', ' ') + color('pending', ' %d pending');
 
-    Base.println(fmt, stats.pending);
+    Base.consoleLog(fmt, stats.pending);
   }
 
   // failures
   if (stats.failures) {
     fmt = color('fail', '  %d failing');
 
-    Base.println(fmt, stats.failures);
+    Base.consoleLog(fmt, stats.failures);
 
     Base.list(this.failures);
-    Base.println();
+    Base.consoleLog();
   }
 
-  Base.println();
+  Base.consoleLog();
 };
 
 /**
@@ -493,6 +493,6 @@ function sameType(a, b) {
   return objToString.call(a) === objToString.call(b);
 }
 
-Base.println = println;
+Base.consoleLog = consoleLog;
 
 Base.abstract = true;

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -21,11 +21,6 @@ var EVENT_SUITE_END = constants.EVENT_SUITE_END;
 exports = module.exports = Doc;
 
 /**
- * Save log references to avoid tests interfering (see GH-3604).
- */
-var println = console.log;
-
-/**
  * Constructs a new `Doc` reporter instance.
  *
  * @public
@@ -39,6 +34,7 @@ function Doc(runner, options) {
   Base.call(this, runner, options);
 
   var indents = 2;
+  var self = this;
 
   function indent() {
     return Array(indents).join('  ');
@@ -49,41 +45,41 @@ function Doc(runner, options) {
       return;
     }
     ++indents;
-    println('%s<section class="suite">', indent());
+    self.println('%s<section class="suite">', indent());
     ++indents;
-    println('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
-    println('%s<dl>', indent());
+    self.println('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
+    self.println('%s<dl>', indent());
   });
 
   runner.on(EVENT_SUITE_END, function(suite) {
     if (suite.root) {
       return;
     }
-    println('%s</dl>', indent());
+    self.println('%s</dl>', indent());
     --indents;
-    println('%s</section>', indent());
+    self.println('%s</section>', indent());
     --indents;
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
-    println('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
+    self.println('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
     var code = utils.escape(utils.clean(test.body));
-    println('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
+    self.println('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test, err) {
-    println(
+    self.println(
       '%s  <dt class="error">%s</dt>',
       indent(),
       utils.escape(test.title)
     );
     var code = utils.escape(utils.clean(test.body));
-    println(
+    self.println(
       '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
       indent(),
       code
     );
-    println('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
+    self.println('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
   });
 }
 

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -44,41 +44,45 @@ function Doc(runner, options) {
       return;
     }
     ++indents;
-    Base.println('%s<section class="suite">', indent());
+    Base.consoleLog('%s<section class="suite">', indent());
     ++indents;
-    Base.println('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
-    Base.println('%s<dl>', indent());
+    Base.consoleLog('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
+    Base.consoleLog('%s<dl>', indent());
   });
 
   runner.on(EVENT_SUITE_END, function(suite) {
     if (suite.root) {
       return;
     }
-    Base.println('%s</dl>', indent());
+    Base.consoleLog('%s</dl>', indent());
     --indents;
-    Base.println('%s</section>', indent());
+    Base.consoleLog('%s</section>', indent());
     --indents;
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
-    Base.println('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
+    Base.consoleLog('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
     var code = utils.escape(utils.clean(test.body));
-    Base.println('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
+    Base.consoleLog('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test, err) {
-    Base.println(
+    Base.consoleLog(
       '%s  <dt class="error">%s</dt>',
       indent(),
       utils.escape(test.title)
     );
     var code = utils.escape(utils.clean(test.body));
-    Base.println(
+    Base.consoleLog(
       '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
       indent(),
       code
     );
-    Base.println('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
+    Base.consoleLog(
+      '%s  <dd class="error">%s</dd>',
+      indent(),
+      utils.escape(err)
+    );
   });
 }
 

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -21,6 +21,11 @@ var EVENT_SUITE_END = constants.EVENT_SUITE_END;
 exports = module.exports = Doc;
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * Constructs a new `Doc` reporter instance.
  *
  * @public
@@ -44,41 +49,41 @@ function Doc(runner, options) {
       return;
     }
     ++indents;
-    console.log('%s<section class="suite">', indent());
+    println('%s<section class="suite">', indent());
     ++indents;
-    console.log('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
-    console.log('%s<dl>', indent());
+    println('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
+    println('%s<dl>', indent());
   });
 
   runner.on(EVENT_SUITE_END, function(suite) {
     if (suite.root) {
       return;
     }
-    console.log('%s</dl>', indent());
+    println('%s</dl>', indent());
     --indents;
-    console.log('%s</section>', indent());
+    println('%s</section>', indent());
     --indents;
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
-    console.log('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
+    println('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
     var code = utils.escape(utils.clean(test.body));
-    console.log('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
+    println('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test, err) {
-    console.log(
+    println(
       '%s  <dt class="error">%s</dt>',
       indent(),
       utils.escape(test.title)
     );
     var code = utils.escape(utils.clean(test.body));
-    console.log(
+    println(
       '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
       indent(),
       code
     );
-    console.log('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
+    println('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
   });
 }
 

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -34,7 +34,6 @@ function Doc(runner, options) {
   Base.call(this, runner, options);
 
   var indents = 2;
-  var self = this;
 
   function indent() {
     return Array(indents).join('  ');
@@ -45,41 +44,41 @@ function Doc(runner, options) {
       return;
     }
     ++indents;
-    self.println('%s<section class="suite">', indent());
+    Base.println('%s<section class="suite">', indent());
     ++indents;
-    self.println('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
-    self.println('%s<dl>', indent());
+    Base.println('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
+    Base.println('%s<dl>', indent());
   });
 
   runner.on(EVENT_SUITE_END, function(suite) {
     if (suite.root) {
       return;
     }
-    self.println('%s</dl>', indent());
+    Base.println('%s</dl>', indent());
     --indents;
-    self.println('%s</section>', indent());
+    Base.println('%s</section>', indent());
     --indents;
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
-    self.println('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
+    Base.println('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
     var code = utils.escape(utils.clean(test.body));
-    self.println('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
+    Base.println('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test, err) {
-    self.println(
+    Base.println(
       '%s  <dt class="error">%s</dt>',
       indent(),
       utils.escape(test.title)
     );
     var code = utils.escape(utils.clean(test.body));
-    self.println(
+    Base.println(
       '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
       indent(),
       code
     );
-    self.println('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
+    Base.println('%s  <dd class="error">%s</dd>', indent(), utils.escape(err));
   });
 }
 

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -22,6 +22,11 @@ var EVENT_RUN_END = constants.EVENT_RUN_END;
 exports = module.exports = Dot;
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * Constructs a new `Dot` reporter instance.
  *
  * @public
@@ -68,7 +73,7 @@ function Dot(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    console.log();
+    println();
     self.epilogue();
   });
 }

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -73,7 +73,7 @@ function Dot(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    println();
+    self.println();
     self.epilogue();
   });
 }

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -73,7 +73,7 @@ function Dot(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    self.println();
+    Base.println();
     self.epilogue();
   });
 }

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -22,11 +22,6 @@ var EVENT_RUN_END = constants.EVENT_RUN_END;
 exports = module.exports = Dot;
 
 /**
- * Save log references to avoid tests interfering (see GH-3604).
- */
-var println = console.log;
-
-/**
  * Constructs a new `Dot` reporter instance.
  *
  * @public

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -73,7 +73,7 @@ function Dot(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    Base.consoleLog();
+    process.stdout.write('\n');
     self.epilogue();
   });
 }

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -73,7 +73,7 @@ function Dot(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    Base.println();
+    Base.consoleLog();
     self.epilogue();
   });
 }

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -95,7 +95,7 @@ function Landing(runner, options) {
 
   runner.once(EVENT_RUN_END, function() {
     cursor.show();
-    console.log();
+    process.stdout.write('\n');
     self.epilogue();
   });
 }

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -25,11 +25,6 @@ var cursor = Base.cursor;
 exports = module.exports = List;
 
 /**
- * Save log references to avoid tests interfering (see GH-3604).
- */
-var println = console.log;
-
-/**
  * Constructs a new `List` reporter instance.
  *
  * @public

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -46,7 +46,7 @@ function List(runner, options) {
   var n = 0;
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    Base.println();
+    Base.consoleLog();
   });
 
   runner.on(EVENT_TEST_BEGIN, function(test) {
@@ -55,7 +55,7 @@ function List(runner, options) {
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = color('checkmark', '  -') + color('pending', ' %s');
-    Base.println(fmt, test.fullTitle());
+    Base.consoleLog(fmt, test.fullTitle());
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -64,12 +64,12 @@ function List(runner, options) {
       color('pass', ' %s: ') +
       color(test.speed, '%dms');
     cursor.CR();
-    Base.println(fmt, test.fullTitle(), test.duration);
+    Base.consoleLog(fmt, test.fullTitle(), test.duration);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
     cursor.CR();
-    Base.println(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    Base.consoleLog(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -46,7 +46,7 @@ function List(runner, options) {
   var n = 0;
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    self.println();
+    Base.println();
   });
 
   runner.on(EVENT_TEST_BEGIN, function(test) {
@@ -55,7 +55,7 @@ function List(runner, options) {
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = color('checkmark', '  -') + color('pending', ' %s');
-    self.println(fmt, test.fullTitle());
+    Base.println(fmt, test.fullTitle());
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -64,12 +64,12 @@ function List(runner, options) {
       color('pass', ' %s: ') +
       color(test.speed, '%dms');
     cursor.CR();
-    self.println(fmt, test.fullTitle(), test.duration);
+    Base.println(fmt, test.fullTitle(), test.duration);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
     cursor.CR();
-    self.println(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    Base.println(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -25,6 +25,11 @@ var cursor = Base.cursor;
 exports = module.exports = List;
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * Constructs a new `List` reporter instance.
  *
  * @public
@@ -41,7 +46,7 @@ function List(runner, options) {
   var n = 0;
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    console.log();
+    println();
   });
 
   runner.on(EVENT_TEST_BEGIN, function(test) {
@@ -50,7 +55,7 @@ function List(runner, options) {
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = color('checkmark', '  -') + color('pending', ' %s');
-    console.log(fmt, test.fullTitle());
+    println(fmt, test.fullTitle());
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -59,12 +64,12 @@ function List(runner, options) {
       color('pass', ' %s: ') +
       color(test.speed, '%dms');
     cursor.CR();
-    console.log(fmt, test.fullTitle(), test.duration);
+    println(fmt, test.fullTitle(), test.duration);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
     cursor.CR();
-    console.log(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    println(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -46,7 +46,7 @@ function List(runner, options) {
   var n = 0;
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    println();
+    self.println();
   });
 
   runner.on(EVENT_TEST_BEGIN, function(test) {
@@ -55,7 +55,7 @@ function List(runner, options) {
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = color('checkmark', '  -') + color('pending', ' %s');
-    println(fmt, test.fullTitle());
+    self.println(fmt, test.fullTitle());
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -64,12 +64,12 @@ function List(runner, options) {
       color('pass', ' %s: ') +
       color(test.speed, '%dms');
     cursor.CR();
-    println(fmt, test.fullTitle(), test.duration);
+    self.println(fmt, test.fullTitle(), test.duration);
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
     cursor.CR();
-    println(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    self.println(color('fail', '  %d) %s'), ++n, test.fullTitle());
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -22,11 +22,6 @@ var cursor = Base.cursor;
 exports = module.exports = Progress;
 
 /**
- * Save log references to avoid tests interfering (see GH-3604).
- */
-var println = console.log;
-
-/**
  * General progress bar color.
  */
 
@@ -96,7 +91,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.once(EVENT_RUN_END, function() {
     cursor.show();
-    println();
+    self.println();
     self.epilogue();
   });
 }

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -91,7 +91,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.once(EVENT_RUN_END, function() {
     cursor.show();
-    self.println();
+    Base.println();
     self.epilogue();
   });
 }

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -22,6 +22,11 @@ var cursor = Base.cursor;
 exports = module.exports = Progress;
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * General progress bar color.
  */
 
@@ -91,7 +96,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.once(EVENT_RUN_END, function() {
     cursor.show();
-    console.log();
+    println();
     self.epilogue();
   });
 }

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -91,7 +91,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.once(EVENT_RUN_END, function() {
     cursor.show();
-    Base.println();
+    Base.consoleLog();
     self.epilogue();
   });
 }

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -58,7 +58,7 @@ function Progress(runner, options) {
 
   // tests started
   runner.on(EVENT_RUN_BEGIN, function() {
-    console.log();
+    process.stdout.write('\n');
     cursor.hide();
   });
 

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -91,7 +91,7 @@ function Progress(runner, options) {
   // and the failures if any
   runner.once(EVENT_RUN_END, function() {
     cursor.show();
-    Base.consoleLog();
+    process.stdout.write('\n');
     self.epilogue();
   });
 }

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -25,6 +25,11 @@ var color = Base.color;
 exports = module.exports = Spec;
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * Constructs a new `Spec` reporter instance.
  *
  * @public
@@ -46,24 +51,24 @@ function Spec(runner, options) {
   }
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    console.log();
+    println();
   });
 
   runner.on(EVENT_SUITE_BEGIN, function(suite) {
     ++indents;
-    console.log(color('suite', '%s%s'), indent(), suite.title);
+    println(color('suite', '%s%s'), indent(), suite.title);
   });
 
   runner.on(EVENT_SUITE_END, function() {
     --indents;
     if (indents === 1) {
-      console.log();
+      println();
     }
   });
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = indent() + color('pending', '  - %s');
-    console.log(fmt, test.title);
+    println(fmt, test.title);
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -73,19 +78,19 @@ function Spec(runner, options) {
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s');
-      console.log(fmt, test.title);
+      println(fmt, test.title);
     } else {
       fmt =
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s') +
         color(test.speed, ' (%dms)');
-      console.log(fmt, test.title, test.duration);
+      println(fmt, test.title, test.duration);
     }
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
-    console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    println(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -51,24 +51,24 @@ function Spec(runner, options) {
   }
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    self.println();
+    Base.println();
   });
 
   runner.on(EVENT_SUITE_BEGIN, function(suite) {
     ++indents;
-    self.println(color('suite', '%s%s'), indent(), suite.title);
+    Base.println(color('suite', '%s%s'), indent(), suite.title);
   });
 
   runner.on(EVENT_SUITE_END, function() {
     --indents;
     if (indents === 1) {
-      self.println();
+      Base.println();
     }
   });
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = indent() + color('pending', '  - %s');
-    self.println(fmt, test.title);
+    Base.println(fmt, test.title);
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -78,19 +78,19 @@ function Spec(runner, options) {
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s');
-      self.println(fmt, test.title);
+      Base.println(fmt, test.title);
     } else {
       fmt =
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s') +
         color(test.speed, ' (%dms)');
-      self.println(fmt, test.title, test.duration);
+      Base.println(fmt, test.title, test.duration);
     }
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
-    self.println(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    Base.println(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -51,24 +51,24 @@ function Spec(runner, options) {
   }
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    println();
+    self.println();
   });
 
   runner.on(EVENT_SUITE_BEGIN, function(suite) {
     ++indents;
-    println(color('suite', '%s%s'), indent(), suite.title);
+    self.println(color('suite', '%s%s'), indent(), suite.title);
   });
 
   runner.on(EVENT_SUITE_END, function() {
     --indents;
     if (indents === 1) {
-      println();
+      self.println();
     }
   });
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = indent() + color('pending', '  - %s');
-    println(fmt, test.title);
+    self.println(fmt, test.title);
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -78,19 +78,19 @@ function Spec(runner, options) {
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s');
-      println(fmt, test.title);
+      self.println(fmt, test.title);
     } else {
       fmt =
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s') +
         color(test.speed, ' (%dms)');
-      println(fmt, test.title, test.duration);
+      self.println(fmt, test.title, test.duration);
     }
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
-    println(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    self.println(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -25,11 +25,6 @@ var color = Base.color;
 exports = module.exports = Spec;
 
 /**
- * Save log references to avoid tests interfering (see GH-3604).
- */
-var println = console.log;
-
-/**
  * Constructs a new `Spec` reporter instance.
  *
  * @public

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -51,24 +51,24 @@ function Spec(runner, options) {
   }
 
   runner.on(EVENT_RUN_BEGIN, function() {
-    Base.println();
+    Base.consoleLog();
   });
 
   runner.on(EVENT_SUITE_BEGIN, function(suite) {
     ++indents;
-    Base.println(color('suite', '%s%s'), indent(), suite.title);
+    Base.consoleLog(color('suite', '%s%s'), indent(), suite.title);
   });
 
   runner.on(EVENT_SUITE_END, function() {
     --indents;
     if (indents === 1) {
-      Base.println();
+      Base.consoleLog();
     }
   });
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     var fmt = indent() + color('pending', '  - %s');
-    Base.println(fmt, test.title);
+    Base.consoleLog(fmt, test.title);
   });
 
   runner.on(EVENT_TEST_PASS, function(test) {
@@ -78,19 +78,19 @@ function Spec(runner, options) {
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s');
-      Base.println(fmt, test.title);
+      Base.consoleLog(fmt, test.title);
     } else {
       fmt =
         indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
         color('pass', ' %s') +
         color(test.speed, ' (%dms)');
-      Base.println(fmt, test.title, test.duration);
+      Base.consoleLog(fmt, test.title, test.duration);
     }
   });
 
   runner.on(EVENT_TEST_FAIL, function(test) {
-    Base.println(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    Base.consoleLog(indent() + color('fail', '  %d) %s'), ++n, test.title);
   });
 
   runner.once(EVENT_RUN_END, self.epilogue.bind(self));

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -28,11 +28,6 @@ var escape = utils.escape;
 var Date = global.Date;
 
 /**
- * Save log references to avoid tests interfering (see GH-3604).
- */
-var println = console.log;
-
-/**
  * Expose `XUnit`.
  */
 
@@ -147,7 +142,7 @@ XUnit.prototype.write = function(line) {
   } else if (typeof process === 'object' && process.stdout) {
     process.stdout.write(line + '\n');
   } else {
-    println(line);
+    this.println(line);
   }
 };
 

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -28,6 +28,11 @@ var escape = utils.escape;
 var Date = global.Date;
 
 /**
+ * Save log references to avoid tests interfering (see GH-3604).
+ */
+var println = console.log;
+
+/**
  * Expose `XUnit`.
  */
 
@@ -142,7 +147,7 @@ XUnit.prototype.write = function(line) {
   } else if (typeof process === 'object' && process.stdout) {
     process.stdout.write(line + '\n');
   } else {
-    console.log(line);
+    println(line);
   }
 };
 

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -142,7 +142,7 @@ XUnit.prototype.write = function(line) {
   } else if (typeof process === 'object' && process.stdout) {
     process.stdout.write(line + '\n');
   } else {
-    Base.println(line);
+    Base.consoleLog(line);
   }
 };
 

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -142,7 +142,7 @@ XUnit.prototype.write = function(line) {
   } else if (typeof process === 'object' && process.stdout) {
     process.stdout.write(line + '\n');
   } else {
-    this.println(line);
+    Base.println(line);
   }
 };
 

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -417,4 +417,20 @@ describe('Base reporter', function() {
     var errOut = stdout.join('\n').trim();
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
+
+  it('should let you stub out console.log without effecting reporters output', function() {
+    var logCached = console.log;
+    var logRes = [];
+
+    console.log = function(line) {
+      logRes.push(line);
+    };
+    var base = new Base({on: function() {}, stats: {duration: 0, passes: 3}});
+    base.epilogue();
+
+    expect(stdout[1], 'to contain', '3 passing');
+    expect(logRes, 'to have length', 0);
+
+    console.log = logCached;
+  });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -420,7 +420,13 @@ describe('Base reporter', function() {
 
   it('should let you stub out console.log without effecting reporters output', function() {
     sinon.stub(console, 'log');
+    sinon.stub(Base, 'consoleLog');
     Base.list([]);
+
+    expect(Base.consoleLog, 'was called');
     expect(console.log, 'was not called');
+
+    console.log.restore();
+    Base.consoleLog.restore();
   });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -5,7 +5,6 @@ var chai = require('chai');
 var sinon = require('sinon');
 var helpers = require('./helpers');
 var reporters = require('../../').reporters;
-var Base = reporters.Base;
 var AssertionError = assert.AssertionError;
 var Base = reporters.Base;
 var chaiExpect = chai.expect;

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -5,7 +5,7 @@ var chai = require('chai');
 var sinon = require('sinon');
 var helpers = require('./helpers');
 var reporters = require('../../').reporters;
-
+var Base = reporters.Base;
 var AssertionError = assert.AssertionError;
 var Base = reporters.Base;
 var chaiExpect = chai.expect;
@@ -419,18 +419,8 @@ describe('Base reporter', function() {
   });
 
   it('should let you stub out console.log without effecting reporters output', function() {
-    var logCached = console.log;
-    var logRes = [];
-
-    console.log = function(line) {
-      logRes.push(line);
-    };
-    var base = new Base({on: function() {}, stats: {duration: 0, passes: 3}});
-    base.epilogue();
-
-    expect(stdout[1], 'to contain', '3 passing');
-    expect(logRes, 'to have length', 0);
-
-    console.log = logCached;
+    sinon.stub(console, 'log');
+    Base.list([]);
+    expect(console.log, 'was not called');
   });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -418,15 +418,24 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
-  it('should let you stub out console.log without effecting reporters output', function() {
-    sinon.stub(console, 'log');
-    sinon.stub(Base, 'consoleLog');
-    Base.list([]);
+  describe('when reporter output immune to user test changes', function() {
+    var sandbox;
 
-    expect(Base.consoleLog, 'was called');
-    expect(console.log, 'was not called');
+    beforeEach(function() {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(console, 'log');
+      sandbox.stub(Base, 'consoleLog').callThrough();
+    });
 
-    console.log.restore();
-    Base.consoleLog.restore();
+    it('should let you stub out console.log without effecting reporters output', function() {
+      Base.list([]);
+
+      expect(Base.consoleLog, 'was called');
+      expect(console.log, 'was not called');
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
   });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -420,17 +420,19 @@ describe('Base reporter', function() {
 
   describe('when reporter output immune to user test changes', function() {
     var sandbox;
+    var baseConsoleLog;
 
     beforeEach(function() {
       sandbox = sinon.createSandbox();
       sandbox.stub(console, 'log');
-      sandbox.stub(Base, 'consoleLog').callThrough();
+      baseConsoleLog = sandbox.stub(Base, 'consoleLog');
     });
 
     it('should let you stub out console.log without effecting reporters output', function() {
       Base.list([]);
+      baseConsoleLog.restore();
 
-      expect(Base.consoleLog, 'was called');
+      expect(baseConsoleLog, 'was called');
       expect(console.log, 'was not called');
     });
 

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -277,14 +277,14 @@ describe('XUnit reporter', function() {
     });
 
     describe('when output directed to console', function() {
-      it("should call 'console.log' with line", function() {
+      it("should call 'Base.consoleLog' with line", function() {
         // :TODO: XUnit needs a trivially testable means to force console.log()
         var realProcess = process;
         process = false; // eslint-disable-line no-native-reassign, no-global-assign
 
         var xunit = new XUnit(runner);
         var fakeThis = {fileStream: false};
-        var consoleLogStub = sinon.stub(console, 'log');
+        var consoleLogStub = sinon.stub(Base, 'consoleLog');
         xunit.write.call(fakeThis, expectedLine);
         consoleLogStub.restore();
 


### PR DESCRIPTION
### Description of the Change
Small fix so that users can silence their own code (focused on just console.log's).
```js
// yuck.spec.js
it('should do, but it do not', function() {
  // user wants to hide output generated by console.log calls in fn 'foo'
  console.log = function() {};
  foo();
});
```

We can still stub its underlying mechanism. 
Decided this small fix offers enough for now. Let me know if others feel strongly that its not.

### Alternate Designs

Thinking more about how to unify the reporters (and `process.stdout.write`). 

### Applicable Issues

#3604

