### PR TITLE
Add ability to unload files from `require` cache (redux)

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -249,9 +249,7 @@ exports.watchRun = (
   };
 
   const purge = () => {
-    watchFiles.forEach(file => {
-      delete require.cache[file];
-    });
+    watchFiles.forEach(mocha.unloadFile);
   };
 
   loadAndRun();

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -8,12 +8,13 @@
  */
 
 const fs = require('fs');
-const debug = require('debug')('mocha:cli:run:helpers');
-const Context = require('../context');
 const path = require('path');
-const utils = require('../utils');
-const minimatch = require('minimatch');
 const ansi = require('ansi-colors');
+const debug = require('debug')('mocha:cli:run:helpers');
+const minimatch = require('minimatch');
+const Context = require('../context');
+const Mocha = require('../mocha');
+const utils = require('../utils');
 
 const cwd = (exports.cwd = process.cwd());
 
@@ -249,7 +250,7 @@ exports.watchRun = (
   };
 
   const purge = () => {
-    watchFiles.forEach(mocha.unloadFile);
+    watchFiles.forEach(Mocha.unloadFile);
   };
 
   loadAndRun();

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -329,10 +329,11 @@ Mocha.prototype.loadFiles = function(fn) {
  * Removes a previously loaded file from Node's `require` cache.
  *
  * @private
+ * @static
  * @see {@link Mocha#unloadFiles}
  * @param {string} file - Pathname of file to be unloaded.
  */
-Mocha.prototype.unloadFile = function(file) {
+Mocha.unloadFile = function(file) {
   delete require.cache[require.resolve(file)];
 };
 
@@ -343,17 +344,17 @@ Mocha.prototype.unloadFile = function(file) {
  * This allows files to be "freshly" reloaded, providing the ability
  * to reuse a Mocha instance programmatically.
  *
- * <strong>Not needed for (or used by) CLI.</strong>
+ * <strong>Intended for consumers &mdash; not used internally</strong>
  *
  * @public
- * @see {@link Mocha#unloadFile}
+ * @see {@link Mocha.unloadFile}
  * @see {@link Mocha#loadFiles}
  * @see {@link Mocha#run}
  * @returns {Mocha} this
  * @chainable
  */
 Mocha.prototype.unloadFiles = function() {
-  this.files.forEach(this.unloadFile, this);
+  this.files.forEach(Mocha.unloadFile);
   return this;
 };
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -301,7 +301,6 @@ Mocha.prototype.ui = function(name) {
 };
 
 /**
- * @summary
  * Loads `files` prior to execution.
  *
  * @description
@@ -310,6 +309,8 @@ Mocha.prototype.ui = function(name) {
  *
  * @private
  * @see {@link Mocha#addFile}
+ * @see {@link Mocha#run}
+ * @see {@link Mocha#unloadFiles}
  * @param {Function} [fn] - Callback invoked upon completion.
  */
 Mocha.prototype.loadFiles = function(fn) {
@@ -322,6 +323,38 @@ Mocha.prototype.loadFiles = function(fn) {
     suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
   });
   fn && fn();
+};
+
+/**
+ * Removes a previously loaded file from Node's `require` cache.
+ *
+ * @private
+ * @see {@link Mocha#unloadFiles}
+ * @param {string} file - Pathname of file to be unloaded.
+ */
+Mocha.prototype.unloadFile = function(file) {
+  delete require.cache[require.resolve(file)];
+};
+
+/**
+ * Unloads `files` from Node's `require` cache.
+ *
+ * @description
+ * This allows files to be "freshly" reloaded, providing the ability
+ * to reuse a Mocha instance programmatically.
+ *
+ * <strong>Not needed for (or used by) CLI.</strong>
+ *
+ * @public
+ * @see {@link Mocha#unloadFile}
+ * @see {@link Mocha#loadFiles}
+ * @see {@link Mocha#run}
+ * @returns {Mocha} this
+ * @chainable
+ */
+Mocha.prototype.unloadFiles = function() {
+  this.files.forEach(this.unloadFile, this);
+  return this;
 };
 
 /**
@@ -741,8 +774,7 @@ Object.defineProperty(Mocha.prototype, 'version', {
  */
 
 /**
- * @summary
- * Runs tests and invokes `fn()` when complete.
+ * Runs root suite and invokes `fn()` when complete.
  *
  * @description
  * To run tests multiple times (or to run tests in files that are
@@ -751,6 +783,7 @@ Object.defineProperty(Mocha.prototype, 'version', {
  *
  * @public
  * @see {@link Mocha#loadFiles}
+ * @see {@link Mocha#unloadFiles}
  * @see {@link Runner#run}
  * @param {DoneCB} [fn] - Callback invoked when test execution completed.
  * @return {Runner} runner instance
@@ -787,7 +820,7 @@ Mocha.prototype.run = function(fn) {
   exports.reporters.Base.hideDiff = options.hideDiff;
 
   function done(failures) {
-    fn = fn || function fn() {};
+    fn = fn || utils.noop;
     if (reporter.done) {
       reporter.done(failures, fn);
     } else {

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -6,11 +6,46 @@ const utils = require('../../lib/utils');
 
 describe('Mocha', function() {
   const opts = {reporter: utils.noop}; // no output
+  const testFiles = [
+    __filename,
+    path.join(__dirname, 'cli', 'config.spec.js'),
+    path.join(__dirname, 'cli', 'run.spec.js')
+  ];
+  const resolvedTestFiles = testFiles.map(require.resolve);
 
-  describe('.unloadFile()', function() {
+  describe('#addFile', function() {
+    it('should add the given file to the files array', function() {
+      const mocha = new Mocha(opts);
+      mocha.addFile(__filename);
+      expect(mocha.files, 'to have length', 1).and('to contain', __filename);
+    });
+
+    it('should be chainable', function() {
+      const mocha = new Mocha(opts);
+      expect(mocha.addFile(__filename), 'to be', mocha);
+    });
+  });
+
+  describe('#loadFiles', function() {
+    it('should load all files from the files array', function() {
+      const mocha = new Mocha(opts);
+
+      testFiles.forEach(mocha.addFile, mocha);
+      mocha.loadFiles();
+      expect(require.cache, 'to have keys', resolvedTestFiles);
+    });
+
+    it('should execute the optional callback if given', function() {
+      const mocha = new Mocha(opts);
+      expect(cb => {
+        mocha.loadFiles(cb);
+      }, 'to call the callback');
+    });
+  });
+
+  describe('.unloadFile', function() {
     it('should unload a specific file from cache', function() {
       const resolvedFilePath = require.resolve(__filename);
-
       require(__filename);
       expect(require.cache, 'to have key', resolvedFilePath);
 
@@ -19,23 +54,19 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.unloadFiles()', function() {
+  describe('#unloadFiles', function() {
     it('should unload all test files from cache', function() {
       const mocha = new Mocha(opts);
-      let resolvedTestFiles;
-      const testFiles = [
-        __filename,
-        path.join(__dirname, 'cli', 'config.spec.js'),
-        path.join(__dirname, 'cli', 'run.spec.js')
-      ];
 
       testFiles.forEach(mocha.addFile, mocha);
       mocha.loadFiles();
-      resolvedTestFiles = testFiles.map(require.resolve);
-      expect(require.cache, 'to have keys', resolvedTestFiles);
-
       mocha.unloadFiles();
       expect(require.cache, 'not to have keys', resolvedTestFiles);
+    });
+
+    it('should be chainable', function() {
+      const mocha = new Mocha(opts);
+      expect(mocha.unloadFiles(), 'to be', mocha);
     });
   });
 });

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const path = require('path');
+const Mocha = require('../../lib/mocha');
+const utils = require('../../lib/utils');
+
+describe('Mocha', function() {
+  const opts = {reporter: utils.noop}; // no output
+
+  describe('.unloadFile()', function() {
+    it('should unload a specific file from cache', function() {
+      const resolvedFilePath = require.resolve(__filename);
+
+      require(__filename);
+      expect(require.cache, 'to have key', resolvedFilePath);
+
+      Mocha.unloadFile(__filename);
+      expect(require.cache, 'not to have key', resolvedFilePath);
+    });
+  });
+
+  describe('.unloadFiles()', function() {
+    it('should unload all test files from cache', function() {
+      const mocha = new Mocha(opts);
+      let resolvedTestFiles;
+      const testFiles = [
+        __filename,
+        path.join(__dirname, 'cli', 'config.spec.js'),
+        path.join(__dirname, 'cli', 'run.spec.js')
+      ];
+
+      testFiles.forEach(mocha.addFile, mocha);
+      mocha.loadFiles();
+      resolvedTestFiles = testFiles.map(require.resolve);
+      expect(require.cache, 'to have keys', resolvedTestFiles);
+
+      mocha.unloadFiles();
+      expect(require.cache, 'not to have keys', resolvedTestFiles);
+    });
+  });
+});

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -21,6 +21,7 @@ describe('Mocha', function() {
       sandbox.stub(Mocha.prototype, 'useColors').returnsThis();
       sandbox.stub(utils, 'deprecate');
     });
+
     it('should prefer "color" over "useColors"', function() {
       // eslint-disable-next-line no-new
       new Mocha({useColors: true, color: false});
@@ -67,14 +68,6 @@ describe('Mocha', function() {
           expect.fail(e.message);
         }
       }, 'not to throw');
-    });
-  });
-
-  describe('.addFile()', function() {
-    it('should add the given file to the files array', function() {
-      var mocha = new Mocha(opts);
-      mocha.addFile('myFile.js');
-      expect(mocha.files, 'to have length', 1).and('to contain', 'myFile.js');
     });
   });
 
@@ -153,6 +146,7 @@ describe('Mocha', function() {
         expect(mocha.options, 'to have property', 'growl', true);
       });
     });
+
     describe('if not capable of notifications', function() {
       it('should set the growl option to false', function() {
         var mocha = new Mocha(opts);
@@ -163,6 +157,7 @@ describe('Mocha', function() {
         expect(mocha.options, 'to have property', 'growl', false);
       });
     });
+
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
       expect(mocha.growl(), 'to be', mocha);
@@ -195,10 +190,16 @@ describe('Mocha', function() {
   });
 
   describe('.noHighlighting()', function() {
+    // :NOTE: Browser-only option...
     it('should set the noHighlighting option to true', function() {
       var mocha = new Mocha(opts);
       mocha.noHighlighting();
       expect(mocha.options, 'to have property', 'noHighlighting', true);
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.noHighlighting(), 'to be', mocha);
     });
   });
 
@@ -208,6 +209,11 @@ describe('Mocha', function() {
       mocha.allowUncaught();
       expect(mocha.options, 'to have property', 'allowUncaught', true);
     });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.allowUncaught(), 'to be', mocha);
+    });
   });
 
   describe('.delay()', function() {
@@ -216,6 +222,11 @@ describe('Mocha', function() {
       mocha.delay();
       expect(mocha.options, 'to have property', 'delay', true);
     });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.delay(), 'to be', mocha);
+    });
   });
 
   describe('.bail()', function() {
@@ -223,6 +234,11 @@ describe('Mocha', function() {
       var mocha = new Mocha(opts);
       mocha.bail();
       expect(mocha.suite._bail, 'to be', true);
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.bail(), 'to be', mocha);
     });
   });
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -226,6 +226,58 @@ describe('Mocha', function() {
     });
   });
 
+  describe('.unloadFile()', function() {
+    before(function() {
+      if (process.browser) {
+        this.skip();
+      }
+    });
+
+    it('should unload a specific file from cache', function() {
+      var mocha = new Mocha(opts);
+      var resolvedFilePath;
+      var filePath = __filename;
+
+      mocha.addFile(filePath);
+      mocha.loadFiles();
+      resolvedFilePath = require.resolve(filePath);
+      expect(require.cache, 'to have key', resolvedFilePath);
+
+      mocha.unloadFile(filePath);
+      expect(require.cache, 'not to have key', resolvedFilePath);
+    });
+  });
+
+  describe('.unloadFiles()', function() {
+    var path;
+
+    before(function() {
+      if (process.browser) {
+        this.skip();
+      } else {
+        path = require('path');
+      }
+    });
+
+    it('should unload all test files from cache', function() {
+      var mocha = new Mocha(opts);
+      var resolvedTestFiles;
+      var testFiles = [
+        __filename,
+        path.join(__dirname, 'throw.spec.js'),
+        path.join(__dirname, 'context.spec.js')
+      ];
+
+      testFiles.forEach(mocha.addFile, mocha);
+      mocha.loadFiles();
+      resolvedTestFiles = testFiles.map(require.resolve);
+      expect(require.cache, 'to have keys', resolvedTestFiles);
+
+      mocha.unloadFiles();
+      expect(require.cache, 'not to have keys', resolvedTestFiles);
+    });
+  });
+
   describe('error handling', function() {
     it('should throw reporter error if an invalid reporter is given', function() {
       var updatedOpts = {reporter: 'invalidReporter', reporterOptions: {}};

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -226,58 +226,6 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.unloadFile()', function() {
-    before(function() {
-      if (process.browser) {
-        this.skip();
-      }
-    });
-
-    it('should unload a specific file from cache', function() {
-      var mocha = new Mocha(opts);
-      var resolvedFilePath;
-      var filePath = __filename;
-
-      mocha.addFile(filePath);
-      mocha.loadFiles();
-      resolvedFilePath = require.resolve(filePath);
-      expect(require.cache, 'to have key', resolvedFilePath);
-
-      mocha.unloadFile(filePath);
-      expect(require.cache, 'not to have key', resolvedFilePath);
-    });
-  });
-
-  describe('.unloadFiles()', function() {
-    var path;
-
-    before(function() {
-      if (process.browser) {
-        this.skip();
-      } else {
-        path = require('path');
-      }
-    });
-
-    it('should unload all test files from cache', function() {
-      var mocha = new Mocha(opts);
-      var resolvedTestFiles;
-      var testFiles = [
-        __filename,
-        path.join(__dirname, 'throw.spec.js'),
-        path.join(__dirname, 'context.spec.js')
-      ];
-
-      testFiles.forEach(mocha.addFile, mocha);
-      mocha.loadFiles();
-      resolvedTestFiles = testFiles.map(require.resolve);
-      expect(require.cache, 'to have keys', resolvedTestFiles);
-
-      mocha.unloadFiles();
-      expect(require.cache, 'not to have keys', resolvedTestFiles);
-    });
-  });
-
   describe('error handling', function() {
     it('should throw reporter error if an invalid reporter is given', function() {
       var updatedOpts = {reporter: 'invalidReporter', reporterOptions: {}};


### PR DESCRIPTION
### Description of the Change
Adds a feature which allows unloading test files from `require` cache programmatically.
This feature simplifies rerunning tests since there is no need to recreate the Mocha instance.

Currently handled by one of these options:
1. The user has to implement same logic in his own code.
1. The user has to create a new Mocha instance before each run.

### Alternative Designs
A potentially more complete design could take a snapshot of the cache before testing begins and remove _everything_ added afterwards. Prefer to see how well this implementation does before going further.

### Why should this be in core?
1. Because it allows reuse of object instances.
1. Provides missing half of Mocha's public API referenced [here](https://github.com/mochajs/mocha/blob/d1902a20663a6766ffaae646f155a884fcf3e141/lib/mocha.js#L579-L585).
1. (Hopeful) reduction of user questions about how to do this.

### Benefits
Better reusability, fewer headaches for programmers.

### Possible Drawbacks
Still possible that even though registered files were unloaded from the `require` cache,
they may have in turn `require`d something else which _will_ remain in the cache.

### Applicable issues
Closes #3534 (original PR from Oct 2018 redone against current master)
semver-minor