### PR TITLE
remove a post-processing code having no effect; closes #3708

### DIFF
--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -269,7 +269,7 @@ function _spawnMochaWithListeners(args, fn, opts) {
 
   mocha.on('close', function(code) {
     fn(null, {
-      output: output.split('\n').join('\n'),
+      output: output,
       code: code,
       args: args
     });


### PR DESCRIPTION
### Description of the Change

Remove unnecessary post-processing code because it does not have any effect.

```js
// test/integration/helpers.js
mocha.on('close', function(code) {
  fn(null, {
<<<<<<< issues/3708
    output: output,
=======
    output: output.split('\n').join('\n'),
>>>>>>> master
    code: code,
    args: args
  });
});
```
`split('\n').join('\n')` always returns the original value.

```js
> var foo = '\n\n\n\nasd\n\nasd\n\nasd\n\n\n'
> var bar = foo.split('\n').join('\n')
> foo === bar
true
```

### Applicable issues

Fixes #3708 
semver-patch