### PR TITLE
Edit Hook.prototype.error to Hook.prototype.getError

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -28,19 +28,14 @@ function Hook(title, fn) {
 inherits(Hook, Runnable);
 
 /**
- * Get or set the test `err`.
+ * Get the test error.
  *
  * @memberof Hook
  * @public
- * @param {Error} err
  * @return {Error}
  */
-Hook.prototype.error = function(err) {
-  if (!arguments.length) {
-    err = this._error;
-    this._error = null;
-    return err;
-  }
-
-  this._error = err;
+Hook.prototype.getError = function() {
+  var err = this._error;
+  this._error = null;
+  return err;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -380,7 +380,7 @@ Runner.prototype.hook = function(name, fn) {
     }
 
     hook.run(function(err) {
-      var testError = hook.error();
+      var testError = hook.getError();
       if (testError) {
         self.fail(self.test, testError);
       }


### PR DESCRIPTION
### Description of the Change
Change error function to getError because the function to set error is not used.
There is only one place to use Hook.prototype.error. ([/lib/runner.js](https://github.com/mochajs/mocha/blob/master/lib/runner.js))
```
hook.run(function(err) {
  var testError = hook.error();
....
```
Using 'get' only, it seems good to remove 'set' code.

### Benefits
Unnecessary code is removed.