### PR TITLE
Fix `.globals` to remove falsy values

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -543,7 +543,9 @@ Mocha.prototype._growl = growl.notify;
  * mocha.globals(['jQuery', 'MyLib']);
  */
 Mocha.prototype.globals = function(globals) {
-  this.options.globals = (this.options.globals || []).concat(globals);
+  this.options.globals = (this.options.globals || [])
+    .concat(globals)
+    .filter(Boolean);
   return this;
 };
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -41,71 +41,29 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.run(fn)', function() {
-    it('should not raise errors if callback was not provided', function() {
-      sandbox.stub(Mocha.Runner.prototype, 'run');
+  describe('.allowUncaught()', function() {
+    it('should set the allowUncaught option to true', function() {
       var mocha = new Mocha(opts);
-      expect(function() {
-        mocha.run();
-      }, 'not to throw');
-    });
-
-    it('should execute the callback when complete', function(done) {
-      var mocha = new Mocha(opts);
-      sandbox.stub(Mocha.Runner.prototype, 'run').callsArg(0);
-      mocha.run(done);
-    });
-  });
-
-  describe('.reporter("xunit").run(fn)', function() {
-    it('should not raise errors if callback was not provided', function() {
-      var mocha = new Mocha();
-      expect(function() {
-        try {
-          mocha.reporter('xunit').run();
-        } catch (e) {
-          console.log(e);
-          expect.fail(e.message);
-        }
-      }, 'not to throw');
-    });
-  });
-
-  describe('.invert()', function() {
-    it('should set the invert option to true', function() {
-      var mocha = new Mocha(opts);
-      mocha.invert();
-      expect(mocha.options, 'to have property', 'invert', true);
+      mocha.allowUncaught();
+      expect(mocha.options, 'to have property', 'allowUncaught', true);
     });
 
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
-      expect(mocha.invert(), 'to be', mocha);
+      expect(mocha.allowUncaught(), 'to be', mocha);
     });
   });
 
-  describe('.ignoreLeaks()', function() {
-    it('should set the ignoreLeaks option to true when param equals true', function() {
+  describe('.bail()', function() {
+    it('should set the suite._bail to true if there is no arguments', function() {
       var mocha = new Mocha(opts);
-      mocha.ignoreLeaks(true);
-      expect(mocha.options, 'to have property', 'ignoreLeaks', true);
-    });
-
-    it('should set the ignoreLeaks option to false when param equals false', function() {
-      var mocha = new Mocha(opts);
-      mocha.ignoreLeaks(false);
-      expect(mocha.options, 'to have property', 'ignoreLeaks', false);
-    });
-
-    it('should set the ignoreLeaks option to false when the param is undefined', function() {
-      var mocha = new Mocha(opts);
-      mocha.ignoreLeaks();
-      expect(mocha.options, 'to have property', 'ignoreLeaks', false);
+      mocha.bail();
+      expect(mocha.suite._bail, 'to be', true);
     });
 
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
-      expect(mocha.ignoreLeaks(), 'to be', mocha);
+      expect(mocha.bail(), 'to be', mocha);
     });
   });
 
@@ -119,6 +77,19 @@ describe('Mocha', function() {
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
       expect(mocha.checkLeaks(), 'to be', mocha);
+    });
+  });
+
+  describe('.delay()', function() {
+    it('should set the delay option to true', function() {
+      var mocha = new Mocha(opts);
+      mocha.delay();
+      expect(mocha.options, 'to have property', 'delay', true);
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.delay(), 'to be', mocha);
     });
   });
 
@@ -210,6 +181,88 @@ describe('Mocha', function() {
     });
   });
 
+  describe('.ignoreLeaks()', function() {
+    it('should set the ignoreLeaks option to true when param equals true', function() {
+      var mocha = new Mocha(opts);
+      mocha.ignoreLeaks(true);
+      expect(mocha.options, 'to have property', 'ignoreLeaks', true);
+    });
+
+    it('should set the ignoreLeaks option to false when param equals false', function() {
+      var mocha = new Mocha(opts);
+      mocha.ignoreLeaks(false);
+      expect(mocha.options, 'to have property', 'ignoreLeaks', false);
+    });
+
+    it('should set the ignoreLeaks option to false when the param is undefined', function() {
+      var mocha = new Mocha(opts);
+      mocha.ignoreLeaks();
+      expect(mocha.options, 'to have property', 'ignoreLeaks', false);
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.ignoreLeaks(), 'to be', mocha);
+    });
+  });
+
+  describe('.invert()', function() {
+    it('should set the invert option to true', function() {
+      var mocha = new Mocha(opts);
+      mocha.invert();
+      expect(mocha.options, 'to have property', 'invert', true);
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.invert(), 'to be', mocha);
+    });
+  });
+
+  describe('.noHighlighting()', function() {
+    // :NOTE: Browser-only option...
+    it('should set the noHighlighting option to true', function() {
+      var mocha = new Mocha(opts);
+      mocha.noHighlighting();
+      expect(mocha.options, 'to have property', 'noHighlighting', true);
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.noHighlighting(), 'to be', mocha);
+    });
+  });
+
+  describe('.reporter("xunit").run(fn)', function() {
+    it('should not raise errors if callback was not provided', function() {
+      var mocha = new Mocha();
+      expect(function() {
+        try {
+          mocha.reporter('xunit').run();
+        } catch (e) {
+          console.log(e);
+          expect.fail(e.message);
+        }
+      }, 'not to throw');
+    });
+  });
+
+  describe('.run(fn)', function() {
+    it('should not raise errors if callback was not provided', function() {
+      sandbox.stub(Mocha.Runner.prototype, 'run');
+      var mocha = new Mocha(opts);
+      expect(function() {
+        mocha.run();
+      }, 'not to throw');
+    });
+
+    it('should execute the callback when complete', function(done) {
+      var mocha = new Mocha(opts);
+      sandbox.stub(Mocha.Runner.prototype, 'run').callsArg(0);
+      mocha.run(done);
+    });
+  });
+
   describe('.useInlineDiffs()', function() {
     it('should set the useInlineDiffs option to true when param equals true', function() {
       var mocha = new Mocha(opts);
@@ -232,59 +285,6 @@ describe('Mocha', function() {
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
       expect(mocha.useInlineDiffs(), 'to be', mocha);
-    });
-  });
-
-  describe('.noHighlighting()', function() {
-    // :NOTE: Browser-only option...
-    it('should set the noHighlighting option to true', function() {
-      var mocha = new Mocha(opts);
-      mocha.noHighlighting();
-      expect(mocha.options, 'to have property', 'noHighlighting', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.noHighlighting(), 'to be', mocha);
-    });
-  });
-
-  describe('.allowUncaught()', function() {
-    it('should set the allowUncaught option to true', function() {
-      var mocha = new Mocha(opts);
-      mocha.allowUncaught();
-      expect(mocha.options, 'to have property', 'allowUncaught', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.allowUncaught(), 'to be', mocha);
-    });
-  });
-
-  describe('.delay()', function() {
-    it('should set the delay option to true', function() {
-      var mocha = new Mocha(opts);
-      mocha.delay();
-      expect(mocha.options, 'to have property', 'delay', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.delay(), 'to be', mocha);
-    });
-  });
-
-  describe('.bail()', function() {
-    it('should set the suite._bail to true if there is no arguments', function() {
-      var mocha = new Mocha(opts);
-      mocha.bail();
-      expect(mocha.suite._bail, 'to be', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.bail(), 'to be', mocha);
     });
   });
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -5,7 +5,7 @@ var Mocha = require('../../lib/mocha');
 var sinon = require('sinon');
 
 describe('Mocha', function() {
-  var opts = {reporter: function() {}}; // no output
+  var opts = {reporter: utils.noop}; // no output
   var sandbox;
 
   beforeEach(function() {
@@ -132,6 +132,52 @@ describe('Mocha', function() {
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
       expect(mocha.fullTrace(), 'to be', mocha);
+    });
+  });
+
+  describe('.globals()', function() {
+    it('should be an empty array initially', function() {
+      var mocha = new Mocha();
+      expect(mocha.options.globals, 'to be empty');
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.globals(), 'to be', mocha);
+    });
+
+    describe('when argument is invalid', function() {
+      it('should not add empty string to the whitelist', function() {
+        var mocha = new Mocha(opts);
+        mocha.globals('');
+        expect(mocha.options.globals, 'to be empty');
+      });
+
+      it('should not add empty array to the whitelist', function() {
+        var mocha = new Mocha(opts);
+        mocha.globals([]);
+        expect(mocha.options.globals, 'to be empty');
+      });
+    });
+
+    describe('when argument is valid', function() {
+      var elem = 'foo';
+      var elem2 = 'bar';
+
+      it('should add string to the whitelist', function() {
+        var mocha = new Mocha(opts);
+        mocha.globals(elem);
+        expect(mocha.options.globals, 'to contain', elem);
+        expect(mocha.options.globals, 'to have length', 1);
+      });
+
+      it('should add string array to the whitelist', function() {
+        var mocha = new Mocha(opts);
+        var elems = [elem, elem2];
+        mocha.globals(elems);
+        expect(mocha.options.globals, 'to contain', elem, elem2);
+        expect(mocha.options.globals, 'to have length', elems.length);
+      });
     });
   });
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -41,7 +41,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.allowUncaught()', function() {
+  describe('#allowUncaught()', function() {
     it('should set the allowUncaught option to true', function() {
       var mocha = new Mocha(opts);
       mocha.allowUncaught();
@@ -54,7 +54,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.bail()', function() {
+  describe('#bail()', function() {
     it('should set the suite._bail to true if there is no arguments', function() {
       var mocha = new Mocha(opts);
       mocha.bail();
@@ -67,7 +67,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.checkLeaks()', function() {
+  describe('#checkLeaks()', function() {
     it('should set the ignoreLeaks option to false', function() {
       var mocha = new Mocha(opts);
       mocha.checkLeaks();
@@ -80,7 +80,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.delay()', function() {
+  describe('#delay()', function() {
     it('should set the delay option to true', function() {
       var mocha = new Mocha(opts);
       mocha.delay();
@@ -93,7 +93,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.fullTrace()', function() {
+  describe('#fullTrace()', function() {
     it('should set the fullStackTrace option to true', function() {
       var mocha = new Mocha(opts);
       mocha.fullTrace();
@@ -106,7 +106,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.globals()', function() {
+  describe('#globals()', function() {
     it('should be an empty array initially', function() {
       var mocha = new Mocha();
       expect(mocha.options.globals, 'to be empty');
@@ -152,7 +152,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.growl()', function() {
+  describe('#growl()', function() {
     describe('if capable of notifications', function() {
       it('should set the growl option to true', function() {
         var mocha = new Mocha(opts);
@@ -181,7 +181,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.ignoreLeaks()', function() {
+  describe('#ignoreLeaks()', function() {
     it('should set the ignoreLeaks option to true when param equals true', function() {
       var mocha = new Mocha(opts);
       mocha.ignoreLeaks(true);
@@ -206,7 +206,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.invert()', function() {
+  describe('#invert()', function() {
     it('should set the invert option to true', function() {
       var mocha = new Mocha(opts);
       mocha.invert();
@@ -219,7 +219,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.noHighlighting()', function() {
+  describe('#noHighlighting()', function() {
     // :NOTE: Browser-only option...
     it('should set the noHighlighting option to true', function() {
       var mocha = new Mocha(opts);
@@ -233,7 +233,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.reporter("xunit").run(fn)', function() {
+  describe('#reporter("xunit")#run(fn)', function() {
     it('should not raise errors if callback was not provided', function() {
       var mocha = new Mocha();
       expect(function() {
@@ -247,7 +247,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.run(fn)', function() {
+  describe('#run(fn)', function() {
     it('should not raise errors if callback was not provided', function() {
       sandbox.stub(Mocha.Runner.prototype, 'run');
       var mocha = new Mocha(opts);
@@ -263,7 +263,7 @@ describe('Mocha', function() {
     });
   });
 
-  describe('.useInlineDiffs()', function() {
+  describe('#useInlineDiffs()', function() {
     it('should set the useInlineDiffs option to true when param equals true', function() {
       var mocha = new Mocha(opts);
       mocha.useInlineDiffs(true);

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -118,13 +118,13 @@ describe('Mocha', function() {
     });
 
     describe('when argument is invalid', function() {
-      it('should not add empty string to the whitelist', function() {
+      it('should not modify the whitelist when given empty string', function() {
         var mocha = new Mocha(opts);
         mocha.globals('');
         expect(mocha.options.globals, 'to be empty');
       });
 
-      it('should not add empty array to the whitelist', function() {
+      it('should not modify the whitelist when given empty array', function() {
         var mocha = new Mocha(opts);
         mocha.globals([]);
         expect(mocha.options.globals, 'to be empty');
@@ -142,7 +142,7 @@ describe('Mocha', function() {
         expect(mocha.options.globals, 'to have length', 1);
       });
 
-      it('should add string array to the whitelist', function() {
+      it('should add contents of string array to the whitelist', function() {
         var mocha = new Mocha(opts);
         var elems = [elem, elem2];
         mocha.globals(elems);

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -253,21 +253,13 @@ describe('Mocha', function() {
     });
   });
 
-  describe('#reporter("xunit")#run(fn)', function() {
-    it('should not raise errors if callback was not provided', function() {
-      var mocha = new Mocha();
-      expect(function() {
-        try {
-          mocha.reporter('xunit').run();
-        } catch (e) {
-          console.log(e);
-          expect.fail(e.message);
-        }
-      }, 'not to throw');
-    });
-  });
-
   describe('#run(fn)', function() {
+    it('should execute the callback when complete', function(done) {
+      var mocha = new Mocha(opts);
+      sandbox.stub(Mocha.Runner.prototype, 'run').callsArg(0);
+      mocha.run(done);
+    });
+
     it('should not raise errors if callback was not provided', function() {
       sandbox.stub(Mocha.Runner.prototype, 'run');
       var mocha = new Mocha(opts);
@@ -276,10 +268,19 @@ describe('Mocha', function() {
       }, 'not to throw');
     });
 
-    it('should execute the callback when complete', function(done) {
-      var mocha = new Mocha(opts);
-      sandbox.stub(Mocha.Runner.prototype, 'run').callsArg(0);
-      mocha.run(done);
+    describe('#reporter("xunit")#run(fn)', function() {
+      // :TBD: Why does specifying reporter differentiate this test from preceding one
+      it('should not raise errors if callback was not provided', function() {
+        var mocha = new Mocha();
+        expect(function() {
+          try {
+            mocha.reporter('xunit').run();
+          } catch (e) {
+            console.log(e);
+            expect.fail(e.message);
+          }
+        }, 'not to throw');
+      });
     });
   });
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -233,6 +233,26 @@ describe('Mocha', function() {
     });
   });
 
+  describe('#reporter()', function() {
+    it('should throw reporter error if an invalid reporter is given', function() {
+      var updatedOpts = {reporter: 'invalidReporter', reporterOptions: {}};
+      var throwError = function() {
+        // eslint-disable-next-line no-new
+        new Mocha(updatedOpts);
+      };
+      expect(throwError, 'to throw', {
+        message: "invalid reporter 'invalidReporter'",
+        code: 'ERR_MOCHA_INVALID_REPORTER',
+        reporter: 'invalidReporter'
+      });
+    });
+
+    it('should be chainable', function() {
+      var mocha = new Mocha(opts);
+      expect(mocha.reporter(), 'to be', mocha);
+    });
+  });
+
   describe('#reporter("xunit")#run(fn)', function() {
     it('should not raise errors if callback was not provided', function() {
       var mocha = new Mocha();
@@ -285,21 +305,6 @@ describe('Mocha', function() {
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
       expect(mocha.useInlineDiffs(), 'to be', mocha);
-    });
-  });
-
-  describe('error handling', function() {
-    it('should throw reporter error if an invalid reporter is given', function() {
-      var updatedOpts = {reporter: 'invalidReporter', reporterOptions: {}};
-      var throwError = function() {
-        // eslint-disable-next-line no-new
-        new Mocha(updatedOpts);
-      };
-      expect(throwError, 'to throw', {
-        message: "invalid reporter 'invalidReporter'",
-        code: 'ERR_MOCHA_INVALID_REPORTER',
-        reporter: 'invalidReporter'
-      });
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

Mocha constructor (via `.globals`) creates `this.options.globals` array containing `undefined` element (which it shouldn't). Corrected `.globals` by removing falsy values.

Cleaned up Mocha unit test specification in the process.

### Alternate Designs

Better error checking of arguments could have prevented the problem.

### Why should this be in core?

NA - already in core

### Benefits

Existing code has bug. This fixes it.

### Possible Drawbacks

None.

### Applicable issues

Closes #3668 
semver-patch
