### PR TITLE
Uppercase JSON reporter name in `describe` title

### DIFF
--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -5,7 +5,7 @@ var Suite = Mocha.Suite;
 var Runner = Mocha.Runner;
 var Test = Mocha.Test;
 
-describe('json reporter', function() {
+describe('JSON reporter', function() {
   var suite, runner;
   var testTitle = 'json test 1';
 


### PR DESCRIPTION
### Description of the Change
Uppercased JSON reporter name in `describe` title.

### Alternate Designs
NA

### Why should this be in core?
NA

### Benefits
All of the other reporter test suites
Used to laugh and call him names...

### Possible Drawbacks
None

### Applicable issues
semver-patch
