### PR TITLE
Fix this.skip() async calls

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -781,6 +781,9 @@ Runner.prototype.runSuite = function(suite, fn) {
  * @private
  */
 Runner.prototype.uncaught = function(err) {
+  if (err instanceof Pending) {
+    return;
+  }
   if (err) {
     debug('uncaught exception %O', err);
   } else {

--- a/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-hooks.fixture.js
@@ -14,8 +14,7 @@ describe('outer suite', function () {
       console.log('inner before');
       var self = this;
       setTimeout(function () {
-        self.skip();
-        done();
+        self.skip();   // done() is not required
       }, 0);
     });
 

--- a/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before-nested.fixture.js
@@ -2,8 +2,7 @@ describe('skip in before with nested describes', function () {
   before(function (done) {
     var self = this;
     setTimeout(function () {
-      self.skip();
-      done();
+      self.skip();   // done() is not required
     }, 0);
   });
 

--- a/test/integration/fixtures/pending/skip-async-before.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-before.fixture.js
@@ -7,7 +7,7 @@ describe('outer describe', function () {
     before(function (done) {
       var self = this;
       setTimeout(function () {
-        self.skip();
+        self.skip();   // done() is not required
       }, 0);
     });
 

--- a/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-beforeEach.fixture.js
@@ -4,18 +4,17 @@ describe('skip in beforeEach', function () {
   beforeEach(function (done) {
     var self = this;
     setTimeout(function () {
-      self.skip();
-      done();
+      self.skip();   // done() is not required
     }, 0);
   });
 
-  it('should skip this test', function () {
+  it('should skip this test-1', function () {
     throw new Error('never run this test');
   });
-  it('should not reach this test', function () {
+  it('should skip this test-2', function () {
     throw new Error('never run this test');
   });
-  it('should not reach this test', function () {
+  it('should skip this test-3', function () {
     throw new Error('never run this test');
   });
 });

--- a/test/integration/fixtures/pending/skip-async-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-spec.fixture.js
@@ -4,7 +4,7 @@ describe('skip in test', function () {
   it('should skip async', function (done) {
     var self = this;
     setTimeout(function () {
-      self.skip();
+      self.skip();   // done() is not required
     }, 0);
   });
 

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -258,18 +258,21 @@ describe('pending', function() {
 
     describe('in beforeEach', function() {
       it('should skip all suite specs', function(done) {
-        run('pending/skip-async-beforeEach.fixture.js', args, function(
-          err,
-          res
-        ) {
+        var fixture = 'pending/skip-async-beforeEach.fixture.js';
+        run(fixture, args, function(err, res) {
           if (err) {
-            done(err);
-            return;
+            return done(err);
           }
-          assert.strictEqual(res.stats.pending, 1);
-          assert.strictEqual(res.stats.passes, 0);
-          assert.strictEqual(res.stats.failures, 1);
-          assert.strictEqual(res.code, 1);
+          expect(res, 'to have passed')
+            .and('to have passed test count', 0)
+            .and('to have pending test count', 3)
+            .and(
+              'to have pending test order',
+              'should skip this test-1',
+              'should skip this test-2',
+              'should skip this test-3'
+            )
+            .and('to have failed test count', 0);
           done();
         });
       });


### PR DESCRIPTION
### Description

The async call of `this.skip` in a `beforeEach` hook results in an error.

```js
'use strict';

describe('skip in beforeEach', function () {
  beforeEach(function (done) {
    var self = this;
    setTimeout(function () {
      self.skip();
      done();
    }, 0);
  });

  it('should skip this test', function () {
    throw new Error('never run this test');
  });
  it('should not reach this test', function () {
    throw new Error('never run this test');
  });
  it('should not reach this test', function () {
    throw new Error('never run this test');
  });
});
```
```
skip in beforeEach
    - should skip this test
    1) "before each" hook

  0 passing (19ms)
  1 pending
  1 failing

  1) skip in beforeEach
       "before each" hook:
     Uncaught async skip; aborting execution
```
The async `this.skip` does not abort the hook/test (as the sync version does). This is just usual behavior since neither `done()`, `done(err)` nor "resolving/rejecting" a promise do abort an async running function.
To enforce this abortion Mocha throws an uncaught error. This is a very crude mechanisme which sometimes works and othertimes doesn't.

The user documentation states:
> Best practice: To avoid confusion, do not execute further instructions in a test or hook after calling this.skip().

I propose to remove this uncaught error. In order to abort a running async function, in some cases `this.skip()` has to be replaced by `return this.skip()`.

Consequences for the user:
- `this.skip()` works in async `beforeEach` hooks.
- "Bad practice" users have to insert the `return` statement in `before` hooks and `it` tests to abort execution.
- an explicit call of `done()` will result in an `Error: done() called multiple times`.

### Description of the Change

~~Remove uncaught error in "runnable.js".~~
Fix Runner.prototype.uncaught()

### Applicable issues

#3740 partially