### PR TITLE
Revert default glob to match Mocha-5.2

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -245,7 +245,7 @@ exports.builder = yargs =>
       }
     })
     .positional('spec', {
-      default: ['test/'],
+      default: ['test'],
       description: 'One or more files, directories, or globs to test',
       type: 'array'
     })


### PR DESCRIPTION
### Description of the Change

The old glob 'test' would allow "test.js" to be used by default (rather than requiring spec file be
placed inside "test" directory).

In minimalist repos, users were simply using "test.js" rather than "test/\<file\>.js", allowing...
```sh
$ mocha
```

### Alternate Designs
NA

### Why should this be in core?
NA - already there

### Benefits
Restore compatibility with previous releases.
Prevent a boatload of more issues from minimalist repositories using Mocha.

### Possible Drawbacks
None

### Applicable issues

Fixes #3750
semver-patch