### PR TITLE
Add new cmdline option to denote implicit returns

### DIFF
--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -35,6 +35,7 @@ exports.types = {
     'forbid-pending',
     'full-trace',
     'growl',
+    'implicit-returns',
     'inline-diffs',
     'interfaces',
     'invert',

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -143,6 +143,10 @@ exports.builder = yargs =>
         description: 'Enable Growl notifications',
         group: GROUPS.OUTPUT
       },
+      'implicit-returns': {
+        description: 'Denote source language uses implicit returns',
+        group: GROUPS.RULES
+      },
       'inline-diffs': {
         description:
           'Display actual/expected differences inline within each string',

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,9 +1,11 @@
 'use strict';
 
+var util = require('util');
 var Suite = require('../suite');
 var utils = require('../utils');
 var errors = require('../errors');
 var createMissingArgumentError = errors.createMissingArgumentError;
+var dQuote = utils.dQuote;
 
 /**
  * Functions common to more than one interface.
@@ -139,13 +141,14 @@ module.exports = function(suites, context, mocha) {
         }
         if (typeof opts.fn === 'function') {
           var result = opts.fn.call(suite);
-          if (typeof result !== 'undefined') {
+          if (typeof result !== 'undefined' && !mocha.options.implicitReturns) {
             utils.deprecate(
-              'Suites ignore return values. Suite "' +
-                suite.fullTitle() +
-                '" in ' +
-                suite.file +
-                ' returned a value; this may be a bug in your test code'
+              util.format(
+                'Suites ignore return values. Suite %s in %s returned a value; ' +
+                  'this may be a bug in your test code',
+                dQuote(suite.fullTitle()),
+                dQuote(suite.file)
+              )
             );
           }
           suites.shift();

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -81,6 +81,7 @@ exports.Test = require('./test');
  * @param {boolean} [options.growl] - Enable desktop notifications?
  * @param {boolean} [options.hideDiff] - Suppress diffs from failures?
  * @param {boolean} [options.ignoreLeaks] - Ignore global leaks?
+ * @param {boolean} [options.implicitReturns] - Language uses implicit returns?
  * @param {boolean} [options.invert] - Invert test filter matches?
  * @param {boolean} [options.noHighlighting] - Disable syntax highlighting?
  * @param {string} [options.reporter] - Reporter name.


### PR DESCRIPTION
### Description of the Change
Coffeescript automatically returns the result of the last expression (implicit return).
The change made to deprecate suites returning a value causes a warning for _every_ `describe`. This adds a cmdline option which can disable the deprecation warning.

### Alternate Designs
Simplest and most expedient solution.

### Why should this be in core?
NA - already in core

### Benefits
Allows CoffeeScript users to upgrade.

### Possible Drawbacks
None

### Applicable issues
Fixes #3744
Original PR #3243
semver-patch