### PR TITLE
backout deprecation of value returned from suite; closes #3744

### DIFF
--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Suite = require('../suite');
-var utils = require('../utils');
 var errors = require('../errors');
 var createMissingArgumentError = errors.createMissingArgumentError;
 
@@ -138,16 +137,7 @@ module.exports = function(suites, context, mocha) {
           }
         }
         if (typeof opts.fn === 'function') {
-          var result = opts.fn.call(suite);
-          if (typeof result !== 'undefined') {
-            utils.deprecate(
-              'Suites ignore return values. Suite "' +
-                suite.fullTitle() +
-                '" in ' +
-                suite.file +
-                ' returned a value; this may be a bug in your test code'
-            );
-          }
+          opts.fn.call(suite);
           suites.shift();
         } else if (typeof opts.fn === 'undefined' && !suite.pending) {
           throw createMissingArgumentError(

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -51,7 +51,7 @@ describe('skipped suite w/ callback', function() {
 });
 
 describe('suite returning a value', function() {
-  it('should give a deprecation warning for suite callback returning a value', function(done) {
+  it('should not give a deprecation warning for suite callback returning a value', function(done) {
     run(
       'suite/suite-returning-value.fixture.js',
       args,
@@ -59,9 +59,7 @@ describe('suite returning a value', function() {
         if (err) {
           return done(err);
         }
-        var pattern = new RegExp('Suites ignore return values', 'g');
-        var result = res.output.match(pattern) || [];
-        expect(result, 'to have length', 1);
+        expect(res, 'not to contain output', /Suites ignore return values/);
         done();
       },
       {stdio: 'pipe'}


### PR DESCRIPTION
This just kills the deprecation as I suggested [here](https://github.com/mochajs/mocha/issues/3744#issuecomment-465853188).