### PR TITLE
Eliminate "noise" Karma middleware warning 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10475,9 +10475,9 @@
       }
     },
     "karma-browserify": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-5.3.0.tgz",
-      "integrity": "sha512-EMaUd1RNyQVGTETI80dtX/fEtYs57/A5sl3rClvzJFImPW1s3EtsbESfqNtk7/OkzfYuAHLh4RSZSSbVgvhNdQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-6.0.0.tgz",
+      "integrity": "sha512-G3dGjoy1/6P8I6qTp799fbcAxs4P+1JcyEKUzy9g1/xMakqf9FFPwW2T9iEtCbWoH5WIKD3z+YwGL5ysBhzrsg==",
       "dev": true,
       "requires": {
         "convert-source-map": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -540,7 +540,7 @@
     "husky": "^1.2.1",
     "jsdoc": "^3.5.5",
     "karma": "^4.0.0",
-    "karma-browserify": "^5.3.0",
+    "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.4",


### PR DESCRIPTION
### Description of the Change

Updates ['karma-browserify'](https://www.npmjs.com/package/karma-browserify) module to eliminate Karma middleware warning.
```console
WARN [middleware:karma]: Invalid file type, defaulting to js. browserify
```
As shown in the output below, the 'karma-browserify'-5.3.0 was creating its temporary file with the extension name ".browserify". This is the cause of the Karma middleware warning. 
```sh
$ TMPDIR=/tmp/karma DEBUG=*,-log4js:* karma start --log-level debug --no-auto-watch --single-run karma.conf.js
[SNIP]
22 02 2019 09:49:28.103:DEBUG [plugin]: Loading plugin /var/tmp/mocha-ya/node_modules/karma-browserify.
[SNIP]
22 02 2019 09:49:28.651:DEBUG [framework.browserify]: created browserify bundle: /tmp/karma/d188a37070bebec4a6e48de4cce2e645.browserify
22 02 2019 09:49:28.670:DEBUG [framework.browserify]: add bundle to config.files at position 4
```
The current version (6.0.0) creates now uses ".browserify.js", which doesn't trigger the warning.

### Alternate Designs
NA

### Why should this be in core?
NA

### Benefits
Karma test output will be cleaner...

### Possible Drawbacks
None

### Applicable issues

Reference: karma-runner/karma#3276
Reference: nikku/karma-browserify#219
semver-patch
