### PR TITLE
Display website sponsor logos on non-white background

### DIFF
--- a/docs/_includes/sponsors.md
+++ b/docs/_includes/sponsors.md
@@ -4,6 +4,6 @@ Use Mocha at Work?  Ask your manager or marketing team if they'd help [support](
 
 <!-- markdownlint-disable MD034 -->
 {% for i in (0..15) %}[![](https://opencollective.com/mochajs/sponsor/{{ i }}/avatar.jpg)](https://opencollective.com/mochajs/sponsor/{{ i }}/website){: target="_blank"} {% endfor %}
-{: .image-list .faded-images}
+{: .image-list .faded-images id="_sponsors"}
 
 <script src="js/avatars.js"></script>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -144,7 +144,7 @@ a.direct-link {
   opacity: 0;
 }
 
-a[href="https://opencollective.com/mochajs/sponsor/3/website"], a[href="https://opencollective.com/mochajs/sponsor/4/website"] {
+#_sponsors {
     background-color: #a9a3a3e8;
     box-shadow: 0px 0px 16px 8px #9e9a9ad6;
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -144,6 +144,11 @@ a.direct-link {
   opacity: 0;
 }
 
+a[href="https://opencollective.com/mochajs/sponsor/3/website"], a[href="https://opencollective.com/mochajs/sponsor/4/website"] {
+    background-color: #a9a3a3e8;
+    box-shadow: 0px 0px 16px 8px #9e9a9ad6;
+}
+
 :hover > a.direct-link {
   opacity: 1;
 }


### PR DESCRIPTION

### Description of the Change

I have changed the website style sheet to change the links style of the "Principal" and "TripleByte" sponsors. This way, they can be seen against a blurred grey background. 

### Alternate Designs

N/A

### Why should this be in core?

N/A

### Benefits

Now there is a grey background in the third and fourth sponsor's logo, so now they can be seen.

### Possible Drawbacks

None

### Applicable issues

Fixes #3736 
semver-patch
