### PR TITLE
Make reporter ctors support optional 'options' parameter

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -92,10 +92,10 @@ if (process.platform === 'win32') {
  * as well as user-defined color
  * schemes.
  *
+ * @private
  * @param {string} type
  * @param {string} str
  * @return {string}
- * @private
  */
 var color = (exports.color = function(type, str) {
   if (!exports.useColors) {
@@ -168,7 +168,8 @@ function stringifyDiffObjs(err) {
 /**
  * Returns a diff between 2 strings with coloured ANSI output.
  *
- * The diff will be either inline or unified dependant on the value
+ * @description
+ * The diff will be either inline or unified dependent on the value
  * of `Base.inlineDiff`.
  *
  * @param {string} actual
@@ -182,14 +183,14 @@ var generateDiff = (exports.generateDiff = function(actual, expected) {
 });
 
 /**
- * Output the given `failures` as a list.
+ * Outputs the given `failures` as a list.
  *
  * @public
  * @memberof Mocha.reporters.Base
  * @variation 1
- * @param {Array} failures
+ * @param {Object[]} failures - Each is Test instance with corresponding
+ *     Error property
  */
-
 exports.list = function(failures) {
   console.log();
   failures.forEach(function(test, i) {
@@ -257,25 +258,26 @@ exports.list = function(failures) {
 };
 
 /**
- * Initialize a new `Base` reporter.
+ * Constructs a new `Base` reporter instance.
  *
- * All other reporters generally
- * inherit from this reporter.
+ * @description
+ * All other reporters generally inherit from this reporter.
  *
- * @memberof Mocha.reporters
  * @public
  * @class
- * @param {Runner} runner
+ * @memberof Mocha.reporters
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-
-function Base(runner) {
+function Base(runner, options) {
   var failures = (this.failures = []);
 
   if (!runner) {
     throw new TypeError('Missing runner argument');
   }
-  this.stats = runner.stats; // assigned so Reporters keep a closer reference
+  this.options = options || {};
   this.runner = runner;
+  this.stats = runner.stats; // assigned so Reporters keep a closer reference
 
   runner.on(EVENT_TEST_PASS, function(test) {
     if (test.duration > test.slow()) {
@@ -297,11 +299,10 @@ function Base(runner) {
 }
 
 /**
- * Output common epilogue used by many of
- * the bundled reporters.
+ * Outputs common epilogue used by many of the bundled reporters.
  *
- * @memberof Mocha.reporters.Base
  * @public
+ * @memberof Mocha.reporters.Base
  */
 Base.prototype.epilogue = function() {
   var stats = this.stats;
@@ -338,7 +339,7 @@ Base.prototype.epilogue = function() {
 };
 
 /**
- * Pad the given `str` to `len`.
+ * Pads the given `str` to `len`.
  *
  * @private
  * @param {string} str
@@ -351,7 +352,7 @@ function pad(str, len) {
 }
 
 /**
- * Returns an inline diff between 2 strings with coloured ANSI output.
+ * Returns inline diff between 2 strings with coloured ANSI output.
  *
  * @private
  * @param {String} actual
@@ -388,7 +389,7 @@ function inlineDiff(actual, expected) {
 }
 
 /**
- * Returns a unified diff between two strings with coloured ANSI output.
+ * Returns unified diff between two strings with coloured ANSI output.
  *
  * @private
  * @param {String} actual
@@ -431,7 +432,7 @@ function unifiedDiff(actual, expected) {
 }
 
 /**
- * Return a character diff for `err`.
+ * Returns character diff for `err`.
  *
  * @private
  * @param {String} actual
@@ -454,7 +455,7 @@ function errorDiff(actual, expected) {
 }
 
 /**
- * Color lines for `str`, using the color `name`.
+ * Colors lines for `str`, using the color `name`.
  *
  * @private
  * @param {string} name
@@ -476,7 +477,7 @@ function colorLines(name, str) {
 var objToString = Object.prototype.toString;
 
 /**
- * Check that a / b have the same type.
+ * Checks that a / b have the same type.
  *
  * @private
  * @param {Object} a

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -21,16 +21,17 @@ var EVENT_SUITE_END = constants.EVENT_SUITE_END;
 exports = module.exports = Doc;
 
 /**
- * Initialize a new `Doc` reporter.
+ * Constructs a new `Doc` reporter instance.
  *
+ * @public
  * @class
  * @memberof Mocha.reporters
- * @extends {Base}
- * @public
- * @param {Runner} runner
+ * @extends Mocha.reporters.Base
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function Doc(runner) {
-  Base.call(this, runner);
+function Doc(runner, options) {
+  Base.call(this, runner, options);
 
   var indents = 2;
 

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -22,16 +22,17 @@ var EVENT_RUN_END = constants.EVENT_RUN_END;
 exports = module.exports = Dot;
 
 /**
- * Initialize a new `Dot` matrix test reporter.
+ * Constructs a new `Dot` reporter instance.
  *
+ * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @public
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function Dot(runner) {
-  Base.call(this, runner);
+function Dot(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var width = (Base.window.width * 0.75) | 0;

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -47,16 +47,17 @@ var statsTemplate =
 var playIcon = '&#x2023;';
 
 /**
- * Initialize a new `HTML` reporter.
+ * Constructs a new `HTML` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function HTML(runner) {
-  Base.call(this, runner);
+function HTML(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var stats = this.stats;

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -24,12 +24,13 @@ exports = module.exports = JSONStream;
  *
  * @public
  * @class
- * @extends Mocha.reporters.Base
  * @memberof Mocha.reporters
+ * @extends Mocha.reporters.Base
  * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function JSONStream(runner) {
-  Base.call(this, runner);
+function JSONStream(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var total = runner.total;

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -21,16 +21,17 @@ var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 exports = module.exports = JSONReporter;
 
 /**
- * Initialize a new `JSON` reporter.
+ * Constructs a new `JSON` reporter instance.
  *
  * @public
  * @class JSON
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function JSONReporter(runner) {
-  Base.call(this, runner);
+function JSONReporter(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var tests = [];

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -42,16 +42,17 @@ Base.colors['plane crash'] = 31;
 Base.colors.runway = 90;
 
 /**
- * Initialize a new `Landing` reporter.
+ * Constructs a new `Landing` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function Landing(runner) {
-  Base.call(this, runner);
+function Landing(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var width = (Base.window.width * 0.75) | 0;

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -25,16 +25,17 @@ var cursor = Base.cursor;
 exports = module.exports = List;
 
 /**
- * Initialize a new `List` test reporter.
+ * Constructs a new `List` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function List(runner) {
-  Base.call(this, runner);
+function List(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var n = 0;

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -27,16 +27,17 @@ var SUITE_PREFIX = '$';
 exports = module.exports = Markdown;
 
 /**
- * Initialize a new `Markdown` reporter.
+ * Constructs a new `Markdown` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function Markdown(runner) {
-  Base.call(this, runner);
+function Markdown(runner, options) {
+  Base.call(this, runner, options);
 
   var level = 0;
   var buf = '';

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -19,16 +19,20 @@ var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 exports = module.exports = Min;
 
 /**
- * Initialize a new `Min` minimal test reporter (best used with --watch).
+ * Constructs a new `Min` reporter instance.
+ *
+ * @description
+ * This minimal test reporter is best used with '--watch'.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function Min(runner) {
-  Base.call(this, runner);
+function Min(runner, options) {
+  Base.call(this, runner, options);
 
   runner.on(EVENT_RUN_BEGIN, function() {
     // clear screen

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -22,17 +22,17 @@ var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 exports = module.exports = NyanCat;
 
 /**
- * Initialize a new `Dot` matrix test reporter.
+ * Constructs a new `Nyan` reporter instance.
  *
- * @param {Runner} runner
  * @public
  * @class Nyan
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-
-function NyanCat(runner) {
-  Base.call(this, runner);
+function NyanCat(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var width = (Base.window.width * 0.75) | 0;

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -28,17 +28,17 @@ exports = module.exports = Progress;
 Base.colors.progress = 90;
 
 /**
- * Initialize a new `Progress` bar test reporter.
+ * Constructs a new `Progress` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
- * @param {Object} options
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
 function Progress(runner, options) {
-  Base.call(this, runner);
+  Base.call(this, runner, options);
 
   var self = this;
   var width = (Base.window.width * 0.5) | 0;

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -25,16 +25,17 @@ var color = Base.color;
 exports = module.exports = Spec;
 
 /**
- * Initialize a new `Spec` test reporter.
+ * Constructs a new `Spec` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
-function Spec(runner) {
-  Base.call(this, runner);
+function Spec(runner, options) {
+  Base.call(this, runner, options);
 
   var self = this;
   var indents = 0;

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -25,12 +25,12 @@ var sprintf = util.format;
 exports = module.exports = TAP;
 
 /**
- * Constructs a new TAP reporter with runner instance and reporter options.
+ * Constructs a new `TAP` reporter instance.
  *
  * @public
  * @class
- * @extends Mocha.reporters.Base
  * @memberof Mocha.reporters
+ * @extends Mocha.reporters.Base
  * @param {Runner} runner - Instance triggers reporter actions.
  * @param {Object} [options] - runner options
  */

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -34,16 +34,17 @@ var Date = global.Date;
 exports = module.exports = XUnit;
 
 /**
- * Initialize a new `XUnit` reporter.
+ * Constructs a new `XUnit` reporter instance.
  *
  * @public
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
- * @param {Runner} runner
+ * @param {Runner} runner - Instance triggers reporter actions.
+ * @param {Object} [options] - runner options
  */
 function XUnit(runner, options) {
-  Base.call(this, runner);
+  Base.call(this, runner, options);
 
   var stats = this.stats;
   var tests = [];


### PR DESCRIPTION
### Description of the Change
Change allows for passing settings to _any_ reporter.
The same `options` parameter is passed to abstract `Base` superctor.

Fixed/standardized some of JSDoc as well.

### Alternate Designs
Only means to pass settings to reporters.

### Why should this be in core?
NA

### Benefits
Immediately, none. Prerequisite step to further upgrades.

### Possible Drawbacks
None, since changes only allow possibility of future changes.

### Applicable issues
semver-patch
