### PR TITLE
fix broken positional arguments in config; ensure positional args are unique; closes #3763

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -301,12 +301,15 @@ const loadOptions = (argv = []) => {
 
   if (rcConfig) {
     args.config = false;
+    args._ = args._.concat(rcConfig._ || []);
   }
   if (pkgConfig) {
     args.package = false;
+    args._ = args._.concat(pkgConfig._ || []);
   }
   if (optsConfig) {
     args.opts = false;
+    args._ = args._.concat(optsConfig._ || []);
   }
 
   args = parse(
@@ -323,6 +326,9 @@ const loadOptions = (argv = []) => {
     args._ = args._.concat(args.spec);
     delete args.spec;
   }
+
+  // make unique
+  args._ = Array.from(new Set(args._));
 
   return args;
 };

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -165,14 +165,13 @@ describe('options', function() {
 
         describe('when path to mocha.opts (`--opts <path>`) is valid', function() {
           let result;
-
           beforeEach(function() {
             const filepath = '/path/to/mocha.opts';
             readFileSync = sandbox.stub();
             // package.json
             readFileSync.onFirstCall().throws();
             // mocha.opts
-            readFileSync.onSecondCall().returns('--retries 3');
+            readFileSync.onSecondCall().returns('--retries 3 foobar.spec.js');
             findConfig = sandbox.stub().returns('/some/.mocharc.json');
             loadConfig = sandbox.stub().returns({});
             findupSync = sandbox.stub().returns('/some/package.json');
@@ -191,7 +190,7 @@ describe('options', function() {
               'to equal',
               Object.assign(
                 {
-                  _: []
+                  _: ['foobar.spec.js']
                 },
                 defaults,
                 {
@@ -353,7 +352,9 @@ describe('options', function() {
             const filepath = '/some/package.json';
             readFileSync = sandbox.stub();
             // package.json
-            readFileSync.onFirstCall().returns('{"mocha": {"retries": 3}}');
+            readFileSync
+              .onFirstCall()
+              .returns('{"mocha": {"retries": 3, "_": ["foobar.spec.js"]}}');
             // mocha.opts
             readFileSync.onSecondCall().throws();
             findConfig = sandbox.stub().returns('/some/.mocharc.json');
@@ -374,7 +375,7 @@ describe('options', function() {
               'to equal',
               Object.assign(
                 {
-                  _: []
+                  _: ['foobar.spec.js']
                 },
                 defaults,
                 {
@@ -443,8 +444,10 @@ describe('options', function() {
             readFileSync = sandbox.stub();
             readFileSync
               .onFirstCall()
-              .returns('{"mocha": {"check-leaks": true}}');
-            readFileSync.onSecondCall().returns('--retries 3');
+              .returns(
+                '{"mocha": {"check-leaks": true, "_": ["foobar.spec.js"]}}'
+              );
+            readFileSync.onSecondCall().returns('--retries 3 foobar.spec.js');
             findConfig = sandbox.stub();
             loadConfig = sandbox.stub();
             findupSync = sandbox.stub().returns('/some/package.json');
@@ -463,7 +466,7 @@ describe('options', function() {
             expect(
               result,
               'to equal',
-              Object.assign({_: []}, defaults, {
+              Object.assign({_: ['foobar.spec.js']}, defaults, {
                 'check-leaks': true,
                 config: false,
                 opts: false,


### PR DESCRIPTION
nobody is going to put `"_": ["file", "file"]` in a config file, *but if they do*, we have them covered.

also noticed specifying the same positional arg across various configs and such resulted in dupe filenames, so fixed that too.