### PR TITLE
Include timing of beforeEach in test duration

### DIFF
--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -42,6 +42,7 @@ exports.types = {
     'recursive',
     'reporters',
     'sort',
+    'time-setup',
     'watch'
   ],
   number: ['retries', 'slow', 'timeout'],

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -233,6 +233,11 @@ exports.builder = yargs =>
         description: 'Specify test timeout threshold (in milliseconds)',
         group: GROUPS.RULES
       },
+      'time-setup': {
+        description:
+          'Include any beforeEach (or setup) time in duration of each test',
+        group: GROUPS.RULES
+      },
       ui: {
         default: defaults.ui,
         description: 'Specify user interface',

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -113,6 +113,7 @@ function Mocha(options) {
     .reporter(options.reporter, options.reporterOptions)
     .useColors(options.color)
     .slow(options.slow)
+    .timeSetup(options.timeSetup)
     .useInlineDiffs(options.inlineDiffs)
     .globals(options.globals);
 
@@ -663,6 +664,21 @@ Mocha.prototype.retries = function(n) {
  */
 Mocha.prototype.slow = function(msecs) {
   this.suite.slow(msecs);
+  return this;
+};
+
+/**
+ * Sets time setup option, which will cause time for any beforeEach (setup)
+ * methods to be included in the duration of each test.
+ *
+ * @public
+ * @see {@link https://mochajs.org/#-s---time-setup|CLI option}
+ * @param {boolean} timeSetup - Whether to enable the time setup option.
+ * @return {Mocha} this
+ * @chainable
+ */
+Mocha.prototype.timeSetup = function(timeSetup) {
+  this.suite.timeSetup(timeSetup);
   return this;
 };
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -290,10 +290,10 @@ Runnable.prototype.globals = function(globals) {
 Runnable.prototype.run = function(fn) {
   var self = this;
   var start;
-  if (typeof self.start === 'number') {
+  if (self.start) {
     start = self.start;
   } else {
-    start = Date.now();
+    start = new Date();
   }
   var ctx = this.ctx;
   var finished;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -289,7 +289,12 @@ Runnable.prototype.globals = function(globals) {
  */
 Runnable.prototype.run = function(fn) {
   var self = this;
-  var start = new Date();
+  var start;
+  if (typeof self.start === 'number') {
+    start = self.start;
+  } else {
+    start = Date.now();
+  }
   var ctx = this.ctx;
   var finished;
   var emitted;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -501,6 +501,7 @@ Runner.prototype.parents = function() {
 Runner.prototype.runTest = function(fn) {
   var self = this;
   var test = this.test;
+  test.start = self.start;
 
   if (!test) {
     return;
@@ -623,6 +624,7 @@ Runner.prototype.runTests = function(suite, fn) {
     }
 
     // execute test and hook(s)
+    self.start = Date.now();
     self.emit(constants.EVENT_TEST_BEGIN, (self.test = test));
     self.hookDown(HOOK_TYPE_BEFORE_EACH, function(err, errSuite) {
       if (test.isPending()) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -28,6 +28,11 @@ var createInvalidExceptionError = require('./errors')
   .createInvalidExceptionError;
 
 /**
+ * Save timer references to avoid Sinon interfering (see GH-237).
+ */
+var Date = global.Date;
+
+/**
  * Non-enumerable globals.
  * @readonly
  */
@@ -501,13 +506,15 @@ Runner.prototype.parents = function() {
 Runner.prototype.runTest = function(fn) {
   var self = this;
   var test = this.test;
-  test.start = self.start;
 
   if (!test) {
     return;
   }
 
   var suite = this.parents().reverse()[0] || this.suite;
+  if (suite._timeSetup) {
+    test.start = self.start;
+  }
   if (this.forbidOnly && suite.hasOnly()) {
     fn(new Error('`.only` forbidden'));
     return;
@@ -624,7 +631,9 @@ Runner.prototype.runTests = function(suite, fn) {
     }
 
     // execute test and hook(s)
-    self.start = Date.now();
+    if (suite._timeSetup) {
+      self.start = new Date();
+    }
     self.emit(constants.EVENT_TEST_BEGIN, (self.test = test));
     self.hookDown(HOOK_TYPE_BEFORE_EACH, function(err, errSuite) {
       if (test.isPending()) {

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -70,6 +70,7 @@ function Suite(title, parentContext, isRoot) {
   this._timeout = 2000;
   this._enableTimeouts = true;
   this._slow = 75;
+  this._timeSetup = false;
   this._bail = false;
   this._retries = -1;
   this._onlyTests = [];
@@ -107,6 +108,7 @@ Suite.prototype.clone = function() {
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
   suite.bail(this.bail());
+  suite.timeSetup(this.timeSetup());
   return suite;
 };
 
@@ -180,6 +182,22 @@ Suite.prototype.slow = function(ms) {
   }
   debug('slow %d', ms);
   this._slow = ms;
+  return this;
+};
+
+/**
+ * Set or get time setup option.
+ *
+ * @private
+ * @param {boolean} timeSetup
+ * @return {Suite|boolean} for chaining
+ */
+Suite.prototype.timeSetup = function(timeSetup) {
+  if (!arguments.length) {
+    return this._timeSetup;
+  }
+  debug('timeSetup %s', timeSetup);
+  this._timeSetup = timeSetup;
   return this;
 };
 
@@ -338,6 +356,7 @@ Suite.prototype.addSuite = function(suite) {
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
   suite.bail(this.bail());
+  suite.timeSetup(this.timeSetup());
   this.suites.push(suite);
   this.emit(constants.EVENT_SUITE_ADD_SUITE, suite);
   return this;

--- a/test/integration/fixtures/options/time-setup.fixture.js
+++ b/test/integration/fixtures/options/time-setup.fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+describe('time-setup', function () {
+  beforeEach(function(done) {
+    // simulate some slow setup process
+    setTimeout(done, 20);
+  });
+
+  it('should run quickly', function () {});
+});

--- a/test/integration/options/timeSetup.spec.js
+++ b/test/integration/options/timeSetup.spec.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var path = require('path').posix;
+var helpers = require('../helpers');
+var runMochaJSON = helpers.runMochaJSON;
+
+describe('--time-setup', function() {
+  var args = [];
+
+  describe('with the option', function() {
+    before(function() {
+      args = ['--time-setup'];
+    });
+
+    it('should include the setup time', function(done) {
+      var fixture = path.join('options', 'time-setup');
+      runMochaJSON(fixture, args, function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.tests[0].duration, 'to be greater than or equal to', 20);
+        done();
+      });
+    });
+  });
+
+  it('should not include the setup time if --time-setup is not specified', function(done) {
+    var fixture = path.join('options', 'time-setup');
+    runMochaJSON(fixture, args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.tests[0].duration, 'to be less than', 20);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Change
As noted in #419 it is sometimes desirable to include the duration of any `beforeEach`/`setup` hooks in the duration of tests. This PR adds an option `--time-setup` which allows this. The `--time-setup` option is helpful when looking to discover slow tests, where the setup makes up a significant portion of the total duration. Without this option, the user has no visibility into the time being spent in setup. The `--time-setup` option can be combined with `--slow` to find tests that exceed a slow threshold.

### Alternate Designs
Alternative designs:
1. Include detailed timing about all hooks and allow plugins or reporters to decide what to do with the timing information. The existing `duration` attribute would not need to be redefined.
1. Add pseudo-tests for timing of before()/after() hooks #3368.

The design implemented in this PR has the advantage of being compatible with existing tooling and the `--slow` feature. For users who want to opt in to measuring beforeEach hooks, all existing test reporters can display this redefined duration in place of the normal tests-only duration. The alternatives described above could make this feature obsolete, but are significantly larger scope.

Alternative option names:
1. `measure-before` https://github.com/mochajs/mocha/issues/700
1. `include-before-each`
1. `include-setup-time`
1. `before-each-timing`

I'm open to renaming the option.

### Why should this be in core?
Mocha does not expose a mechanism for a plugin to extend or override how the duration of each test is calculated. Detailed timing information is not available for tests.

### Benefits
Users are able to detect slow beforeEach hooks and better understand the overall performance of their test suites.

### Possible Drawbacks
Increased complexity. Yet another option to document, understand, and maintain.

### Applicable issues
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
Fixes #419
semver-minor