### PR TITLE
Fixes Parts of #3783

### DIFF
--- a/docs/_includes/default.html
+++ b/docs/_includes/default.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/normalize.css" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/prism.css" />
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="icon" href="favicon.ico" />
 
     <!--[if lt IE 9]> <script src="js/html5shiv.min.js"></script> <![endif]-->
   </head>
@@ -23,10 +23,9 @@
       <h1>
         <a href="/">
           <img
+            id="mocha-logo"
             src="/images/mocha-logo.svg"
-            alt="Mocha"
-            width="192"
-            height="192"
+            alt="Mocha logo"
           />
         </a>
       </h1>
@@ -37,14 +36,14 @@
     <main id="content">{{ content }}</main>
 
     <footer>
-      <span>
+      <div>
         <a href="https://mochajs.org">mochajs.org</a> is licensed under a
-        <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"
+        <a rel="license" external href="http://creativecommons.org/licenses/by/4.0/"
           >Creative Commons Attribution 4.0 International License</a
         >.
         <p>
           <em>Last updated: {{ 'now' | date: '%a %b %d %H:%M:%S %Y' }}</em>
-        </p></span
+        </p></div
       >
     </footer>
   </body>

--- a/docs/_includes/default.html
+++ b/docs/_includes/default.html
@@ -37,14 +37,14 @@
 
     <footer>
       <div>
-        <a href="https://mochajs.org">mochajs.org</a> is licensed under a
-        <a rel="license" external href="http://creativecommons.org/licenses/by/4.0/"
+        <a rel="home" href="https://mochajs.org">mochajs.org</a> is licensed under a
+        <a rel="license external noopener" href="http://creativecommons.org/licenses/by/4.0/"
           >Creative Commons Attribution 4.0 International License</a
         >.
         <p>
           <em>Last updated: {{ 'now' | date: '%a %b %d %H:%M:%S %Y' }}</em>
-        </p></div
-      >
+        </p>
+      </div>
     </footer>
   </body>
 </html>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -200,7 +200,7 @@ footer {
   border-top: 1px solid #ddd;
 }
 
-footer span {
+footer div {
   display: block;
   margin-right: 30px;
   color: #888;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -39,6 +39,11 @@ header {
   padding-top: 20px;
 }
 
+#mocha-logo {
+  width:192;
+  height:192;
+}
+
 #content {
   padding-bottom: 60px;
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -40,8 +40,8 @@ header {
 }
 
 #mocha-logo {
-  width:192;
-  height:192;
+  width:192px;
+  height:192px;
 }
 
 #content {


### PR DESCRIPTION
### Description of the Change
Fixes some issues outlined in #3783.
* Modified the alt text for the mocha logo and gave it an ID attribute, which is then used in styles.css to set the logo's width and height.
* Added the `external` attribute to the link to the Creative Commons License
* Removed the `shortcut` attribute from the favicon.

### Alternate Designs
N/A

### Why should this be in core?
N/A

### Benefits
It improves the website.
Removes meaningless attributes while updating HTML/CSS to more modern standards.

### Possible Drawbacks
None to knowledge.

### Applicable issues
Partial #3783.
semver-patch