### PR TITLE
closes #3787 Allow passing multiple node flags

### DIFF
--- a/lib/cli/node-flags.js
+++ b/lib/cli/node-flags.js
@@ -81,5 +81,6 @@ exports.unparseNodeFlags = opts => {
         .split(/\b/)
         .map(arg => (arg === ' ' ? '=' : arg))
         .join('')
+        .split(' ')
     : [];
 };

--- a/test/node-unit/cli/node-flags.spec.js
+++ b/test/node-unit/cli/node-flags.spec.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const nodeEnvFlags = require('node-environment-flags');
-const {isNodeFlag, impliesNoTimeouts} = require('../../../lib/cli/node-flags');
+const {
+  isNodeFlag,
+  impliesNoTimeouts,
+  unparseNodeFlags
+} = require('../../../lib/cli/node-flags');
 
 describe('node-flags', function() {
   describe('isNodeFlag()', function() {
@@ -84,6 +88,48 @@ describe('node-flags', function() {
       expect(impliesNoTimeouts('inspect'), 'to be true');
       expect(impliesNoTimeouts('debug-brk'), 'to be true');
       expect(impliesNoTimeouts('inspect-brk'), 'to be true');
+    });
+  });
+
+  describe('unparseNodeFlags()', function() {
+    it('should handle single v8 flags', function() {
+      expect(unparseNodeFlags({'v8-numeric': 100}), 'to equal', [
+        '--v8-numeric=100'
+      ]);
+      expect(unparseNodeFlags({'v8-boolean': true}), 'to equal', [
+        '--v8-boolean'
+      ]);
+    });
+
+    it('should handle multiple v8 flags', function() {
+      expect(
+        unparseNodeFlags({'v8-numeric-one': 1, 'v8-numeric-two': 2}),
+        'to equal',
+        ['--v8-numeric-one=1', '--v8-numeric-two=2']
+      );
+      expect(
+        unparseNodeFlags({'v8-boolean-one': true, 'v8-boolean-two': true}),
+        'to equal',
+        ['--v8-boolean-one', '--v8-boolean-two']
+      );
+      expect(
+        unparseNodeFlags({
+          'v8-boolean-one': true,
+          'v8-numeric-one': 1,
+          'v8-boolean-two': true
+        }),
+        'to equal',
+        ['--v8-boolean-one', '--v8-numeric-one=1', '--v8-boolean-two']
+      );
+      expect(
+        unparseNodeFlags({
+          'v8-numeric-one': 1,
+          'v8-boolean-one': true,
+          'v8-numeric-two': 2
+        }),
+        'to equal',
+        ['--v8-numeric-one=1', '--v8-boolean-one', '--v8-numeric-two=2']
+      );
     });
   });
 });


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Fixes support for multiple node flags. Previously, the node flags were splatted onto a single string rather than separate elements in an array of strings.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
