### PR TITLE
Remove "package" flag from sample config file because it can only be passes as CLI arg

### DIFF
--- a/example/config/.mocharc.yml
+++ b/example/config/.mocharc.yml
@@ -29,6 +29,7 @@ inline-diffs: false
 # needs to be used with grep or fgrep
 # invert: false
 opts: './test/mocha.opts'
+# Only allowed as a CLI flag; ignored in config files.  For example `mocha --package ./manifest.json`
 package: './package.json'
 recursive: false
 reporter: spec

--- a/example/config/.mocharc.yml
+++ b/example/config/.mocharc.yml
@@ -29,8 +29,6 @@ inline-diffs: false
 # needs to be used with grep or fgrep
 # invert: false
 opts: './test/mocha.opts'
-# Only allowed as a CLI flag; ignored in config files.  For example `mocha --package ./manifest.json`
-package: './package.json'
 recursive: false
 reporter: spec
 reporter-option:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Adds comments to `.mocharc.yml` to clarify that `--package` can be specified as a CLI argument but will be ignored within a `.mocharc` file.
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

Alternatively, mocha could support `package` within config files.  Then it would merge the config from package.json with the config from `.mocharc`.  But that doesn't seem useful.

### Why should this be in core?

N/A; this is a docs tweak.

### Benefits

Better docs.

### Possible Drawbacks

N/A

### Applicable issues

N/A; this is a docs tweak.