### PR TITLE
Stop inlining stuff.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -95,7 +95,7 @@ nav.badges a + a {
 
 #_backers a img {
   width: 64px;
-  background: url(/images/backer-background.svg?inline) center center no-repeat;
+  background: url(/images/backer-background.svg) center center no-repeat;
 }
 
 h2 {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -276,7 +276,7 @@ module.exports = {
       },
       postbuild: {
         script:
-          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
+          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 0 --inlinehtmlscript 0 --inlinecssimage 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
         description: 'Post-process docs after build',
         hiddenFromHelp: true
       },


### PR DESCRIPTION
This should make the HTML size ~-120KB (uncompressed, -90 compressed) HTML, the images can now be cached and should lead to faster TTFB.

![2019-03-03_13-24-13](https://user-images.githubusercontent.com/349621/53694448-c088a180-3db7-11e9-8676-9fcd0b0dfc2b.jpg)

We can adapt this of course, like still inline small SVG images in the HTML so that they can be styled etc.