### PR TITLE
Fix --inspect-brk and --inspect usage for dev-tools debugging

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -110,11 +110,7 @@ if (/^(debug|inspect)$/.test(mochaArgs._[0])) {
   });
 
 // ignore --inspect when --inspect-brk is present, on Node.js v8 or newer
-if (
-  !nodeEnv.has('debug') &&
-  !nodeEnv.has('debug-brk') &&
-  (nodeArgs['inspect'] && nodeArgs['inspect-brk'])
-) {
+if (!nodeEnv.has('debug') && (nodeArgs['inspect'] && nodeArgs['inspect-brk'])) {
   warn(
     '"--inspect" and "--inspect-brk" together is redundant. Use just "--inspect-brk"'
   );

--- a/bin/mocha
+++ b/bin/mocha
@@ -109,8 +109,8 @@ if (/^(debug|inspect)$/.test(mochaArgs._[0])) {
     delete nodeArgs[opt];
   });
 
-// ignore --inspect when --inspect-brk is present, on Node.js v8 or newer
-if (!nodeEnv.has('debug') && (nodeArgs['inspect'] && nodeArgs['inspect-brk'])) {
+// ignore --inspect when --inspect-brk is present
+if (nodeArgs['inspect'] && nodeArgs['inspect-brk']) {
   warn(
     '"--inspect" and "--inspect-brk" together is redundant. Use just "--inspect-brk"'
   );

--- a/bin/mocha
+++ b/bin/mocha
@@ -109,6 +109,18 @@ if (/^(debug|inspect)$/.test(mochaArgs._[0])) {
     delete nodeArgs[opt];
   });
 
+// ignore --inspect when --inspect-brk is present, on Node.js v8 or newer
+if (
+  !nodeEnv.has('debug') &&
+  !nodeEnv.has('debug-brk') &&
+  (nodeArgs['inspect'] && nodeArgs['inspect-brk'])
+) {
+  warn(
+    '"--inspect" and "--inspect-brk" together is redundant. Use just "--inspect-brk"'
+  );
+  delete nodeArgs['inspect'];
+}
+
 // historical
 if (nodeArgs.gc) {
   deprecate(

--- a/test/integration/options/debug.spec.js
+++ b/test/integration/options/debug.spec.js
@@ -45,25 +45,7 @@ describe('--debug', function() {
       }, 2000);
     });
 
-    it('should respect custom host/port', function(done) {
-      invokeMocha(
-        ['--debug=127.0.0.1:9229', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(
-            res,
-            'to contain output',
-            /Debugger listening on .*127.0.0.1:9229/i
-          );
-          done();
-        },
-        'pipe'
-      );
-    });
-
-    it('should start debugger if supply both --debug and --debug-brk', function(done) {
+    it('should invoke --inspect-brk for combination --debug and --debug-brk', function(done) {
       var proc = invokeMocha(
         ['--debug', '--debug-brk', DEFAULT_FIXTURE],
         function(err, res) {
@@ -80,6 +62,24 @@ describe('--debug', function() {
       setTimeout(function() {
         process.kill(proc.pid, 'SIGINT');
       }, 2000);
+    });
+
+    it('should respect custom host/port', function(done) {
+      invokeMocha(
+        ['--debug=127.0.0.1:9229', DEFAULT_FIXTURE],
+        function(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(
+            res,
+            'to contain output',
+            /Debugger listening on .*127.0.0.1:9229/i
+          );
+          done();
+        },
+        'pipe'
+      );
     });
 
     it('should warn about incorrect usage for version', function(done) {

--- a/test/integration/options/debug.spec.js
+++ b/test/integration/options/debug.spec.js
@@ -45,25 +45,6 @@ describe('--debug', function() {
       }, 2000);
     });
 
-    it('should invoke --debug and --debug-brk', function(done) {
-      var proc = invokeMocha(
-        ['--debug', '--debug-brk', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res, 'to contain output', /Debugger listening/i);
-          done();
-        },
-        'pipe'
-      );
-
-      // debugger must be manually killed
-      setTimeout(function() {
-        process.kill(proc.pid, 'SIGINT');
-      }, 2000);
-    });
-
     it('should respect custom host/port', function(done) {
       invokeMocha(
         ['--debug=127.0.0.1:9229', DEFAULT_FIXTURE],
@@ -80,6 +61,25 @@ describe('--debug', function() {
         },
         'pipe'
       );
+    });
+
+    it('should start debugger if supply both --debug and --debug-brk', function(done) {
+      var proc = invokeMocha(
+        ['--debug', '--debug-brk', DEFAULT_FIXTURE],
+        function(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to contain output', /Debugger listening/i);
+          done();
+        },
+        'pipe'
+      );
+
+      // debugger must be manually killed
+      setTimeout(function() {
+        process.kill(proc.pid, 'SIGINT');
+      }, 2000);
     });
 
     it('should warn about incorrect usage for version', function(done) {

--- a/test/integration/options/inspect.spec.js
+++ b/test/integration/options/inspect.spec.js
@@ -5,7 +5,7 @@ var invokeMocha = helpers.invokeMocha;
 var DEFAULT_FIXTURE = helpers.DEFAULT_FIXTURE;
 
 describe('--inspect', function() {
-  it('should start debugger from --inspect', function(done) {
+  it('should run deubgger from --inspect', function(done) {
     invokeMocha(
       ['--inspect', DEFAULT_FIXTURE],
       function(err, res) {
@@ -19,7 +19,7 @@ describe('--inspect', function() {
     );
   });
 
-  it('should start deubgger from --inspect-brk', function(done) {
+  it('should run deubgger from --inspect-brk', function(done) {
     var proc = invokeMocha(
       ['--inspect-brk', DEFAULT_FIXTURE],
       function(err, res) {
@@ -38,7 +38,7 @@ describe('--inspect', function() {
     }, 2000);
   });
 
-  it('should start debugger if supply both --inspect and --inspect-brk', function(done) {
+  it('should invoke --inspect-brk for combination --inspect and --inspect-brk', function(done) {
     var proc = invokeMocha(
       ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
       function(err, res) {

--- a/test/integration/options/inspect.spec.js
+++ b/test/integration/options/inspect.spec.js
@@ -5,103 +5,96 @@ var invokeMocha = helpers.invokeMocha;
 var DEFAULT_FIXTURE = helpers.DEFAULT_FIXTURE;
 
 describe('--inspect', function() {
-  describe('Node.js v8+', function() {
-    before(function() {
-      if (process.version.substring(0, 2) === 'v6') {
-        this.skip();
-      }
-    });
-    it('should start debugger from --inspect', function(done) {
-      invokeMocha(
-        ['--inspect', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res, 'to contain output', /Debugger listening/i);
-          done();
-        },
-        'pipe'
-      );
-    });
+  it('should start debugger from --inspect', function(done) {
+    invokeMocha(
+      ['--inspect', DEFAULT_FIXTURE],
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, 'to contain output', /Debugger listening/i);
+        done();
+      },
+      'pipe'
+    );
+  });
 
-    it('should start deubgger from --inspect-brk', function(done) {
-      var proc = invokeMocha(
-        ['--inspect-brk', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res, 'to contain output', /Debugger listening/i);
-          done();
-        },
-        'pipe'
-      );
+  it('should start deubgger from --inspect-brk', function(done) {
+    var proc = invokeMocha(
+      ['--inspect-brk', DEFAULT_FIXTURE],
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, 'to contain output', /Debugger listening/i);
+        done();
+      },
+      'pipe'
+    );
 
-      // debugger must be manually killed
-      setTimeout(function() {
-        process.kill(proc.pid, 'SIGINT');
-      }, 2000);
-    });
+    // debugger must be manually killed
+    setTimeout(function() {
+      process.kill(proc.pid, 'SIGINT');
+    }, 2000);
+  });
 
-    it('should start debugger if supply both --inspect and --inspect-brk', function(done) {
-      var proc = invokeMocha(
-        ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res, 'to contain output', /Debugger listening/i);
-          done();
-        },
-        'pipe'
-      );
+  it('should start debugger if supply both --inspect and --inspect-brk', function(done) {
+    var proc = invokeMocha(
+      ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, 'to contain output', /Debugger listening/i);
+        done();
+      },
+      'pipe'
+    );
 
-      // debugger must be manually killed
-      setTimeout(function() {
-        process.kill(proc.pid, 'SIGINT');
-      }, 2000);
-    });
+    // debugger must be manually killed
+    setTimeout(function() {
+      process.kill(proc.pid, 'SIGINT');
+    }, 2000);
+  });
 
-    it('should respect custom host/port', function(done) {
-      invokeMocha(
-        ['--inspect=127.0.0.1:9229', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(
-            res,
-            'to contain output',
-            /Debugger listening on .*127.0.0.1:9229/i
-          );
-          done();
-        },
-        'pipe'
-      );
-    });
+  it('should respect custom host/port', function(done) {
+    invokeMocha(
+      ['--inspect=127.0.0.1:9229', DEFAULT_FIXTURE],
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(
+          res,
+          'to contain output',
+          /Debugger listening on .*127.0.0.1:9229/i
+        );
+        done();
+      },
+      'pipe'
+    );
+  });
 
-    it('should warn about incorrect usage', function(done) {
-      var proc = invokeMocha(
-        ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(
-            res,
-            'to contain output',
-            /"--inspect" and "--inspect-brk" together is redundant/i
-          );
-          done();
-        },
-        'pipe'
-      );
+  it('should warn about incorrect usage', function(done) {
+    var proc = invokeMocha(
+      ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(
+          res,
+          'to contain output',
+          /"--inspect" and "--inspect-brk" together is redundant/i
+        );
+        done();
+      },
+      'pipe'
+    );
 
-      // debugger must be manually killed
-      setTimeout(function() {
-        process.kill(proc.pid, 'SIGINT');
-      }, 2000);
-    });
+    // debugger must be manually killed
+    setTimeout(function() {
+      process.kill(proc.pid, 'SIGINT');
+    }, 2000);
   });
 });

--- a/test/integration/options/inspect.spec.js
+++ b/test/integration/options/inspect.spec.js
@@ -11,7 +11,7 @@ describe('--inspect', function() {
         this.skip();
       }
     });
-    it('should invoke --inspect', function(done) {
+    it('should start debugger from --inspect', function(done) {
       invokeMocha(
         ['--inspect', DEFAULT_FIXTURE],
         function(err, res) {
@@ -25,7 +25,7 @@ describe('--inspect', function() {
       );
     });
 
-    it('should invoke --inspect-brk', function(done) {
+    it('should start deubgger from --inspect-brk', function(done) {
       var proc = invokeMocha(
         ['--inspect-brk', DEFAULT_FIXTURE],
         function(err, res) {
@@ -44,7 +44,7 @@ describe('--inspect', function() {
       }, 2000);
     });
 
-    it('should invoke --inspect and --inspect-brk', function(done) {
+    it('should start debugger if supply both --inspect and --inspect-brk', function(done) {
       var proc = invokeMocha(
         ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
         function(err, res) {
@@ -81,7 +81,7 @@ describe('--inspect', function() {
       );
     });
 
-    it('should warn about incorrect usage for version', function(done) {
+    it('should warn about incorrect usage', function(done) {
       var proc = invokeMocha(
         ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
         function(err, res) {

--- a/test/integration/options/inspect.spec.js
+++ b/test/integration/options/inspect.spec.js
@@ -4,17 +4,16 @@ var helpers = require('../helpers');
 var invokeMocha = helpers.invokeMocha;
 var DEFAULT_FIXTURE = helpers.DEFAULT_FIXTURE;
 
-describe('--debug', function() {
+describe('--inspect', function() {
   describe('Node.js v8+', function() {
     before(function() {
       if (process.version.substring(0, 2) === 'v6') {
         this.skip();
       }
     });
-
     it('should invoke --inspect', function(done) {
       invokeMocha(
-        ['--debug', DEFAULT_FIXTURE],
+        ['--inspect', DEFAULT_FIXTURE],
         function(err, res) {
           if (err) {
             return done(err);
@@ -28,7 +27,7 @@ describe('--debug', function() {
 
     it('should invoke --inspect-brk', function(done) {
       var proc = invokeMocha(
-        ['--debug-brk', DEFAULT_FIXTURE],
+        ['--inspect-brk', DEFAULT_FIXTURE],
         function(err, res) {
           if (err) {
             return done(err);
@@ -45,9 +44,9 @@ describe('--debug', function() {
       }, 2000);
     });
 
-    it('should invoke --debug and --debug-brk', function(done) {
+    it('should invoke --inspect and --inspect-brk', function(done) {
       var proc = invokeMocha(
-        ['--debug', '--debug-brk', DEFAULT_FIXTURE],
+        ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
         function(err, res) {
           if (err) {
             return done(err);
@@ -66,7 +65,7 @@ describe('--debug', function() {
 
     it('should respect custom host/port', function(done) {
       invokeMocha(
-        ['--debug=127.0.0.1:9229', DEFAULT_FIXTURE],
+        ['--inspect=127.0.0.1:9229', DEFAULT_FIXTURE],
         function(err, res) {
           if (err) {
             return done(err);
@@ -83,50 +82,8 @@ describe('--debug', function() {
     });
 
     it('should warn about incorrect usage for version', function(done) {
-      invokeMocha(
-        ['--debug=127.0.0.1:9229', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res, 'to contain output', /"--debug" is not available/i);
-          done();
-        },
-        'pipe'
-      );
-    });
-  });
-
-  describe('Node.js v6', function() {
-    // note that v6.3.0 and newer supports --inspect but still supports --debug.
-    before(function() {
-      if (process.version.substring(0, 2) !== 'v6') {
-        this.skip();
-      }
-    });
-
-    it('should start debugger', function(done) {
       var proc = invokeMocha(
-        ['--debug', DEFAULT_FIXTURE],
-        function(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res, 'to contain output', /Debugger listening/i);
-          done();
-        },
-        'pipe'
-      );
-
-      // debugger must be manually killed
-      setTimeout(function() {
-        process.kill(proc.pid, 'SIGINT');
-      }, 2000);
-    });
-
-    it('should respect custom host/port', function(done) {
-      var proc = invokeMocha(
-        ['--debug=127.0.0.1:9229', DEFAULT_FIXTURE],
+        ['--inspect', '--inspect-brk', DEFAULT_FIXTURE],
         function(err, res) {
           if (err) {
             return done(err);
@@ -134,13 +91,14 @@ describe('--debug', function() {
           expect(
             res,
             'to contain output',
-            /Debugger listening on .*127.0.0.1:9229/i
+            /"--inspect" and "--inspect-brk" together is redundant/i
           );
           done();
         },
         'pipe'
       );
 
+      // debugger must be manually killed
       setTimeout(function() {
         process.kill(proc.pid, 'SIGINT');
       }, 2000);


### PR DESCRIPTION
### Description of the Change

If using chrome dev-tools debugger, remove `inspect` from the arguments if `inspect-brk` is present.

- Couldn't find an issue with node.js native/internal debugger (issue sounded like just chrome dev-tools one).
- Fix didnt seem to fit with the 2 blocks above it (i.e. "native debugger handling" or "--debug invoke --inspect")
- If this should work differently on node version <8 please let me know.

### Applicable issues

https://github.com/mochajs/mocha/issues/3775
