### PR TITLE
Use HTML5 syntax for charset declaration in browser template

### DIFF
--- a/lib/browser/template.html
+++ b/lib/browser/template.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="utf-8">
     <title>Mocha</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="mocha.css" />
+    <link rel="stylesheet" href="mocha.css">
   </head>
   <body>
     <div id="mocha"></div>


### PR DESCRIPTION
### Description of the Change

Use HTML5 syntax for charset declaration in "/lib/browser/template.html".

### Alternate Designs

NA
### Why should this be in core?

NA
### Benefits

HTML5

### Possible Drawbacks

None

### Applicable issues

semver-patch