### PR TITLE
No double reloading defaults, fixes #3808

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -322,14 +322,7 @@ const loadOptions = (argv = []) => {
     args._ = args._.concat(optsConfig._ || []);
   }
 
-  args = parse(
-    args._,
-    args,
-    rcConfig || {},
-    pkgConfig || {},
-    optsConfig || {},
-    mocharc
-  );
+  args = parse(args._, args, rcConfig || {}, pkgConfig || {}, optsConfig || {});
 
   // recombine positional arguments and "spec"
   if (args.spec) {


### PR DESCRIPTION
### Description of the Change

As the mocha defaults were merged early on(https://github.com/mochajs/mocha/blob/master/lib/cli/options.js#L331), it prevented the yargs parser to properly fallback to its defaults configuration for each cli argument (which are coming from the same defaults (https://github.com/mochajs/mocha/blob/master/lib/cli/run.js#L26). With this fix 'js' is no longer always included in the list of extensions.

### Why should this be in core?

This fixes issue #3808

### Benefits

Allow mocha to properly run i.e. in Typescript based projects.