### PR TITLE
do not fork if no node flags present

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -120,30 +120,34 @@ if (nodeArgs.gc) {
 
 debug('final node args', nodeArgs);
 
-const args = [].concat(
-  unparseNodeFlags(nodeArgs),
-  mochaPath,
-  unparse(mochaArgs, {alias: aliases})
-);
+if (Object.keys(nodeArgs).length) {
+  const args = [].concat(
+    unparseNodeFlags(nodeArgs),
+    mochaPath,
+    unparse(mochaArgs, {alias: aliases})
+  );
 
-debug(`exec ${process.execPath} w/ args:`, args);
+  debug(`exec ${process.execPath} w/ args:`, args);
 
-const proc = spawn(process.execPath, args, {
-  stdio: 'inherit'
-});
-
-proc.on('exit', (code, signal) => {
-  process.on('exit', () => {
-    if (signal) {
-      process.kill(process.pid, signal);
-    } else {
-      process.exit(code);
-    }
+  const proc = spawn(process.execPath, args, {
+    stdio: 'inherit'
   });
-});
 
-// terminate children.
-process.on('SIGINT', () => {
-  proc.kill('SIGINT'); // calls runner.abort()
-  proc.kill('SIGTERM'); // if that didn't work, we're probably in an infinite loop, so make it die.
-});
+  proc.on('exit', (code, signal) => {
+    process.on('exit', () => {
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code);
+      }
+    });
+  });
+
+  // terminate children.
+  process.on('SIGINT', () => {
+    proc.kill('SIGINT'); // calls runner.abort()
+    proc.kill('SIGTERM'); // if that didn't work, we're probably in an infinite loop, so make it die.
+  });
+} else {
+  require('../lib/cli/cli').main(unparse(mochaArgs, {alias: aliases}));
+}

--- a/bin/mocha
+++ b/bin/mocha
@@ -3,14 +3,14 @@
 'use strict';
 
 /**
- * This wrapper executable checks for known node flags and appends them when found, before invoking the "real" _mocha(1) executable.
+ * This wrapper executable checks for known node flags and appends them when found,
+ * before invoking the "real" executable (`lib/cli/cli.js`)
  *
  * @module bin/mocha
  * @private
  */
 
 const {deprecate, warn} = require('../lib/utils');
-const {spawn} = require('child_process');
 const {loadOptions} = require('../lib/cli/options');
 const {
   unparseNodeFlags,
@@ -22,7 +22,6 @@ const debug = require('debug')('mocha:cli:mocha');
 const {aliases} = require('../lib/cli/run-option-metadata');
 const nodeEnv = require('node-environment-flags');
 
-const mochaPath = require.resolve('./_mocha');
 const mochaArgs = {};
 const nodeArgs = {};
 
@@ -118,9 +117,12 @@ if (nodeArgs.gc) {
   delete nodeArgs.gc;
 }
 
-debug('final node args', nodeArgs);
-
 if (Object.keys(nodeArgs).length) {
+  const {spawn} = require('child_process');
+  const mochaPath = require.resolve('../lib/cli/cli.js');
+
+  debug('final node args', nodeArgs);
+
   const args = [].concat(
     unparseNodeFlags(nodeArgs),
     mochaPath,

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 /**


### PR DESCRIPTION
This is *likely* a quick win, but there may be unforeseen consequences.

If we don't detect any flags that must be sent to `node`, *don't spawn a child process*; instead, pass the unparsed arguments directly to `lib/cli/cli.js` for handling by `yargs`.

This means two things:

1. Depending on the use-case, there's no extra overhead.  This decreases the time spent running our `node`-specific tests:

    ```shell
    # before
    $ nps test.node  143.66s user 33.77s system 100% cpu 2:56.31 total
    # after
    $ nps test.node  115.04s user 26.46s system 97% cpu 2:25.53 total
    ```

1. Users leveraging debuggers which invoke `node --inspect` (VSCode does this, likely Webstorm too) can now execute `bin/mocha` instead of needing to specify `bin/_mocha`.  

It also means that we're a step closer to killing `bin/_mocha` entirely.  Instead of `bin/mocha` spawning `bin/_mocha`, it can actually just spawn *itself*, since all Node.js flags will be handed off to `node` and `lib/cli/cli.js` will be invoked!

(We'll tackle that in another PR though. We need to discuss how to remove/deprecate `bin/_mocha`.)