### PR TITLE
fix timeout/slow string values and duplicate arguments

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -54,15 +54,26 @@ const configuration = Object.assign({}, YARGS_PARSER_CONFIG, {
 });
 
 /**
- * This is a really fancy way to ensure unique values for `array`-type
- * options.
+ * This is a really fancy way to:
+ * - ensure unique values for `array`-type options
+ * - use its array's last element for `boolean`/`number`/`string`- options given multiple times
  * This is passed as the `coerce` option to `yargs-parser`
  * @private
  * @ignore
  */
-const coerceOpts = types.array.reduce(
-  (acc, arg) => Object.assign(acc, {[arg]: v => Array.from(new Set(list(v)))}),
-  {}
+const coerceOpts = Object.assign(
+  types.array.reduce(
+    (acc, arg) =>
+      Object.assign(acc, {[arg]: v => Array.from(new Set(list(v)))}),
+    {}
+  ),
+  types.boolean
+    .concat(types.string, types.number)
+    .reduce(
+      (acc, arg) =>
+        Object.assign(acc, {[arg]: v => (Array.isArray(v) ? v.pop() : v)}),
+      {}
+    )
 );
 
 /**

--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -45,7 +45,17 @@ exports.types = {
     'watch'
   ],
   number: ['retries'],
-  string: ['fgrep', 'grep', 'package', 'reporter', 'ui', 'slow', 'timeout']
+  string: [
+    'config',
+    'fgrep',
+    'grep',
+    'opts',
+    'package',
+    'reporter',
+    'ui',
+    'slow',
+    'timeout'
+  ]
 };
 
 /**

--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -44,8 +44,8 @@ exports.types = {
     'sort',
     'watch'
   ],
-  number: ['retries', 'slow', 'timeout'],
-  string: ['fgrep', 'grep', 'package', 'reporter', 'ui']
+  number: ['retries'],
+  string: ['fgrep', 'grep', 'package', 'reporter', 'ui', 'slow', 'timeout']
 };
 
 /**

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -258,6 +258,13 @@ exports.builder = yargs =>
         }
       });
 
+      types.boolean
+        .concat(types.string, types.number)
+        .filter(opt => Array.isArray(argv[opt]))
+        .forEach(opt => {
+          argv[opt] = argv[opt].pop();
+        });
+
       // yargs.implies() isn't flexible enough to handle this
       if (argv.invert && !('fgrep' in argv || 'grep' in argv)) {
         throw createMissingArgumentError(

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -258,13 +258,6 @@ exports.builder = yargs =>
         }
       });
 
-      types.boolean
-        .concat(types.string, types.number)
-        .filter(opt => Array.isArray(argv[opt]))
-        .forEach(opt => {
-          argv[opt] = argv[opt].pop();
-        });
-
       // yargs.implies() isn't flexible enough to handle this
       if (argv.invert && !('fgrep' in argv || 'grep' in argv)) {
         throw createMissingArgumentError(

--- a/test/integration/duplicate-arguments.spec.js
+++ b/test/integration/duplicate-arguments.spec.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var runMocha = require('./helpers').runMocha;
+
+describe('when non-array argument is provided multiple times', function() {
+  describe('when the same argument name is used', function() {
+    it('should prefer the last value', function(done) {
+      runMocha(
+        'passing-sync',
+        ['--no-async-only', '--async-only', '--no-async-only'],
+        function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result, 'to have passed');
+          done();
+        }
+      );
+    });
+  });
+
+  describe('when a different argument name is used', function() {
+    it('should prefer the last value', function(done) {
+      runMocha('passing-async', ['--timeout', '100', '-t', '10'], function(
+        err,
+        result
+      ) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, 'to have failed');
+        done();
+      });
+    });
+  });
+});

--- a/test/integration/fixtures/options/slow-test.fixture.js
+++ b/test/integration/fixtures/options/slow-test.fixture.js
@@ -1,0 +1,11 @@
+'use strict';
+
+describe('a suite', function() {
+  it('should succeed in 500ms', function(done) {
+    setTimeout(done, 500);
+  });
+
+  it('should succeed in 1.5s', function(done) {
+    setTimeout(done, 1500);
+  });
+});

--- a/test/integration/fixtures/passing-async.fixture.js
+++ b/test/integration/fixtures/passing-async.fixture.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('a suite', function() {
+  it('should succeed in 50ms', function(done) {
+    setTimeout(done, 50);
+  });
+});

--- a/test/integration/fixtures/passing-sync.fixture.js
+++ b/test/integration/fixtures/passing-sync.fixture.js
@@ -1,0 +1,6 @@
+'use strict';
+
+describe('a suite', function() {
+  it('should succeed', function() {
+  });
+});

--- a/test/integration/invalid-arguments.spec.js
+++ b/test/integration/invalid-arguments.spec.js
@@ -3,18 +3,20 @@
 var invokeMocha = require('./helpers').invokeMocha;
 
 describe('invalid arguments', function() {
-  it('should exit with failure if arguments are invalid', function(done) {
-    invokeMocha(
-      ['--ui'],
-      function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result, 'to have failed');
-        expect(result.output, 'to match', /not enough arguments/i);
-        done();
-      },
-      {stdio: 'pipe'}
-    );
+  describe('when argument is missing required value', function() {
+    it('should exit with failure', function(done) {
+      invokeMocha(
+        ['--ui'],
+        function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result, 'to have failed');
+          expect(result.output, 'to match', /not enough arguments/i);
+          done();
+        },
+        {stdio: 'pipe'}
+      );
+    });
   });
 });

--- a/test/integration/options/timeout.spec.js
+++ b/test/integration/options/timeout.spec.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var helpers = require('../helpers');
+var runMochaJSON = helpers.runMochaJSON;
+
+describe('--timeout', function() {
+  it('should allow human-readable string value', function(done) {
+    runMochaJSON('options/slow-test', ['--timeout', '1s'], function(err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, 'to have failed')
+        .and('to have passed test count', 1)
+        .and('to have failed test count', 1);
+      done();
+    });
+  });
+
+  it('should allow numeric value', function(done) {
+    runMochaJSON('options/slow-test', ['--timeout', '1000'], function(
+      err,
+      res
+    ) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, 'to have failed')
+        .and('to have passed test count', 1)
+        .and('to have failed test count', 1);
+      done();
+    });
+  });
+
+  it('should allow multiple values', function(done) {
+    var fixture = 'options/slow-test';
+    runMochaJSON(fixture, ['--timeout', '2s', '--timeout', '1000'], function(
+      err,
+      res
+    ) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, 'to have failed')
+        .and('to have passed test count', 1)
+        .and('to have failed test count', 1);
+      done();
+    });
+  });
+});

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -86,7 +86,7 @@ describe('options', function() {
             config: false,
             opts: false,
             package: false,
-            retries: 3
+            retries: '3'
           })
         );
       });
@@ -202,7 +202,7 @@ describe('options', function() {
                   config: false,
                   opts: false,
                   package: false,
-                  retries: 3
+                  retries: '3'
                 }
               )
             );
@@ -427,7 +427,7 @@ describe('options', function() {
                 config: false,
                 opts: false,
                 package: false,
-                retries: 3
+                retries: '3'
               })
             );
           });
@@ -476,7 +476,7 @@ describe('options', function() {
                 config: false,
                 opts: false,
                 package: false,
-                retries: 3
+                retries: '3'
               })
             );
           });

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -629,7 +629,7 @@ describe('options', function() {
           findupSync
         });
 
-        expect(loadOptions(), 'to satisfy', {timeout: 800, require: ['foo']});
+        expect(loadOptions(), 'to satisfy', {timeout: '800', require: ['foo']});
       });
 
       it('should prioritize package.json over mocha.opts', function() {
@@ -692,7 +692,7 @@ describe('options', function() {
           loadOptions('--timeout 500'),
           'to have property',
           'timeout',
-          500
+          '500'
         );
       });
     });


### PR DESCRIPTION
This fixes two problems:

1. ~~Duplicate values are no longer allowed on the command line, and an error will be thrown (e.g., `--timeout 0 --timeout 0`)~~
1. String values of `timeout` and `slow` (e.g., `1s`, `500ms`) are no longer evaluated to `NaN` (because their type was set to `number`).  It appears that a value of `NaN` would cause timeouts to be disabled.

Ref: #3817 

UPDATE: Duplicate arguments are now allowed; the last value is chosen.