### PR TITLE
remove yargs-unparser; run yargs only once

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -11,22 +11,20 @@
 
 const {deprecate, warn} = require('../lib/utils');
 const {spawn} = require('child_process');
-const {loadOptions} = require('../lib/cli/options');
+const {parseArgv} = require('../lib/cli/cli');
 const {
   unparseNodeFlags,
   isNodeFlag,
   impliesNoTimeouts
 } = require('../lib/cli/node-flags');
-const unparse = require('yargs-unparser');
 const debug = require('debug')('mocha:cli:mocha');
-const {aliases} = require('../lib/cli/run-option-metadata');
 const nodeEnv = require('node-environment-flags');
 
 const mochaPath = require.resolve('./_mocha');
 const mochaArgs = {};
 const nodeArgs = {};
 
-const opts = loadOptions(process.argv.slice(2));
+const opts = parseArgv(process.argv.slice(2));
 debug('loaded opts', opts);
 
 /**
@@ -123,7 +121,8 @@ debug('final node args', nodeArgs);
 const args = [].concat(
   unparseNodeFlags(nodeArgs),
   mochaPath,
-  unparse(mochaArgs, {alias: aliases})
+  '--preParsedJsonOptions',
+  JSON.stringify(mochaArgs)
 );
 
 debug(`exec ${process.execPath} w/ args:`, args);

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -11,10 +11,7 @@
 
 const debug = require('debug')('mocha:cli:cli');
 const symbols = require('log-symbols');
-const yargs = require('yargs');
 const path = require('path');
-const {loadOptions, YARGS_PARSER_CONFIG} = require('./options');
-const commands = require('./commands');
 const ansi = require('ansi-colors');
 const {repository, homepage, version, gitter} = require('../../package.json');
 
@@ -32,7 +29,33 @@ exports.main = (argv = process.argv.slice(2)) => {
 
   Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
 
-  yargs
+  const args = exports.parseArgv(argv);
+  const {handler} = require(`./${args.command.name}`);
+  args.command = null;
+  handler(args);
+};
+
+exports.yargsParse = function(argv) {
+  const {loadOptions} = require('./options');
+  return exports
+    .createYargs()
+    .parse(argv, Object.assign(loadOptions(argv), {command: {}}));
+};
+
+exports.showUsageAndError = function(error) {
+  exports
+    .createYargs()
+    .check(() => {
+      throw error;
+    })
+    .parse([]);
+};
+
+exports.createYargs = function() {
+  const yargs = require('yargs');
+  const {YARGS_PARSER_CONFIG} = require('./options');
+  const commands = require('./commands');
+  return yargs
     .scriptName('mocha')
     .command(commands.run)
     .command(commands.init)
@@ -59,8 +82,14 @@ exports.main = (argv = process.argv.slice(2)) => {
     Docs: ${ansi.yellow(homepage)}
       `
     )
-    .parserConfiguration(YARGS_PARSER_CONFIG)
-    .parse(argv, loadOptions(argv));
+    .parserConfiguration(YARGS_PARSER_CONFIG);
+};
+
+exports.parseArgv = function(argv = process.argv.slice(2)) {
+  if (argv.length === 2 && argv[0] === '--preParsedJsonOptions') {
+    return JSON.parse(argv[1]);
+  }
+  return exports.yargsParse(argv);
 };
 
 // allow direct execution

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -10,6 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
+const debug = require('debug')('mocha:cli:init');
 
 exports.command = 'init <path>';
 
@@ -22,6 +23,11 @@ exports.builder = yargs =>
   });
 
 exports.handler = argv => {
+  debug('post-yargs config', argv);
+  if (argv.command) {
+    argv.command.name = 'init';
+    return;
+  }
   const destdir = argv.path;
   const srcdir = path.join(__dirname, '..', '..');
   mkdirp.sync(destdir);

--- a/lib/cli/node-flags.js
+++ b/lib/cli/node-flags.js
@@ -7,7 +7,6 @@
  */
 
 const nodeFlags = require('node-environment-flags');
-const unparse = require('yargs-unparser');
 
 /**
  * These flags are considered "debug" flags.
@@ -74,13 +73,20 @@ exports.impliesNoTimeouts = flag => debugFlags.has(flag);
  * @private
  */
 exports.unparseNodeFlags = opts => {
-  var args = unparse(opts);
-  return args.length
-    ? args
-        .join(' ')
-        .split(/\b/)
-        .map(arg => (arg === ' ' ? '=' : arg))
-        .join('')
-        .split(' ')
-    : [];
+  const args = [];
+  for (let k in opts) {
+    if (Object.prototype.hasOwnProperty.call(opts, k)) {
+      args.push(map(opts[k], k));
+    }
+  }
+  return args;
+  function map(value, key) {
+    if (value === true) {
+      return `--${key}`;
+    } else if (value === false) {
+      // TODO
+    } else {
+      return `--${key}=${value}`;
+    }
+  }
 };

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -274,11 +274,6 @@ exports.builder = yargs =>
         );
       }
 
-      // load requires first, because it can impact "plugin" validation
-      handleRequires(argv.require);
-      validatePlugin(argv, 'reporter', Mocha.reporters);
-      validatePlugin(argv, 'ui', Mocha.interfaces);
-
       return true;
     })
     .array(types.array)
@@ -289,6 +284,19 @@ exports.builder = yargs =>
 
 exports.handler = argv => {
   debug('post-yargs config', argv);
+  if (argv.command) {
+    argv.command.name = 'run';
+    return;
+  }
+  try {
+    // load requires first, because it can impact "plugin" validation
+    handleRequires(argv.require);
+    validatePlugin(argv, 'reporter', Mocha.reporters);
+    validatePlugin(argv, 'ui', Mocha.interfaces);
+  } catch (e) {
+    require('./cli').showUsageAndError(e);
+  }
+
   const mocha = new Mocha(argv);
   const files = handleFiles(argv);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,21 +6084,6 @@
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
-    "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "requires": {
-        "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
-      }
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -6961,7 +6946,8 @@
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -10212,7 +10198,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -17673,7 +17660,8 @@
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "requirejs": {
       "version": "2.3.6",
@@ -21485,48 +21473,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "yargs-unparser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
-      "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.11",
-        "yargs": "^12.0.5"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "11.1.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-              "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        }
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -513,8 +513,7 @@
     "which": "1.3.1",
     "wide-align": "1.1.3",
     "yargs": "13.2.2",
-    "yargs-parser": "13.0.0",
-    "yargs-unparser": "1.5.0"
+    "yargs-parser": "13.0.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.7.1",

--- a/test/node-unit/cli/run.spec.js
+++ b/test/node-unit/cli/run.spec.js
@@ -7,7 +7,14 @@ describe('command', function() {
   describe('run', function() {
     describe('builder', function() {
       const IGNORED_OPTIONS = new Set(['help', 'version']);
-      const options = builder(require('yargs')).getOptions();
+      const yargs = require('yargs');
+      // Without doing this first, yargs will throw an error when we call `.positional()` below.
+      yargs
+        .command('foo', 'bar', yargs => {
+          return yargs;
+        })
+        .parse(['foo']);
+      const options = builder(yargs).getOptions();
       ['number', 'string', 'boolean', 'array'].forEach(type => {
         describe(`${type} type`, function() {
           Array.from(new Set(options[type])).forEach(option => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

This removes the yargs-unparser dependency and avoids loading yargs within `_mocha` unless necessary.  I still need to double-check these results, but it seems to reduce the installed size from 12M to about 6.6M.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

Faster startup and install time; simpler runtime behavior because yargs is only running once.

### Benefits

Faster startup and install time; simpler runtime behavior because yargs is only running once.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
