### PR TITLE
Fix this.skip() async calls: "self.test" undefined in Browser

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -389,7 +389,9 @@ Runner.prototype.hook = function(name, fn) {
       if (err) {
         if (err instanceof Pending) {
           if (name === HOOK_TYPE_BEFORE_EACH || name === HOOK_TYPE_AFTER_EACH) {
-            self.test.pending = true;
+            if (self.test) {
+              self.test.pending = true;
+            }
           } else {
             suite.tests.forEach(function(test) {
               test.pending = true;


### PR DESCRIPTION
### Description of the Change

In addition to #3745 

> it also appears we need this around 390
```js
        if (err instanceof Pending) {
          if (name === HOOK_TYPE_BEFORE_EACH || name === HOOK_TYPE_AFTER_EACH) {
            if (self.test) {
              self.test.pending = true;
            }
          } else {
```
> When Pending is thrown async like this, we might no longer have a test, which causes its own exception.
