### PR TITLE
fixed anchors to configuration section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1053,7 +1053,7 @@ Can be specified as a comma-delimited list.
 
 > _New in v6.0.0._
 
-Specify an explicit path to a [configuration file](#configuring-mocha-node-js).
+Specify an explicit path to a [configuration file](#configuring-mocha-nodejs).
 
 By default, Mocha will search for a config file if `--config` is not specified; use `--no-config` to suppress this behavior.
 
@@ -1069,7 +1069,7 @@ By default, Mocha looks for a `mocha.opts` in `test/mocha.opts`; use `--no-opts`
 
 > _New in v6.0.0._
 
-Specify an explicit path to a [`package.json` file](#configuring-mocha-node-js) (ostensibly containing configuration in a `mocha` property).
+Specify an explicit path to a [`package.json` file](#configuring-mocha-nodejs) (ostensibly containing configuration in a `mocha` property).
 
 By default, Mocha looks for a `package.json` in the current working directory or nearest ancestor, and will use the first file found (regardless of whether it contains a `mocha` property); to suppress `package.json` lookup, use `--no-package`.
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Several doc links specified an invalid anchor, so this PR fixes `#configuring-mocha-node-js` to `#configuring-mocha-nodejs`.

### Alternate Designs

Um... I don't know how this could have be done in an alternate way.

### Why should this be in core?

If affects documentation navigation.  

### Benefits

Documentation navigation will be correct.   

### Possible Drawbacks

None 

### Applicable issues

Documentation patch
