### PR TITLE
Copy Suite root when cloning

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -102,6 +102,7 @@ Suite.prototype.clone = function() {
   var suite = new Suite(this.title);
   debug('clone');
   suite.ctx = this.ctx;
+  suite.root = this.root;
   suite.timeout(this.timeout());
   suite.retries(this.retries());
   suite.enableTimeouts(this.enableTimeouts());

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -23,7 +23,7 @@ describe('Suite', function() {
 
   describe('.clone()', function() {
     beforeEach(function() {
-      this.suite = new Suite('To be cloned');
+      this.suite = new Suite('To be cloned', {}, true);
       this.suite._timeout = 3043;
       this.suite._slow = 101;
       this.suite._bail = true;
@@ -73,6 +73,10 @@ describe('Suite', function() {
 
     it('should not copy the values from the _afterAll array', function() {
       expect(this.suite.clone()._afterAll, 'to be empty');
+    });
+
+    it('should copy the root property', function() {
+      expect(this.suite.clone().root, 'to be', true);
     });
   });
 


### PR DESCRIPTION
### Description of the Change
Issue #3847 describes how reruns of the same test suite changes the test title.
This pull request fixes that issue, by making sure to copy the root property from the original suite.

### Why should this be in core? 
The bug present in the core makes the API work in non-intuitive ways. This would remedy that.

### Benefits  
The API will work as advertised.

### Possible Drawbacks  
N/A

 ### Applicable issues  
- closes #3847
- Bug fix -> Patch release