### PR TITLE
Remove pound icon showing on header hover on docs #3714

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -141,6 +141,7 @@ a.direct-link {
   background: url(../images/link-icon.svg) center center no-repeat;
   background-size: auto 60%;
   opacity: 0;
+  overflow: hidden;
   position: absolute;
   text-decoration: none;
   text-indent: -60px;


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

cannot pass nothing to `markdown-it-anchor` so passing span
min-height on span tag or defaults to 0 and svg doesn't show

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
could remove svg all together and pass link icon but then it looks too far to the left

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->
just a doc patch

### Benefits

<!-- What benefits will be realized by the code change? -->
cleaner look

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
pretty sure span won't effect anything but i could be wrong

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
bug fix #3714 
