### PR TITLE
Fix hook pattern of this.skip() in it() tests

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -673,11 +673,6 @@ Runner.prototype.runTests = function(suite, fn) {
             self.fail(test, err);
           }
           self.emit(constants.EVENT_TEST_END, test);
-
-          if (err instanceof Pending) {
-            return next();
-          }
-
           return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
         }
 

--- a/test/integration/fixtures/pending/skip-async-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-async-spec.fixture.js
@@ -1,12 +1,30 @@
 'use strict';
+var assert = require('assert');
 
 describe('skip in test', function () {
+  var runOrder = [];
+  beforeEach(function () {
+    runOrder.push('beforeEach');
+  });
+
   it('should skip async', function (done) {
     var self = this;
     setTimeout(function () {
       self.skip();   // done() is not required
     }, 0);
   });
+  it('should run other tests in suite', function () {});
 
-  it('should run other tests in the suite', function () {});
+  afterEach(function() {
+    runOrder.push('afterEach');
+  });
+  after(function() {
+    runOrder.push('after');
+    assert.deepStrictEqual(runOrder, [
+      'beforeEach', 'afterEach',
+      'beforeEach', 'afterEach',
+      'after'
+    ]);
+    throw new Error('should throw this error');
+  });
 });

--- a/test/integration/fixtures/pending/skip-sync-spec.fixture.js
+++ b/test/integration/fixtures/pending/skip-sync-spec.fixture.js
@@ -1,10 +1,28 @@
 'use strict';
+var assert = require('assert');
 
 describe('skip in test', function () {
+  var runOrder = [];
+  beforeEach(function () {
+    runOrder.push('beforeEach');
+  });
+
   it('should skip immediately', function () {
     this.skip();
     throw new Error('never run this test');
   });
+  it('should run other tests in suite', function () {});
 
-  it('should run other tests in the suite', function () {});
+  afterEach(function() {
+    runOrder.push('afterEach');
+  });
+  after(function() {
+    runOrder.push('after');
+    assert.deepStrictEqual(runOrder, [
+      'beforeEach', 'afterEach',
+      'beforeEach', 'afterEach',
+      'after'
+    ]);
+    throw new Error('should throw this error');
+  });
 });

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -59,13 +59,14 @@ describe('pending', function() {
       it('should immediately skip the spec and run all others', function(done) {
         run('pending/skip-sync-spec.fixture.js', args, function(err, res) {
           if (err) {
-            done(err);
-            return;
+            return done(err);
           }
-          assert.strictEqual(res.stats.pending, 1);
-          assert.strictEqual(res.stats.passes, 1);
-          assert.strictEqual(res.stats.failures, 0);
-          assert.strictEqual(res.code, 0);
+          expect(res, 'to have failed with error', 'should throw this error')
+            .and('to have failed test count', 1)
+            .and('to have pending test count', 1)
+            .and('to have pending test order', 'should skip immediately')
+            .and('to have passed test count', 1)
+            .and('to have passed tests', 'should run other tests in suite');
           done();
         });
       });
@@ -192,13 +193,14 @@ describe('pending', function() {
       it('should immediately skip the spec and run all others', function(done) {
         run('pending/skip-async-spec.fixture.js', args, function(err, res) {
           if (err) {
-            done(err);
-            return;
+            return done(err);
           }
-          assert.strictEqual(res.stats.pending, 1);
-          assert.strictEqual(res.stats.passes, 1);
-          assert.strictEqual(res.stats.failures, 0);
-          assert.strictEqual(res.code, 0);
+          expect(res, 'to have failed with error', 'should throw this error')
+            .and('to have failed test count', 1)
+            .and('to have pending test count', 1)
+            .and('to have pending test order', 'should skip async')
+            .and('to have passed test count', 1)
+            .and('to have passed tests', 'should run other tests in suite');
           done();
         });
       });


### PR DESCRIPTION
### Description

The current hook pattern is incorrect. When a test is skipped at runtime, all `beforeEach` hooks have already been executed, nevertheless all `afterEach` hooks are ignored completely.

As a general rule: when a `beforeEach` hook runs, the corresponding `afterEach` should run also for correct cleanup. This same pattern has already been implemented with failing hooks, `this.skip()` in `beforeEach`  and also while using the `--bail` option.

The correct hook pattern should be:
- run all `beforeEach` hooks ("A", "B")
- abort test execution and set test to `pending`
- run all corresponding `afterEach` hooks ("Y", "Z")

By contrast: tests skipped at compile-time with `it.skip()` do not run neither `beforeEach` nor `afterEach` hooks.

```js
describe('outer', function() {
    beforeEach(function() {
      console.log("A");              // yes, does run
    });
    describe('inner', function() {
      beforeEach(function() {
        console.log("B");            // yes, does run
      });
      it('test case', function() {
        this.skip();                 // pending
        console.log("C");            // aborted, does not print "C"
      });
      afterEach(function() {
        console.log("Y");            // no, does not run  => should run
      });
    });
    afterEach(function() {
      console.log("Z");              // no, does not run  => should run
    });
  });
```

### Description of the Change


### Applicable issues

#3740 partially