### PR TITLE
Fix `--config` loading: cwd-relative, fallback to require()

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const findUp = require('find-up');
 const path = require('path');
 const debug = require('debug')('mocha:cli:config');
+const utils = require('../utils');
 
 /**
  * These are the valid config files, in order of precedence;
@@ -31,6 +32,8 @@ exports.CONFIG_FILES = [
 /**
  * Parsers for various config filetypes.  Each accepts a filepath and
  * returns an object (but could throw)
+ *
+ * Filepath *must* be absolute; external logic resolves relative paths.
  */
 const parsers = (exports.parsers = {
   yaml: filepath =>
@@ -45,23 +48,64 @@ const parsers = (exports.parsers = {
 /**
  * Loads and parses, based on file extension, a config file.
  * "JSON" files may have comments.
- * @param {string} filepath - Config file path to load
+ * @param {string} filepath - Config file path or module name to load
  * @returns {Object} Parsed config object
  * @private
  */
 exports.loadConfig = filepath => {
+  const {absFilepath, discoveryMethod} = exports.resolveConfigPath(filepath);
+  return exports.parseConfig(absFilepath, discoveryMethod);
+};
+
+/**
+ * Resolve the location of a config on disk and the method of discovery:
+ * cwd-relative path or require.resolve
+ *
+ * As opposed to findConfig, this does not ascend the filesystem.
+ * When the user specifies `--config`, findConfig is not called, but
+ * `resolveConfigPath` is still called.
+ *
+ * @param {string} filepath - Config file path or module name to load
+ * @private
+ */
+exports.resolveConfigPath = filepath => {
+  /** @type {'cwd-relative' | 'node-require-resolve'} */
+  let discoveryMethod = 'cwd-relative';
+  let absFilepath = path.resolve(filepath);
+  if (!fs.existsSync(absFilepath) || fs.statSync(absFilepath).isDirectory()) {
+    discoveryMethod = 'node-require-resolve';
+    try {
+      absFilepath = utils.requireResolveRelative(filepath);
+    } catch (e) {
+      throw new Error(
+        `failed to locate ${filepath} as either a relative path or a require()-able node module`
+      );
+    }
+  }
+  return {discoveryMethod, absFilepath};
+};
+
+/**
+ * @param {string} absFilepath absolute path to config file
+ * @param {'cwd-relative' | 'node-require-resolve'} discoveryMethod
+ */
+exports.parseConfig = (absFilepath, discoveryMethod) => {
   let config = {};
-  const ext = path.extname(filepath);
+  const ext = path.extname(absFilepath);
   try {
-    if (/\.ya?ml/.test(ext)) {
-      config = parsers.yaml(filepath);
+    if (discoveryMethod === 'node-require-resolve') {
+      config = require(absFilepath);
+    } else if (/\.ya?ml/.test(ext)) {
+      config = parsers.yaml(absFilepath);
     } else if (ext === '.js') {
-      config = parsers.js(filepath);
+      config = parsers.js(absFilepath);
     } else {
-      config = parsers.json(filepath);
+      config = parsers.json(absFilepath);
     }
   } catch (err) {
-    throw new Error(`failed to parse ${filepath}: ${err}`);
+    throw new Error(
+      `failed to parse ${path.relative(process.cwd(), absFilepath)}: ${err}`
+    );
   }
   return config;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,7 @@
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
+var Module = require('module');
 var glob = require('glob');
 var he = require('he');
 var errors = require('./errors');
@@ -894,4 +895,26 @@ exports.defineConstants = function(obj) {
     throw new TypeError('Invalid argument; expected a non-empty object');
   }
   return Object.freeze(exports.createMap(obj));
+};
+
+/**
+ * require.resolve() relative to the given path.
+ *
+ * Usually used to require() modules relative to user's project root or cwd.
+ * - for `--config nodeModule`
+ * - for loading custom reporters
+ *
+ * ALTERNATIVE:
+ * We can use `require('require-relative').resolve()`  It's tiny.
+ * npm.im/require-relative
+ * https://unpkg.com/require-relative@0.8.7/index.js
+ */
+exports.requireResolveRelative = function(request, cwd) {
+  if (cwd === undefined) cwd = process.cwd();
+  // Create a fake module that resides in the cwd directory
+  var m = new Module(path.join(cwd, '__mocha_resolve_relative.js'), null);
+  m.filename = m.id;
+  m.paths = Module._nodeModulePaths(cwd);
+  // Ask node's module API to resolve the requested module relative to our fake module
+  return Module._resolveFilename(request, m);
 };

--- a/test/integration/fixtures/config/node_modules/shared-config/mocha-config.js
+++ b/test/integration/fixtures/config/node_modules/shared-config/mocha-config.js
@@ -1,0 +1,1 @@
+module.exports = {ok: true};

--- a/test/integration/fixtures/config/node_modules/shared-config/package.json
+++ b/test/integration/fixtures/config/node_modules/shared-config/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "mocha-config"
+}

--- a/test/integration/fixtures/config/subdir/mocha-config.js
+++ b/test/integration/fixtures/config/subdir/mocha-config.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// a comment
+module.exports = {
+  require: ['foo', 'bar'],
+  bail: true,
+  reporter: 'dot',
+  slow: 60
+};

--- a/test/integration/fixtures/config/subdir/mocha-config.json
+++ b/test/integration/fixtures/config/subdir/mocha-config.json
@@ -1,0 +1,7 @@
+{
+  // a comment
+  "require": ["foo", "bar"],
+  "bail": true,
+  "reporter": "dot",
+  "slow": 60
+}

--- a/test/integration/fixtures/config/subdir/mocha-config.yaml
+++ b/test/integration/fixtures/config/subdir/mocha-config.yaml
@@ -1,0 +1,7 @@
+# a comment
+require:
+  - foo
+  - bar
+bail: true
+reporter: dot
+slow: 60


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Fixes #3822.

`--config` is first interpreted as a cwd-relative path.  We check if it exists and is a file. (not directory)
If found, we try to parse it according to its file extension. (this behavior is unchanged)
If not found, we attempt to `require.resolve()` it relative to cwd.
If `require.resolve()` is able to locate a file, we `require()` it.  We do not check file extension nor use a custom loader.

Error messages are logged for a) failing to locate a file in the first place and b) failing to parse or load the file that was found.  For b) the error message logs the resolved path, so users can see that we found e.g. `../../node_modules/monorepo-shared-config/mocha.js`.

---

Worth noting, `cwd` may not *always* be the correct directory for resolving.  For example, if in the future the `--config` value comes from a package.json file -- `"mocha": "@cspotcode/my-mocha-config"` -- then we should resolve relative to the directory containing package.json, not necessarily cwd.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

#3822 
#3823 
#3829 