### PR TITLE
Fix yargs global pollution

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -11,7 +11,7 @@
 
 const debug = require('debug')('mocha:cli:cli');
 const symbols = require('log-symbols');
-const yargs = require('yargs');
+const yargs = require('yargs/yargs');
 const path = require('path');
 const {loadOptions, YARGS_PARSER_CONFIG} = require('./options');
 const commands = require('./commands');
@@ -32,7 +32,7 @@ exports.main = (argv = process.argv.slice(2)) => {
 
   Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
 
-  yargs
+  yargs(argv)
     .scriptName('mocha')
     .command(commands.run)
     .command(commands.init)

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -32,7 +32,7 @@ exports.main = (argv = process.argv.slice(2)) => {
 
   Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
 
-  yargs(argv)
+  yargs()
     .scriptName('mocha')
     .command(commands.run)
     .command(commands.init)

--- a/test/node-unit/cli/run.spec.js
+++ b/test/node-unit/cli/run.spec.js
@@ -7,7 +7,7 @@ describe('command', function() {
   describe('run', function() {
     describe('builder', function() {
       const IGNORED_OPTIONS = new Set(['help', 'version']);
-      const options = builder(require('yargs')).getOptions();
+      const options = builder(require('yargs/yargs')().reset()).getOptions();
       ['number', 'string', 'boolean', 'array'].forEach(type => {
         describe(`${type} type`, function() {
           Array.from(new Set(options[type])).forEach(option => {


### PR DESCRIPTION
### Description of the Change

Yargs exports a global singleton by default. Using it directly will break testing apps using yargs themselves.

### Alternate Designs

I followed the [best-practice example in yargs' documentation](https://github.com/yargs/yargs/blob/master/docs/advanced.md#using-the-non-singleton-interface). One test had to be adjusted slightly, using a separate yargs instance which has been reset: this is [what yargs does internally](https://github.com/yargs/yargs/blob/master/lib/command.js#L188) and required, because `run.builder()` calls `.positional()` which cannot be called on the outer yargs instance.

### Benefits

Makes mocha compatible with other projects depending on yargs.

### Possible Drawbacks

If we need access to mocha's yargs instance, we'll have to expose it ourselves, instead of relying on the global one.

I think this should be a bug fix (patch release).