### PR TITLE
WIP: Reporter Output via Mixins

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -278,6 +278,7 @@ function Base(runner, options) {
   this.options = options || {};
   this.runner = runner;
   this.stats = runner.stats; // assigned so Reporters keep a closer reference
+  this.preferConsole = !!(this.options.reporterOptions || {}).preferConsole;
 
   runner.on(EVENT_TEST_PASS, function(test) {
     if (test.duration > test.slow()) {

--- a/lib/reporters/writers/console.js
+++ b/lib/reporters/writers/console.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * Save timer references (mochajs/mocha#237).
+ */
+var setTimeout = global.setTimeout;
+
+/**
+ * Provides methods used for output by console-oriented reporters.
+ *
+ * @description
+ * Not meant to be used directly.
+ *
+ * @package
+ * @mixin ConsoleWriter
+ */
+var ConsoleWriter = function() {
+  var buffer = '';
+
+  /**
+   * Writes string to reporter output.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.write = function(str) {
+    if (str) {
+      buffer += str; // Store until `console.log` invoked
+    }
+    return this;
+  };
+
+  /**
+   * Writes newline-terminated string to reporter output.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.writeln = function(str) {
+    this.write(str);
+    console.log(buffer);
+    buffer = ''; // Reset
+    return this;
+  };
+
+  /**
+   * Invokes provided completion function.
+   *
+   * @description
+   * Writes any buffered output.
+   *
+   * @package
+   * @param {Function} cb - Callback invoked when cleanup done
+   */
+  this._done = function(cb) {
+    if (buffer) {
+      var delay = 1000; // One second
+
+      this.writeln();
+      setTimeout(cb, delay);
+    } else {
+      cb();
+    }
+  };
+
+  return this;
+};
+
+module.exports = ConsoleWriter;

--- a/lib/reporters/writers/file.js
+++ b/lib/reporters/writers/file.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var errors = require('../../errors');
+
+var createUnsupportedError = errors.createUnsupportedError;
+
+/**
+ * Provides methods used for output by file-oriented reporters.
+ *
+ * @description
+ * Not meant to be used directly.
+ *
+ * @package
+ * @mixin FileWriter
+ */
+var FileWriter = function() {
+  /**
+   * Writes string to reporter output.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.write = function(str) {
+    this._fileStream.write(str);
+    return this;
+  };
+
+  /**
+   * Writes newline-terminated string to reporter output.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.writeln = function(str) {
+    return this.write(str + '\n');
+  };
+
+  /**
+   * Invokes provided completion function.
+   *
+   * @description
+   * Closes the filesystem output stream.
+   *
+   * @package
+   * @param {Function} cb - Callback invoked when cleanup done
+   */
+  this._done = function(cb) {
+    var self = this;
+    this._fileStream.end(function() {
+      self._fileStream = null;
+      cb();
+    });
+  };
+
+  return this;
+};
+
+/**
+ * Creates filesystem output stream, if possible.
+ *
+ * @static
+ * @package
+ * @param {Object} reporter - Instance of reporter
+ * @param {string} pathname - Pathname of desired output file
+ * @throws Various errors are possible
+ */
+FileWriter.createWriteStream = function(reporter, pathname) {
+  if (!fs.createWriteStream) {
+    throw createUnsupportedError('file output not supported in browser');
+  }
+
+  mkdirp.sync(path.dirname(pathname));
+  reporter._fileStream = fs.createWriteStream(pathname);
+};
+
+/**
+ * Determines if writer should write output to filesystem.
+ *
+ * @public
+ * @static
+ * @returns {boolean} whether writer should use `FileWriter` methods
+ */
+FileWriter.isFileWriter = function(reporter) {
+  return reporter.hasOwnProperty('_fileStream') && !!reporter._fileStream;
+};
+
+module.exports = FileWriter;

--- a/lib/reporters/writers/index.js
+++ b/lib/reporters/writers/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.ReportWriter = require('./report');

--- a/lib/reporters/writers/report.js
+++ b/lib/reporters/writers/report.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var sprintf = require('util').format;
+var ConsoleWriter = require('./console');
+var FileWriter = require('./file');
+var StreamWriter = require('./stream');
+
+/**
+ * Provides methods used for output by reporters.
+ *
+ * @description
+ * Not meant to be used directly. Runtime-adaptive.
+ * Once _any_ functional mixin method is iinvoked, specializations will occur
+ * which may augment/replace existing methods/properties.
+ *
+ * @public
+ * @mixin ReportWriter
+ * @example
+ * var ReportWriter = require('./writers/report');
+ * var MyReporter = function(runner, options) {
+ *   runner.on(EVENT_TEST_PASS, function(test) {
+ *     this.println(test);
+ *   });
+ * };
+ * ReportWriter.call(MyReporter.prototype);
+ */
+var ReportWriter = function() {
+  /**
+   * Adapts prototype methods to specific output destination.
+   *
+   * @param {Object} reporter - Reporter instance
+   * @returns {reporter}
+   * @chainable
+   */
+  function adapt(reporter) {
+    var preferConsole = !!reporter.preferConsole;
+
+    // :DEBUG: console.log('reporter:', reporter);
+    if (ReportWriter.isFileWriter(reporter)) {
+      // :DEBUG: console.log('### specialized as FileWriter');
+      FileWriter.call(reporter);
+    } else if (!preferConsole && ReportWriter.stdoutExists()) {
+      // :DEBUG: console.log('### specialized as StreamWriter');
+      StreamWriter.call(reporter);
+    } else {
+      // :DEBUG: console.log('### specialized as ConsoleWriter');
+      ConsoleWriter.call(reporter);
+    }
+
+    return reporter;
+  }
+
+  /**
+   * Writes string to reporter output.
+   *
+   * @description
+   * Overrides this class method by creating same-named instance method.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.write = function(str) {
+    return adapt(this).write(str);
+  };
+
+  /**
+   * Writes newline-terminated string to reporter output.
+   *
+   * @description
+   * Overrides this class method by creating same-named instance method.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.writeln = function(str) {
+    return adapt(this).writeln(str);
+  };
+
+  /**
+   * Writes formatted string to reporter output.
+   * @see {@link https://nodejs.org/api/util.html#util_util_format_format_args}
+   *
+   * @package
+   * @param {string} format - `printf`-like format string
+   * @param {...*} [varArgs] - Format string arguments
+   * @returns {this}
+   * @chainable
+   */
+  this.print = function(format, varArgs) {
+    var vargs = Array.prototype.slice.call(arguments);
+    var str = sprintf.apply(null, vargs);
+    return this.write(str);
+  };
+
+  /**
+   * Writes newline-terminated formatted string to reporter output.
+   *
+   * @package
+   * @param {string} format - `printf`-like format string
+   * @param {...*} [varArgs] - Format string arguments
+   * @returns {this}
+   * @chainable
+   */
+  this.println = function(format, varArgs) {
+    var vargs = Array.prototype.slice.call(arguments);
+    vargs[0] += '\n';
+    return this.print(this, vargs);
+  };
+
+  /**
+   * Invokes provided completion function.
+   *
+   * @package
+   * @param {number} nfailures - Count of failed tests (integer)
+   * @param {DoneCB} fn - Callback invoked when test execution completes
+   */
+  this.done = function(nfailures, fn) {
+    if (this._done) {
+      this._done(function() {
+        fn(nfailures);
+      });
+    } else {
+      fn(nfailures);
+    }
+  };
+
+  return this;
+};
+
+/**
+ * Attempts creation of filesystem output stream, if
+ * <code>reporter.options.output</code> given.
+ *
+ * @public
+ * @static
+ * @param {Object} reporter - Instance of reporter
+ * @throws Various errors are possible if file creation attempted
+ */
+ReportWriter.maybeCreateFileOutput = function(reporter) {
+  var reporterOptions = (reporter.options || {}).reporterOptions || {};
+  var pathname = reporterOptions.output;
+
+  if (pathname) {
+    FileWriter.createWriteStream(reporter, pathname);
+  }
+};
+
+/**
+ * Determines if writer can write output to filesystem.
+ *
+ * @private
+ * @static
+ * @param {Object} reporter - Instance of reporter
+ * @returns {boolean} whether writer should use `FileWriter` methods
+ */
+ReportWriter.isFileWriter = function(reporter) {
+  return FileWriter.isFileWriter(reporter);
+};
+
+/**
+ * Determines if `process.stdout` exists in current execution environment.
+ *
+ * @description
+ * On PhantomJS, `process.stdout` doesn't exist...
+ *
+ * @public
+ * @static
+ * @returns {boolean} whether `process.stdout` can be used
+ */
+ReportWriter.stdoutExists = function() {
+  return typeof process === 'object' && !!process.stdout;
+};
+
+module.exports = ReportWriter;

--- a/lib/reporters/writers/stream.js
+++ b/lib/reporters/writers/stream.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Provides methods used for output by stream-oriented reporters.
+ *
+ * @description
+ * Not meant to be used directly.
+ *
+ * @package
+ * @mixin StreamWriter
+ */
+var StreamWriter = function() {
+  var stream = process.stdout;
+
+  /**
+   * Writes string to reporter output.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.write = function(str) {
+    stream.write(str);
+    return this;
+  };
+
+  /**
+   * Writes newline-terminated string to reporter output.
+   *
+   * @package
+   * @param {string} str - String to write to the reporter output.
+   * @returns {this}
+   * @chainable
+   */
+  this.writeln = function(str) {
+    return this.write(str + '\n');
+  };
+
+  /**
+   * Invokes provided completion function.
+   *
+   * @package
+   * @param {Function} cb - Callback invoked when cleanup done
+   */
+  this._done = function(cb) {
+    cb();
+  };
+
+  return this;
+};
+
+module.exports = StreamWriter;

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -8,11 +8,7 @@
 
 var Base = require('./base');
 var utils = require('../utils');
-var fs = require('fs');
-var mkdirp = require('mkdirp');
-var path = require('path');
-var errors = require('../errors');
-var createUnsupportedError = errors.createUnsupportedError;
+var ReportWriter = require('./writers/report');
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
@@ -30,7 +26,6 @@ var Date = global.Date;
 /**
  * Expose `XUnit`.
  */
-
 exports = module.exports = XUnit;
 
 /**
@@ -40,38 +35,22 @@ exports = module.exports = XUnit;
  * @class
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
+ * @mixes StreamWriter
  * @param {Runner} runner - Instance triggers reporter actions.
  * @param {Object} [options] - runner options
  */
 function XUnit(runner, options) {
   Base.call(this, runner, options);
 
+  var self = this;
   var stats = this.stats;
   var tests = [];
-  var self = this;
 
-  // the name of the test suite, as it will appear in the resulting XML file
-  var suiteName;
+  // Name of the test suite, as it will appear in the resulting XML file
+  var suiteName = XUnit.getSuiteName(this);
 
-  // the default name of the test suite if none is provided
-  var DEFAULT_SUITE_NAME = 'Mocha Tests';
-
-  if (options && options.reporterOptions) {
-    if (options.reporterOptions.output) {
-      if (!fs.createWriteStream) {
-        throw createUnsupportedError('file output not supported in browser');
-      }
-
-      mkdirp.sync(path.dirname(options.reporterOptions.output));
-      self.fileStream = fs.createWriteStream(options.reporterOptions.output);
-    }
-
-    // get the suite name from the reporter options (if provided)
-    suiteName = options.reporterOptions.suiteName;
-  }
-
-  // fall back to the default suite name
-  suiteName = suiteName || DEFAULT_SUITE_NAME;
+  // Write to file, if requested
+  ReportWriter.maybeCreateFileOutput(this);
 
   runner.on(EVENT_TEST_PENDING, function(test) {
     tests.push(test);
@@ -86,7 +65,7 @@ function XUnit(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    self.write(
+    self.writeln(
       tag(
         'testsuite',
         {
@@ -106,7 +85,7 @@ function XUnit(runner, options) {
       self.test(t);
     });
 
-    self.write('</testsuite>');
+    self.writeln('</testsuite>');
   });
 }
 
@@ -114,37 +93,7 @@ function XUnit(runner, options) {
  * Inherit from `Base.prototype`.
  */
 inherits(XUnit, Base);
-
-/**
- * Override done to close the stream (if it's a file).
- *
- * @param failures
- * @param {Function} fn
- */
-XUnit.prototype.done = function(failures, fn) {
-  if (this.fileStream) {
-    this.fileStream.end(function() {
-      fn(failures);
-    });
-  } else {
-    fn(failures);
-  }
-};
-
-/**
- * Write out the given line.
- *
- * @param {string} line
- */
-XUnit.prototype.write = function(line) {
-  if (this.fileStream) {
-    this.fileStream.write(line + '\n');
-  } else if (typeof process === 'object' && process.stdout) {
-    process.stdout.write(line + '\n');
-  } else {
-    console.log(line);
-  }
-};
+ReportWriter.call(XUnit.prototype);
 
 /**
  * Output tag for the given `test.`
@@ -166,7 +115,7 @@ XUnit.prototype.test = function(test) {
       Base.hideDiff || !err.actual || !err.expected
         ? ''
         : '\n' + Base.generateDiff(err.actual, err.expected);
-    this.write(
+    this.writeln(
       tag(
         'testcase',
         attrs,
@@ -180,10 +129,24 @@ XUnit.prototype.test = function(test) {
       )
     );
   } else if (test.isPending()) {
-    this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    this.writeln(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    this.write(tag('testcase', attrs, true));
+    this.writeln(tag('testcase', attrs, true));
   }
+};
+
+/**
+ * Gets the name of the test suite.
+ *
+ * @static
+ * @param {Object} reporter - Instance of XUnit
+ * @returns {String} name of test suite
+ */
+XUnit.getSuiteName = function(reporter) {
+  var DEFAULT_SUITE_NAME = 'Mocha Tests';
+  var reporterOptions = (reporter.options || {}).reporterOptions || {};
+
+  return reporterOptions.suiteName || DEFAULT_SUITE_NAME;
 };
 
 /**


### PR DESCRIPTION
### Description of the Change

Created class mixins to allow a reporter to support multiple output destinations.
Hope would be to _eventually_ make reporters use these mixins to standardize
built-in reporters across the board.

This PR transformed `XUnit` first, since it already had unit tests dealing with file output.
Would like both `JSON` and `TAP` to get the "treatment" soon.

Looking for comments on the approach taken.

### Alternate Designs

We _could_ add the same "XUnit" code to each reporter that desired file output.

### Why should this be in core?

**Magnets!!!**

### Benefits

Trivializes adding support for file output to another reporter.

### Possible Drawbacks

None found in XUnit thusfar.

### Applicable issues

semver-minor