### PR TITLE
chore: add .npmrc, ensure registry=https://registry.npmjs.org/

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+


### PR DESCRIPTION
### Description of the Change

Adding a `.npmrc` file that explicitly points to `https://registry.npmjs.org/` allows contributors to more easily and confidently execute npm commands on the appropriate registry.

### Why should this be in core?

For the reason mentioned above.

### Benefits

Eases the efforts of contributors.

### Possible Drawbacks

None.

### Applicable issues

Patch level update.
