### PR TITLE
fix styles on mochajs.org

### DIFF
--- a/docs/css/prism.css
+++ b/docs/css/prism.css
@@ -115,7 +115,6 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string {
     color: #9a6e3a;
-    background: hsla(0, 0%, 100%, .5);
 }
 
 .token.atrule,

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -174,6 +174,12 @@ code {
   line-height: 1.8;
 }
 
+:not(pre)>code {
+  background-color: #f5f2f0;
+  border-radius: 3px;
+  padding: .2em .4em;
+}
+
 pre {
   background-color: #f3f3f3;
   border: 1px solid #ddd;

--- a/docs/index.md
+++ b/docs/index.md
@@ -1176,7 +1176,7 @@ Requires either `--grep` or `--fgrep` (but not both).
 
 ### `--debug, --inspect, --debug-brk, --inspect-brk, debug, inspect`
 
-> _BREAKING CHANGE in v6.0.0; `-d` is no longer an alias for `--debug`._ > _Other updates in v6.0.0:_ > _In versions of Node.js implementing `--inspect` and `--inspect-brk`, `--debug` and `--debug-brk` are respectively aliases for these two options._ > _Likewise, `debug` (not `--debug`) is an alias for `inspect` (not `--inspect`) in Node.js versions where `debug` is deprecated._
+> _BREAKING CHANGE in v6.0.0; `-d` is no longer an alias for `--debug`. Other updates in v6.0.0: In versions of Node.js implementing `--inspect` and `--inspect-brk`, `--debug` and `--debug-brk` are respectively aliases for these two options. Likewise, `debug` (not `--debug`) is an alias for `inspect` (not `--inspect`) in Node.js versions where `debug` is deprecated._
 
 Enables Node.js' debugger or inspector.
 
@@ -1630,7 +1630,7 @@ In addition to supporting the legacy [`mocha.opts`](#mochaopts) run-control form
 - **JavaScript**: Create a `.mocharc.js` in your project's root directory, and export an object (`module.exports = {/* ... */}`) containing your configuration.
 - **YAML**: Create a `.mocharc.yaml` (or `.mocharc.yml`) in your project's root directory.
 - **JSON**: Create a `.mocharc.json` (or `.mocharc.jsonc`) in your project's root directory. Comments &mdash; while not valid JSON &mdash; are allowed in this file, and will be ignored by Mocha.
-- **`package.json`**: Create a `mocha` property in your project's `package.json`.
+- **package.json**: Create a `mocha` property in your project's `package.json`.
 
 Mocha suggests using one of the above strategies for configuration instead of the legacy `mocha.opts` format.
 


### PR DESCRIPTION
### Description of the Change

1. remove unnecessary white background color for an operator in a code block

<img width="324" alt="스크린샷 2019-04-20 15 38 33" src="https://user-images.githubusercontent.com/390146/56453922-250db900-6384-11e9-9595-38015f745fcc.png">

2. make bold configuration file format like others

<img width="448" alt="스크린샷 2019-04-20 15 39 38" src="https://user-images.githubusercontent.com/390146/56453939-61d9b000-6384-11e9-9e3b-1622d33a5bbd.png">

3. fix broken markdown syntax for [quotes](https://mochajs.org/#-debug-inspect-debug-brk-inspect-brk-debug-inspect)
4. add style inline code block like GitHub

### Alternate Designs
N/A

### Benefits
Users can easy to read the document