### PR TITLE
Add Node v12 in test matrix instead v11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ stages:
 
 # defaults
 language: node_js
-node_js: '11'
+node_js: '12'
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,15 @@ node_js: '12'
 addons:
   apt:
     packages:
+      # Growl
       - libnotify-bin
+      # Canvas
+      - pkg-config
+      - libcairo2-dev
       - libpango1.0-dev
+      - libjpeg-dev
+      - libgif-dev
+      - librsvg2-dev
 # `nvm install` happens before the cache is restored, which means
 # we must install our own npm elsewhere (`~/npm`)
 before_install: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
   apt:
     packages:
       - libnotify-bin
+      - libpango1.0-dev
 # `nvm install` happens before the cache is restored, which means
 # we must install our own npm elsewhere (`~/npm`)
 before_install: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ shallow_clone: true
 clone_depth: 1
 environment:
   matrix:
-    - nodejs_version: '11'
+    - nodejs_version: '12'
     - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,9 @@ install:
   ## Node-related installs
   - ps: Add-AppveyorMessage "Installing Node..."
   - set PATH=%APPDATA%\npm;C:\MinGW\bin;%PATH%
-  - ps: Install-Product node $env:nodejs_version x64
+  ## :NOTE: Using slower `Update-NodeJSInstallation` until pre-installed Node-12 image made available...
+  #- ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
   - ps: Add-AppveyorMessage "Installing npm..."
   - npm install -g npm
   ## Mocha-related package installs


### PR DESCRIPTION
Today Node v12 has been released. So, it's a new current version of Node.
Test mocha with Node v12 instead of v11.