### PR TITLE
Fix parsing of config files with "_mocha" binary

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -32,6 +32,8 @@ exports.main = (argv = process.argv.slice(2)) => {
 
   Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
 
+  var args = loadOptions(argv);
+
   yargs()
     .scriptName('mocha')
     .command(commands.run)
@@ -60,7 +62,8 @@ exports.main = (argv = process.argv.slice(2)) => {
       `
     )
     .parserConfiguration(YARGS_PARSER_CONFIG)
-    .parse(argv, loadOptions(argv));
+    .config(args)
+    .parse(args._);
 };
 
 // allow direct execution


### PR DESCRIPTION
### Description

In [cli/cli.js](https://github.com/mochajs/mocha/blob/master/lib/cli/cli.js#L63) the arguments of the config files are passed incorrectly:

`.parse(argv, loadOptions(argv)); `

The signature: `Yargs#parse([args], [context], [parseCallback])`

The config object is passed as "context" parameter instead of as config object. One consequence is that the `coerce` function is not triggered.

### Description of the Change

Use Yargs `--config` option.



### Applicable issues

closes #3826