### PR TITLE
Node v12 and preserve-symlinks/-main flags

### DIFF
--- a/test/node-unit/cli/node-flags.spec.js
+++ b/test/node-unit/cli/node-flags.spec.js
@@ -35,9 +35,12 @@ describe('node-flags', function() {
       it('should return true for flags starting with "preserve-symlinks"', function() {
         expect(isNodeFlag('preserve-symlinks'), 'to be true');
         expect(isNodeFlag('preserve-symlinks-main'), 'to be true');
-        // XXX this is not true in some newer versions of Node.js.  figure out where
-        // this changed.
-        expect(isNodeFlag('preserve_symlinks'), 'to be false');
+        // Node >= v12 both flags exist in process.allowedNodeEnvironmentFlags
+        const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10);
+        expect(
+          isNodeFlag('preserve_symlinks'),
+          nodeVersion >= 12 ? 'to be true' : 'to be false'
+        );
       });
 
       it('should return true for flags starting with "harmony-" or "harmony_"', function() {


### PR DESCRIPTION
### Description

With newer versions Node flags can be written with "-" or "_":
f.e. `--abort-on-uncaught-exception`  <==> `--abort_on_uncaught_exception`

The same rule works for the two Node flags
- `--preserve-symlinks` (since v6.3.0) <==> `--preserve_symlinks`
- `--preserve-symlinks-main` (since v10.2.0) <==> `--preserve_symlinks_main`

Mocha treats both flags as special cases, since they haven't been part of `process.allowedNodeEnvironmentFlags` before Node v12.



### Description of the Change

Update unit test.

### Applicable issues

closes #3896
