### PR TITLE
Fix regression/bug in "lookupFiles()"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -576,25 +576,27 @@ exports.lookupFiles = function lookupFiles(filepath, extensions, recursive) {
   var stat;
 
   if (!fs.existsSync(filepath)) {
-    // Check all extensions, using first match found (if any)
-    if (
-      !extensions.some(function(ext) {
-        if (fs.existsSync(filepath + '.' + ext)) {
-          filepath += '.' + ext;
-          return true;
-        }
-      })
-    ) {
-      // Handle glob
-      files = glob.sync(filepath, {nodir: true});
-      if (!files.length) {
-        throw createNoFilesMatchPatternError(
-          'Cannot find any files matching pattern ' + exports.dQuote(filepath),
-          filepath
-        );
-      }
-      return files;
+    var pattern;
+    if (glob.hasMagic(filepath)) {
+      // Handle glob as is without extensions
+      pattern = filepath;
+    } else {
+      // glob pattern e.g. 'filepath+(.js|.ts)'
+      var strExtensions = extensions
+        .map(function(v) {
+          return '.' + v;
+        })
+        .join('|');
+      pattern = filepath + '+(' + strExtensions + ')';
     }
+    files = glob.sync(pattern, {nodir: true});
+    if (!files.length) {
+      throw createNoFilesMatchPatternError(
+        'Cannot find any files matching pattern ' + exports.dQuote(filepath),
+        filepath
+      );
+    }
+    return files;
   }
 
   // Handle file

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -563,35 +563,38 @@ function isHiddenOnUnix(pathname) {
  * @public
  * @memberof Mocha.utils
  * @param {string} filepath - Base path to start searching from.
- * @param {string[]} extensions - File extensions to look for.
- * @param {boolean} recursive - Whether to recurse into subdirectories.
+ * @param {string[]} [extensions=[]] - File extensions to look for.
+ * @param {boolean} [recursive=false] - Whether to recurse into subdirectories.
  * @return {string[]} An array of paths.
  * @throws {Error} if no files match pattern.
  * @throws {TypeError} if `filepath` is directory and `extensions` not provided.
  */
 exports.lookupFiles = function lookupFiles(filepath, extensions, recursive) {
   extensions = extensions || [];
+  recursive = recursive || false;
   var files = [];
   var stat;
 
   if (!fs.existsSync(filepath)) {
-    // check all extensions
-    extensions.forEach(function(ext) {
-      if (fs.existsSync(filepath + '.' + ext)) {
-        files.push(filepath + '.' + ext);
-      }
-    });
-    if (!files.length) {
+    // Check all extensions, using first match found (if any)
+    if (
+      !extensions.some(function(ext) {
+        if (fs.existsSync(filepath + '.' + ext)) {
+          filepath += '.' + ext;
+          return true;
+        }
+      })
+    ) {
       // Handle glob
-      files = glob.sync(filepath);
+      files = glob.sync(filepath, {nodir: true});
       if (!files.length) {
         throw createNoFilesMatchPatternError(
           'Cannot find any files matching pattern ' + exports.dQuote(filepath),
           filepath
         );
       }
+      return files;
     }
-    return files;
   }
 
   // Handle file

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -66,6 +66,34 @@ describe('file utils', function() {
       expect(res, 'to contain', nonJsFile).and('to have length', 1);
     });
 
+    it('should return only the ".js" file', function() {
+      var TsFile = tmpFile('mocha-utils.ts');
+      fs.writeFileSync(TsFile, 'yippy skippy ying yang yow');
+
+      var res = utils
+        .lookupFiles(tmpFile('mocha-utils'), ['js'], false)
+        .map(path.normalize.bind(path));
+      expect(res, 'to contain', tmpFile('mocha-utils.js')).and(
+        'to have length',
+        1
+      );
+    });
+
+    it('should return ".js" and ".ts" files', function() {
+      var TsFile = tmpFile('mocha-utils.ts');
+      fs.writeFileSync(TsFile, 'yippy skippy ying yang yow');
+
+      var res = utils
+        .lookupFiles(tmpFile('mocha-utils'), ['js', 'ts'], false)
+        .map(path.normalize.bind(path));
+      expect(
+        res,
+        'to contain',
+        tmpFile('mocha-utils.js'),
+        tmpFile('mocha-utils.ts')
+      ).and('to have length', 2);
+    });
+
     it('should require the extensions parameter when looking up a file', function() {
       var dirLookup = function() {
         return utils.lookupFiles(tmpFile('mocha-utils'), undefined, false);


### PR DESCRIPTION
### Description of Change

* fix (my) regession: in some cases directories are returned, but only files are expected.

* fix existing bug: in some cases `glob.sync` returns directories, but only files are expected.
Directories can be excluded with options `{nodir: true}`.
BTW: Mocha's flag `--recursive` has no effect in our `glob.sync` implementation, but the same result can be achieved by using the glob pattern `**`, eg. "test/**/*"

* implement: a filename can be entered without extension. In this case all matches with option `extension[]` are returned. Currently only a constant extension `.js` is used.

### Applicable issues

#3834 
