### PR TITLE
modify Mocha constructor to accept options.global or options.globals

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -114,7 +114,7 @@ function Mocha(options) {
     .useColors(options.color)
     .slow(options.slow)
     .useInlineDiffs(options.inlineDiffs)
-    .globals(options.globals);
+    .globals(options.global || options.globals);
 
   if ('enableTimeouts' in options) {
     utils.deprecate(

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -106,6 +106,11 @@ function Mocha(options) {
     options.color = 'color' in options ? options.color : options.useColors;
   }
 
+  // Globals are passed in as options.global, with options.globals for backward
+  // compatibility. Globals are stored internally at this.options.globals.
+  options.globals = options.global || options.globals || [];
+  delete options.global;
+
   this.grep(options.grep)
     .fgrep(options.fgrep)
     .ui(options.ui)
@@ -114,7 +119,7 @@ function Mocha(options) {
     .useColors(options.color)
     .slow(options.slow)
     .useInlineDiffs(options.inlineDiffs)
-    .globals(options.global || options.globals);
+    .globals(options.globals);
 
   if ('enableTimeouts' in options) {
     utils.deprecate(
@@ -551,9 +556,12 @@ Mocha.prototype._growl = growl.notify;
  * mocha.globals(['jQuery', 'MyLib']);
  */
 Mocha.prototype.globals = function(globals) {
-  this.options.globals = (this.options.globals || [])
+  this.options.globals = this.options.globals
     .concat(globals)
-    .filter(Boolean);
+    .filter(Boolean)
+    .filter(function(elt, idx, arr) {
+      return arr.indexOf(elt) === idx;
+    });
   return this;
 };
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -545,7 +545,7 @@ Mocha.prototype._growl = growl.notify;
  * Specifies whitelist of variable names to be expected in global scope.
  *
  * @public
- * @see {@link https://mochajs.org/#--globals-names|CLI option}
+ * @see {@link https://mochajs.org/#-global-variable-name|CLI option}
  * @see {@link Mocha#checkLeaks}
  * @param {String[]|String} globals - Accepted global variable name(s).
  * @return {Mocha} this

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -106,8 +106,7 @@ function Mocha(options) {
     options.color = 'color' in options ? options.color : options.useColors;
   }
 
-  // Globals are passed in as options.global, with options.globals for backward
-  // compatibility. Globals are stored internally at this.options.globals.
+  // Globals are passed in as options.global, with options.globals for backward compatibility.
   options.globals = options.global || options.globals || [];
   delete options.global;
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -21,6 +21,7 @@ describe('Mocha', function() {
       sandbox.stub(Mocha.prototype, 'useColors').returnsThis();
       sandbox.stub(utils, 'deprecate');
       sandbox.stub(Mocha.prototype, 'timeout').returnsThis();
+      sandbox.stub(Mocha.prototype, 'globals').returnsThis();
     });
 
     describe('when "useColors" option is defined', function() {
@@ -62,6 +63,36 @@ describe('Mocha', function() {
         expect(Mocha.prototype.timeout, 'to have a call satisfying', [0]).and(
           'was called once'
         );
+      });
+    });
+
+    describe('when options.global is provided', function() {
+      it('should pass options.global to #globals()', function() {
+        // eslint-disable-next-line no-new
+        new Mocha({global: ['singular']});
+        expect(Mocha.prototype.globals, 'to have a call satisfying', [
+          ['singular']
+        ]).and('was called once');
+      });
+    });
+
+    describe('when options.globals is provided', function() {
+      it('should pass options.globals to #globals()', function() {
+        // eslint-disable-next-line no-new
+        new Mocha({globals: ['plural']});
+        expect(Mocha.prototype.globals, 'to have a call satisfying', [
+          ['plural']
+        ]).and('was called once');
+      });
+    });
+
+    describe('when options.global AND options.globals are provided', function() {
+      it('should pass options.global to #globals(), ignoring options.globals', function() {
+        // eslint-disable-next-line no-new
+        new Mocha({global: ['singular'], globals: ['plural']});
+        expect(Mocha.prototype.globals, 'to have a call satisfying', [
+          ['singular']
+        ]).and('was called once');
       });
     });
   });

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -66,7 +66,7 @@ describe('Mocha', function() {
       });
     });
 
-    describe.skip('when options.global is provided', function() {
+    describe('when options.global is provided', function() {
       it('should pass options.global to #globals()', function() {
         // eslint-disable-next-line no-new
         new Mocha({global: ['singular']});
@@ -76,7 +76,7 @@ describe('Mocha', function() {
       });
     });
 
-    describe.skip('when options.globals is provided', function() {
+    describe('when options.globals is provided', function() {
       it('should pass options.globals to #globals()', function() {
         // eslint-disable-next-line no-new
         new Mocha({globals: ['plural']});
@@ -86,7 +86,7 @@ describe('Mocha', function() {
       });
     });
 
-    describe.skip('when options.global AND options.globals are provided', function() {
+    describe('when options.global AND options.globals are provided', function() {
       it('should pass options.global to #globals(), ignoring options.globals', function() {
         // eslint-disable-next-line no-new
         new Mocha({global: ['singular'], globals: ['plural']});

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -66,7 +66,7 @@ describe('Mocha', function() {
       });
     });
 
-    describe('when options.global is provided', function() {
+    describe.skip('when options.global is provided', function() {
       it('should pass options.global to #globals()', function() {
         // eslint-disable-next-line no-new
         new Mocha({global: ['singular']});
@@ -76,7 +76,7 @@ describe('Mocha', function() {
       });
     });
 
-    describe('when options.globals is provided', function() {
+    describe.skip('when options.globals is provided', function() {
       it('should pass options.globals to #globals()', function() {
         // eslint-disable-next-line no-new
         new Mocha({globals: ['plural']});
@@ -86,7 +86,7 @@ describe('Mocha', function() {
       });
     });
 
-    describe('when options.global AND options.globals are provided', function() {
+    describe.skip('when options.global AND options.globals are provided', function() {
       it('should pass options.global to #globals(), ignoring options.globals', function() {
         // eslint-disable-next-line no-new
         new Mocha({global: ['singular'], globals: ['plural']});

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -198,6 +198,7 @@ describe('Mocha', function() {
     describe('when argument is valid', function() {
       var elem = 'foo';
       var elem2 = 'bar';
+      var elem3 = 'baz';
 
       it('should add string to the whitelist', function() {
         var mocha = new Mocha(opts);
@@ -216,9 +217,9 @@ describe('Mocha', function() {
 
       it('should not have duplicates', function() {
         var mocha = new Mocha({globals: [elem, elem2]});
-        var elems = [elem, elem2];
+        var elems = [elem, elem2, elem3];
         mocha.globals(elems);
-        expect(mocha.options.globals, 'to contain', elem, elem2);
+        expect(mocha.options.globals, 'to contain', elem, elem2, elem3);
         expect(mocha.options.globals, 'to have length', elems.length);
       });
     });

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -66,8 +66,8 @@ describe('Mocha', function() {
       });
     });
 
-    describe('when options.global is provided', function() {
-      it('should pass options.global to #globals()', function() {
+    describe('when "options.global" is provided', function() {
+      it('should pass "options.global" to #globals()', function() {
         // eslint-disable-next-line no-new
         new Mocha({global: ['singular']});
         expect(Mocha.prototype.globals, 'to have a call satisfying', [
@@ -80,8 +80,8 @@ describe('Mocha', function() {
       });
     });
 
-    describe('when options.globals is provided', function() {
-      it('should pass options.globals to #globals()', function() {
+    describe('when "options.globals" is provided', function() {
+      it('should pass "options.globals" to #globals()', function() {
         // eslint-disable-next-line no-new
         new Mocha({globals: ['plural']});
         expect(Mocha.prototype.globals, 'to have a call satisfying', [
@@ -90,8 +90,8 @@ describe('Mocha', function() {
       });
     });
 
-    describe('when options.global AND options.globals are provided', function() {
-      it('should pass options.global to #globals(), ignoring options.globals', function() {
+    describe('when "options.global" AND "options.globals" are provided', function() {
+      it('should pass "options.global" to #globals(), ignoring "options.globals"', function() {
         // eslint-disable-next-line no-new
         new Mocha({global: ['singular'], globals: ['plural']});
         expect(Mocha.prototype.globals, 'to have a call satisfying', [

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -74,6 +74,10 @@ describe('Mocha', function() {
           ['singular']
         ]).and('was called once');
       });
+      it('should delete mocha.options.global', function() {
+        var mocha = new Mocha({global: ['singular']});
+        expect(mocha.options.global, 'to be', undefined);
+      });
     });
 
     describe('when options.globals is provided', function() {
@@ -93,6 +97,10 @@ describe('Mocha', function() {
         expect(Mocha.prototype.globals, 'to have a call satisfying', [
           ['singular']
         ]).and('was called once');
+      });
+      it('should delete mocha.options.global', function() {
+        var mocha = new Mocha({global: ['singular'], globals: ['plural']});
+        expect(mocha.options.global, 'to be', undefined);
       });
     });
   });
@@ -200,6 +208,14 @@ describe('Mocha', function() {
 
       it('should add contents of string array to the whitelist', function() {
         var mocha = new Mocha(opts);
+        var elems = [elem, elem2];
+        mocha.globals(elems);
+        expect(mocha.options.globals, 'to contain', elem, elem2);
+        expect(mocha.options.globals, 'to have length', elems.length);
+      });
+
+      it('should not have duplicates', function() {
+        var mocha = new Mocha({globals: [elem, elem2]});
         var elems = [elem, elem2];
         mocha.globals(elems);
         expect(mocha.options.globals, 'to contain', elem, elem2);


### PR DESCRIPTION
Fixes https://github.com/mochajs/mocha/issues/3913

### Description of the Change

[The docs](https://mochajs.org/#-global-variable-name) say: 

`Updated in v6.0.0; the option is --global and --globals is now an alias.`

and [the inline docs](https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L79) say:

` * @param {string[]} [options.global] - Variables expected in global scope.`

(Note the singular options.global)


but when creating a Mocha instance programmatically, only options.globals is accepted. Test repo here: https://github.com/pascalpp/mocha-globals-repro

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

n/a

### Why should this be in core?

Minor change to Mocha instance API to match documentation.

### Benefits

Users who expect `options.global` to work the same as the command-line option will not wonder why it doesn't.

### Possible Drawbacks

Not sure. All existing tests pass with this change. I also added some new tests to test this change directly.

### Applicable issues

https://github.com/mochajs/mocha/issues/3913
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

Not sure if this should be considered a breaking change, an enhancement, or a bug fix.