### PR TITLE
Update CI config files to use Node-12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ addons:
     packages:
       # Growl
       - libnotify-bin
-      # Canvas
-      - libpango1.0-dev
-      - libgif-dev
 # `nvm install` happens before the cache is restored, which means
 # we must install our own npm elsewhere (`~/npm`)
 before_install: |
@@ -53,6 +50,8 @@ jobs:
       node_js: '6'
 
     - script: npm start test.bundle test.browser
+      # XXX: update when canvas supplies a prebuilt binary for Node.js v12.x
+      node_js: 10
       install: npm ci # we need the native modules here
       addons:
         artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,15 @@ stages:
 
 # defaults
 language: node_js
-node_js: '11'
+node_js: '12'
 addons:
   apt:
     packages:
+      # Growl
       - libnotify-bin
+      # Canvas
+      - libpango1.0-dev
+      - libgif-dev
 # `nvm install` happens before the cache is restored, which means
 # we must install our own npm elsewhere (`~/npm`)
 before_install: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,14 @@ install:
   ## Node-related installs
   - ps: Add-AppveyorMessage "Installing Node..."
   - set PATH=%APPDATA%\npm;C:\MinGW\bin;%PATH%
-  ## :NOTE: Use slower `Update-NodeJSInstallation` until pre-installed Node-12 image available
-  #- ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
+  ## Prefer pre-installed Node versions, with fallback to manual update
+  - ps: |
+      try {
+      Install-Product node $env:nodejs_version $env:platform
+      } catch {
+      Add-AppveyorMessage "  install failed - attempting manual update..."
+      Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
+      }
   - ps: Add-AppveyorMessage "Installing npm..."
   - npm install -g npm
   ## Mocha-related package installs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ shallow_clone: true
 clone_depth: 1
 environment:
   matrix:
-    - nodejs_version: '11'
+    - nodejs_version: '12'
     - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'
@@ -35,7 +35,9 @@ install:
   ## Node-related installs
   - ps: Add-AppveyorMessage "Installing Node..."
   - set PATH=%APPDATA%\npm;C:\MinGW\bin;%PATH%
-  - ps: Install-Product node $env:nodejs_version x64
+  ## :NOTE: Use slower `Update-NodeJSInstallation` until pre-installed Node-12 image available
+  #- ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
   - ps: Add-AppveyorMessage "Installing npm..."
   - npm install -g npm
   ## Mocha-related package installs


### PR DESCRIPTION
### Description of the Change

Update CI configuration files to use current version of Node.
* AppVeyor's images still do not have pre-built Node-12 so changed script to use alternative install method.
* Changed Travis browser test to use Node-10 so we can use pre-built "canvas" package.

### Alternate Designs

NA

### Benefits

Code tested against current Node release.

### Possible Drawbacks

Code **not** being tested against current Node release.

### Applicable issues

Use of Node-10 for browser test can be revisited once we determine AG-B dependency updates for Node-12. See further explanation [here](https://github.com/mochajs/mocha/pull/3940#issuecomment-499559492), but as noted, the Node version is essentially meaningless for this test anyway.

semver-patch
