### PR TITLE
More, improved integration tests for watching

### DIFF
--- a/test/integration/fixtures/options/watch/dependency.fixture.js
+++ b/test/integration/fixtures/options/watch/dependency.fixture.js
@@ -1,0 +1,1 @@
+module.exports.testShouldFail = false;

--- a/test/integration/fixtures/options/watch/test-file-change.fixture.js
+++ b/test/integration/fixtures/options/watch/test-file-change.fixture.js
@@ -1,0 +1,8 @@
+// This will be replaced in the tests
+const testShouldFail = true;
+
+it('checks dependency', () => {
+  if (testShouldFail === true) {
+    throw new Error('test failed');
+  }
+});

--- a/test/integration/fixtures/options/watch/test-with-dependency.fixture.js
+++ b/test/integration/fixtures/options/watch/test-with-dependency.fixture.js
@@ -1,0 +1,7 @@
+const dependency = require('./lib/dependency');
+
+it('checks dependency', () => {
+  if (dependency.testShouldFail === true) {
+    throw new Error('test failed');
+  }
+});

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -113,39 +113,6 @@ module.exports = {
       opts
     );
   },
-  /**
-   * Invokes the mocha binary with the given arguments fixture using
-   * the JSON reporter. Returns the child process and a promise for the
-   * results of running the command. The result includes the **raw**
-   * string output, as well as exit code.
-   *
-   * By default, `STDERR` is ignored. Pass `{stdio: 'pipe'}` as `opts` if you
-   * want it as part of the result output.
-   *
-   * @param {string[]} args - Array of args
-   * @param {Object} [opts] - Opts for `spawn()`
-   * @returns {[ChildProcess|Promise<Result>]}
-   */
-  runMochaJSONRawAsync: function(args, opts) {
-    args = args || [];
-
-    let childProcess;
-    const resultPromise = new Promise((resolve, reject) => {
-      childProcess = invokeSubMocha(
-        [...args, '--reporter', 'json'],
-        function(err, resRaw) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(resRaw);
-          }
-        },
-        opts
-      );
-    });
-
-    return [childProcess, resultPromise];
-  },
 
   /**
    * regular expression used for splitting lines based on new line / dot symbol.
@@ -173,6 +140,8 @@ module.exports = {
    * @param {Object} [opts] - Options for `spawn()`
    */
   invokeMocha: invokeMocha,
+
+  invokeMochaAsync: invokeMochaAsync,
 
   /**
    * Resolves the path to a fixture to the full path.
@@ -225,6 +194,37 @@ function invokeMocha(args, fn, opts) {
     fn,
     opts
   );
+}
+
+/**
+ * Invokes the mocha binary with the given arguments. Returns the
+ * child process and a promise for the results of running the
+ * command. The promise resolves when the child process exits. The
+ * result includes the **raw** string output, as well as exit code.
+ *
+ * By default, `STDERR` is ignored. Pass `{stdio: 'pipe'}` as `opts` if you
+ * want it as part of the result output.
+ *
+ * @param {string[]} args - Array of args
+ * @param {Object} [opts] - Opts for `spawn()`
+ * @returns {[ChildProcess|Promise<Result>]}
+ */
+function invokeMochaAsync(args, opts) {
+  let mochaProcess;
+  const resultPromise = new Promise((resolve, reject) => {
+    mochaProcess = _spawnMochaWithListeners(
+      defaultArgs([MOCHA_EXECUTABLE].concat(args)),
+      (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      },
+      opts
+    );
+  });
+  return [mochaProcess, resultPromise];
 }
 
 function invokeSubMocha(args, fn, opts) {


### PR DESCRIPTION
### Requirements

We want to further extend the test coverage of the watch feature and prepare the code so that we can easily write tests for the features described in #3912.

### Description of the Change

To extend the test coverage for mocha in watch mode we add the following two tests:
* Check that test files are reloaded
* Check that watched dependencies are reloaded

To support this change we consolidate `runMochaJSONWatchAsync`, `runMochaJSONRawAsync`, and repeated code in tests into `runMochaWatch`. We introduce `invokeMochaAsync` in `test/integration/helpers` as an async alternative to `invokeMocha`.

We also eliminate the test for the cursor control character in the output. Its usefulness is dubious as it relies on an implementation detail and the other tests cover the intended behavior.

We are also more explicit which test fixtures are used. Instead of setting `this.testFile` in a `beforeEach` hook we do this explicitly for the tests that require it. This prevents interference in tests that do not use the file.

### Alternate Designs

N.A.

### Benefits

* Better test coverage of the watch feature
* Tests for watch features are easily extendible
