### PR TITLE
Extract `watchRun` into separate module

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -12,11 +12,12 @@ const path = require('path');
 const ansi = require('ansi-colors');
 const debug = require('debug')('mocha:cli:run:helpers');
 const minimatch = require('minimatch');
-const Context = require('../context');
-const Mocha = require('../mocha');
 const utils = require('../utils');
+const watchRun = require('./watch-run');
 
 const cwd = (exports.cwd = process.cwd());
+
+exports.watchRun = watchRun;
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
@@ -63,32 +64,6 @@ const exitMocha = code => {
   });
 
   done();
-};
-
-/**
- * Hide the cursor.
- * @ignore
- * @private
- */
-const hideCursor = () => {
-  process.stdout.write('\u001b[?25l');
-};
-
-/**
- * Show the cursor.
- * @ignore
- * @private
- */
-const showCursor = () => {
-  process.stdout.write('\u001b[?25h');
-};
-
-/**
- * Stop cursor business
- * @private
- */
-const stop = () => {
-  process.stdout.write('\u001b[2K');
 };
 
 /**
@@ -208,76 +183,6 @@ exports.singleRun = (mocha, {files = [], exit = false} = {}) => {
 };
 
 /**
- * Run Mocha in "watch" mode
- * @param {Mocha} mocha - Mocha instance
- * @param {Object} [opts] - Options
- * @param {string[]} [opts.extension] - List of extensions to watch
- * @param {string|RegExp} [opts.grep] - Grep for test titles
- * @param {string} [opts.ui=bdd] - User interface
- * @param {string[]} [files] - Array of test files
- * @private
- */
-exports.watchRun = (
-  mocha,
-  {extension = [], grep = '', ui = 'bdd', files = []} = {}
-) => {
-  let runner;
-
-  console.log();
-  hideCursor();
-  process.on('SIGINT', () => {
-    showCursor();
-    console.log('\n');
-    process.exit(130);
-  });
-
-  const watchFiles = utils.files(cwd, extension);
-  let runAgain = false;
-
-  const loadAndRun = () => {
-    try {
-      mocha.files = files;
-      runAgain = false;
-      runner = mocha.run(() => {
-        runner = null;
-        if (runAgain) {
-          rerun();
-        }
-      });
-    } catch (e) {
-      console.log(e.stack);
-    }
-  };
-
-  const purge = () => {
-    watchFiles.forEach(Mocha.unloadFile);
-  };
-
-  loadAndRun();
-
-  const rerun = () => {
-    purge();
-    stop();
-    if (!grep) {
-      mocha.grep(null);
-    }
-    mocha.suite = mocha.suite.clone();
-    mocha.suite.ctx = new Context();
-    mocha.ui(ui);
-    loadAndRun();
-  };
-
-  utils.watch(watchFiles, () => {
-    runAgain = true;
-    if (runner) {
-      runner.abort();
-    } else {
-      rerun();
-    }
-  });
-};
-
-/**
  * Actually run tests
  * @param {Mocha} mocha - Mocha instance
  * @param {Object} [opts] - Options
@@ -295,7 +200,7 @@ exports.runMocha = (
   files = []
 ) => {
   if (watch) {
-    exports.watchRun(mocha, {extension, grep, ui, files});
+    watchRun(mocha, {extension, grep, ui, files});
   } else {
     exports.singleRun(mocha, {files, exit});
   }

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const utils = require('../utils');
+const Context = require('../context');
+const Mocha = require('../mocha');
+
+/**
+ * Exports the `watchRun` function that runs mocha in "watch" mode.
+ * @see module:lib/cli/run-helpers
+ * @module
+ * @private
+ */
+
+/**
+ * Run Mocha in "watch" mode
+ * @param {Mocha} mocha - Mocha instance
+ * @param {Object} opts - Options
+ * @param {string[]} opts.extension - List of extensions to watch
+ * @param {string|RegExp} opts.grep - Grep for test titles
+ * @param {string} opts.ui - User interface
+ * @param {string[]} opts.files - Array of test files
+ * @private
+ */
+module.exports = (mocha, {extension, grep, ui, files}) => {
+  let runner;
+
+  console.log();
+  hideCursor();
+  process.on('SIGINT', () => {
+    showCursor();
+    console.log('\n');
+    // By UNIX/Posix convention this indicates that the process was
+    // killed by SIGINT which has portable number 2.
+    process.exit(128 + 2);
+  });
+
+  const watchFiles = utils.files(process.cwd(), extension);
+  let runAgain = false;
+
+  const loadAndRun = () => {
+    try {
+      mocha.files = files;
+      runAgain = false;
+      runner = mocha.run(() => {
+        runner = null;
+        if (runAgain) {
+          rerun();
+        }
+      });
+    } catch (e) {
+      console.log(e.stack);
+    }
+  };
+
+  const purge = () => {
+    watchFiles.forEach(Mocha.unloadFile);
+  };
+
+  loadAndRun();
+
+  const rerun = () => {
+    purge();
+    eraseLine();
+    if (!grep) {
+      mocha.grep(null);
+    }
+    mocha.suite = mocha.suite.clone();
+    mocha.suite.ctx = new Context();
+    mocha.ui(ui);
+    loadAndRun();
+  };
+
+  utils.watch(watchFiles, () => {
+    runAgain = true;
+    if (runner) {
+      runner.abort();
+    } else {
+      rerun();
+    }
+  });
+};
+
+/**
+ * Hide the cursor.
+ * @ignore
+ * @private
+ */
+const hideCursor = () => {
+  process.stdout.write('\u001b[?25l');
+};
+
+/**
+ * Show the cursor.
+ * @ignore
+ * @private
+ */
+const showCursor = () => {
+  process.stdout.write('\u001b[?25h');
+};
+
+/**
+ * Erases the line on stdout
+ * @private
+ */
+const eraseLine = () => {
+  process.stdout.write('\u001b[2K');
+};


### PR DESCRIPTION
### Requirements

As per @juergba’s suggestion in #3912 we extract the `watchRun` code into its separate module to prepare for #3912.

### Description of the Change

We move `watchRun` from `lib/cli/run-helpers` to `lib/cli/watch-run`. We also don’t use default values for the options anymore. The defaults are handled by `runMocha` and we want to avoid the default values getting out of sync. No other code has changed.
