### PR TITLE
Bug/3840 --forbid-only doesn't recognize `it.only` when `before` crashes

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -621,14 +621,14 @@ Runner.prototype.runTests = function(suite, fn) {
     }
 
     if (test.isPending()) {
-      if (self.forbidPending) {
+      if (self.forbidPending || (self.forbidOnly && suite.hasOnly())) {
+        var error = self.forbidPending
+          ? new Error('Pending test forbidden')
+          : new Error('`.only` forbidden');
+
         test.isPending = alwaysFalse;
-        self.fail(test, new Error('Pending test forbidden'));
-        delete test.isPending;
-      } else if (self.forbidOnly && suite.hasOnly()) {
-        var error = new Error('`.only` forbidden');
         self.fail(test, error);
-        self.emit(constants.EVENT_TEST_FAIL, test, error);
+        delete test.isPending;
       } else {
         self.emit(constants.EVENT_TEST_PENDING, test);
       }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -626,12 +626,9 @@ Runner.prototype.runTests = function(suite, fn) {
         self.fail(test, new Error('Pending test forbidden'));
         delete test.isPending;
       } else if (self.forbidOnly && suite.hasOnly()) {
-        self.fail(test, new Error('`.only` forbidden'));
-        self.emit(
-          constants.EVENT_TEST_FAIL,
-          test,
-          new Error('`.only` forbidden')
-        );
+        var error = new Error('`.only` forbidden');
+        self.fail(test, error);
+        self.emit(constants.EVENT_TEST_FAIL, test, error);
       } else {
         self.emit(constants.EVENT_TEST_PENDING, test);
       }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -625,6 +625,13 @@ Runner.prototype.runTests = function(suite, fn) {
         test.isPending = alwaysFalse;
         self.fail(test, new Error('Pending test forbidden'));
         delete test.isPending;
+      } else if (self.forbidOnly && suite.hasOnly()) {
+        self.fail(test, new Error('`.only` forbidden'));
+        self.emit(
+          constants.EVENT_TEST_FAIL,
+          test,
+          new Error('`.only` forbidden')
+        );
       } else {
         self.emit(constants.EVENT_TEST_PENDING, test);
       }

--- a/test/integration/fixtures/regression/issue-3840.fixture.js
+++ b/test/integration/fixtures/regression/issue-3840.fixture.js
@@ -1,0 +1,9 @@
+'use strict';
+
+describe('something', () => {
+  before(function() {
+    //this.skip();
+  });
+  it.only('only test', () => {});
+});
+

--- a/test/integration/fixtures/regression/issue-3840.fixture.js
+++ b/test/integration/fixtures/regression/issue-3840.fixture.js
@@ -1,9 +1,8 @@
 'use strict';
 
-describe('something', () => {
+describe('test marked with only and before has skip', function() {
   before(function() {
-    //this.skip();
+    this.skip();
   });
-  it.only('only test', () => {});
+  it.only('only test', function() {});
 });
-

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -113,4 +113,20 @@ describe('regressions', function() {
       done();
     });
   });
+
+  it('issue-3840: --forbid-only does not recognize `it.only` when `before` crashes', function(done) {
+    var onlyErrorMessage = '`.only` forbidden';
+
+    runJSON('regression/issue-3840.fixture.js', ['--forbid-only'], function(
+      err,
+      res
+    ) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, 'to have failed with error', onlyErrorMessage);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

`--forbid-only` doesn't recognize `it.only` when `before` crashes.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
This is an attempt to solve the above-mentioned bug.
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
This is an attempt to solve the above-mentioned bug.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
Fixes #3840 

* Is this a breaking change (major release)? **No**
* Is it an enhancement (minor release)? **No**
* Is it a bug fix, or does it not impact production code (patch release)? **Yes**

