### PR TITLE
Fix No Files error when file is passed via --files

### DIFF
--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -54,6 +54,18 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
     files = files.concat(newFiles);
   });
 
+  const fileArgs = file.map(filepath => path.resolve(filepath));
+  files = files.map(filepath => path.resolve(filepath));
+
+  // ensure we don't sort the stuff from fileArgs; order is important!
+  if (sort) {
+    files.sort();
+  }
+
+  // add files given through --file to be ran first
+  files = fileArgs.concat(files);
+  debug('files (in order): ', files);
+
   if (!files.length) {
     // give full message details when only 1 file is missing
     const noneFoundMsg =
@@ -69,16 +81,5 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
     });
   }
 
-  const fileArgs = file.map(filepath => path.resolve(filepath));
-  files = files.map(filepath => path.resolve(filepath));
-
-  // ensure we don't sort the stuff from fileArgs; order is important!
-  if (sort) {
-    files.sort();
-  }
-
-  // add files given through --file to be ran first
-  files = fileArgs.concat(files);
-  debug('files (in order): ', files);
   return files;
 };

--- a/test/integration/options/file.spec.js
+++ b/test/integration/options/file.spec.js
@@ -52,4 +52,16 @@ describe('--file', function() {
       done();
     });
   });
+
+  it('should support having no other test files', function(done) {
+    args = ['--file', resolvePath(fixtures.alpha)];
+
+    runMochaJSON('filethatdoesnotexist.js', args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+      expect(res, 'to have passed').and('to have passed test count', 1);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Change

Check if there are no files to load *after* we've added files from `--files`. This fixes #3941.

### Alternate Designs

None

### Why should this be in core?

Fixes bug involving `--file`.

### Benefits

Fixes #3941.

### Possible Drawbacks

None that I can think of.

### Applicable issues
#3941

This would be a bug fix (patch release).
