### PR TITLE
fix: fixed mocha grep regex instantiation, closes #3949

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -428,7 +428,9 @@ Mocha.prototype.grep = function(re) {
   if (utils.isString(re)) {
     // extract args if it's regex-like, i.e: [string, pattern, flag]
     var arg = re.match(/^\/(.*)\/(g|i|)$|.*/);
-    this.options.grep = new RegExp(arg[1] || arg[0], arg[2]);
+    this.options.grep = arg[1]
+      ? new RegExp(arg[1], arg[2])
+      : new RegExp(arg[0]);
   } else {
     this.options.grep = re;
   }


### PR DESCRIPTION
### Description of the Change

There is a problem in the instantiation of `RegExp` in `mocha` `grep`
The problem is explained in https://github.com/mochajs/mocha/issues/3949

### Why should this be in core?

Without this passing regex-like string to `grep` will not work correctly

### Benefits

Enhancing `grep` option

### Applicable issues

This is a bug fix
