### PR TITLE
tty.getWindowSize is not a function inside a "worker_threads" worker

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -25,7 +25,7 @@ exports = module.exports = Base;
  * Check if both stdio streams are associated with a tty.
  */
 
-var isatty = Boolean(process.stdout.isTTY) && Boolean(process.stderr.isTTY);
+var isatty = process.stdout.isTTY && process.stderr.isTTY;
 
 /**
  * Save log references to avoid tests interfering (see GH-3604).

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -25,7 +25,7 @@ exports = module.exports = Base;
  * Check if both stdio streams are associated with a tty.
  */
 
-var isatty = tty.isatty(1) && tty.isatty(2);
+var isatty = Boolean(process.stdout.isTTY) && Boolean(process.stderr.isTTY);
 
 /**
  * Save log references to avoid tests interfering (see GH-3604).


### PR DESCRIPTION
### Description of the Change

Thanks for reviewing this PR. I'm the maintainer of [mocha-parallel-tests](https://github.com/mocha-parallel/mocha-parallel-tests) - a wrapper on top of mocha which runs mocha tests in either parallel processes forked via `child_process` or in parallel threads created with `worker_threads`.

Recently I added an opportunity to run mocha tests via `worker_threads` if the API is available (IIRC this should be node@12). I got a couple of reports saying that [tty.getWindowSize is not a function](https://github.com/mocha-parallel/mocha-parallel-tests/issues/247). I spent a big amount of time investigating the issue and I discovered that the root cause is the `worker_threads` environment. While I understand this is probably not an issue with mocha because it never runs in `worker_threads`-created threads, I believe that people like me still might run mocha in threads for different reasons. And it looks like `tty.isatty(fd)` behaves wrong in `worker_threads`. I'm not even sure if it's a Node.JS issue or not, but `process.stdout.isTTY` is False in `worker_threads` environment` whereas `tty.isatty(1)` is True. This leads to the issue people reported.

I have a [monkey-patch fix](https://github.com/mocha-parallel/mocha-parallel-tests/pull/250) for my repository but I believe we can improve mocha here and this issue will be solved not only for mocha-parallel-tests but also for other thread-based environments.

I also raised an [issue](https://github.com/nodejs/node/issues/28386) inside Node.JS repo.

### Why should this be in core?

Everyone who runs mocha in a `worker_threads`-created worker will have this issue.

### Benefits

Everyone who runs mocha in a `worker_threads`-created worker will not have this issue.

### Applicable issues

This is a bug fix