### PR TITLE
fix: remove duplicate line-height property

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -139,7 +139,6 @@ body {
 #mocha .test .html-error {
   overflow: auto;
   color: black;
-  line-height: 1.5;
   display: block;
   float: left;
   clear: left;


### PR DESCRIPTION
### Description of the Change
The `line-height` is already set in the `font` shorthand declaration.
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs
N/A
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
N/A
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
N/A
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
N/A
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
