### PR TITLE
Don't re-initialize grep option on watch re-run

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -118,7 +118,6 @@ exports.runMocha = (mocha, options) => {
   const {
     watch = false,
     extension = [],
-    grep = '',
     ui = 'bdd',
     exit = false,
     ignore = [],
@@ -138,7 +137,7 @@ exports.runMocha = (mocha, options) => {
   };
 
   if (watch) {
-    watchRun(mocha, {ui, grep}, fileCollectParams);
+    watchRun(mocha, {ui}, fileCollectParams);
   } else {
     exports.singleRun(mocha, {exit}, fileCollectParams);
   }

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -16,14 +16,13 @@ const collectFiles = require('./collect-files');
  * Run Mocha in "watch" mode
  * @param {Mocha} mocha - Mocha instance
  * @param {Object} opts - Options
- * @param {string|RegExp} opts.grep - Grep for test titles
  * @param {string} opts.ui - User interface
  * @param {Object} fileCollectParams - Parameters that control test
  *   file collection. See `lib/cli/collect-files.js`.
  * @param {string[]} fileCollectParams.extension - List of extensions to watch
  * @private
  */
-module.exports = (mocha, {grep, ui}, fileCollectParams) => {
+module.exports = (mocha, {ui}, fileCollectParams) => {
   let runner;
   const files = collectFiles(fileCollectParams);
 
@@ -64,9 +63,6 @@ module.exports = (mocha, {grep, ui}, fileCollectParams) => {
   const rerun = () => {
     purge();
     eraseLine();
-    if (!grep) {
-      mocha.grep(null);
-    }
     mocha.suite = mocha.suite.clone();
     mocha.suite.ctx = new Context();
     mocha.ui(ui);

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -115,6 +115,20 @@ describe('--watch', function() {
         expect(results[1].failures, 'to have length', 1);
       });
     });
+
+    // Regression test for https://github.com/mochajs/mocha/issues/2027
+    it('respects --fgrep on re-runs', function() {
+      const testFile = path.join(this.tempDir, 'test.js');
+      copyFixture('options/grep', testFile);
+
+      return runMochaWatch([testFile, '--fgrep', 'match'], this.tempDir, () => {
+        touchFile(testFile);
+      }).then(results => {
+        expect(results, 'to have length', 2);
+        expect(results[0].tests, 'to have length', 2);
+        expect(results[1].tests, 'to have length', 2);
+      });
+    });
   });
 });
 
@@ -160,7 +174,7 @@ function touchFile(file) {
 }
 
 /**
- * Synchronously eplace all substrings matched by `pattern` with
+ * Synchronously replace all substrings matched by `pattern` with
  * `replacement` in the file’s content.
  */
 function replaceFileContents(file, pattern, replacement) {
@@ -170,8 +184,8 @@ function replaceFileContents(file, pattern, replacement) {
 }
 
 /**
- * Synchronously copy a fixture to the given destion file path. Creates
- * parent directories of the destination path if necessary.
+ * Synchronously copy a fixture to the given destination file path.
+ * Creates parent directories of the destination path if necessary.
  */
 function copyFixture(fixtureName, dest) {
   const fixtureSource = helpers.resolveFixturePath(fixtureName);


### PR DESCRIPTION
### Requirements

* Fix #2027
* Remove unexplained and unneeded code
* Clearer separation of responsibilities and dependencies.

### Description of the Change

We remove code that called `mocha.grep(null)` on watch re-runs if the `--grep` option was not supplied. The code seems to serve no purpose and is the cause of #2027.

### Alternate Designs

N.A.

### Benefits

Fixes #2027

We consolidate CLI option handling. The majority of CLI options are handled by the `Mocha` constructor. But this reponsibility is shared with `watchRun` which changes behavior based on a CLI option. With this change we reduce the reliance of `watchRun` on the CLI options, a point that was brought up in https://github.com/mochajs/mocha/pull/3953#discussion_r294672564. To finish this it would make sense to follow up with a PR that makes the use of the `ui` option unnecessary.

### Possible Drawbacks

The code might actually serve some purpose that is not covered by the test suite. Since it was introduced in #3556 maybe @boneskull can shed some light on this.


### Applicable issues

Fixes #2027