### PR TITLE
Hide stacktrace when cli args are missing

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -133,7 +133,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
   });
   if (result.error) {
     const error = createMissingArgumentError(result.error.message);
-    console.error(ansi.red(`Error: ${error.message}`));
+    console.error(ansi.red(`Error: ${result.error.message}`));
     process.exit(1);
   }
 

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -7,6 +7,7 @@
  */
 
 const fs = require('fs');
+const ansi = require('ansi-colors');
 const yargsParser = require('yargs-parser');
 const {types, aliases} = require('./run-option-metadata');
 const {ONE_AND_DONE_ARGS} = require('./one-and-dones');
@@ -131,7 +132,9 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
     boolean: types.boolean.concat(nodeArgs.map(pair => pair[0]))
   });
   if (result.error) {
-    throw createMissingArgumentError(result.error.message);
+    const error = createMissingArgumentError(result.error.message);
+    console.error(ansi.red(`Error: ${error.message}`));
+    process.exit(1);
   }
 
   // reapply "=" arg values from above

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -17,7 +17,6 @@ const {loadConfig, findConfig} = require('./config');
 const findUp = require('find-up');
 const {deprecate} = require('../utils');
 const debug = require('debug')('mocha:cli:options');
-const {createMissingArgumentError} = require('../errors');
 const {isNodeFlag} = require('./node-flags');
 
 /**
@@ -132,7 +131,6 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
     boolean: types.boolean.concat(nodeArgs.map(pair => pair[0]))
   });
   if (result.error) {
-    const error = createMissingArgumentError(result.error.message);
     console.error(ansi.red(`Error: ${result.error.message}`));
     process.exit(1);
   }


### PR DESCRIPTION
### Description of the Change
When arguments are not following for CLI string flags, currently mocha show stacktrace.

<img width="1434" alt="스크린샷 2019-06-29 17 23 11" src="https://user-images.githubusercontent.com/390146/60381639-f18d9000-9a92-11e9-85c6-a2d45c903e79.png">

Stacktrace is useless here because it is a valid validation. 
So, this PR show only error message for users like:

<img width="615" alt="스크린샷 2019-06-29 17 23 19" src="https://user-images.githubusercontent.com/390146/60381666-44ffde00-9a93-11e9-9b6f-27b0eb53e38d.png">

### Alternate Designs
Handle these kinds of a message in yargs or other places.

### Why should this be in core?
The current behavior is unfriendly to users.

### Benefits
Users can easily realize what is a problem.
