### PR TITLE
remove extraGlobals()

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -141,7 +141,7 @@ function Runner(suite, delay) {
   });
   this._defaultGrep = /.*/;
   this.grep(this._defaultGrep);
-  this.globals(this.globalProps().concat(extraGlobals()));
+  this.globals(this.globalProps());
 }
 
 /**
@@ -1014,30 +1014,6 @@ function thrown2Error(err) {
   return new Error(
     'the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)'
   );
-}
-
-/**
- * Array of globals dependent on the environment.
- *
- * @return {Array}
- * @deprecated
- * @todo remove; long since unsupported
- * @private
- */
-function extraGlobals() {
-  if (typeof process === 'object' && typeof process.version === 'string') {
-    var parts = process.version.split('.');
-    var nodeVersion = parts.reduce(function(a, v) {
-      return (a << 8) | v;
-    });
-
-    // 'errno' was renamed to process._errno in v0.9.11.
-    if (nodeVersion < 0x00090b) {
-      return ['errno'];
-    }
-  }
-
-  return [];
 }
 
 Runner.constants = constants;


### PR DESCRIPTION
### Description of the Change

Remove private function `extraGlobals()` since the support of Node v0.9.11 has been dropped years ago.