### PR TITLE
Override reporter-options by command line

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -201,7 +201,10 @@ exports.builder = yargs =>
               );
             }
 
-            acc[pair[0]] = pair.length === 2 ? pair[1] : true;
+            // use first value for the same key
+            if (!acc[pair[0]]) {
+              acc[pair[0]] = pair.length === 2 ? pair[1] : true;
+            }
             return acc;
           }, {}),
         description: 'Reporter-specific options (<k=v,[k1=v1,..]>)',


### PR DESCRIPTION
### Description of the Change
`reporter-options`/`reporter-option` couldn't be overridden by command line, because current logic overwrites with last value for the same key. 
So, the value from a config file always win. Now...

Case 1:
* config file: `--reporter-options output=./1.xml`
* cli: `--reporter-options output=./2.xml`

`2.xml` is win.

Case 2: (I'm not sure this case is user acceptable)
* config file: `--reporter-options output=./1.xml`
* cli: `--reporter-options output=./2.xml,output=./3.xml` or `--reporter-option output=./2.xml --reporter-option output=./3.xml`

`2.xml` is win.

### Applicable issues
fix #3951 