### PR TITLE
Travis: don't run Smoke with Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,6 @@ jobs:
     - <<: *smoke
       node_js: '8'
 
-    - <<: *smoke
-      node_js: '6'
-
     - stage: precache
       script: true
 


### PR DESCRIPTION
### Description of the Change

In addition to #3885 which still runs `Smoke` with Node v6.