### PR TITLE
Package 'esm': spawn child-process for correct loading

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -117,6 +117,16 @@ if (nodeArgs.gc) {
   delete nodeArgs.gc;
 }
 
+// --require/-r is treated as Mocha flag except when 'esm' is preloaded
+if (mochaArgs.require && mochaArgs.require.includes('esm')) {
+  nodeArgs.require = ['esm'];
+  mochaArgs.require = mochaArgs.require.filter(mod => mod !== 'esm');
+  if (!mochaArgs.require.length) {
+    delete mochaArgs.require;
+  }
+  delete mochaArgs.r;
+}
+
 if (Object.keys(nodeArgs).length) {
   const {spawn} = require('child_process');
   const mochaPath = require.resolve('../lib/cli/cli.js');


### PR DESCRIPTION
### Description

The package `esm` is not loaded correctly when `--require esm` is passed via **configuration file**.
However the result is as expected when passing it via **CLI** .
This is a regression.

### Description of the Change

We handle `--require esm` as Node option: `node --require=esm mocha`:
- we add `esm` to the Node option `require`
- we remove `esm` from the Mocha option `require`

This way Node is extended with `esm` before Mocha is launched in a child-process.

### Applicable issues

closes #3975