### PR TITLE
fix sponsors background color for readability

### DIFF
--- a/docs/_includes/sponsors.md
+++ b/docs/_includes/sponsors.md
@@ -1,9 +1,10 @@
 ## Sponsors
 
-Use Mocha at Work?  Ask your manager or marketing team if they'd help [support](https://opencollective.com/mochajs#support) our project.  Your company's logo will also be displayed on [npmjs.com](http://npmjs.com/package/mocha) and our [GitHub repository](https://github.com/mochajs/mocha#sponsors).
+Use Mocha at Work? Ask your manager or marketing team if they'd help [support](https://opencollective.com/mochajs#support) our project. Your company's logo will also be displayed on [npmjs.com](http://npmjs.com/package/mocha) and our [GitHub repository](https://github.com/mochajs/mocha#sponsors).
 
 <!-- markdownlint-disable MD034 -->
-{% for i in (0..15) %}[![](https://opencollective.com/mochajs/sponsor/{{ i }}/avatar.jpg)](https://opencollective.com/mochajs/sponsor/{{ i }}/website){: target="_blank"} {% endfor %}
+
+{% for i in (0..15) %}[![](https://opencollective.com/mochajs/sponsor/{{ i }}/avatar.png)](https://opencollective.com/mochajs/sponsor/{{ i }}/website){: target="\_blank"} {% endfor %}
 {: .image-list .faded-images}
 
 <script src="js/avatars.js"></script>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -92,7 +92,6 @@ nav.badges a + a {
 .faded-images {
   background-color: #ddd;
   border-radius: 20px;
-  box-shadow: 0px 0px 8px 8px #ddd;
 }
 
 .faded-images img {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -91,7 +91,11 @@ nav.badges a + a {
 
 .faded-images {
   background-color: #ddd;
-  border-radius: 20px;
+  border: 1px solid;
+  border-color: #ddd #ddd #ccc;
+  border-radius: 3px;
+  padding: 1em;
+  box-shadow: inset 0 0 10px #ccc;
 }
 
 .faded-images img {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -76,16 +76,23 @@ nav.badges a + a {
 
 .image-list {
   overflow: hidden;
+  text-align: center;
 }
 
 .image-list a {
-  float: left;
+  display: inline-block;
   margin: 6px;
 }
 
 .image-list a img {
   display: block;
   height: 64px;
+}
+
+.faded-images {
+  background-color: #ddd;
+  border-radius: 20px;
+  box-shadow: 0px 0px 8px 8px #ddd;
 }
 
 .faded-images img {


### PR DESCRIPTION
### Description of the Change
If sponsors use white-tone logo, users can't see the sponsor's logo.

<img width="933" alt="스크린샷 2019-08-16 16 41 45" src="https://user-images.githubusercontent.com/390146/63151569-c233e200-c044-11e9-8e2e-d0832511f8df.png">

So, I added grey background to sponsors.(And align them center)

<img width="1002" alt="스크린샷 2019-08-16 16 55 39" src="https://user-images.githubusercontent.com/390146/63152398-b21d0200-c046-11e9-864a-c8ab52765d47.png">

I knew it is not pretty design, but grey is best for both light-tone and dark-tone logos. I thought making sponsor logos readable is more important than pretty design.

### Alternate Designs
Another color or design?

### Applicable issues
close #3736 
