### PR TITLE
WIP: replaced diff to diff-match-patch (#3675)

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -8,6 +8,7 @@
 
 var tty = require('tty');
 var diff = require('diff');
+var DiffMatchPatch = require('diff-match-patch');
 var milliseconds = require('ms');
 var utils = require('../utils');
 var supportsColor = process.browser ? null : require('supports-color');
@@ -394,6 +395,28 @@ function inlineDiff(actual, expected) {
 }
 
 /**
+ * diff-match-patch
+ *
+ * @private
+ * @param {String} actual
+ * @param {String} expected
+ * @return {string} The diff.
+ */
+
+function createPatch(actual, expected) {
+  var dmp = new DiffMatchPatch();
+  var a = dmp.diff_linesToChars_(actual, expected);
+  var lineText1 = a.chars1;
+  var lineText2 = a.chars2;
+  var lineArray = a.lineArray;
+  var diffs = dmp.diff_main(lineText1, lineText2);
+  dmp.diff_charsToLines_(diffs, lineArray);
+  var patch = dmp.patch_make(diffs);
+  var msg = dmp.patch_toText(patch);
+  return decodeURI(msg);
+}
+
+/**
  * Returns unified diff between two strings with coloured ANSI output.
  *
  * @private
@@ -421,8 +444,8 @@ function unifiedDiff(actual, expected) {
   function notBlank(line) {
     return typeof line !== 'undefined' && line !== null;
   }
-  var msg = diff.createPatch('string', actual, expected);
-  var lines = msg.split('\n').splice(5);
+  var msg = createPatch(actual, expected);
+  var lines = msg.split('\n').splice(1);
   return (
     '\n      ' +
     colorLines('diff added', '+ expected') +

--- a/package-lock.json
+++ b/package-lock.json
@@ -4407,6 +4407,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
+    "diff-match-patch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
+      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg=="
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -516,6 +516,7 @@
     "browser-stdout": "1.3.1",
     "debug": "3.2.6",
     "diff": "3.5.0",
+    "diff-match-patch": "^1.0.4",
     "escape-string-regexp": "1.0.5",
     "find-up": "3.0.0",
     "glob": "7.1.3",


### PR DESCRIPTION
### Description of the Change
I checked the #3675  issue and changed the existing diff library to Google's diff-patch-match.

### Benefits
* Diff speed is improved for large data.


Test Code (copy from issue)
```javascript
var _ = require('lodash');
const {expect} = require('chai')
it('Test failing', function () {
  const longArray = _.times(10000, function (i) {
    return {a : i}
  })
  const shortArray = []
  expect(longArray).deep.equal(shortArray)
}
```

Before change: About 2 minutes 1 second
```bash
/bin/mocha ../../pycon/mocha/my/test_issue  121.94s user 0.55s system 100% cpu 2:01.74 total
```
 After change: About 1 second
```bash
./bin/mocha ../../pycon/mocha/my/test_issue  0.91s user 0.09s system 93% cpu 1.071 total
```

### Applicable issues

Diff-patch-match is character-based, unlike diff.
So it is written to be processed line by line using line-mode.

However, the result screen is different because there is a difference from Patch Process.

Test Code
```javascript
it('Test failing2', function () {
  const expected = { a: 123 };
  const actual = { a: 123, b: 456 };
  expect(expected).deep.equal(actual);
})
```

#### Comparison of Patch Results
Before
``` javascript
Index: string
===================================================================
--- string
+++ string
@@ -1,3 +1,4 @@
 {
   "a": 123
+  "b": 456
 }
\ No newline at end of file
```

After
```javascript
@@ -6,9 +6,20 @@
 a": 123

+  "b": 456

 }
```

#### Comparison of Excution Results
Before
``` javascript
       {
         "a": 123
      +  "b": 456
       }
```

After
```javascript
       a": 123
      +  "b": 456
       }
```

#### RESULT
So I don't think it's user friendly.

Would it be better to work on the same output as the existing result? Or would you like to hear other ways to find out?

Please, I want to listen to the comments and advices.

* All test code is run on MacBook Pro 2017 (16GB)
* reference links
[Line mode](https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs)
[That library is character-based](https://github.com/google/diff-match-patch/wiki/Unidiff)
