### PR TITLE
Add indentation to error message when it has several line breaks(#2159)

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -257,7 +257,14 @@ exports.list = function(failures) {
       }
       testTitle += str;
     });
-
+    if (msg.includes('\n')) {
+      var errStrSplit = msg.split('\n');
+      var strIndented = errStrSplit[0];
+      errStrSplit.slice(1).forEach(function(word) {
+        strIndented = strIndented + '\n     ' + word;
+      });
+      msg = strIndented;
+    }
     Base.consoleLog(fmt, i + 1, testTitle, msg, stack);
   });
 };

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -259,11 +259,7 @@ exports.list = function(failures) {
     });
     if (msg.includes('\n')) {
       var errStrSplit = msg.split('\n');
-      var strIndented = errStrSplit[0];
-      errStrSplit.slice(1).forEach(function(word) {
-        strIndented = strIndented + '\n     ' + word;
-      });
-      msg = strIndented;
+      msg = errStrSplit.join('\n     ');
     }
     Base.consoleLog(fmt, i + 1, testTitle, msg, stack);
   });

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -239,8 +239,12 @@ exports.list = function(failures) {
         color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);
-
       msg += generateDiff(err.actual, err.expected);
+    } else {
+      if (msg.includes('\n')) {
+        var errStrSplit = msg.split('\n');
+        msg = errStrSplit.join('\n            ');
+      }
     }
 
     // indent stack trace
@@ -257,10 +261,6 @@ exports.list = function(failures) {
       }
       testTitle += str;
     });
-    if (msg.includes('\n')) {
-      var errStrSplit = msg.split('\n');
-      msg = errStrSplit.join('\n     ');
-    }
     Base.consoleLog(fmt, i + 1, testTitle, msg, stack);
   });
 };


### PR DESCRIPTION
At the moment mocha only indent the first line of the report message.
This PR would indent all lines of the message when it has line breaks so that it would look neat. 
I checked out that it worked out with the example below.
```
describe('suite', function() {
  it('test', function() {});
  it('test2', function() {
    throw new Error('foo\nbar\nbaz');
  });
});
```
by the way, I ran "npm test" before creating PR and got 185 passing, 4 pending, 6 failing.
but the errors seems regardless of code that I added. 
So I ran "npm test" again after commenting out changes I made and got exactly same result. 
[errlog_original.txt](https://github.com/mochajs/mocha/files/3509598/errlog_original.txt)
I was wondering if there's any other ways to check this changes is safe. 

