### PR TITLE
[WIP] FIX issue #3990 & Question for progress

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -118,6 +118,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
     []
   );
 
+  delete nargOpts['ignore'];
   const result = yargsParser.detailed(args, {
     configuration,
     configObjects,


### PR DESCRIPTION


### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

#### Abstraction 

This PR is WIP, because there is confusing things.

So i make **question** section and if question is resolved, then i'll update commit.

All environment and test dir structure is almost set like #3990 .


#### Progress

First I check original process.argv like below picture.

![bin_mocha_argv_debug](https://user-images.githubusercontent.com/4661295/63291914-811b2680-c2ff-11e9-81a8-df45d3a83d8e.png)

'mocha:cli:mocha real raw argv' is what i want and I found one problem.

'test/issue/external*.js' and 'test/issue/**/*.js' is extended, so it cannot distinguish what is ignore files or mocha spec files.

To make problem simple, I use --file option like below.

![2_using_file_option](https://user-images.githubusercontent.com/4661295/63292469-ab211880-c300-11e9-8d91-94fc9f17251d.png)

Next, i check yargs-parser result that is output of yargs-parser.detailed() in lib/cli/options.js.

I found problem that issue #3990 refer.

![2_1_using_file_option](https://user-images.githubusercontent.com/4661295/63292660-24b90680-c301-11e9-8e83-82c8aacd0f23.png)

Ignore only have one file, but it must have external/1.js, ,2.js and 3.js.

So, i search some options and have identified the cause of the bug.

There are yargs-parser options and 'nargs' is a point.

'nargs' option limit the command's argument count, like nargs.ignore = 1, that means ignore option's argument count is only one.

It is happend in this code, so it cannot accept several ignore argument, like --ignore a b c.

![3_problem_narg](https://user-images.githubusercontent.com/4661295/63293160-5d0d1480-c302-11e9-8ad1-112eab0d3e6b.png)

nargs.ignore is 1, so yargs-parser inner also interpret ignore is only accept one, although it set array option. (array option is for accepting '--ignore a b c')

![3_1_log_of_yargs_Inner](https://user-images.githubusercontent.com/4661295/63293332-ddcc1080-c302-11e9-921f-77752e4ee406.png)

![3_2_yargs_parser_inner](https://user-images.githubusercontent.com/4661295/63293356-eae8ff80-c302-11e9-9b6a-16cadeda410f.png)

Last, i delete narg.ignore for accepting more than one arguments, like below code. 

![4_2_code_for_test](https://user-images.githubusercontent.com/4661295/63293459-1e2b8e80-c303-11e9-9b95-6774fb9a1659.png)

It works well. ignore has 3 files.

![4_1_result_options](https://user-images.githubusercontent.com/4661295/63293660-88dcca00-c303-11e9-9d48-6ccdc5a480ca.png)

#### Question

##### First

I don't know how to distinguish between the option input and mocha spec input.

```
./bin/mocha --ignore test/external/*.js test/*
```

how to distinguish what is ignore files or mocha spec files before?

##### Second

I found this code that make yargs-parser's narg option.

```
/**
 * We do not have a case when multiple arguments are ever allowed after a flag
 * (e.g., `--foo bar baz quux`), so we fix the number of arguments to 1 across
 * the board of non-boolean options.
 * This is passed as the `narg` option to `yargs-parser`
 * @private
 * @ignore
 */
const nargOpts = types.array
  .concat(types.string, types.number)
  .reduce((acc, arg) => Object.assign(acc, {[arg]: 1}), {});
```

I was confused to see this. The kind of options like ignore requires multiple arguments. But this code comment say that mocha don't want to use '--foo bar baz quux'. Then, how should we take multiple arguments?

This comment stopped me from working on more. (I cannot change code logic, because i don't ensure what is right)


### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?

WIP, so I can't judge yet.

Thank you for reading this PR! :)