### PR TITLE
Options parsing: fix and optimize

### DIFF
--- a/lib/cli/one-and-dones.js
+++ b/lib/cli/one-and-dones.js
@@ -48,14 +48,14 @@ exports.ONE_AND_DONES = {
    * Dump list of built-in interfaces
    * @private
    */
-  'list-interfaces': () => {
+  listInterfaces: () => {
     showKeys(Mocha.interfaces);
   },
   /**
    * Dump list of built-in reporters
    * @private
    */
-  'list-reporters': () => {
+  listReporters: () => {
     showKeys(Mocha.reporters);
   }
 };

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -38,20 +38,11 @@ const {isNodeFlag} = require('./node-flags');
 const YARGS_PARSER_CONFIG = {
   'combine-arrays': true,
   'short-option-groups': false,
-  'dot-notation': false
+  'dot-notation': false,
+  'camel-case-expansion': true, // default
+  'strip-aliased': true,
+  'strip-dashed': true
 };
-
-/**
- * This is the config pulled from the `yargs` property of Mocha's
- * `package.json`, but it also disables camel case expansion as to
- * avoid outputting non-canonical keynames, as we need to do some
- * lookups.
- * @private
- * @ignore
- */
-const configuration = Object.assign({}, YARGS_PARSER_CONFIG, {
-  'camel-case-expansion': false
-});
 
 /**
  * This is a really fancy way to:
@@ -119,7 +110,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
   );
 
   const result = yargsParser.detailed(args, {
-    configuration,
+    configuration: YARGS_PARSER_CONFIG,
     configObjects,
     default: defaultValues,
     coerce: coerceOpts,

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -16,7 +16,8 @@ const proxyLoadOptions = ({
 } = {}) =>
   rewiremock.proxy(modulePath, r => ({
     fs: r.with({readFileSync}).directChildOnly(),
-    [mocharcPath]: defaults,
+    // tests fail when `defaults` is assigned directly
+    [mocharcPath]: Object.assign({}, defaults),
     'find-up': r
       .by(() => (findupSync ? {sync: findupSync} : {}))
       .directChildOnly(),
@@ -25,8 +26,6 @@ const proxyLoadOptions = ({
 
 const defaults = {
   timeout: 1000,
-  timeouts: 1000,
-  t: 1000,
   opts: '/default/path/to/mocha.opts',
   extension: ['js']
 };
@@ -247,7 +246,7 @@ describe('options', function() {
               result,
               'to equal',
               Object.assign({_: []}, defaults, {
-                'check-leaks': false,
+                checkLeaks: false,
                 config: false,
                 opts: false,
                 package: false,
@@ -422,7 +421,7 @@ describe('options', function() {
               result,
               'to equal',
               Object.assign({_: []}, defaults, {
-                'check-leaks': true,
+                checkLeaks: true,
                 config: false,
                 opts: false,
                 package: false,
@@ -471,7 +470,7 @@ describe('options', function() {
               result,
               'to equal',
               Object.assign({_: ['foobar.spec.js']}, defaults, {
-                'check-leaks': true,
+                checkLeaks: true,
                 config: false,
                 opts: false,
                 package: false,


### PR DESCRIPTION
### Description

We take advantage of two new **yargs-parser** configuration settings in order to:
- fix a bug while parsing camel-cased options
- optimize the parsing result: we just keep the canonical or its camel-cased versions of the option names.

### Description of the Change

Additional settings of  **yargs-parser** configuration:
- `'camel-case-expansion': true`: 
for correct parsing of camel-cased options, eg. `watchFiles` ==> `watch-files`
- `'strip-aliased': true`:
aliases are removed from result.
- `'strip-dashed': true`:
dashed options (`watch-files`) are removed from result, we keep only the camel-cased versions (`watchFiles`)