### PR TITLE
Don't issue deprecation error for -compilers with --ignore-compilers

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -279,7 +279,7 @@ exports.builder = yargs =>
         );
       }
 
-      if (argv.compilers) {
+      if (argv.compilers && !argv['ignore-compilers']) {
         throw createUnsupportedError(
           `--compilers is DEPRECATED and no longer supported.
           See https://git.io/vdcSr for migration information.`


### PR DESCRIPTION
### Description of the Change

Don't throw an error if deprecated --compilers option is provided if --ignore-compilers is also provided.

### Benefits

This is useful when a project has multiple test directories, some using older mocha with -compilers and others that don't need a compiler. WebStorm only supports a single global configuration in a project for mocha options, so with this --ignore-compilers option, the older mocha continues to use compilers and the new mocha doesn't throw an error.

### Possible Drawbacks

None

### Applicable issues

Patch release
