### PR TITLE
uncaughtException: fix double EVENT_RUN_END events

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -860,7 +860,7 @@ Runner.prototype.uncaught = function(err) {
   }
 
   // bail
-  this.emit(constants.EVENT_RUN_END);
+  this.abort();
 };
 
 /**

--- a/test/integration/fixtures/regression/issue-1327.fixture.js
+++ b/test/integration/fixtures/regression/issue-1327.fixture.js
@@ -1,17 +1,17 @@
 'use strict';
 
+// we cannot recover gracefully if a Runnable has already passed
+// then fails asynchronously
 it('test 1', function () {
-  console.log('testbody1');
   process.nextTick(function () {
     throw new Error('Too bad');
   });
 });
 
 it('test 2', function () {
-  console.log('testbody2');
+  throw new Error('should not run - test 2');
 });
 
 it('test 3', function () {
-  console.log('testbody3');
-  throw new Error('OUCH');
+  throw new Error('should not run - test 3');
 });

--- a/test/integration/fixtures/uncaught-fatal.fixture.js
+++ b/test/integration/fixtures/uncaught-fatal.fixture.js
@@ -1,11 +1,22 @@
 'use strict';
 
-it('should bail if a successful test asynchronously fails', function(done) {
-  done();
-  process.nextTick(function () {
-    throw new Error('global error');
-  });
-});
+describe('fatal uncaught exception', function () {
+  describe('first suite', function () {
+    it('should bail if a successful test asynchronously fails', function (done) {
+      done();
+      process.nextTick(function () {
+        throw new Error('global error');
+      });
+    });
 
-it('should not actually get run', function () {
+    it('should not actually get run', function () {
+      throw new Error('should never throw - first suite');
+    });
+  });
+  
+  describe('second suite', function () {
+    it('should not actually get run', function () {
+      throw new Error('should never throw - second suite');
+    });
+  });
 });

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -4,22 +4,17 @@ var run = require('./helpers').runMocha;
 var runJSON = require('./helpers').runMochaJSON;
 
 describe('regressions', function() {
-  it('issue-1327: should run all 3 specs exactly once', function(done) {
+  it('issue-1327: should run the first test and then bail', function(done) {
     var args = [];
-    run('regression/issue-1327.fixture.js', args, function(err, res) {
-      var occurences = function(str) {
-        var pattern = new RegExp(str, 'g');
-        return (res.output.match(pattern) || []).length;
-      };
-
+    runJSON('regression/issue-1327.fixture.js', args, function(err, res) {
       if (err) {
-        done(err);
-        return;
+        return done(err);
       }
-      expect(res, 'to have failed');
-      expect(occurences('testbody1'), 'to be', 1);
-      expect(occurences('testbody2'), 'to be', 1);
-      expect(occurences('testbody3'), 'to be', 1);
+      expect(res, 'to have failed')
+        .and('to have passed test count', 1)
+        .and('to have failed test count', 1)
+        .and('to have passed test', 'test 1')
+        .and('to have failed test', 'test 1');
       done();
     });
   });

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -50,23 +50,16 @@ describe('uncaught exceptions', function() {
   it('handles uncaught exceptions from which Mocha cannot recover', function(done) {
     run('uncaught-fatal.fixture.js', args, function(err, res) {
       if (err) {
-        done(err);
-        return;
+        return done(err);
       }
-      assert.strictEqual(res.stats.pending, 0);
-      assert.strictEqual(res.stats.passes, 1);
-      assert.strictEqual(res.stats.failures, 1);
 
-      assert.strictEqual(
-        res.failures[0].title,
-        'should bail if a successful test asynchronously fails'
-      );
-      assert.strictEqual(
-        res.passes[0].title,
-        'should bail if a successful test asynchronously fails'
-      );
+      var testName = 'should bail if a successful test asynchronously fails';
+      expect(res, 'to have failed')
+        .and('to have passed test count', 1)
+        .and('to have failed test count', 1)
+        .and('to have passed test', testName)
+        .and('to have failed test', testName);
 
-      assert.strictEqual(res.code, 1);
       done();
     });
   });

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -831,15 +831,16 @@ describe('Runner', function() {
               ]).and('was called once');
             });
 
-            it('should notify run has ended', function() {
+            it('should abort the runner without emitting end event', function() {
               expect(
                 function() {
                   runner.uncaught(err);
                 },
-                'to emit from',
+                'not to emit from',
                 runner,
                 'end'
               );
+              expect(runner._abort, 'to be', true);
             });
           });
 


### PR DESCRIPTION
### Description

Per default Mocha tries to recover from `uncaughtException` and to map the exception to the correct test case. It's not possible to recover gracefully if a Runnable has already passed successfully and then fails asynchronously.

Firing an `EVENT_RUN_END` out of a suite **other than the root suite** is wrong and will result in the emission of double `EVENT_RUN_END` events. The first event will not abort the runner and a second event will be fired by the root suite. We already had a similar issue, see #3617.
 
To prevent double test epilogues the reporters have been "fixed" in the past by using `runner.once(EVENT_RUN_END, ...)`.

Following tests were ineffective:
- test\integration\fixtures\uncaught-fatal.fixture.js:
```
√ should bail if a successful test asynchronously fails
  1) should bail if a successful test asynchronously fails

  1 passing (8ms)
  1 failing

  1) should bail if a successful test asynchronously fails:
     Uncaught Error: global error
      [...]

  √ should not actually get run      // runner keeps going after first end event
```
- test\integration\fixtures\regression\issue-1327.fixture.js
```
testbody1
  √ test 1
  1) test 1

  1 passing (8ms)
  1 failing

  1) test 1:
     Uncaught Error: Too bad
      [...]

testbody2              // runner keeps going after first end event
  √ test 2
testbody3
  2) test 3
```

### Description of the Change

Instead of emitting an `EVENT_RUN_END` event we use ~~`Suite#bail()`~~ `Runner#abort()` to bail the runner cleanly.

### Applicable issues

