### PR TITLE
Catch unhandled promise rejections during tests

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -783,16 +783,19 @@ Runner.prototype.runSuite = function(suite, fn) {
  * Handle uncaught exceptions.
  *
  * @param {Error} err
+ * @param {string} unwhat It this an 'uncaught' exception, or 'unhandled' rejection
  * @private
  */
-Runner.prototype.uncaught = function(err) {
+Runner.prototype.uncaught = function(err, unwhat) {
+  unwhat = unwhat || 'uncaught';
+
   if (err instanceof Pending) {
     return;
   }
   if (err) {
-    debug('uncaught exception %O', err);
+    debug('%s exception %O', unwhat, err);
   } else {
-    debug('uncaught undefined/falsy exception');
+    debug('%s undefined/falsy exception', unwhat);
     err = createInvalidExceptionError(
       'Caught falsy/undefined exception which would otherwise be uncaught. No stack trace found; try a debugger',
       err
@@ -802,12 +805,13 @@ Runner.prototype.uncaught = function(err) {
   if (!isError(err)) {
     err = thrown2Error(err);
   }
-  err.uncaught = true;
+  err[unwhat] = true;
 
   var runnable = this.currentRunnable;
 
   if (!runnable) {
-    runnable = new Runnable('Uncaught error outside test suite');
+    var capitalisedUnwhat = unwhat === 'uncaught' ? 'Uncaught' : 'Unhandled';
+    runnable = new Runnable(capitalisedUnwhat + ' error outside test suite');
     runnable.parent = this.suite;
 
     if (this.started) {
@@ -879,7 +883,10 @@ Runner.prototype.run = function(fn) {
   fn = fn || function() {};
 
   function uncaught(err) {
-    self.uncaught(err);
+    self.uncaught(err, 'uncaught');
+  }
+  function unhandled(err) {
+    self.uncaught(err, 'unhandled');
   }
 
   function start() {
@@ -910,11 +917,14 @@ Runner.prototype.run = function(fn) {
   this.on(constants.EVENT_RUN_END, function() {
     debug(constants.EVENT_RUN_END);
     process.removeListener('uncaughtException', uncaught);
+    process.removeListener('unhandledRejection', unhandled);
     fn(self.failures);
   });
 
   // uncaught exception
   process.on('uncaughtException', uncaught);
+  // unhandled rejection
+  process.on('unhandledRejection', unhandled);
 
   if (this._delay) {
     // for reporters, I guess.

--- a/test/integration/fixtures/unhandled.fixture.js
+++ b/test/integration/fixtures/unhandled.fixture.js
@@ -1,0 +1,40 @@
+'use strict';
+
+function rejectWith(err) {
+  return new Promise(function (resolve, reject) {
+    reject(err);
+  });
+}
+
+// We wish to test unhandled rejections, which happen after a tick at the
+// earliest, so we need a way some way to signal mocha our tests are async. One
+// way is to accept the `done` parameter without ever using it. Another is
+// returning a promise which never resolves. Since this tests promise handling,
+// why don't we go all the way with the promises?
+var unresolvedPromise = new Promise(function () {});
+
+it('fails when faced with an unhandled rejection', function () {
+  rejectWith(new Error('rejection'));
+
+  return unresolvedPromise;
+});
+
+it('fails exactly once when a global promise is rejected first', function () {
+  setTimeout(function () {
+    rejectWith(new Error('global error'));
+  }, 0);
+
+  return unresolvedPromise;
+});
+
+it('fails exactly once when a global promise is rejected second', function () {
+  setTimeout(function () {
+    rejectWith(new Error('test error'));
+  }, 0);
+
+  setTimeout(function () {
+    rejectWith(new Error('global error'));
+  }, 0);
+
+  return unresolvedPromise;
+});

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -71,3 +71,22 @@ describe('uncaught exceptions', function() {
     });
   });
 });
+
+describe('unhandled rejections', function() {
+  it('handles unhandled rejections from async specs', function(done) {
+    run('unhandled.fixture.js', args, function(err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      assert.strictEqual(res.stats.pending, 0);
+      assert.strictEqual(res.stats.passes, 0);
+      assert.strictEqual(res.stats.failures, 3);
+
+      assert.strictEqual(res.code, 3);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

Listen to the unhandledRejection event when running tests, catching promises who
got rejected without being cared for, and failing the test in which said
promises were left unhandled.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

AFAIK, this is the cleanest way to gracefully capture unhandled rejections.

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

This changes how tests are run in mocha, and provides a nice parallel to the
existing `allowUncaught` option.

### Benefits

<!-- What benefits will be realized by the code change? -->

Async tests which now trigger, by themselves or down their call tree,
promises left unresolved now silently pass, with a scary stack trace printed in
the console. For existing issues, see #2640 and #2785 (among others).

### Possible Drawbacks

This is only part of handling unhandled rejections, some things not yet included
are:

- Handling unhandled rejections outside spec tests (e.g. testhooks)
- Making it work in a browser
- Amend error messages which reference unhandled rejections
- Testing the new signature of the `Runner.prototype.uncaught` method
- A sister flag to `allow-uncaught`

If this commit looks interesting enough, a future commit will amend these shortcomings.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

This may be a breaking change. Tests passing with unhandled rejections will fail starting with this change.
