### PR TITLE
uncaughtException: report more than one exception per test

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -197,6 +197,7 @@ var generateDiff = (exports.generateDiff = function(actual, expected) {
  *     Error property
  */
 exports.list = function(failures) {
+  var multipleErr, multipleTest;
   Base.consoleLog();
   failures.forEach(function(test, i) {
     // format
@@ -207,7 +208,16 @@ exports.list = function(failures) {
 
     // msg
     var msg;
-    var err = test.err;
+    var err;
+    if (test.err && test.err.multiple) {
+      if (multipleTest !== test) {
+        multipleTest = test;
+        multipleErr = [test.err].concat(test.err.multiple);
+      }
+      err = multipleErr.shift();
+    } else {
+      err = test.err;
+    }
     var message;
     if (err.message && typeof err.message.toString === 'function') {
       message = err.message + '';
@@ -298,7 +308,12 @@ function Base(runner, options) {
     if (showDiff(err)) {
       stringifyDiffObjs(err);
     }
-    test.err = err;
+    // more than one error per test
+    if (test.err && err instanceof Error) {
+      test.err.multiple = (test.err.multiple || []).concat(err);
+    } else {
+      test.err = err;
+    }
     failures.push(test);
   });
 }

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -417,6 +417,22 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
+  it('should list multiple Errors per test', function() {
+    var err = new Error('First Error');
+    err.multiple = [new Error('Second Error - same test')];
+    var test = makeTest(err);
+
+    list([test, test]);
+
+    var errOut = stdout.join('\n').trim();
+    expect(
+      errOut,
+      'to contain',
+      'Error: First Error',
+      'Error: Second Error - same test'
+    );
+  });
+
   describe('when reporter output immune to user test changes', function() {
     var sandbox;
     var baseConsoleLog;


### PR DESCRIPTION
### Description

```js
describe('suite', function() {
  it('should report the first of multiple exceptions', function(done) {
    process.nextTick(() => {
      console.log('first');
      throw new Error('first');
    });
    process.nextTick(() => {
      console.log('second');
      done(new Error('second'));
    });
  });
});
```
The first error is not reported at all, instead the output shows two copies of the second error.
```
  suite
first
    1) should report the first of multiple exceptions
second
    2) should report the first of multiple exceptions

  0 passing (10ms)
  2 failing

  1) suite
       should report the first of multiple exceptions:
     Error: second
      [...]

  2) suite
       should report the first of multiple exceptions:
     Error: second
      [...]
```

### Description of the Change

- `test.err`: currently is storing just one error per test, in case of multiple errors it's the last one. I haven't changed its type to `Array` for backwards compability and instead introduced a new property `test.err.multiple` to store additional errors. The latter is set within the `EVENT_TEST_FAIL` event handler.
- output: I applied the changes to `Base.list()` which is part of the epilogue used by most builtin reporters.
- Reporters as "json" or "XUnit" which don't rely on the `Base#epilogue()` remain mostly unchanged and do not list multiple errors per test. They list now the first error instead of the last one.


### Applicable issues

#2906 partially