### PR TITLE
fixed bug issue #3675

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -239,10 +239,7 @@ exports.list = function(failures) {
         color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);
-      msg += generateDiff(
-        err.actual.replace(/\s/g, ''),
-        err.expected.replace(/\s/g, '')
-      );
+      msg += generateDiff(err.actual, err.expected);
     }
 
     // indent stack trace
@@ -278,7 +275,6 @@ exports.list = function(failures) {
  */
 function Base(runner, options) {
   var failures = (this.failures = []);
-
   if (!runner) {
     throw new TypeError('Missing runner argument');
   }
@@ -335,9 +331,7 @@ Base.prototype.epilogue = function() {
   // failures
   if (stats.failures) {
     fmt = color('fail', '  %d failing');
-
     Base.consoleLog(fmt, stats.failures);
-
     Base.list(this.failures);
     Base.consoleLog();
   }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -239,8 +239,10 @@ exports.list = function(failures) {
         color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
       var match = message.match(/^([^:]+): expected/);
       msg = '\n      ' + color('error message', match ? match[1] : msg);
-
-      msg += generateDiff(err.actual, err.expected);
+      msg += generateDiff(
+        err.actual.replace(/\s/g, ''),
+        err.expected.replace(/\s/g, '')
+      );
     }
 
     // indent stack trace

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -349,7 +349,6 @@ Runnable.prototype.run = function(fn) {
       // the failure.
       throw new Pending('async skip; aborting execution');
     };
-    console.log(1);
     if (this.allowUncaught) {
       return callFnAsync(this.fn);
     }
@@ -384,7 +383,6 @@ Runnable.prototype.run = function(fn) {
 
   function callFn(fn) {
     var result = fn.call(ctx);
-    console.log('ret : ', result);
     if (result && typeof result.then === 'function') {
       self.resetTimeout();
       result.then(

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -349,7 +349,7 @@ Runnable.prototype.run = function(fn) {
       // the failure.
       throw new Pending('async skip; aborting execution');
     };
-
+    console.log(1);
     if (this.allowUncaught) {
       return callFnAsync(this.fn);
     }
@@ -361,7 +361,6 @@ Runnable.prototype.run = function(fn) {
     }
     return;
   }
-
   if (this.allowUncaught) {
     if (this.isPending()) {
       done();
@@ -385,6 +384,7 @@ Runnable.prototype.run = function(fn) {
 
   function callFn(fn) {
     var result = fn.call(ctx);
+    console.log('ret : ', result);
     if (result && typeof result.then === 'function') {
       self.resetTimeout();
       result.then(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -235,7 +235,6 @@ var type = (exports.type = function type(value) {
  */
 exports.stringify = function(value) {
   var typeHint = type(value);
-
   if (!~['object', 'array', 'function'].indexOf(typeHint)) {
     if (typeHint === 'buffer') {
       var json = Buffer.prototype.toJSON.call(value);
@@ -343,9 +342,9 @@ function jsonStringify(object, spaces, depth) {
     }
     --length;
     str +=
-      '\n ' +
-      repeat(' ', space) +
-      (Array.isArray(object) ? '' : '"' + i + '": ') + // key
+      // '\n ' +
+      repeat('', space) +
+      (Array.isArray(object) ? '' : '"' + i + '":') + // key
       _stringify(object[i]) + // value
       (length ? ',' : ''); // comma
   }
@@ -353,7 +352,8 @@ function jsonStringify(object, spaces, depth) {
   return (
     str +
     // [], {}
-    (str.length !== 1 ? '\n' + repeat(' ', --space) + end : end)
+    // (str.length !== 1 ? '\n' + repeat(' ', --space) + end : end)
+    (str.length !== 1 ? repeat('', --space) + end : end)
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4517,9 +4517,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -15322,6 +15322,12 @@
         "supports-color": "^5.5.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -516,7 +516,7 @@
     "browser-stdout": "1.3.1",
     "chokidar": "3.0.2",
     "debug": "3.2.6",
-    "diff": "3.5.0",
+    "diff": "^4.0.1",
     "escape-string-regexp": "1.0.5",
     "find-up": "3.0.0",
     "glob": "7.1.3",


### PR DESCRIPTION
https://github.com/mochajs/mocha/issues/3675#
I found and fixed bug

Before entering the js diff function, there were unnecessary characters in the string, which slowed down Mocha. So I fixed it
  
In jsdiff structure is like that 
set diff variable and logic..
## lib > patch > create.js > structuredPatch 
```
var diff =
  /*istanbul ignore start*/
  (0,
  /*istanbul ignore end*/

  /*istanbul ignore start*/
  _line
  /*istanbul ignore end*/
  .
  /*istanbul ignore start*/
  diffLines)
  /*istanbul ignore end*/
  (oldStr, newStr, options);

console.log(diff, _line.diffLines, oldStr, newStr, options)
```
and then.. it said like this in before mocha
```
 {\n    "a": 9789\n  }\n  {\n    "a": 9790\n  }\n  {\n    "a": 9791\n  }\n  {\n    "a": 9792\n  }\n  {\n    "a": 9793\n  }\n  {\n    "a": 9794\n  }\n  {\n    "a": 9795\n  }\n  {\n    "a": 9796\n  }\n  {\n    "a": 9797\n  }\n  {\n    "a": 9798\n  }\n  {\n    "a": 9799\n  }\n  {\n    "a": 9800\n  }\n  {\n    "a": 9801\n  }\n  {\n    "a": 9802\n  }\n  {\n    "a": 9803\n  }\n  {\n    "a": 9804\n  }\n  {\n    "a": 9805\n  }\n  {\n    "a": 9806\n  }\n  {\n    "a": 9807\n  }\n  {\n    "a": 9808\n  }\n  {\n    "a": 9809\n  }\n  {\n    "a": 9810\n  }\n  {\n    "a": 9811\n  }\n  {\n    "a": 9812\n  }\n  {\n    "a": 9813\n  }\n  {\n    "a": 9814\n  }\n  {\n    "a": 9815\n  }\n  {\n   
```
but..!!! 
in only diff
```
"a":9949},{"a":9950},{"a":9951},{"a":9952},{"a":9953},{"a":9954},{"a":9955},{"a":9956},{"a":9957},{"a":9958},{"a":9959},{"a":9960},{"a":9961},{"a":9962},{"a":9963},{"a":9964},{"a":9965},{"a":9966},{"a":9967},{"a":9968},{"a":9969},{"a":9970},{"a":9971},{"a":9972},{"a":9973},{"a":9974},{"a":9975},{"a":9976},{"a":9977},{"a":9978},{"a":9979},{"a":9980},{"a":9981},{"a":9982},{"a":9983},{"a":9984},{"a":9985},{"a":9986},{"a":9987},{"a":9988},{"a":9989},{"a":9990},{"a":9991},{"a":9992},{"a":9993},{"a":9994},{"a":9995},{"a":9996},{"a":9997},{"a":9998},{"a":9999}]'
```
very clear 

So I did Before mocha put it into a diff function replace \s. and It's quickening Mocha and fixing bugs.
and..
## the result
I fixed it!
in my mocha
```js
const {expect} = require('chai')
const _ = require('lodash')
it('Test failing', function () {
    const longArray = _.times(10000, function (i) {
      return {a : i}
    })
    const shortArray = []
    expect(longArray).deep.equal(shortArray)
})
``` 
the test code spend a time like this
real 0m1.657s
user 0m0.878s
sys 0m0.119s


