### PR TITLE
Add a description for installing GraphicsMagick or ImageMagick in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ _So you wanna build the site?_
 - `docs/_dist` is where the deployed site lives. `docs/_site` is essentially a build step. These directories are _not_ under version control.
 - If you get the error message below when running `npm start docs`, follow [this guide](https://www.npmjs.com/package/gm) to install GraphicsMagick.
 
-```
+```console
 ⚠ WARN: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
 (node:45255) UnhandledPromiseRejectionWarning: Error: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
     at Socket.stdout.on.once (/Users/temp/Downloads/exercise2/mocha/node_modules/express-processimage/lib/getFilterInfosAndTargetContentTypeFromQueryString.js:821:31)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ _So you wanna build the site?_
 - The content lives in `docs/index.md`; everything else is markup, scripts, assets, etc.
 - This file (`docs/README.md`) should _not_ be included in the build.
 - `docs/_dist` is where the deployed site lives. `docs/_site` is essentially a build step. These directories are _not_ under version control.
-- If you get the error message below when running `npm start docs`, follow [this guide](https://www.npmjs.com/package/gm) to install GraphicsMagick.
+- If you get the error message below when running `npm start docs`, follow [this guide](https://www.npmjs.com/package/gm) to install GraphicsMagick or ImageMagick.
 
 ```console
 ⚠ WARN: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ _So you wanna build the site?_
 ```console
 ⚠ WARN: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
 (node:45255) UnhandledPromiseRejectionWarning: Error: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
-    at Socket.stdout.on.once (/Users/temp/Downloads/exercise2/mocha/node_modules/express-processimage/lib/getFilterInfosAndTargetContentTypeFromQueryString.js:821:31)
+    at Socket.stdout.on.once (/Users/username/mocha/node_modules/express-processimage/lib/getFilterInfosAndTargetContentTypeFromQueryString.js:821:31)
     at Object.onceWrapper (events.js:286:20)
     at Socket.emit (events.js:203:15)
     at endReadableNT (_stream_readable.js:1145:12)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,21 @@ _So you wanna build the site?_
 - The content lives in `docs/index.md`; everything else is markup, scripts, assets, etc.
 - This file (`docs/README.md`) should _not_ be included in the build.
 - `docs/_dist` is where the deployed site lives. `docs/_site` is essentially a build step. These directories are _not_ under version control.
+- If you get the error message below when running `npm start docs`, follow [this guide](https://www.npmjs.com/package/gm) to install GraphicsMagick.
+
+```
+⚠ WARN: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
+(node:45255) UnhandledPromiseRejectionWarning: Error: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
+    at Socket.stdout.on.once (/Users/temp/Downloads/exercise2/mocha/node_modules/express-processimage/lib/getFilterInfosAndTargetContentTypeFromQueryString.js:821:31)
+    at Object.onceWrapper (events.js:286:20)
+    at Socket.emit (events.js:203:15)
+    at endReadableNT (_stream_readable.js:1145:12)
+    at process._tickCallback (internal/process/next_tick.js:63:19)
+(node:45255) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
+(node:45255) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
+cp: docs/_dist/_headers: No such file or directory
+```
+
 - See `package-scripts.js` for details on what the builds are actually doing; especially see [markdown-magic](https://npm.im/markdown-magic) for how we're dynamically inserting information into `docs/index.md`.
 
 ## License


### PR DESCRIPTION
### Description of the Change
To try to contribute to Mocha docs, I proceeded with the installation  as described in [**README.md** of docs](https://github.com/mochajs/mocha/blob/master/docs/README.md) directory. However, when I tried to use `npm start docs` after installing, the following error occurred:

```
nps is executing `docs.postbuild` : buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers
Guessing --root from input files: file:///Users/temp/Downloads/exercise2/mocha/docs/_site/
 ✔ 0.006 secs: logEvents
 ✔ 1.320 secs: loadAssets
 ✔ 0.008 secs: bundleWebpack
 ✔ 0.063 secs: populate
 ✔ 0.015 secs: bundleSystemJs
 ✔ 0.057 secs: bundleRequireJs
 ✔ 12.659 secs: populate
 ✔ 0.096 secs: populate
 ✔ 3.664 secs: checkIncompatibleTypes
 ✔ 0.020 secs: removeRelations
 ✔ 1.916 secs: populate
 ✔ 1.895 secs: populate
 ✔ 1.249 secs: removeRelations
 ✔ 1.766 secs: addDataVersionAttributeToHtmlElement
 ✔ 1.488 secs: stripDebug
 ✔ 2.555 secs: externalizeRelations
 ✔ 0.004 secs: mergeIdenticalAssets
objc[45255]: Class GNotificationCenterDelegate is implemented in both /Users/temp/Downloads/exercise2/mocha/node_modules/canvas/build/Release/libgio-2.0.0.dylib (0x105f31578) and /Users/temp/Downloads/exercise2/mocha/node_modules/sharp/vendor/lib/libgio-2.0.0.dylib (0x107bdf498). One of the two will be used. Which one is undefined.
 ✔ 0.274 secs: processImages
 ✔ 1.484 secs: spriteBackgroundImages
(node:45255) DeprecationWarning: max() is deprecated, use resize({ fit: "inside" }) instead
(node:45255) DeprecationWarning: withoutEnlargement() is deprecated, use resize({ withoutEnlargement: true }) instead
 ⚠ WARN: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
(node:45255) UnhandledPromiseRejectionWarning: Error: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
    at Socket.stdout.on.once (/Users/temp/Downloads/exercise2/mocha/node_modules/express-processimage/lib/getFilterInfosAndTargetContentTypeFromQueryString.js:821:31)
    at Object.onceWrapper (events.js:286:20)
    at Socket.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:45255) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:45255) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
cp: docs/_dist/_headers: No such file or directory
The script called "docs.postbuild" which runs "buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers" failed with exit code 1 https://github.com/kentcdodds/nps/blob/v5.9.5/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
The script called "docs" which runs "nps docs.prebuild && nps docs.api && eleventy && nps docs.linkcheck && nps docs.postbuild" failed with exit code 1 https://github.com/kentcdodds/nps/blob/v5.9.5/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mocha@6.2.0 start: `nps "docs"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mocha@6.2.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/temp/.npm/_logs/2019-10-03T08_45_45_219Z-debug.log
```

After searching, I installed GraphicsMagick and finally I was able to make it work. It is understood that GraphicsMagick must be installed for execution, but I believe there is not enough explanation about it. Therefore, I think some additional description of this case can be more helpful for beginners(like me!). I propose to add the description as follows:

- If you get the error message below when running `npm start docs`, follow [this guide](https://www.npmjs.com/package/gm) to install GraphicsMagick.

```
⚠ WARN: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
(node:45255) UnhandledPromiseRejectionWarning: Error: docs/_site/images/matomo-logo.png: Error executing Stream: The gm stream ended without emitting any data
    at Socket.stdout.on.once (/Users/username/mocha/node_modules/express-processimage/lib/getFilterInfosAndTargetContentTypeFromQueryString.js:821:31)
    at Object.onceWrapper (events.js:286:20)
    at Socket.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:45255) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:45255) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
cp: docs/_dist/_headers: No such file or directory
```

### Benefits
I believe it can be more helpful for beginners.