### PR TITLE
deprecate noHighlighting and replace it with reporterOptions.highlight  #3701

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -130,7 +130,17 @@ mocha.setup = function(opts) {
   }
   for (var opt in opts) {
     if (opts.hasOwnProperty(opt)) {
-      this[opt](opts[opt]);
+      if (opt === 'noHighlighting' && opt) {
+        require('./lib/utils').deprecate(
+          'noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().'
+        );
+      }
+
+      if (opt === 'reporterOptions') {
+        this.options.reporterOptions = opts[opt];
+      } else {
+        this[opt](opts[opt]);
+      }
     }
   }
   return this;
@@ -157,14 +167,7 @@ mocha.run = function(fn) {
 
   return Mocha.prototype.run.call(mocha, function(err) {
     // The DOM Document is not available in Web Workers.
-    var document = global.document;
-    if (
-      document &&
-      document.getElementById('mocha') &&
-      options.noHighlighting !== true
-    ) {
-      Mocha.utils.highlightTags('code');
-    }
+
     if (fn) {
       fn(err);
     }

--- a/browser-entry.js
+++ b/browser-entry.js
@@ -130,12 +130,6 @@ mocha.setup = function(opts) {
   }
   for (var opt in opts) {
     if (opts.hasOwnProperty(opt)) {
-      if (opt === 'noHighlighting' && opt) {
-        require('./lib/utils').deprecate(
-          'noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().'
-        );
-      }
-
       if (opt === 'reporterOptions') {
         this.options.reporterOptions = opts[opt];
       } else {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1588,8 +1588,17 @@ You can pass a reporter's name or a custom reporter's constructor. You can find 
 
 #### Options that _only_ function in browser context:
 
-`noHighlighting` _{boolean}_  
-If set to `true`, do not attempt to use syntax highlighting on output test code.
+> _`BREAKING CHANGE in v7.0.0; noHighlighting` is DEPRECATED. We recommend using `reporterOptions.highlight` instead._
+
+`reporterOptions.highlight` _{boolean}_
+
+If set to `false`, do not attempt to use syntax highlighting on output test code.
+
+```js
+reporterOptions: {
+  highlight: false;
+}
+```
 
 ### Reporting
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -682,15 +682,17 @@ Mocha.prototype.asyncOnly = function() {
  * Disables syntax highlighting (in browser).
  *
  * @public
+ * @param {boolean} enableHighlight - Whether to enable highlight.
  * @return {Mocha} this
  * @chainable
  */
-Mocha.prototype.noHighlighting = function() {
+Mocha.prototype.noHighlighting = function(enableHighlight) {
   utils.deprecate(
     'noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().'
   );
-
-  this.options.noHighlighting = true;
+  enableHighlight = enableHighlight === undefined ? true : enableHighlight;
+  this.options.reporterOptions = this.options.reporterOptions || {};
+  this.options.reporterOptions.highlight = enableHighlight !== true;
   return this;
 };
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -686,6 +686,10 @@ Mocha.prototype.asyncOnly = function() {
  * @chainable
  */
 Mocha.prototype.noHighlighting = function() {
+  utils.deprecate(
+    'noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().'
+  );
+
   this.options.noHighlighting = true;
   return this;
 };

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -690,9 +690,9 @@ Mocha.prototype.noHighlighting = function(enableHighlight) {
   utils.deprecate(
     'noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().'
   );
-  enableHighlight = enableHighlight === undefined ? true : enableHighlight;
   this.options.reporterOptions = this.options.reporterOptions || {};
-  this.options.reporterOptions.highlight = enableHighlight !== true;
+  this.options.reporterOptions.highlight =
+    enableHighlight !== undefined && enableHighlight !== true;
   return this;
 };
 

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -18,6 +18,7 @@ var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_SUITE_BEGIN = constants.EVENT_SUITE_BEGIN;
 var EVENT_SUITE_END = constants.EVENT_SUITE_END;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
+var EVENT_RUN_END = constants.EVENT_RUN_END;
 var escape = utils.escape;
 
 /**
@@ -58,6 +59,17 @@ var playIcon = '&#x2023;';
  */
 function HTML(runner, options) {
   Base.call(this, runner, options);
+  for (var opt in options) {
+    if (options.hasOwnProperty(opt) && opt === 'reporterOptions') {
+      if (options[opt]) {
+        if (options[opt].highlight && options[opt].highlight !== false) {
+          options[opt].highlight = true;
+        }
+      } else {
+        options[opt] = {highlight: true};
+      }
+    }
+  }
 
   var self = this;
   var stats = this.stats;
@@ -222,6 +234,12 @@ function HTML(runner, options) {
     );
     appendToStack(el);
     updateStats();
+  });
+
+  runner.once(EVENT_RUN_END, function() {
+    if (options.reporterOptions.highlight === true) {
+      utils.highlightTags('code');
+    }
   });
 
   function appendToStack(el) {

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -61,11 +61,14 @@ function HTML(runner, options) {
   Base.call(this, runner, options);
   for (var opt in options) {
     if (options.hasOwnProperty(opt) && opt === 'reporterOptions') {
-      if (options[opt]) {
-        if (options[opt].highlight && options[opt].highlight !== false) {
-          options[opt].highlight = true;
-        }
-      } else {
+      if (
+        options[opt] &&
+        (options[opt].highlight ||
+          typeof options[opt].highlight === 'undefined')
+      ) {
+        options[opt].highlight = true;
+      }
+      if (!options[opt]) {
         options[opt] = {highlight: true};
       }
     }

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -59,19 +59,14 @@ var playIcon = '&#x2023;';
  */
 function HTML(runner, options) {
   Base.call(this, runner, options);
-  for (var opt in options) {
-    if (options.hasOwnProperty(opt) && opt === 'reporterOptions') {
-      if (
-        options[opt] &&
-        (options[opt].highlight ||
-          typeof options[opt].highlight === 'undefined')
-      ) {
-        options[opt].highlight = true;
-      }
-      if (!options[opt]) {
-        options[opt] = {highlight: true};
-      }
-    }
+
+  var enableHighlight = true;
+  if (
+    options.reporterOptions &&
+    options.reporterOptions.hasOwnProperty('highlight') &&
+    !options.reporterOptions.highlight
+  ) {
+    enableHighlight = false;
   }
 
   var self = this;
@@ -240,7 +235,7 @@ function HTML(runner, options) {
   });
 
   runner.once(EVENT_RUN_END, function() {
-    if (options.reporterOptions.highlight === true) {
+    if (enableHighlight) {
       utils.highlightTags('code');
     }
   });

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -300,6 +300,28 @@ describe('Mocha', function() {
       );
     });
 
+    it('should set the reporterOptions.highlight to false', function() {
+      var mocha = new Mocha(opts);
+      mocha.noHighlighting(true);
+      expect(
+        mocha.options.reporterOptions,
+        'to have property',
+        'highlight',
+        false
+      );
+    });
+
+    it('should set the reporterOptions.highlight to true', function() {
+      var mocha = new Mocha(opts);
+      mocha.noHighlighting(false);
+      expect(
+        mocha.options.reporterOptions,
+        'to have property',
+        'highlight',
+        true
+      );
+    });
+
     it('should be chainable', function() {
       var mocha = new Mocha(opts);
       expect(mocha.noHighlighting(), 'to be', mocha);

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -289,10 +289,15 @@ describe('Mocha', function() {
 
   describe('#noHighlighting()', function() {
     // :NOTE: Browser-only option...
-    it('should set the noHighlighting option to true', function() {
+    it('should set the reporterOptions.highlight to false', function() {
       var mocha = new Mocha(opts);
       mocha.noHighlighting();
-      expect(mocha.options, 'to have property', 'noHighlighting', true);
+      expect(
+        mocha.options.reporterOptions,
+        'to have property',
+        'highlight',
+        false
+      );
     });
 
     it('should be chainable', function() {


### PR DESCRIPTION
### Description

I added a deprecation notice for `noHighlighting` in browser and replace it with reporterOptions.highlight as mentioned in #3701 

### Description of the Change

**1.** 

`
If a user supplies {noHighlighting: true} to mocha.setup() or calls mocha.noHighlighting() in the browser, we should print a deprecation message along the lines of "noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().
`

while I was working on it. I found out **a bug** related to `noHighlighting`. 

**Problem**

Even though you pass `false` to noHighlighting  in `mocha.setup()` like below,
```js
mocha.setup({ui: 'bdd', noHighlighting: false});
```
`noHighlighting` turns into `true`, therefore we can't highlight text.

**Reason**

I tracked down the code to deal with it, and found out a reason about it.
in `mocha.setup` in `browser-entry.js`, you can see the code below. if options are passed, it calls the function named after the options.
```js
 this[opt](opts[opt]);
```

for example, if we supply `noHighlighting` to `mocha.setup()`, noHighlighting() function will be invoked. 
In `noHighlighting() function` it set `true` to  `noHighlighting`, No matter which value were passed. Here's the code in `/lib/mocha.js`

```js
Mocha.prototype.noHighlighting = function() {
  this.options.noHighlighting = true;
  return this;
};
```

**Solution**

 I changed `Mocha.prototype.noHighlighting()` in `lib/mocha.js` like one below.
I let function get a parameter called `enableHighlight`. 
If we call `mocha.noHighlighting()`, it will be `undefined`, then `reporterOptions.highlight` is set as `false`.
If we set value to noHighlighting in `mocha.setup()`,  `reporterOptions.highlight` is set as the value depending on which value are supplied by user.

As you can see it, I added a deprecation notice inside the function as well. 
```js
Mocha.prototype.noHighlighting = function(enableHighlight) {
  utils.deprecate(
    'noHighlighting is deprecated; provide {reporterOption: {highlight: false}} to mocha.setup().'
  );
  this.options.reporterOptions = this.options.reporterOptions || {};
  this.options.reporterOptions.highlight =
    enableHighlight !== undefined && enableHighlight !== true;
  return this;
};
```
In addition, In case they pass `{reporterOptions: {highlight: false}}` to `mocha.setup()`, to avoid throwing an error I added conditional statements below in `browser-entry.js` as well. Because **there's no function called `reporterOptions`**

```js
      if (opt === 'reporterOptions') {
        this.options.reporterOptions = opts[opt];
      } else {
        this[opt](opts[opt]);
      }
```

**2.** 

`The html reporter's constructor should accept a reporterOptions object, which may be undefined, and may have a boolean highlight property. If the property is anything other than explicitly false, default to true. in order to set reporterOptions.highlight value to options `

I add the code to set the default value to it. so if they didn't pass false to `reporterOptions.highlight`, it will be `true` as default.

```js
var enableHighlight = true;
if (
  options.reporterOptions &&
  options.reporterOptions.hasOwnProperty('highlight') &&
  !options.reporterOptions.highlight
) {
  enableHighlight = false;
}
```

**3.** 

`
The reporter's constructor should execute Mocha.utils.highlightTags('code') when the end event is emitted by the runner property.
`

to run it, I added the code below in `html.js`. The value of `enableHighlight` is going to be set as mentioned in **2**

```js
  runner.once(EVENT_RUN_END, function() {
    if (enableHighlight) {
      utils.highlightTags('code');
    }
  });
```

I didn't check out whether `document` exists or not, because in html.js , I found out the code to throw an error when there's no `document`

```js
  if (!root) {
    return error('#mocha div missing, add it to your document');
  }

```

**4.**

`As I moved the highlighting code to html.js, I removed the duplicated checks below from browser-entry.js as mentioned in #3701 `

```js
    var document = global.document;
    if (
      document &&
      document.getElementById('mocha') &&
      options.noHighlighting !== true
    ) {
      Mocha.utils.highlightTags('code');
    }
```

**5.**

`add unit tests which assert the new behavior in test/unit/mocha.spec.js. `

I modified test code of `noHighlighting` in `test/unit/mocha.spec.js`. 
as a result of it, we can check out that if user calls `mocha.noHighlighting()`, `reporterOptions.highlight` will be false.

```js
    it('should set the reporterOptions.highlight to false', function() {
      var mocha = new Mocha(opts);
      mocha.noHighlighting();
      expect(
        mocha.options.reporterOptions,
        'to have property',
        'highlight',
        false
      );
    });

```
**In fact I wanted to add another test only for reporterOptions.highlight. but I wasn't able to do it. I added the code to set the default value to reporterOptions.highlight in `html.js`. so If I want to add a test, I think I should do it to `html.spec.js`, but There is nothing..** 

**6.**

`add the description about it in documentation, so I added the text to index.md.`

Here's what it looks like.

<img width="931" alt="스크린샷 2019-10-06 오후 9 46 43" src="https://user-images.githubusercontent.com/35101854/66269398-e5c81b80-e882-11e9-8b0e-adbc36bb70e5.png">

### Benefits

As I stated above, I also fix the bug about `noHighlighting()`, so it's going to be helpful to deal with it as well.

### Applicable issues
#3701 

Thank you for reading my request :)