### PR TITLE
Throw well formatted error if file passed via argument cannot be found (closes #4047)

### DIFF
--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -70,7 +70,7 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
   // Check if the given files are resolvable
   files.forEach(fileArg => {
     if (!fs.existsSync(fileArg)) {
-      console.error(ansi.red(`Cannot find file '${fileArg}'`));
+      console.error(ansi.red(`Error: Cannot find file '${fileArg}'`));
       process.exit(1);
     }
   });

--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 const ansi = require('ansi-colors');
 const debug = require('debug')('mocha:cli:run:helpers');
 const minimatch = require('minimatch');
@@ -65,6 +66,14 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
   // add files given through --file to be ran first
   files = fileArgs.concat(files);
   debug('files (in order): ', files);
+
+  // Check if the given files are resolvable
+  files.forEach(fileArg => {
+    if (!fs.existsSync(fileArg)) {
+      console.error(ansi.red(`Cannot find file '${fileArg}'`));
+      process.exit(1);
+    }
+  });
 
   if (!files.length) {
     // give full message details when only 1 file is missing

--- a/test/integration/options/file.spec.js
+++ b/test/integration/options/file.spec.js
@@ -2,6 +2,7 @@
 
 var path = require('path').posix;
 var helpers = require('../helpers');
+var invokeMocha = helpers.invokeMocha;
 var runMochaJSON = helpers.runMochaJSON;
 var resolvePath = helpers.resolveFixturePath;
 
@@ -63,5 +64,22 @@ describe('--file', function() {
       expect(res, 'to have passed').and('to have passed test count', 1);
       done();
     });
+  });
+
+  it('should fail if the file can not be found', function(done) {
+    args = ['--file', 'non-existent'];
+
+    invokeMocha(
+      args,
+      function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, 'to have failed');
+        expect(result.output, 'to match', /Cannot find file/i);
+        done();
+      },
+      {stdio: 'pipe'}
+    );
   });
 });


### PR DESCRIPTION
### Description of the Change
I added a simple loop that checks if files that are given through the `--file` argument are existing. If not an error message is display and the program exited to prevent them from being required later on.

### Alternate Designs
I thought about placing it in `run.js` but the existings checks were all done somewhere more deep. `collect-files()` is used for the single- and watch-run. So we got the changes at one point. 

### Why should this be in core?
It's a functionality already implemented similar in the core.

### Benefits
Users get a better error message if they did something wrong.

### Possible Drawbacks
None
### Applicable issues
None