### PR TITLE
Make unhide function work as expected in html reporter

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -357,8 +357,8 @@ function hideSuitesWithout(classname) {
  */
 function unhide() {
   var els = document.getElementsByClassName('suite hidden');
-  for (var i = 0; i < els.length; ++i) {
-    els[i].className = els[i].className.replace('suite hidden', 'suite');
+  while (els.length > 0) {
+    els[0].className = els[0].className.replace('suite hidden', 'suite');
   }
 }
 


### PR DESCRIPTION
### Description

Fixed the iteration of the HTMLCollection object in the unhide function of the html reporter. Since the length of the HTMLCollection changes as the elements' class names get updated (as HTMLCollection works 'live'), it cannot be updated using an index-based for loop.

### Description of the Change

Changed the index-based for loop iteration to a while loop, updating the first element while the length of the HTMLCollection is larger than 0.

### Why should this be in core?

It a bug (although minor) that makes filtering by passes/failures doesn't work properly as expected.

### Benefits

<!-- What benefits will be realized by the code change? -->
Filtering by passes / filters in html reporter works properly even after unhiding objects.

### Possible Drawbacks

None

### Applicable issues

Closes #4048

