### PR TITLE
Handled exception of`--file` option with non-existed file(#4047)

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -75,10 +75,11 @@ exports.list = str =>
   Array.isArray(str) ? exports.list(str.join(',')) : str.split(/ *, */);
 
 /**
- * `require()` the modules as required by `--require <require>`
- * @param {string[]} requires - Modules to require
+ * `require()` the modules as required by `--require <require>` or `--file <filename>`
+ * @param {string[]} requires - Modules or File to require
  * @private
  */
+
 exports.handleRequires = (requires = []) => {
   requires.forEach(mod => {
     let modpath = mod;

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -75,8 +75,8 @@ exports.list = str =>
   Array.isArray(str) ? exports.list(str.join(',')) : str.split(/ *, */);
 
 /**
- * `require()` the modules as required by `--require <require>` or `--file <filename>`
- * @param {string[]} requires - Modules or File to require
+ * `require()` the modules as required by `--require <require>`
+ * @param {string[]} requires - Modules to require
  * @private
  */
 
@@ -89,6 +89,19 @@ exports.handleRequires = (requires = []) => {
     }
     require(modpath);
     debug(`loaded require "${mod}"`);
+  });
+};
+
+/**
+ * @param {string[]} files - Modules to require by `--file <file>`
+ * @private
+ */
+
+exports.handleFiles = (files = []) => {
+  files.forEach(file => {
+    if (!fs.existsSync(file, {cwd})) {
+      throw Error(`Cannot find module '${file}'`);
+    }
   });
 };
 

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -17,6 +17,7 @@ const {
 const {
   list,
   handleRequires,
+  handleFiles,
   validatePlugin,
   runMocha
 } = require('./run-helpers');
@@ -287,8 +288,9 @@ exports.builder = yargs =>
       }
 
       // load requires first, because it can impact "plugin" validation
+
       handleRequires(argv.require);
-      handleRequires(argv.file);
+      handleFiles(argv.file);
 
       validatePlugin(argv, 'reporter', Mocha.reporters);
       validatePlugin(argv, 'ui', Mocha.interfaces);

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -288,6 +288,8 @@ exports.builder = yargs =>
 
       // load requires first, because it can impact "plugin" validation
       handleRequires(argv.require);
+      handleRequires(argv.file);
+
       validatePlugin(argv, 'reporter', Mocha.reporters);
       validatePlugin(argv, 'ui', Mocha.interfaces);
 


### PR DESCRIPTION
### Description of the Change

In **handleRequires**, a function that handles exceptions when invoking a module that does not exist with the `--require` option. However, function **handleRequires** can also be used to load non-existent files with the `--file` option.

So I added this function to be called when I loaded the file using --file option. And I modified the annotation of this function.

>./bin/mocha --require non-exist-module

<img width="381" alt="module" src="https://user-images.githubusercontent.com/18614517/66473422-31b8d180-eaca-11e9-895c-ff37e389ddfe.png">

>./bin/mocha --file non-exist-file

<img width="381" alt="file" src="https://user-images.githubusercontent.com/18614517/66473430-354c5880-eaca-11e9-923b-8a2097c8a7a3.png">

### Benefits

When user import a non-existent file or module, command line can show the user the same error message and format.