### PR TITLE
fix: add global leaks detection on watch-run

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -85,10 +85,17 @@ const createRerunner = (mocha, beforeRun) => {
 
   let rerunScheduled = false;
 
+  let defaultGlobals = null;
+
   const run = () => {
     try {
       beforeRun();
       resetMocha(mocha);
+
+      if (!defaultGlobals) {
+        defaultGlobals = Object.keys(global);
+      }
+
       runner = mocha.run(() => {
         runner = null;
         if (rerunScheduled) {
@@ -114,6 +121,15 @@ const createRerunner = (mocha, beforeRun) => {
   };
 
   const rerun = () => {
+    if (defaultGlobals) {
+      Object.keys(global).forEach(k => {
+        if (defaultGlobals.indexOf(k) === -1) {
+          delete global[k];
+        }
+      });
+      defaultGlobals = null;
+    }
+
     rerunScheduled = false;
     eraseLine();
     run();

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -85,15 +85,15 @@ const createRerunner = (mocha, beforeRun) => {
 
   let rerunScheduled = false;
 
-  let defaultGlobals = null;
+  let initialGlobals = null;
 
   const run = () => {
     try {
       beforeRun();
       resetMocha(mocha);
 
-      if (!defaultGlobals) {
-        defaultGlobals = Object.keys(global);
+      if (!initialGlobals) {
+        initialGlobals = Object.keys(global);
       }
 
       runner = mocha.run(() => {
@@ -121,13 +121,13 @@ const createRerunner = (mocha, beforeRun) => {
   };
 
   const rerun = () => {
-    if (defaultGlobals) {
+    if (initialGlobals) {
       Object.keys(global).forEach(k => {
-        if (defaultGlobals.indexOf(k) === -1) {
+        if (initialGlobals.indexOf(k) === -1) {
           delete global[k];
         }
       });
-      defaultGlobals = null;
+      initialGlobals = null;
     }
 
     rerunScheduled = false;

--- a/test/integration/fixtures/options/watch/test-global-leak.fixture.js
+++ b/test/integration/fixtures/options/watch/test-global-leak.fixture.js
@@ -1,0 +1,14 @@
+describe('leak detection', function() {
+  function testMe() {
+    x = 123; // leak variable
+  }
+
+  it('should not leak', function(done) {
+    testMe();
+    done(); // just pass
+  });
+
+  before(function() {});
+
+  after(function() {});
+});

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -267,6 +267,19 @@ describe('--watch', function() {
         expect(results[1].tests, 'to have length', 2);
       });
     });
+
+    it('check global variable leaks when test reruns', function() {
+      const testFile = path.join(this.tempDir, 'test.js');
+      copyFixture('options/watch/test-global-leak', testFile);
+
+      return runMochaWatch([testFile, '--check-leaks'], this.tempDir, () => {
+        touchFile(testFile);
+      }).then(results => {
+        expect(results, 'to have length', 2);
+        expect(results[0].failures, 'to have length', 1); // first leaks detection
+        expect(results[1].failures, 'to have length', 1); // second leaks detection
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Description of the Change

- apply global variable reset process when rerunning test in watch mode
- add some test (that detect global leaks and rerun that test through touch that test file, and then detect global leak again)

Fixes #1948.