### PR TITLE
special-case parsing of "require" in unparseNodeArgs(); closes #4035

### DIFF
--- a/lib/cli/node-flags.js
+++ b/lib/cli/node-flags.js
@@ -68,6 +68,7 @@ exports.impliesNoTimeouts = flag => debugFlags.has(flag);
 /**
  * All non-strictly-boolean arguments to node--those with values--must specify those values using `=`, e.g., `--inspect=0.0.0.0`.
  * Unparse these arguments using `yargs-unparser` (which would result in `--inspect 0.0.0.0`), then supply `=` where we have values.
+ * Apparently --require in Node.js v8 does NOT want `=`.
  * There's probably an easier or more robust way to do this; fixes welcome
  * @param {Object} opts - Arguments object
  * @returns {string[]} Unparsed arguments using `=` to specify values
@@ -79,7 +80,9 @@ exports.unparseNodeFlags = opts => {
     ? args
         .join(' ')
         .split(/\b/)
-        .map(arg => (arg === ' ' ? '=' : arg))
+        .map((arg, index, args) =>
+          arg === ' ' && args[index - 1] !== 'require' ? '=' : arg
+        )
         .join('')
         .split(' ')
     : [];

--- a/test/node-unit/cli/node-flags.spec.js
+++ b/test/node-unit/cli/node-flags.spec.js
@@ -132,5 +132,14 @@ describe('node-flags', function() {
         ['--v8-numeric-one=1', '--v8-boolean-one', '--v8-numeric-two=2']
       );
     });
+
+    it('should special-case "--require"', function() {
+      // note the only way for this to happen IN REAL LIFE is if you use "--require esm";
+      // mocha eats all --require args otherwise.
+      expect(unparseNodeFlags({require: 'mcrib'}), 'to equal', [
+        '--require',
+        'mcrib'
+      ]);
+    });
   });
 });


### PR DESCRIPTION
this adds a special case when `unparseNodeArgs()` detects `require`; it removes the `=`, which is apparently required for everything else but prohibited in Node.js v8.