### PR TITLE
Change sh to bash for code block in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,13 +88,13 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 
 Install with [npm][] globally:
 
-```sh
+```bash
 $ npm install --global mocha
 ```
 
 or as a development dependency for your project:
 
-```sh
+```bash
 $ npm install --save-dev mocha
 ```
 
@@ -102,7 +102,7 @@ $ npm install --save-dev mocha
 
 ## Getting Started
 
-```sh
+```bash
 $ npm install mocha
 $ mkdir test
 $ $EDITOR test/test.js # or open with your favorite editor
@@ -123,7 +123,7 @@ describe('Array', function() {
 
 Back in the terminal:
 
-```sh
+```bash
 $ ./node_modules/mocha/bin/mocha
 
   Array
@@ -144,7 +144,7 @@ Set up a test script in package.json:
 
 Then run tests with:
 
-```sh
+```bash
 $ npm test
 ```
 
@@ -203,7 +203,7 @@ it('double done', function(done) {
 
 Running the above test will give you the below error message:
 
-```sh
+```bash
 $ ./node_modules/.bin/mocha mocha.test.js
 
 
@@ -728,7 +728,7 @@ describe('add()', function() {
 
 The above code will produce a suite with three specs:
 
-```sh
+```bash
 $ mocha
 
   add()
@@ -1610,7 +1610,7 @@ Instructions for doing so can be found [here][mocha-wiki-growl].
 
 Enable Mocha's desktop notifications as follows:
 
-```sh
+```bash
 $ mocha --growl
 ```
 
@@ -1729,7 +1729,7 @@ As such, actual command-line arguments will take precedence over the defaults.
 
 For example, suppose you have the following `mocha.opts` file:
 
-```sh
+```bash
 # mocha.opts
   --require should
   --reporter dot
@@ -1741,7 +1741,7 @@ library, and use `bdd` as the interface. With this, you may then invoke `mocha`
 with additional arguments, here changing the reporter to `list` and setting the
 slow threshold to half a second:
 
-```sh
+```bash
 $ mocha --reporter list --slow 500
 ```
 
@@ -1755,13 +1755,13 @@ your tests in `test/` folder. If you want to include subdirectories, pass the
 
 To configure where `mocha` looks for tests, you may pass your own glob:
 
-```sh
+```bash
 $ mocha --recursive "./spec/*.js"
 ```
 
 Some shells support recursive matching by using the globstar (`**`) wildcard. Bash >= 4.3 supports this with the [`globstar` option][bash-globbing] which [must be enabled](https://github.com/mochajs/mocha/pull/3348#issuecomment-383937247) to get the same results as passing the `--recursive` option ([ZSH][zsh-globbing] and [Fish][fish-globbing] support this by default). With recursive matching enabled, the following is the same as passing `--recursive`:
 
-```sh
+```bash
 $ mocha "./spec/**/*.js"
 ```
 
@@ -1846,7 +1846,7 @@ Real live example code:
 
 To run Mocha's tests, you will need GNU Make or compatible; Cygwin should work.
 
-```sh
+```bash
 $ cd /path/to/mocha
 $ npm install
 $ npm test


### PR DESCRIPTION
I was trying to build docs, I found the alert messages which are `Language does not exist sh` and `Language does not exist text`. When I use `npm start docs`, the alert messages come because of `eleventy` like below :

```shell
Hyunsangs-MacBookAir:mocha temp$ npm start docs

> mocha@6.2.0 start /Users/temp/Downloads/exercise/mocha
> nps "docs"

nps is executing `docs` : nps docs.prebuild && nps docs.api && eleventy && nps docs.linkcheck && nps docs.postbuild
nps is executing `docs.prebuild` : rimraf docs/_dist docs/_site && nps docs.preprocess
nps is executing `docs.preprocess` : md-magic --config ./scripts/markdown-magic.config.js --path docs/index.md
Starting markdown-magic docs/index.md
✔ docs/index.md Updated
 Transforms run
  ⁕ usage:executable=bin/mocha
  ⁕ toc:maxdepth=2&bullets=-
  ⁕ manifest:template=[gitter]: ${gitter}

Files processed. markdown-magic Finished! ⊂◉‿◉つ
nps is executing `docs.api` : nps docs.preprocess.api && jsdoc -c jsdoc.conf.json
nps is executing `docs.preprocess.api` : md-magic --config ./scripts/markdown-magic.config.js --path "docs/api-tutorials/*.md"
Starting markdown-magic docs/api-tutorials/*.md
✔ docs/api-tutorials/custom-reporter.md Updated
 Transforms run
  ⁕ file:src=../../test/integration/fixtures/simple-reporter.js&header=// my-reporter.js

Files processed. markdown-magic Finished! ⊂◉‿◉つ
Parsing /Users/temp/Downloads/exercise/mocha/lib/browser/growl.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/browser/progress.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/browser/tty.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/cli.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/collect-files.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/commands.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/config.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/index.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/init.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/node-flags.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/one-and-dones.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/options.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/run-helpers.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/run-option-metadata.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/run.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/cli/watch-run.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/context.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/errors.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/growl.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/hook.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/interfaces/bdd.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/interfaces/common.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/interfaces/exports.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/interfaces/index.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/interfaces/qunit.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/interfaces/tdd.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/mocha.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/pending.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/base.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/doc.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/dot.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/html.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/index.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/json-stream.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/json.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/landing.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/list.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/markdown.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/min.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/nyan.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/progress.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/spec.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/tap.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/reporters/xunit.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/runnable.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/runner.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/stats-collector.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/suite.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/test.js ...
Parsing /Users/temp/Downloads/exercise/mocha/lib/utils.js ...
Generating output files...
Finished running in 2.07 seconds.
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist text
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
Language does not exist sh
```

### Description of the Change
It is the problem of code fences (triple backticks) for highlight.
`Eleventy` is using https://github.com/11ty/eleventy-plugin-syntaxhighlight for syntax highlight, which is utilising `Prism`(The supported languages are https://prismjs.com/#languages-list). That's why `Eleventy` doesn't take `sh` or `text` for highlight, but in `docs/index.md`, it is used `sh`(13 times), and `text`(1 time).
By using `bash` instead of `sh`, the alert messages for `bash` are gone.
* NOTE : Because there was no word to substitute for `text` that ESLint allows, I didn't change it. I tried `bash` and `shell` to replace `text`, but it does not that look good when it is served on the browser. So, there is still one-line alert message that is `Language does not exist text`.