### PR TITLE
XUnit reporter should handle exceptions during diff generation

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -154,14 +154,14 @@ exports.cursor = {
   }
 };
 
-function showDiff(err) {
+var showDiff = (exports.showDiff = function(err) {
   return (
     err &&
     err.showDiff !== false &&
     sameType(err.actual, err.expected) &&
     err.expected !== undefined
   );
-}
+});
 
 function stringifyDiffObjs(err) {
   if (!utils.isString(err.actual) || !utils.isString(err.expected)) {
@@ -182,9 +182,19 @@ function stringifyDiffObjs(err) {
  * @return {string} Diff
  */
 var generateDiff = (exports.generateDiff = function(actual, expected) {
-  return exports.inlineDiffs
-    ? inlineDiff(actual, expected)
-    : unifiedDiff(actual, expected);
+  try {
+    return exports.inlineDiffs
+      ? inlineDiff(actual, expected)
+      : unifiedDiff(actual, expected);
+  } catch (err) {
+    var msg =
+      '\n      ' +
+      color('diff added', '+ expected') +
+      ' ' +
+      color('diff removed', '- actual:  failed to generate Mocha diff') +
+      '\n';
+    return msg;
+  }
 });
 
 /**

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -163,9 +163,9 @@ XUnit.prototype.test = function(test) {
   if (test.state === STATE_FAILED) {
     var err = test.err;
     var diff =
-      Base.hideDiff || !err.actual || !err.expected
-        ? ''
-        : '\n' + Base.generateDiff(err.actual, err.expected);
+      !Base.hideDiff && Base.showDiff(err)
+        ? '\n' + Base.generateDiff(err.actual, err.expected)
+        : '';
     this.write(
       tag(
         'testcase',

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -350,6 +350,42 @@ describe('XUnit reporter', function() {
           '</failure></testcase>';
         expect(expectedWrite, 'to be', expectedTag);
       });
+
+      it('should handle non-string diff values', function() {
+        var runner = new EventEmitter();
+        createStatsCollector(runner);
+        var xunit = new XUnit(runner);
+
+        var expectedTest = {
+          state: STATE_FAILED,
+          title: expectedTitle,
+          parent: {
+            fullTitle: function() {
+              return expectedClassName;
+            }
+          },
+          duration: 1000,
+          err: {
+            actual: 1,
+            expected: 2,
+            message: expectedMessage,
+            stack: expectedStack
+          }
+        };
+
+        sandbox.stub(xunit, 'write').callsFake(function(str) {
+          expectedWrite += str;
+        });
+
+        runner.emit(EVENT_TEST_FAIL, expectedTest, expectedTest.err);
+        runner.emit(EVENT_RUN_END);
+        sandbox.restore();
+
+        var expectedDiff =
+          '\n      + expected - actual\n\n      -1\n      +2\n      ';
+
+        expect(expectedWrite, 'to contain', expectedDiff);
+      });
     });
 
     describe('on test pending', function() {


### PR DESCRIPTION
### Description of the Change

This bugfix addresses a crash in the XUnit reporter, which produced no output because the assertion library used in the ticket provided numerical diff values rather than string values, causing an error during diff generation. To safeguard against unexpected crashes such as these, the same input-checks that the Base reporter uses have been implemented in the XUnit reporter, and exceptions during XUnit diff generation are returned by the reporter.

### Applicable issues

Fixes #4022.