### PR TITLE
add --overspec option to disable promise checking on tests that take a callback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -835,6 +835,8 @@ Rules & Behavior
   --allow-uncaught           Allow uncaught errors to propagate        [boolean]
   --async-only, -A           Require all tests to use a callback (async) or
                              return a Promise                          [boolean]
+  --overspec                 Allow overspec'd tests. Disable promise checking on
+                             callback style tests.                     [boolean]
   --bail, -b                 Abort ("bail") after first test failure   [boolean]
   --check-leaks              Check for global variable leaks           [boolean]
   --delay                    Delay initial execution of root suite     [boolean]
@@ -916,6 +918,10 @@ This flag is useful when debugging particularly difficult-to-track exceptions.
 ### `--async-only, -A`
 
 Enforce a rule that tests must be written in "async" style, meaning each test provides a `done` callback or returns a `Promise`. Non-compliant tests will be marked as failures.
+
+### `--overspec`
+
+Allow overspec'd tests. Disable checking for promises returned from tests that have an arity of one (that take a `done` callback function). Allows use of `done` callback in tests that are defined as `async function`. Useful for mixing async await and callback style tests.
 
 ### `--bail, -b`
 

--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -27,6 +27,7 @@ exports.types = {
   boolean: [
     'allow-uncaught',
     'async-only',
+    'overspec',
     'bail',
     'check-leaks',
     'color',

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -54,6 +54,11 @@ exports.builder = yargs =>
           'Require all tests to use a callback (async) or return a Promise',
         group: GROUPS.RULES
       },
+      overspec: {
+        description:
+          "Allow overspec'd tests. Disable promise checking on callback style tests.",
+        group: GROUPS.RULES
+      },
       bail: {
         description: 'Abort ("bail") after first test failure',
         group: GROUPS.RULES

--- a/lib/context.js
+++ b/lib/context.js
@@ -46,6 +46,21 @@ Context.prototype.timeout = function(ms) {
 };
 
 /**
+ * Set test to allow overspec.
+ *
+ * @private
+ * @param {boolean} flag
+ * @return {Context} self
+ */
+Context.prototype.overspec = function(flag) {
+  if (!arguments.length) {
+    return this.runnable().overspec();
+  }
+  this.runnable().overspec(flag);
+  return this;
+};
+
+/**
  * Set test timeout `enabled`.
  *
  * @private

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -83,6 +83,7 @@ exports.Test = require('./test');
  * @param {boolean} [options.inlineDiffs] - Display inline diffs?
  * @param {boolean} [options.invert] - Invert test filter matches?
  * @param {boolean} [options.noHighlighting] - Disable syntax highlighting?
+ * @param {boolean} [options.overspec] - Disable promise checking on callback style tests.
  * @param {string|constructor} [options.reporter] - Reporter name or constructor.
  * @param {Object} [options.reporterOption] - Reporter settings object.
  * @param {number} [options.retries] - Number of times to retry failed tests.
@@ -124,7 +125,8 @@ function Mocha(options) {
     'forbidPending',
     'fullTrace',
     'growl',
-    'invert'
+    'invert',
+    'overspec'
   ].forEach(function(opt) {
     if (options[opt]) {
       this[opt]();
@@ -663,6 +665,18 @@ Mocha.prototype.enableTimeouts = function(enableTimeouts) {
   this.suite.enableTimeouts(
     arguments.length && enableTimeouts !== undefined ? enableTimeouts : true
   );
+  return this;
+};
+
+/**
+ * Disable promise checking on callback style tests.
+ *
+ * @public
+ * @return {Mocha} this
+ * @chainable
+ */
+Mocha.prototype.overspec = function() {
+  this.suite.overspec(true);
   return this;
 };
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -36,6 +36,7 @@ function Runnable(title, fn) {
   this._timeout = 2000;
   this._slow = 75;
   this._enableTimeouts = true;
+  this._overspec = false;
   this.timedOut = false;
   this._retries = -1;
   this._currentRetry = 0;
@@ -126,6 +127,22 @@ Runnable.prototype.enableTimeouts = function(enabled) {
   debug('enableTimeouts %s', enabled);
   this._enableTimeouts = enabled;
   return this;
+};
+
+/**
+ * Set and get whether overspec is `enabled`.
+ *
+ * @private
+ * @param {boolean} enabled
+ * @return {Runnable|boolean} enabled or Runnable instance.
+ */
+Runnable.prototype.overspec = function(enabled) {
+  if (!arguments.length) {
+    return this._overspec;
+  } else {
+    this._overspec = enabled;
+    return this;
+  }
 };
 
 /**
@@ -423,7 +440,7 @@ Runnable.prototype.run = function(fn) {
         }
         return done(new Error('done() invoked with non-Error: ' + err));
       }
-      if (result && utils.isPromise(result)) {
+      if (!self.overspec() && result && utils.isPromise(result)) {
         return done(
           new Error(
             'Resolution method is overspecified. Specify a callback *or* return a Promise; not both.'

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -70,6 +70,7 @@ function Suite(title, parentContext, isRoot) {
   this._timeout = 2000;
   this._enableTimeouts = true;
   this._slow = 75;
+  this._overspec = false;
   this._bail = false;
   this._retries = -1;
   this._onlyTests = [];
@@ -104,6 +105,7 @@ Suite.prototype.clone = function() {
   suite.ctx = this.ctx;
   suite.root = this.root;
   suite.timeout(this.timeout());
+  suite.overspec(this.overspec());
   suite.retries(this.retries());
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
@@ -147,6 +149,21 @@ Suite.prototype.retries = function(n) {
   }
   debug('retries %d', n);
   this._retries = parseInt(n, 10) || 0;
+  return this;
+};
+
+/**
+ * Set or get overspec to `enabled`.
+ *
+ * @private
+ * @param {boolean} enabled
+ * @return {Suite|boolean} self or enabled
+ */
+Suite.prototype.overspec = function(enabled) {
+  if (!arguments.length) {
+    return this._overspec;
+  }
+  this._overspec = enabled;
   return this;
 };
 
@@ -336,6 +353,7 @@ Suite.prototype.addSuite = function(suite) {
   suite.parent = this;
   suite.root = false;
   suite.timeout(this.timeout());
+  suite.overspec(this.overspec());
   suite.retries(this.retries());
   suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
@@ -355,6 +373,7 @@ Suite.prototype.addSuite = function(suite) {
 Suite.prototype.addTest = function(test) {
   test.parent = this;
   test.timeout(this.timeout());
+  test.overspec(this.overspec());
   test.retries(this.retries());
   test.enableTimeouts(this.enableTimeouts());
   test.slow(this.slow());

--- a/lib/test.js
+++ b/lib/test.js
@@ -39,6 +39,7 @@ utils.inherits(Test, Runnable);
 Test.prototype.clone = function() {
   var test = new Test(this.title, this.fn);
   test.timeout(this.timeout());
+  test.overspec(this.overspec());
   test.slow(this.slow());
   test.enableTimeouts(this.enableTimeouts());
   test.retries(this.retries());

--- a/test/integration/fixtures/options/overspec.fixture.js
+++ b/test/integration/fixtures/options/overspec.fixture.js
@@ -1,0 +1,14 @@
+'use strict';
+
+describe('overspecified asynchronous resolution method', function() {
+  it('should not fail when multiple methods are used', function(done) {
+
+    setTimeout(done, 0);
+
+    return {
+      then: function() {
+        throw Error('This should never be called. handled with done()');
+      }
+    };
+  });
+});

--- a/test/integration/options/overspec.spec.js
+++ b/test/integration/options/overspec.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var path = require('path').posix;
+var helpers = require('../helpers');
+var runMochaJSON = helpers.runMochaJSON;
+
+describe('--overspec', function() {
+  it('should fail over specs', function(done) {
+    var args = [];
+    var fixture = path.join('options', 'overspec');
+    runMochaJSON(fixture, args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+      expect(res, 'to have failed');
+      done();
+    });
+  });
+
+  it('should not fail over spec', function(done) {
+    var args = ['--overspec'];
+    var fixture = path.join('options', 'overspec');
+    runMochaJSON(fixture, args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+      expect(res, 'to have passed');
+      done();
+    });
+  });
+});

--- a/test/unit/overspecified-async.spec.js
+++ b/test/unit/overspecified-async.spec.js
@@ -5,6 +5,22 @@ describe('overspecified asynchronous resolution method', function() {
     setTimeout(done, 0);
 
     // uncomment
-    // return { then: function() {} };
+    // return {
+    //   then: function() {}
+    // };
+  });
+});
+
+describe('overspecified asynchronous resolution method', function() {
+  it('should not fail when multiple methods are used', function(done) {
+    setTimeout(done, 0);
+
+    this.overspec(true);
+
+    return {
+      then: function() {
+        throw Error('This should never be called. handled with done()');
+      }
+    };
   });
 });


### PR DESCRIPTION
Great library. Thanks a ton.

### Description of the Change

Currently if you take a `done` callback in a test and also return a promise, even if the test passes you get an error "Overspecified test, return a callback or a promise, not both."

This change adds an option (and relevant test coverage) to turn off the error. The option is off by default (leaving the status quo) and gives more sophisticated users an option to avoid what's basically protection for people who may make a mistake.

This is particularly a hassle because if you mark a function as `async` you can't avoid returning a promise (see below). If you're migrating a legacy codebase, this mix is inevitable, and the error stops you from doing perfectly reasonable, safe and legal things, in order to protect people from themselves. Which is a good idea, but I'd like the option to turn it off. It feels like a situation where an option or a warning would probably have been preferable in the first place.

Built it for myself, figured it may help others. Happy to make changes if you want them. Also cool if this doesn't fit the philosophy for some reason.

``` 
test('some test', async function(done){
  const foo = await asyncFunction();
  
  someOtherAsync(foo, function(err, bar){
    if(err){ return done(err); }
    assert(bar);
    done();
  });
});
```

### Alternate Designs

I thought about arguing that anyone taking a `done` callback knows what they're doing, and throwing an error to try to protect them from themselves hurts more sophisticated users. I was going to pull out the error altogether. Breaking existing functionality seemed like a bad idea, so I figured an option that was off by default leaves the status quo, and gives experts an option to override the "warning" and probably doesn't ruffle too many feathers.

I could have turned it on by default (bad idea breaking existing functionality). I could have not built it at all (not really feasible for my use case).

### Why should this be in core?

Can't avoid it, it's integral to how the tests are run. You throw an error on tests that would otherwise pass, any function that is marked async will need to be rewritten. You're hurting expert users who know what they're doing.

I'm giving people who know what they're doing the option to avoid an error (that probably should have been a warning or an option in the first place).

### Benefits

Allows tests that take a done callback to be marked `async` and still run. This switch is off by default so it doesn't change existing functionality. Allows people who know what they're doing to make use of more elegant test patterns. Allows for projects to be migrated slowly to async/await without having to rewrite all the tests at once.

Very helpful in large codebase legacy scenarios (like mine).

### Possible Drawbacks

Slight increase in maintenance going forward. May not get a ton of use.

### Applicable issues

Patch release. Totally backwards compatible and off by default.
