### PR TITLE
uncaughtException: fix when current test is pending

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -794,6 +794,10 @@ Runner.prototype.uncaught = function(err) {
   if (err instanceof Pending) {
     return;
   }
+  if (this.allowUncaught) {
+    throw err;
+  }
+
   if (err) {
     debug('uncaught exception %O', err);
   } else {
@@ -829,11 +833,17 @@ Runner.prototype.uncaught = function(err) {
 
   runnable.clearTimeout();
 
-  // Ignore errors if already failed or pending
-  // See #3226
-  if (runnable.isFailed() || runnable.isPending()) {
+  if (runnable.isFailed()) {
+    // Ignore error if already failed
+    return;
+  } else if (runnable.isPending()) {
+    // report 'pending test' retrospectively as failed
+    runnable.isPending = alwaysFalse;
+    this.fail(runnable, err);
+    delete runnable.isPending;
     return;
   }
+
   // we cannot recover gracefully if a Runnable has already passed
   // then fails asynchronously
   var alreadyPassed = runnable.isPassed();

--- a/test/integration/fixtures/options/allow-uncaught/propagate.fixture.js
+++ b/test/integration/fixtures/options/allow-uncaught/propagate.fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+describe('Uncaught exception - throw and exit', () => {
+  it('test1', () => {
+    setTimeout(() => {
+      throw new Error('Uncaught error after test1');
+    }, 1);
+  });
+  it('test2', function () { });
+  it('test3', function () { });
+  it('test4', function () { });
+});

--- a/test/integration/fixtures/uncaught-pending.fixture.js
+++ b/test/integration/fixtures/uncaught-pending.fixture.js
@@ -1,0 +1,15 @@
+'use strict';
+
+describe('Uncaught exception within pending test', () => {
+  it('test1', function () { });
+
+  it('test2', function () {
+    process.nextTick(function () {
+      throw new Error('I am uncaught!');
+    });
+    this.skip();
+  });
+
+  it('test3 - should run', function () { });
+  it('test4 - should run', function () { });
+});

--- a/test/integration/options/allowUncaught.spec.js
+++ b/test/integration/options/allowUncaught.spec.js
@@ -2,10 +2,31 @@
 
 var path = require('path').posix;
 var helpers = require('../helpers');
+var runMocha = helpers.runMocha;
 var runMochaJSON = helpers.runMochaJSON;
 
 describe('--allow-uncaught', function() {
   var args = ['--allow-uncaught'];
+
+  it('should throw an uncaught error and exit process', function(done) {
+    var fixture = path.join('options', 'allow-uncaught', 'propagate');
+    runMocha(
+      fixture,
+      args,
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.code, 'to be greater than', 0);
+        expect(res.output, 'to contain', 'Error: Uncaught error after test1');
+        expect(res.passing, 'to be', 0);
+        expect(res.failing, 'to be', 0);
+        done();
+      },
+      {stdio: 'pipe'}
+    );
+  });
 
   it('should run with conditional `this.skip()`', function(done) {
     var fixture = path.join('options', 'allow-uncaught', 'this-skip-it');

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -63,4 +63,27 @@ describe('uncaught exceptions', function() {
       done();
     });
   });
+
+  it('handles uncaught exceptions within pending tests', function(done) {
+    run('uncaught-pending.fixture.js', args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res, 'to have failed')
+        .and('to have passed test count', 3)
+        .and('to have pending test count', 1)
+        .and('to have failed test count', 1)
+        .and(
+          'to have passed test',
+          'test1',
+          'test3 - should run',
+          'test4 - should run'
+        )
+        .and('to have pending test order', 'test2')
+        .and('to have failed test', 'test2');
+
+      done();
+    });
+  });
 });

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -811,9 +811,9 @@ describe('Runner', function() {
               sandbox.stub(runnable, 'isPending').returns(true);
             });
 
-            it('should not attempt to fail', function() {
+            it('should attempt to fail', function() {
               runner.uncaught(err);
-              expect(runner.fail, 'was not called');
+              expect(runner.fail, 'was called once');
             });
           });
 


### PR DESCRIPTION
### Description

```js
describe('test', () => {
  it('test1', () => {
    setTimeout(() => {
      throw new Error('Uncaught');
    }, 3);
  });
  it('test2', function () { this.skip(); });
  it('test3', function () { this.skip(); });
  it('test4', function () { this.skip(); });
});
```
**output with exitCode: 0**
```
test suite
    √ test1
    - test2
    - test3
    - test4

  1 passing (34ms)
  3 pending
```

### Description of the Change

`Runner#uncaught`:
- per default Mocha tries to map `uncaughtException`s to the correct test case, to recover and keep the `runner` working. This is done on a "best effort" basis. Currently the user has no possibility to escape this recovery effort, not even with the `--allow-uncaught` option. 
Now `--allow-uncaught` throws an error and exit Mocha's process. 

- current test is pending: when an `uncaughtException` bubbles up, we retrospectively label the pending test as failed, then keep the runner going. That way the `exitCode` will be >0.
 
When an `uncaughtException` bubbles up we can't clearly determine its origin. I suppose our recovery process is responsible for a few weird bugs, eg. number of executed tests is varying when rerun, errors are swallowed (reporters?) or non-existing hooks throw errors. So its important to have an effective mean to throw and exit when tracing fuzzy errors. 

Recovery process, when current test is:
- still open: report test as failed, "best effort" recovery, runner keeps going
- failed: ignore `uncaughtException`, runner keeps going
- **pending: report test as failed, runner keeps going**  << new
- passed: report test as failed, abort runner


### Applicable issues

closes #3938 
