### PR TITLE
Support util.inspect.custom with fixing #3985

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -9,6 +9,7 @@
 var tty = require('tty');
 var diff = require('diff');
 var milliseconds = require('ms');
+var util = require('util');
 var utils = require('../utils');
 var supportsColor = process.browser ? null : require('supports-color');
 var constants = require('../runner').constants;
@@ -219,7 +220,9 @@ exports.list = function(failures) {
       err = test.err;
     }
     var message;
-    if (typeof err.inspect === 'function') {
+    if (typeof err[util.inspect.custom] === 'function') {
+      message = util.inspect(err) + '';
+    } else if (typeof err.inspect === 'function') {
       message = err.inspect() + '';
     } else if (err.message && typeof err.message.toString === 'function') {
       message = err.message + '';

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -219,10 +219,10 @@ exports.list = function(failures) {
       err = test.err;
     }
     var message;
-    if (err.message && typeof err.message.toString === 'function') {
-      message = err.message + '';
-    } else if (typeof err.inspect === 'function') {
+    if (typeof err.inspect === 'function') {
       message = err.inspect() + '';
+    } else if (err.message && typeof err.message.toString === 'function') {
+      message = err.message + '';
     } else {
       message = '';
     }

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var util = require('util');
 var assert = require('assert');
 var chai = require('chai');
 var sinon = require('sinon');
@@ -376,7 +377,22 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
-  it("should use 'inspect()' first when generating an error message", function() {
+  it("should use 'util.inspect.custom()' first when generating an error message", function() {
+    var err = {
+      showDiff: false
+    };
+    err[util.inspect.custom] = function() {
+      return 'Error: catch me if you can';
+    };
+    var test = makeTest(err);
+
+    list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    expect(errOut, 'to be', '1) test title:\n     Error: catch me if you can');
+  });
+
+  it("should use 'inspect()' if 'util.inspect.custom()' is not set", function() {
     var err = {
       showDiff: false,
       inspect: function() {
@@ -391,7 +407,7 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     an error happened');
   });
 
-  it("should use message if 'inspect()' is not set", function() {
+  it("should use message if neither 'util.inspect.custom()', nor 'inspect()' is set", function() {
     var err = {
       showDiff: false,
       message: 'foo\nbar'
@@ -404,7 +420,7 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     foo\nbar');
   });
 
-  it("should set an empty message if neither 'inspect()', nor message is set", function() {
+  it("should set an empty message if neither 'util.inspect.custom()', nor 'inspect()', nor message is set", function() {
     var err = {
       showDiff: false
     };

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -376,7 +376,7 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
-  it("should use 'inspect' if 'message' is not set", function() {
+  it("should use 'inspect()' first when generating an error message", function() {
     var err = {
       showDiff: false,
       inspect: function() {
@@ -391,7 +391,20 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     an error happened');
   });
 
-  it("should set an empty message if neither 'message' nor 'inspect' is set", function() {
+  it("should use message if 'inspect()' is not set", function() {
+    var err = {
+      showDiff: false,
+      message: 'foo\nbar'
+    };
+    var test = makeTest(err);
+
+    list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    expect(errOut, 'to be', '1) test title:\n     foo\nbar');
+  });
+
+  it("should set an empty message if neither 'inspect()', nor message is set", function() {
     var err = {
       showDiff: false
     };


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

There are two sub issues in the issue https://github.com/mochajs/mocha/issues/3985
1. Fixing a sequence of error generator of `lib/reporters/base.js`
- As Is
1 - message
2 - inspect()
3 - empty string
- To be
1 - inspect()
2 - message
3 - empty string


2. Supporting `util.inspect.custom()`, which seems standard of nodejs for representing an object for debugging purpose, and use it first when generating an error message. (https://nodejs.org/api/util.html#util_util_inspect_custom)

This PR resolves those issues.

### Benefits

Making developers have more autonomy when they make error message. 

### Possible Drawbacks
Fragmentation of a way to generate error message.
I think we can take it because `util.inspect.custom` is general way to make representative string of object.
But hope no fragmentation anymore.
