### PR TITLE
Add GH Funding Metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: mochajs


### PR DESCRIPTION
With this change, GH will show a Sponsor button at the top.  [Here's how GitHub described the feature:](https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/)

> Open source projects can also express their funding models directly from their repositories. When .github/FUNDING.yml is added to a project’s master branch, a new “Sponsor” button will appear at the top of the repository. Clicking the button opens a natively rendered view of the funding models listed in that file.

