### PR TITLE
Fix unstable CI uncaughtException test

### DIFF
--- a/test/integration/fixtures/uncaught.fixture.js
+++ b/test/integration/fixtures/uncaught.fixture.js
@@ -6,17 +6,17 @@
  */
 
 it('fails exactly once when a global error is thrown first', function (done) {
-  setTimeout(function () {
+  process.nextTick(function () {
     throw new Error('global error');
-  }, 0);
+  });
 });
 
 it('fails exactly once when a global error is thrown second', function (done) {
-  setTimeout(function () {
+  process.nextTick(function () {
     done(new Error('test error'));
-  }, 0);
+  });
 
-  setTimeout(function () {
+  process.nextTick(function () {
     throw new Error('global error');
-  }, 0);
+  });
 });


### PR DESCRIPTION
### Description

One of our CI [tests](https://github.com/mochajs/mocha/blob/master/test/integration/fixtures/uncaught.fixture.js) is unstable and fails occasionally.
- it should fail while the runner is still active which resulted in an `exitCode` of 2 (number of failing tests).
- sometimes it fails too late, after the EVENT_RUN_END event when all tests have finished. Then it is caught by the `uncaughtException` handler and exits with `exitCode` of 7.

Since 2 (expected) !== 7 (actual) ==> the test fails.

### Description of Change

We use `process.nextTick()` instead of `setTimeout()`.

related #4103