### PR TITLE
Adds BigInt support to stringify util function.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,6 +298,9 @@ function jsonStringify(object, spaces, depth) {
             ? '-0'
             : val.toString();
         break;
+      case 'bigint':
+        val = val.toString() + 'n';
+        break;
       case 'date':
         var sDate = isNaN(val.getTime()) ? val.toString() : val.toISOString();
         val = '[Date: ' + sDate + ']';

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -206,10 +206,12 @@ describe('lib/utils', function() {
         expect(stringify(1e9), 'to be', '1000000000');
       });
 
-      it('bigints', function() {
-        expect(stringify(BigInt(1)), 'to be', '1n');
-        expect(stringify(BigInt(2)), 'to be', '2n');
-      });
+      if (typeof BigInt === 'function') {
+        it('should work with bigints when possible', function() {
+          expect(stringify(BigInt(1)), 'to be', '1n');
+          expect(stringify(BigInt(2)), 'to be', '2n');
+        });
+      }
     });
 
     describe('canonicalize example', function() {

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -1,3 +1,4 @@
+/* global BigInt */
 'use strict';
 
 var utils = require('../../lib/utils');
@@ -203,6 +204,11 @@ describe('lib/utils', function() {
         expect(stringify(1), 'to be', '1');
         expect(stringify(1.2), 'to be', '1.2');
         expect(stringify(1e9), 'to be', '1000000000');
+      });
+
+      it('bigints', function() {
+        expect(stringify(BigInt(1)), 'to be', '1n');
+        expect(stringify(BigInt(2)), 'to be', '2n');
       });
     });
 


### PR DESCRIPTION
### Description of the Change
Fixes #4090, adds a new case to the _stringify function in utils so it can handle the BigInt case.

### Alternate Designs
There were two choices considered in the issue `BigInt<123>` or `123n` i went with the latter because it's the standard way JS presents BigInts

### Why should this be in core?
Nice way of representing BigInts in errors.

### Benefits

<!-- What benefits will be realized by the code change? -->
Support for Stringify-ing BigInts
### Possible Drawbacks
I had to add `/* global BigInt */` at the top of the spec file, i don't know if that is the best place for it.

### Applicable issues
Fixes #4090
