### PR TITLE
Update eslint parsing from ES6 to ES2017

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -29,7 +29,7 @@ overrides:
       - test/integration/helpers.js
       - lib/growl.js
     parserOptions:
-      ecmaVersion: 6
+      ecmaVersion: 2017
     env:
       browser: no
 
@@ -77,7 +77,7 @@ overrides:
   - files:
       - test/**/*.mjs
     parserOptions:
-      ecmaVersion: 6
+      ecmaVersion: 2017
       sourceType: module
 
   - files:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,8 +31,10 @@ module.exports = config => {
     browserify: {
       debug: true,
       configure: function configure(b) {
-        b.ignore('glob')
+        b.ignore('./lib/cli/*.js')
+          .ignore('chokidar')
           .ignore('fs')
+          .ignore('glob')
           .ignore('path')
           .ignore('supports-color')
           .on('bundled', (err, content) => {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -23,7 +23,7 @@ function test(testName, mochaParams) {
 module.exports = {
   scripts: {
     build: {
-      script: `browserify -e browser-entry.js --plugin ./scripts/dedefine --ignore 'fs' --ignore 'glob' --ignore 'path' --ignore 'supports-color' --ignore chokidar -o mocha.js`,
+      script: `browserify -e browser-entry.js --plugin ./scripts/dedefine --ignore './lib/cli/*.js' --ignore 'chokidar' --ignore 'fs' --ignore 'glob' --ignore 'path' --ignore 'supports-color' -o mocha.js`,
       description: 'Build browser bundle'
     },
     lint: {

--- a/package.json
+++ b/package.json
@@ -626,11 +626,12 @@
     "./index.js": "./browser-entry.js",
     "./lib/growl.js": "./lib/browser/growl.js",
     "tty": "./lib/browser/tty.js",
+    "./lib/cli/*.js": false,
+    "chokidar": false,
     "fs": false,
     "glob": false,
     "path": false,
-    "supports-color": false,
-    "chokidar": false
+    "supports-color": false
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
### Description of the Change

Some modules of our code base are not used by Mocha's browser environment.
See also `env: browser: no` in `eslintrc.yml`
Currently these modules are eslint-parsed by ES6 rules. 
- we update the eslint parsingOption from ES6 to ES2017 in order to make available `async`/`await`.
The default remains ES5 for IE11 reasons.
As soon as we drop Node v8 support (end of life: 2019-12-31) we should update to ES2018.

Browserify: regarding ignored files
We have three different configuration settings defining files to be ignored. I guess we have some redundant information here, but I'm unsure about that. To stay on the safe side we update all of them:
- `browser` field in package.json
- `ignore()` in `karma.config.js`
- the browserify script with its `--ignore` option

It's unclear to me why we ignore eg. chokidar while `browserify`ing, but not packages like yargs, yargs-parser etc. `browser-entry.js` could be an explanation since it only requires "./lib/mocha" and none of our "CLI" dependencies. Anyway this topic is not part of this PR.