### PR TITLE
Update node-environment-flags to 1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11374,18 +11374,18 @@
       }
     },
     "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -537,7 +537,7 @@
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
-    "node-environment-flags": "1.0.5",
+    "node-environment-flags": "1.0.6",
     "object.assign": "4.1.0",
     "strip-json-comments": "2.0.1",
     "supports-color": "6.0.0",


### PR DESCRIPTION


### Description of the Change

node-environment-flags 1.0.5 and lower do not contain a LICENSE file which can make compliance difficult. This pull request updates the patch release of node-environment-flags to incorporate https://github.com/boneskull/node-environment-flags/pull/5.

### Alternate Designs

Removing the dependency on node-environment-flags.

### Why should this be in core?

To ensure the entire dependency chain of Mocha has dependencies contains valid copyright and licenses.

### Possible Drawbacks

I don't think there are any.

### Applicable issues

> * Mocha follows semantic versioning: http://semver.org
> 
> * Is this a breaking change (major release)?
> * Is it an enhancement (minor release)?
> * Is it a bug fix, or does it not impact production code (patch release)?

It's a bug fix, fixing licensing.

<!--
/c @opichals 
-->