### PR TITLE
Support browserifying the Mocha package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,8 +2420,7 @@
     "browserify-package-json": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-package-json/-/browserify-package-json-1.0.1.tgz",
-      "integrity": "sha1-mN3oqlxWH9bT/km7qhArdLOW/eo=",
-      "dev": true
+      "integrity": "sha1-mN3oqlxWH9bT/km7qhArdLOW/eo="
     },
     "browserify-rsa": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -524,6 +524,7 @@
   "dependencies": {
     "ansi-colors": "3.2.3",
     "browser-stdout": "1.3.1",
+    "browserify-package-json": "^1.0.1",
     "chokidar": "3.3.0",
     "debug": "3.2.6",
     "diff": "3.5.0",
@@ -555,7 +556,6 @@
     "assetgraph-builder": "^6.10.1",
     "autoprefixer": "^9.6.0",
     "browserify": "^16.2.3",
-    "browserify-package-json": "^1.0.1",
     "chai": "^4.2.0",
     "coffee-script": "^1.12.7",
     "coveralls": "^3.0.3",
@@ -612,6 +612,7 @@
     "bin/*mocha",
     "assets/growl/*.png",
     "lib/**/*.{js,html,json}",
+    "scripts",
     "index.js",
     "mocha.css",
     "mocha.js",


### PR DESCRIPTION
### Description of the Change

I would like to browserify Mocha from the npm package, having it as a dependency. Currently, this is not possible because first I get

```
❯ browserify . --bare
Error: Cannot find module './scripts/package-json-cullify' from '/Users/max/projects/mochify-reporter/node_modules/mocha'
    at /usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:118:35
    at load (/usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:137:43)
    at onex (/usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:162:17)
    at /usr/local/lib/node_modules/browserify/node_modules/resolve/lib/async.js:13:69
    at FSReqCallback.oncomplete (fs.js:166:21)
m
```

I fixed this locally with `❯ cp -r ../mocha/scripts node_modules/mocha/`, and then I run into

```
❯ browserify . --bare
internal/modules/cjs/loader.js:613
    throw err;
    ^

Error: Cannot find module 'browserify-package-json'
```

This PR addresses both issues.

### Alternate Designs

I'm maintaining [mochify](https://www.npmjs.com/package/mochify) and would like to move away from depending on the pre-bundled Mocha.

### Why should this be in core?

All the browserify configs are already in the `package.json`.

### Benefits

This allows anyone to browserify Mocha from a dependency.

### Possible Drawbacks

Can't think of any.

### Applicable issues

This can be released as a patch since it only adds a few files to the npm package and doesn't change the code.