### PR TITLE
Export yargs options and check function for consumption by wrapper modules

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -245,6 +245,47 @@ exports.options = {
   }
 };
 
+exports.check = yargs =>
+  function(argv) {
+    // "one-and-dones"; let yargs handle help and version
+    Object.keys(ONE_AND_DONES).forEach(opt => {
+      if (argv[opt]) {
+        ONE_AND_DONES[opt].call(null, yargs);
+        process.exit();
+      }
+    });
+
+    // yargs.implies() isn't flexible enough to handle this
+    if (argv.invert && !('fgrep' in argv || 'grep' in argv)) {
+      throw createMissingArgumentError(
+        '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
+        '--fgrep|--grep',
+        'string|regexp'
+      );
+    }
+
+    if (argv.compilers) {
+      throw createUnsupportedError(
+        `--compilers is DEPRECATED and no longer supported.
+          See https://git.io/vdcSr for migration information.`
+      );
+    }
+
+    if (argv.opts) {
+      throw createUnsupportedError(
+        `--opts: configuring Mocha via 'mocha.opts' is DEPRECATED and no longer supported.
+          Please use a configuration file instead.`
+      );
+    }
+
+    // load requires first, because it can impact "plugin" validation
+    handleRequires(argv.require);
+    validatePlugin(argv, 'reporter', Mocha.reporters);
+    validatePlugin(argv, 'ui', Mocha.interfaces);
+
+    return true;
+  };
+
 exports.builder = yargs =>
   yargs
     .options(this.options)
@@ -253,45 +294,7 @@ exports.builder = yargs =>
       description: 'One or more files, directories, or globs to test',
       type: 'array'
     })
-    .check(argv => {
-      // "one-and-dones"; let yargs handle help and version
-      Object.keys(ONE_AND_DONES).forEach(opt => {
-        if (argv[opt]) {
-          ONE_AND_DONES[opt].call(null, yargs);
-          process.exit();
-        }
-      });
-
-      // yargs.implies() isn't flexible enough to handle this
-      if (argv.invert && !('fgrep' in argv || 'grep' in argv)) {
-        throw createMissingArgumentError(
-          '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
-          '--fgrep|--grep',
-          'string|regexp'
-        );
-      }
-
-      if (argv.compilers) {
-        throw createUnsupportedError(
-          `--compilers is DEPRECATED and no longer supported.
-          See https://git.io/vdcSr for migration information.`
-        );
-      }
-
-      if (argv.opts) {
-        throw createUnsupportedError(
-          `--opts: configuring Mocha via 'mocha.opts' is DEPRECATED and no longer supported.
-          Please use a configuration file instead.`
-        );
-      }
-
-      // load requires first, because it can impact "plugin" validation
-      handleRequires(argv.require);
-      validatePlugin(argv, 'reporter', Mocha.reporters);
-      validatePlugin(argv, 'ui', Mocha.interfaces);
-
-      return true;
-    })
+    .check(this.check(yargs))
     .array(types.array)
     .boolean(types.boolean)
     .string(types.string)

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -42,212 +42,212 @@ exports.command = ['$0 [spec..]', 'inspect'];
 
 exports.describe = 'Run tests with Mocha';
 
+exports.options = {
+  'allow-uncaught': {
+    description: 'Allow uncaught errors to propagate',
+    group: GROUPS.RULES
+  },
+  'async-only': {
+    description:
+      'Require all tests to use a callback (async) or return a Promise',
+    group: GROUPS.RULES
+  },
+  bail: {
+    description: 'Abort ("bail") after first test failure',
+    group: GROUPS.RULES
+  },
+  'check-leaks': {
+    description: 'Check for global variable leaks',
+    group: GROUPS.RULES
+  },
+  color: {
+    description: 'Force-enable color output',
+    group: GROUPS.OUTPUT
+  },
+  config: {
+    config: true,
+    defaultDescription: '(nearest rc file)',
+    description: 'Path to config file',
+    group: GROUPS.CONFIG
+  },
+  delay: {
+    description: 'Delay initial execution of root suite',
+    group: GROUPS.RULES
+  },
+  diff: {
+    default: true,
+    description: 'Show diff on failure',
+    group: GROUPS.OUTPUT
+  },
+  exit: {
+    description: 'Force Mocha to quit after tests complete',
+    group: GROUPS.RULES
+  },
+  extension: {
+    default: defaults.extension,
+    description: 'File extension(s) to load',
+    group: GROUPS.FILES,
+    requiresArg: true,
+    coerce: list
+  },
+  fgrep: {
+    conflicts: 'grep',
+    description: 'Only run tests containing this string',
+    group: GROUPS.FILTERS,
+    requiresArg: true
+  },
+  file: {
+    defaultDescription: '(none)',
+    description: 'Specify file(s) to be loaded prior to root suite execution',
+    group: GROUPS.FILES,
+    normalize: true,
+    requiresArg: true
+  },
+  'forbid-only': {
+    description: 'Fail if exclusive test(s) encountered',
+    group: GROUPS.RULES
+  },
+  'forbid-pending': {
+    description: 'Fail if pending test(s) encountered',
+    group: GROUPS.RULES
+  },
+  'full-trace': {
+    description: 'Display full stack traces',
+    group: GROUPS.OUTPUT
+  },
+  global: {
+    coerce: list,
+    description: 'List of allowed global variables',
+    group: GROUPS.RULES,
+    requiresArg: true
+  },
+  grep: {
+    coerce: value => (!value ? null : value),
+    conflicts: 'fgrep',
+    description: 'Only run tests matching this string or regexp',
+    group: GROUPS.FILTERS,
+    requiresArg: true
+  },
+  growl: {
+    description: 'Enable Growl notifications',
+    group: GROUPS.OUTPUT
+  },
+  ignore: {
+    defaultDescription: '(none)',
+    description: 'Ignore file(s) or glob pattern(s)',
+    group: GROUPS.FILES,
+    requiresArg: true
+  },
+  'inline-diffs': {
+    description:
+      'Display actual/expected differences inline within each string',
+    group: GROUPS.OUTPUT
+  },
+  invert: {
+    description: 'Inverts --grep and --fgrep matches',
+    group: GROUPS.FILTERS
+  },
+  'list-interfaces': {
+    conflicts: Array.from(ONE_AND_DONE_ARGS),
+    description: 'List built-in user interfaces & exit'
+  },
+  'list-reporters': {
+    conflicts: Array.from(ONE_AND_DONE_ARGS),
+    description: 'List built-in reporters & exit'
+  },
+  'no-colors': {
+    description: 'Force-disable color output',
+    group: GROUPS.OUTPUT,
+    hidden: true
+  },
+  package: {
+    description: 'Path to package.json for config',
+    group: GROUPS.CONFIG,
+    normalize: true,
+    requiresArg: true
+  },
+  recursive: {
+    description: 'Look for tests in subdirectories',
+    group: GROUPS.FILES
+  },
+  reporter: {
+    default: defaults.reporter,
+    description: 'Specify reporter to use',
+    group: GROUPS.OUTPUT,
+    requiresArg: true
+  },
+  'reporter-option': {
+    coerce: opts =>
+      list(opts).reduce((acc, opt) => {
+        const pair = opt.split('=');
+        if (pair.length > 2 || !pair.length) {
+          throw createInvalidArgumentValueError(
+            `invalid reporter option '${opt}'`,
+            '--reporter-option',
+            opt,
+            'expected "key=value" format'
+          );
+        }
+
+        acc[pair[0]] = pair.length === 2 ? pair[1] : true;
+        return acc;
+      }, {}),
+    description: 'Reporter-specific options (<k=v,[k1=v1,..]>)',
+    group: GROUPS.OUTPUT,
+    requiresArg: true
+  },
+  require: {
+    defaultDescription: '(none)',
+    description: 'Require module',
+    group: GROUPS.FILES,
+    requiresArg: true
+  },
+  retries: {
+    description: 'Retry failed tests this many times',
+    group: GROUPS.RULES
+  },
+  slow: {
+    default: defaults.slow,
+    description: 'Specify "slow" test threshold (in milliseconds)',
+    group: GROUPS.RULES
+  },
+  sort: {
+    description: 'Sort test files',
+    group: GROUPS.FILES
+  },
+  timeout: {
+    default: defaults.timeout,
+    description: 'Specify test timeout threshold (in milliseconds)',
+    group: GROUPS.RULES
+  },
+  ui: {
+    default: defaults.ui,
+    description: 'Specify user interface',
+    group: GROUPS.RULES,
+    requiresArg: true
+  },
+  watch: {
+    description: 'Watch files in the current working directory for changes',
+    group: GROUPS.FILES
+  },
+  'watch-files': {
+    description: 'List of paths or globs to watch',
+    group: GROUPS.FILES,
+    requiresArg: true,
+    coerce: list
+  },
+  'watch-ignore': {
+    description: 'List of paths or globs to exclude from watching',
+    group: GROUPS.FILES,
+    requiresArg: true,
+    coerce: list,
+    default: defaults['watch-ignore']
+  }
+};
+
 exports.builder = yargs =>
   yargs
-    .options({
-      'allow-uncaught': {
-        description: 'Allow uncaught errors to propagate',
-        group: GROUPS.RULES
-      },
-      'async-only': {
-        description:
-          'Require all tests to use a callback (async) or return a Promise',
-        group: GROUPS.RULES
-      },
-      bail: {
-        description: 'Abort ("bail") after first test failure',
-        group: GROUPS.RULES
-      },
-      'check-leaks': {
-        description: 'Check for global variable leaks',
-        group: GROUPS.RULES
-      },
-      color: {
-        description: 'Force-enable color output',
-        group: GROUPS.OUTPUT
-      },
-      config: {
-        config: true,
-        defaultDescription: '(nearest rc file)',
-        description: 'Path to config file',
-        group: GROUPS.CONFIG
-      },
-      delay: {
-        description: 'Delay initial execution of root suite',
-        group: GROUPS.RULES
-      },
-      diff: {
-        default: true,
-        description: 'Show diff on failure',
-        group: GROUPS.OUTPUT
-      },
-      exit: {
-        description: 'Force Mocha to quit after tests complete',
-        group: GROUPS.RULES
-      },
-      extension: {
-        default: defaults.extension,
-        description: 'File extension(s) to load',
-        group: GROUPS.FILES,
-        requiresArg: true,
-        coerce: list
-      },
-      fgrep: {
-        conflicts: 'grep',
-        description: 'Only run tests containing this string',
-        group: GROUPS.FILTERS,
-        requiresArg: true
-      },
-      file: {
-        defaultDescription: '(none)',
-        description:
-          'Specify file(s) to be loaded prior to root suite execution',
-        group: GROUPS.FILES,
-        normalize: true,
-        requiresArg: true
-      },
-      'forbid-only': {
-        description: 'Fail if exclusive test(s) encountered',
-        group: GROUPS.RULES
-      },
-      'forbid-pending': {
-        description: 'Fail if pending test(s) encountered',
-        group: GROUPS.RULES
-      },
-      'full-trace': {
-        description: 'Display full stack traces',
-        group: GROUPS.OUTPUT
-      },
-      global: {
-        coerce: list,
-        description: 'List of allowed global variables',
-        group: GROUPS.RULES,
-        requiresArg: true
-      },
-      grep: {
-        coerce: value => (!value ? null : value),
-        conflicts: 'fgrep',
-        description: 'Only run tests matching this string or regexp',
-        group: GROUPS.FILTERS,
-        requiresArg: true
-      },
-      growl: {
-        description: 'Enable Growl notifications',
-        group: GROUPS.OUTPUT
-      },
-      ignore: {
-        defaultDescription: '(none)',
-        description: 'Ignore file(s) or glob pattern(s)',
-        group: GROUPS.FILES,
-        requiresArg: true
-      },
-      'inline-diffs': {
-        description:
-          'Display actual/expected differences inline within each string',
-        group: GROUPS.OUTPUT
-      },
-      invert: {
-        description: 'Inverts --grep and --fgrep matches',
-        group: GROUPS.FILTERS
-      },
-      'list-interfaces': {
-        conflicts: Array.from(ONE_AND_DONE_ARGS),
-        description: 'List built-in user interfaces & exit'
-      },
-      'list-reporters': {
-        conflicts: Array.from(ONE_AND_DONE_ARGS),
-        description: 'List built-in reporters & exit'
-      },
-      'no-colors': {
-        description: 'Force-disable color output',
-        group: GROUPS.OUTPUT,
-        hidden: true
-      },
-      package: {
-        description: 'Path to package.json for config',
-        group: GROUPS.CONFIG,
-        normalize: true,
-        requiresArg: true
-      },
-      recursive: {
-        description: 'Look for tests in subdirectories',
-        group: GROUPS.FILES
-      },
-      reporter: {
-        default: defaults.reporter,
-        description: 'Specify reporter to use',
-        group: GROUPS.OUTPUT,
-        requiresArg: true
-      },
-      'reporter-option': {
-        coerce: opts =>
-          list(opts).reduce((acc, opt) => {
-            const pair = opt.split('=');
-
-            if (pair.length > 2 || !pair.length) {
-              throw createInvalidArgumentValueError(
-                `invalid reporter option '${opt}'`,
-                '--reporter-option',
-                opt,
-                'expected "key=value" format'
-              );
-            }
-
-            acc[pair[0]] = pair.length === 2 ? pair[1] : true;
-            return acc;
-          }, {}),
-        description: 'Reporter-specific options (<k=v,[k1=v1,..]>)',
-        group: GROUPS.OUTPUT,
-        requiresArg: true
-      },
-      require: {
-        defaultDescription: '(none)',
-        description: 'Require module',
-        group: GROUPS.FILES,
-        requiresArg: true
-      },
-      retries: {
-        description: 'Retry failed tests this many times',
-        group: GROUPS.RULES
-      },
-      slow: {
-        default: defaults.slow,
-        description: 'Specify "slow" test threshold (in milliseconds)',
-        group: GROUPS.RULES
-      },
-      sort: {
-        description: 'Sort test files',
-        group: GROUPS.FILES
-      },
-      timeout: {
-        default: defaults.timeout,
-        description: 'Specify test timeout threshold (in milliseconds)',
-        group: GROUPS.RULES
-      },
-      ui: {
-        default: defaults.ui,
-        description: 'Specify user interface',
-        group: GROUPS.RULES,
-        requiresArg: true
-      },
-      watch: {
-        description: 'Watch files in the current working directory for changes',
-        group: GROUPS.FILES
-      },
-      'watch-files': {
-        description: 'List of paths or globs to watch',
-        group: GROUPS.FILES,
-        requiresArg: true,
-        coerce: list
-      },
-      'watch-ignore': {
-        description: 'List of paths or globs to exclude from watching',
-        group: GROUPS.FILES,
-        requiresArg: true,
-        coerce: list,
-        default: defaults['watch-ignore']
-      }
-    })
+    .options(this.options)
     .positional('spec', {
       default: ['test'],
       description: 'One or more files, directories, or globs to test',


### PR DESCRIPTION
# Description of the Change

Exports the Yargs `options` and `check` function that `mocha` uses to allow wrapper modules to consume them. This is accomplished by assigning the `options` to an exportable object and the exporting the `check` function before they are used by `mocha` internally.

# Alternate Designs

Without exporting the `options` and `check`, wrapper modules are stuck re-implementing the `options` and `check` themselves, which stinks 💩

# Why should this be in core?

This would provide external modules what they need to avoid reinventing the wheel, and doesn't break or disrupt anything here.

# Benefits

Allows us to implement a fix for [this](https://github.com/sysgears/mochapack/issues/34)

# Possible Drawbacks

I can't think of any.

# Applicable issues

[Aforementioned issue](https://github.com/sysgears/mochapack/issues/34)

* [ ] Is this a breaking change (major release)?
* [x] Is it an enhancement (minor release)?
* [ ] Is it a bug fix, or does it not impact production code (patch release)?
