### PR TITLE
Fix timeout handling with `--inspect-brk`/`--inspect`

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -54,11 +54,13 @@ const trimV8Option = value =>
 Object.keys(opts).forEach(opt => {
   if (isNodeFlag(opt)) {
     nodeArgs[trimV8Option(opt)] = opts[opt];
-    disableTimeouts(opt);
   } else {
     mochaArgs[opt] = opts[opt];
   }
 });
+
+// disable 'timeout' for debugFlags
+Object.keys(nodeArgs).forEach(opt => disableTimeouts(opt));
 
 // Native debugger handling
 // see https://nodejs.org/api/debugger.html#debugger_debugger

--- a/test/integration/fixtures/options/slow-test.fixture.js
+++ b/test/integration/fixtures/options/slow-test.fixture.js
@@ -5,7 +5,7 @@ describe('a suite', function() {
     setTimeout(done, 500);
   });
 
-  it('should succeed in 1.5s', function(done) {
-    setTimeout(done, 1500);
+  it('should succeed in 1.1s', function(done) {
+    setTimeout(done, 1100);
   });
 });

--- a/test/integration/options/timeout.spec.js
+++ b/test/integration/options/timeout.spec.js
@@ -49,4 +49,19 @@ describe('--timeout', function() {
       done();
     });
   });
+
+  it('should disable timeout with --inspect', function(done) {
+    var fixture = 'options/slow-test';
+    runMochaJSON(fixture, ['--inspect', '--timeout', '200'], function(
+      err,
+      res
+    ) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, 'to have passed').and('to have passed test count', 2);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Description

Mocha disables timeouts while debugging in order to avoid timeout errors.
This is true:
- when the Node debugging flags are set via Mocha
- with `bin/mocha` executable (not `bin/_mocha`)

### Description of the Change

In some cases the disabling of the timeouts did not work due to the option's order.
- correct: `--timeout 2000 --inspect-brk`
- fails: `--inspect-brk --timeout 2000`

### Applicable issues

closes #4110