### PR TITLE
Add reporter names enable and Unite names into one

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1917,7 +1917,7 @@ or the [source](https://github.com/mochajs/mocha/blob/master/lib/mocha.js).
 [example-mocha-test]: https://github.com/mochajs/mocha/tree/master/test
 [example-mocha-config]: https://github.com/mochajs/mocha/tree/master/example/config
 [example-superagent-test]: https://github.com/visionmedia/superagent/tree/master/test/node
-[example-third-party-reporter]: https://github.com/mochajs/mocha-examples/tree/master/third-party-reporter
+[example-third-party-reporter]: https://github.com/mochajs/mocha-examples/tree/master/packages/third-party-reporter
 [example-typescript]: https://github.com/mochajs/mocha-examples/tree/master/packages/typescript
 [example-websocket.io-test]: https://github.com/LearnBoost/websocket.io/tree/master/test
 [expect.js]: https://github.com/LearnBoost/expect.js

--- a/docs/index.md
+++ b/docs/index.md
@@ -1535,6 +1535,8 @@ Examples:
 
 ### HTML Reporter
 
+Alias: None
+
 **The HTML reporter is not intended for use on the command-line.**
 
 ## Running Mocha in the Browser

--- a/docs/index.md
+++ b/docs/index.md
@@ -1376,24 +1376,32 @@ Mocha reporters adjust to the terminal window, and always disable ANSI-escape co
 
 ### Spec
 
-This is the default reporter. The "spec" reporter outputs a hierarchical view nested just as the test cases are.
+**Enable Names:** `Spec`, `spec`
+
+The Spec reporter outputs a hierarchical view nested just as the test cases are.
 
 ![spec reporter](images/reporter-spec.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 ![spec reporter with failure](images/reporter-spec-fail.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### Dot Matrix
 
-The dot matrix (or "dot") reporter is simply a series of characters which represent test cases. Failures highlight in red exclamation marks (`!`), pending tests with a blue comma (`,`), and slow tests as yellow. Good if you prefer minimal output.
+**Enable Names:** `Dot`, `dot`
+
+The Dot Matrix reporter is simply a series of characters which represent test cases. Failures highlight in red exclamation marks (`!`), pending tests with a blue comma (`,`), and slow tests as yellow. Good if you prefer minimal output.
 
 ![dot matrix reporter](images/reporter-dot.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### Nyan
 
-The "nyan" reporter is exactly what you might expect:
+**Enable Names:** `Nyan`, `nyan`
+
+The Nyan reporter is exactly what you might expect:
 
 ![js nyan cat reporter](images/reporter-nyan.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### TAP
+
+**Enable Names:** `TAP`, `tap`
 
 The TAP reporter emits lines for a [Test-Anything-Protocol][] consumer.
 
@@ -1401,44 +1409,58 @@ The TAP reporter emits lines for a [Test-Anything-Protocol][] consumer.
 
 ### Landing Strip
 
-The Landing Strip (`landing`) reporter is a gimmicky test reporter simulating a plane landing :) unicode ftw
+**Enable Names:** `Landing`, `landing`
+
+The Landing Strip reporter is a gimmicky test reporter simulating a plane landing :) unicode ftw
 
 ![landing strip plane reporter](images/reporter-landing.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 ![landing strip with failure](images/reporter-landing-fail.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### List
 
-The "list" reporter outputs a simple specifications list as test cases pass or fail, outputting the failure details at the bottom of the output.
+**Enable Names:** `List`, `list`
+
+The List reporter outputs a simple specifications list as test cases pass or fail, outputting the failure details at the bottom of the output.
 
 ![list reporter](images/reporter-list.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### Progress
 
-The "progress" reporter implements a simple progress-bar:
+**Enable Names:** `Progress`, `progress`
+
+The Progress reporter implements a simple progress-bar:
 
 ![progress bar](images/reporter-progress.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### JSON
 
-The "JSON" reporter outputs a single large JSON object when the tests have completed (failures or not).
+**Enable Names:** `JSON`, `json`
+
+The JSON reporter outputs a single large JSON object when the tests have completed (failures or not).
 
 ![json reporter](images/reporter-json.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### JSON Stream
 
-The "JSON stream" reporter outputs newline-delimited JSON "events" as they occur, beginning with a "start" event, followed by test passes or failures, and then the final "end" event.
+**Enable Names:** `JSONStream`, `json-stream`
+
+The JSON Stream reporter outputs newline-delimited JSON "events" as they occur, beginning with a "start" event, followed by test passes or failures, and then the final "end" event.
 
 ![json stream reporter](images/reporter-json-stream.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### Min
 
-The "min" reporter displays the summary only, while still outputting errors on failure. This reporter works great with `--watch` as it clears the terminal in order to keep your test summary at the top.
+**Enable Names:** `Min`, `min`
+
+The Min reporter displays the summary only, while still outputting errors on failure. This reporter works great with `--watch` as it clears the terminal in order to keep your test summary at the top.
 
 ![min reporter](images/reporter-min.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### Doc
 
-The "doc" reporter outputs a hierarchical HTML body representation of your tests. Wrap it with a header, footer, and some styling, then you have some fantastic documentation!
+**Enable Names:** `Doc`, `doc`
+
+The Doc reporter outputs a hierarchical HTML body representation of your tests. Wrap it with a header, footer, and some styling, then you have some fantastic documentation!
 
 ![doc reporter](images/reporter-doc.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
@@ -1485,14 +1507,18 @@ View SuperAgent's [Makefile][superagent-makefile] for reference.
 
 ### Markdown
 
-The "markdown" reporter generates a markdown TOC and body for your test suite.
+**Enable Names:** `Markdown`, `markdown`
+
+The Markdown reporter generates a markdown TOC and body for your test suite.
 This is great if you want to use the tests as documentation within a Github
 wiki page, or a markdown file in the repository that Github can render. For
 example, here is the Connect [test output][connect-test-output].
 
 ### XUnit
 
-The `xunit` reporter is also available. It outputs an XUnit-compatible XML document, often applicable in CI servers.
+**Enable Names:** `XUnit`, `xunit`
+
+The XUnit reporter is also available. It outputs an XUnit-compatible XML document, often applicable in CI servers.
 
 By default, it will output to the console. To write directly to a file, use `--reporter-options output=filename.xml`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1376,16 +1376,16 @@ Mocha reporters adjust to the terminal window, and always disable ANSI-escape co
 
 ### Spec
 
-**Enable Names:** `Spec`, `spec`
+Alias: `Spec`, `spec`
 
-The Spec reporter outputs a hierarchical view nested just as the test cases are.
+This is the default reporter. The Spec reporter outputs a hierarchical view nested just as the test cases are.
 
 ![spec reporter](images/reporter-spec.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 ![spec reporter with failure](images/reporter-spec-fail.png?withoutEnlargement&resize=920,9999){:class="screenshot" lazyload="on"}
 
 ### Dot Matrix
 
-**Enable Names:** `Dot`, `dot`
+Alias: `Dot`, `dot`
 
 The Dot Matrix reporter is simply a series of characters which represent test cases. Failures highlight in red exclamation marks (`!`), pending tests with a blue comma (`,`), and slow tests as yellow. Good if you prefer minimal output.
 
@@ -1393,7 +1393,7 @@ The Dot Matrix reporter is simply a series of characters which represent test ca
 
 ### Nyan
 
-**Enable Names:** `Nyan`, `nyan`
+Alias: `Nyan`, `nyan`
 
 The Nyan reporter is exactly what you might expect:
 
@@ -1401,7 +1401,7 @@ The Nyan reporter is exactly what you might expect:
 
 ### TAP
 
-**Enable Names:** `TAP`, `tap`
+Alias: `TAP`, `tap`
 
 The TAP reporter emits lines for a [Test-Anything-Protocol][] consumer.
 
@@ -1409,7 +1409,7 @@ The TAP reporter emits lines for a [Test-Anything-Protocol][] consumer.
 
 ### Landing Strip
 
-**Enable Names:** `Landing`, `landing`
+Alias: `Landing`, `landing`
 
 The Landing Strip reporter is a gimmicky test reporter simulating a plane landing :) unicode ftw
 
@@ -1418,7 +1418,7 @@ The Landing Strip reporter is a gimmicky test reporter simulating a plane landin
 
 ### List
 
-**Enable Names:** `List`, `list`
+Alias: `List`, `list`
 
 The List reporter outputs a simple specifications list as test cases pass or fail, outputting the failure details at the bottom of the output.
 
@@ -1426,7 +1426,7 @@ The List reporter outputs a simple specifications list as test cases pass or fai
 
 ### Progress
 
-**Enable Names:** `Progress`, `progress`
+Alias: `Progress`, `progress`
 
 The Progress reporter implements a simple progress-bar:
 
@@ -1434,7 +1434,7 @@ The Progress reporter implements a simple progress-bar:
 
 ### JSON
 
-**Enable Names:** `JSON`, `json`
+Alias: `JSON`, `json`
 
 The JSON reporter outputs a single large JSON object when the tests have completed (failures or not).
 
@@ -1442,7 +1442,7 @@ The JSON reporter outputs a single large JSON object when the tests have complet
 
 ### JSON Stream
 
-**Enable Names:** `JSONStream`, `json-stream`
+Alias: `JSONStream`, `json-stream`
 
 The JSON Stream reporter outputs newline-delimited JSON "events" as they occur, beginning with a "start" event, followed by test passes or failures, and then the final "end" event.
 
@@ -1450,7 +1450,7 @@ The JSON Stream reporter outputs newline-delimited JSON "events" as they occur, 
 
 ### Min
 
-**Enable Names:** `Min`, `min`
+Alias: `Min`, `min`
 
 The Min reporter displays the summary only, while still outputting errors on failure. This reporter works great with `--watch` as it clears the terminal in order to keep your test summary at the top.
 
@@ -1458,7 +1458,7 @@ The Min reporter displays the summary only, while still outputting errors on fai
 
 ### Doc
 
-**Enable Names:** `Doc`, `doc`
+Alias: `Doc`, `doc`
 
 The Doc reporter outputs a hierarchical HTML body representation of your tests. Wrap it with a header, footer, and some styling, then you have some fantastic documentation!
 
@@ -1507,7 +1507,7 @@ View SuperAgent's [Makefile][superagent-makefile] for reference.
 
 ### Markdown
 
-**Enable Names:** `Markdown`, `markdown`
+Alias: `Markdown`, `markdown`
 
 The Markdown reporter generates a markdown TOC and body for your test suite.
 This is great if you want to use the tests as documentation within a Github
@@ -1516,7 +1516,7 @@ example, here is the Connect [test output][connect-test-output].
 
 ### XUnit
 
-**Enable Names:** `XUnit`, `xunit`
+Alias: `XUnit`, `xunit`
 
 The XUnit reporter is also available. It outputs an XUnit-compatible XML document, often applicable in CI servers.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1520,9 +1520,9 @@ Alias: `XUnit`, `xunit`
 
 The XUnit reporter is also available. It outputs an XUnit-compatible XML document, often applicable in CI servers.
 
-By default, it will output to the console. To write directly to a file, use `--reporter-options output=filename.xml`.
+By default, it will output to the console. To write directly to a file, use `--reporter-option output=filename.xml`.
 
-To specify custom report title, use `--reporter-options suiteName="Custom name"`.
+To specify custom report title, use `--reporter-option suiteName="Custom name"`.
 
 ### Third-Party Reporters
 
@@ -1535,7 +1535,7 @@ Examples:
 
 ### HTML Reporter
 
-Alias: None
+Alias: `HTML`, `html`
 
 **The HTML reporter is not intended for use on the command-line.**
 


### PR DESCRIPTION
### Description
- Reporter part of Mocha docs was so unkind about enable reporter name.
  - there are two enable names but current docs makes users confused.

### Description of the Change
- Add **enable names** to docs clearly
- Unite reporter name to call a reporter type

### Summary
*before*
The "progress" reporter implements a simple progress-bar:

*after*
**Enable Names:** `Progress`, `progress`
The Progress reporter implements a simple progress-bar:

fix #4054 
fix #4134 