### PR TITLE
Fix: control stringification of error message

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -8,6 +8,7 @@
 
 var diff = require('diff');
 var milliseconds = require('ms');
+var util = require('util');
 var utils = require('../utils');
 var supportsColor = require('supports-color');
 var symbols = require('log-symbols');
@@ -236,10 +237,12 @@ exports.list = function(failures) {
       err = test.err;
     }
     var message;
-    if (err.message && typeof err.message.toString === 'function') {
-      message = err.message + '';
+    if (typeof err[util.inspect.custom] === 'function') {
+      message = util.inspect(err) + '';
     } else if (typeof err.inspect === 'function') {
       message = err.inspect() + '';
+    } else if (err.message && typeof err.message.toString === 'function') {
+      message = err.message + '';
     } else {
       message = '';
     }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -8,7 +8,6 @@
 
 var diff = require('diff');
 var milliseconds = require('ms');
-var util = require('util');
 var utils = require('../utils');
 var supportsColor = require('supports-color');
 var symbols = require('log-symbols');
@@ -237,9 +236,7 @@ exports.list = function(failures) {
       err = test.err;
     }
     var message;
-    if (typeof err[util.inspect.custom] === 'function') {
-      message = util.inspect(err) + '';
-    } else if (typeof err.inspect === 'function') {
+    if (typeof err.inspect === 'function') {
       message = err.inspect() + '';
     } else if (err.message && typeof err.message.toString === 'function') {
       message = err.message + '';

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert');
 var chai = require('chai');
+var util = require('util');
 var sinon = require('sinon');
 var helpers = require('./helpers');
 var reporters = require('../../').reporters;
@@ -366,22 +367,38 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
-  it("should use 'inspect' if 'message' is not set", function() {
-    var err = {
-      showDiff: false,
-      inspect: function() {
-        return 'an error happened';
-      }
+  it("should use 'util.inspect.custom' if err is including util.inspect.custom parameter", function() {
+    var err = new Error('test');
+    err.showDiff = false;
+    err[util.inspect.custom] = function() {
+      return 'Custom Formatted Error';
     };
+
     var test = makeTest(err);
 
     list([test]);
 
     var errOut = stdout.join('\n').trim();
-    expect(errOut, 'to be', '1) test title:\n     an error happened');
+    expect(errOut, 'to contain', 'Custom Formatted Error');
   });
 
-  it("should set an empty message if neither 'message' nor 'inspect' is set", function() {
+  it("should use 'inspect' if 'util.inspect.custom' is not set", function() {
+    var err = new Error('test');
+    err.showDiff = false;
+    err.inspect = function() {
+      return 'Inspect Error';
+    };
+
+    var test = makeTest(err);
+
+    list([test]);
+
+    var errOut = stdout.join('\n').trim();
+
+    expect(errOut, 'to contain', 'Inspect Error');
+  });
+
+  it("should set an empty message if 'util.inspect.custom' and 'inspect' and 'message' is not set", function() {
     var err = {
       showDiff: false
     };

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert');
 var chai = require('chai');
-var util = require('util');
 var sinon = require('sinon');
 var helpers = require('./helpers');
 var reporters = require('../../').reporters;
@@ -367,22 +366,7 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
-  it("should use 'util.inspect.custom' if err is including util.inspect.custom parameter", function() {
-    var err = new Error('test');
-    err.showDiff = false;
-    err[util.inspect.custom] = function() {
-      return 'Custom Formatted Error';
-    };
-
-    var test = makeTest(err);
-
-    list([test]);
-
-    var errOut = stdout.join('\n').trim();
-    expect(errOut, 'to contain', 'Custom Formatted Error');
-  });
-
-  it("should use 'inspect' if 'util.inspect.custom' is not set", function() {
+  it("should use 'inspect' if err include 'inspect' parameter", function() {
     var err = new Error('test');
     err.showDiff = false;
     err.inspect = function() {
@@ -398,7 +382,7 @@ describe('Base reporter', function() {
     expect(errOut, 'to contain', 'Inspect Error');
   });
 
-  it("should set an empty message if 'util.inspect.custom' and 'inspect' and 'message' is not set", function() {
+  it("should set an empty message if neither 'inspect' nor 'message' is set", function() {
     var err = {
       showDiff: false
     };

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -366,9 +366,10 @@ describe('Base reporter', function() {
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
   });
 
-  it("should use 'inspect' if err include 'inspect' parameter", function() {
+  it("should use 'inspect' if 'inspect' and 'message' are set", function() {
     var err = new Error('test');
     err.showDiff = false;
+    err.message = 'error message';
     err.inspect = function() {
       return 'Inspect Error';
     };


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Before, The order of the previous processing is as follows
1. error message is function
2. error include inspect parameter
3. empty

After
1. check include inspect custom function
2. error message is function
3. empty

So developers can custom error message if they want

I have been found util.inspect.custom API, but if set up util.inspect.custom that changed error format 

<img width="951" alt="스크린샷 2019-12-14 오후 5 52 23" src="https://user-images.githubusercontent.com/25384956/70846226-8564e400-1e9a-11ea-9c7e-04b8f5b4548c.png">

So this pr only change ordering with err.inspect function and err.message 😭 

### Benefits

Developer can custom error message handling in mocha

### Applicable issues

[issues:3985](https://github.com/mochajs/mocha/issues/3985)
