### PR TITLE
Throw a descriptive error when a non-function is given to a runnable

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -338,6 +338,15 @@ Runnable.prototype.run = function(fn) {
   // for .resetTimeout()
   this.callback = done;
 
+  if (this.fn && typeof this.fn.call !== 'function') {
+    done(
+      new TypeError(
+        'A runnable must be passed a function as its second argument.'
+      )
+    );
+    return;
+  }
+
   // explicit async with `done` argument
   if (this.async) {
     this.resetTimeout();

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -670,6 +670,20 @@ describe('Runnable(title, fn)', function() {
         });
       });
     });
+
+    describe('when fn is not a function', function() {
+      it('should throw an error', function() {
+        var runnable = new Runnable('foo', 4);
+
+        runnable.run(function(err) {
+          expect(
+            err.message,
+            'to be',
+            'A runnable must be passed a function as its second argument.'
+          );
+        });
+      });
+    });
   });
 
   describe('#isFailed()', function() {


### PR DESCRIPTION
# Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

Given a test such as:

```js
it('foobars', 4);
```

mocha used to throw the following error: `fn.call is not a function`.

After applying this patch, it will throw a more descriptive error message:
`A runnable must be passed a function as its second argument.`

(Thanks to [ssube](https://github.com/ssube) for helping with the error wording.)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

This deals with an error builtin to mocha.

### Benefits

While the previous error is technically true, I have personally spent some minutes of my life chasing what looked like a bug in the test itself, and not in the call to `it`. A more descriptive error message helps bring attention to where the problem originates.

The error message itself is welcome to change. One other possible wording is replacing `runnable`, a phrase internal to mocha, with `test function`, which may be more intuitive to users.

### Possible Drawbacks

- Any code relying on `runner.run` returning the original error will now fail.
- This error is reported as if the test itself failed, which may leave the user confused still, wondering what's wrong with their test and why is it telling them such things, and still not end up looking at the function signature.
- The test for this function is, in my opinion, lacking. It merely tests how mocha behaves when it is passed a number, and not one of many possible values. Is there any prior art in mocha for such "generative" tests, for instance where the `it` string is constructed from variables? A common approach, which may be controversial to introduce if not already present, is something akin to:

```js
var notFunctions = [4, 'four', false, ...];
notFunctions.forEach(function(val) {
    it('handles the value ' + inspect(val), testfn);
});
```

Thank you for your time.