### PR TITLE
update copyright & trademark notices per OJSF; closes #4145

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2011-2018 JS Foundation and contributors, https://js.foundation
+Copyright (c) 2011-2020 OpenJS Foundation and contributors, https://openjsf.org
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ Finally, come [chat with the maintainers](https://gitter.im/mochajs/contributors
 
 ## License
 
-[MIT](LICENSE)
+Copyright 2011-2020 OpenJS Foundation and contributors. Licensed [MIT](https://github.com/mochajs/mocha/blob/master/LICENSE).
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha?ref=badge_large)

--- a/docs/_includes/default.html
+++ b/docs/_includes/default.html
@@ -31,18 +31,13 @@
     <main id="content">{{ content }}</main>
 
     <aside class="sponsorship">
-      <a href="https://matomo.org/" rel="external noopener" target="_blank">
-        <img
-          id="matomoLogo"
-          src="images/matomo-logo.png?trim"
-          alt="Matomo logo"
-        />
+      <a href="https://matomo.org/" rel="external noopener">
+        <img src="images/matomo-logo.png?trim" alt="Matomo logo" />
       </a>
       <a
         title="Mocha is an OpenJS Foundation Project"
         href="https://openjsf.org"
         rel="external noopener"
-        target="_blank"
       >
         <img
           src="/images/openjsf-logo.svg"
@@ -54,27 +49,99 @@
     </aside>
 
     <footer>
-      <div>
-        <a rel="home" href="https://mochajs.org/">mochajs.org</a>
-        is licensed under a
+      <div id="copyright-notice">
+        <a rel="home" href="https://mochajs.org/">mochajs.org</a> is licensed
+        under a
         <a
           rel="license external noopener"
           href="https://creativecommons.org/licenses/by/4.0/"
-        >
-          Creative Commons Attribution 4.0 International License</a
+          >Creative Commons Attribution 4.0 International License</a
         >.
-        <dl class="dl-inline last-modified">
-          <dt>Last updated</dt>
-          <dd>
-            <time
-              itemprop="lastModified"
-              datetime="{{ 'now' | date: '%Y-%m-%dT%H:%M:%SZ' }}"
-            >
-              {{ 'now' | date: '%a %b %d %H:%M:%S %Y' }}
-            </time>
-          </dd>
-        </dl>
+
+        <p>
+          Copyright
+          <a href="https://openjsf.org" rel="external noopener"
+            >OpenJS Foundation</a
+          >
+          and Mocha contributors. All rights reserved. The
+          <a href="https://openjsf.org" rel="external noopener"
+            >OpenJS Foundation</a
+          >
+          has registered trademarks and uses trademarks. For a list of
+          trademarks of the
+          <a href="https://openjsf.org" rel="external noopener"
+            >OpenJS Foundation</a
+          >, please see our
+          <a
+            href="https://trademark-policy.openjsf.org/"
+            rel="external noopener"
+            >Trademark Policy</a
+          >
+          and
+          <a href="https://trademark-list.openjsf.org/" rel="external noopener"
+            >Trademark List</a
+          >. Trademarks and logos not indicated on the
+          <a href="https://trademark-list.openjsf.org" rel="external noopener"
+            >list of OpenJS Foundation trademarks</a
+          >
+          are trademarks™ or registered® trademarks of their respective holders.
+          Use of them does not imply any affiliation with or endorsement by
+          them.
+        </p>
       </div>
+
+      <ul id="openjsf-links">
+        <li>
+          <a href="https://openjsf.org/" rel="external noopener"
+            >The OpenJS Foundation</a
+          >
+        </li>
+        <li>
+          <a href="https://terms-of-use.openjsf.org/" rel="external noopener"
+            >Terms of Use</a
+          >
+        </li>
+        <li>
+          <a href="https://privacy-policy.openjsf.org/" rel="external noopener"
+            >Privacy Policy</a
+          >
+        </li>
+        <li>
+          <a href="https://bylaws.openjsf.org/" rel="external noopener"
+            >OpenJS Foundation Bylaws</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://trademark-policy.openjsf.org/"
+            rel="external noopener"
+            >Trademark Policy</a
+          >
+        </li>
+        <li>
+          <a href="https://trademark-list.openjsf.org/" rel="external noopener"
+            >Trademark List</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://www.linuxfoundation.org/cookies/"
+            rel="external noopener"
+            >Cookie Policy</a
+          >
+        </li>
+      </ul>
+      <dl id="last-modified" class="dl-inline">
+        <dt>Last updated</dt>
+        <dd>
+          <time
+            itemprop="lastModified"
+            datetime="{{ 'now' | date: '%Y-%m-%dT%H:%M:%SZ' }}"
+          >
+            {{ 'now' | date: '%a %b %d %H:%M:%S %Y' }}
+          </time>
+        </dd>
+      </dl>
     </footer>
   </body>
 </html>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -209,9 +209,17 @@ img.screenshot {
   max-width: 100%;
 }
 
-#matomoLogo {
+.sponsorship a {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.sponsorship a img {
   display: block;
-  height: 176px;
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
 }
 
 .sponsorship {
@@ -228,18 +236,39 @@ img.screenshot {
 footer {
   background-color: #eee;
   border-top: 1px solid #ddd;
-  padding: 50px 0;
-  text-align: right;
-}
-
-footer div {
+  padding: 50px 30px;
   color: #888;
   font-size: 0.8em;
-  margin-right: 30px;
 }
 
-.last-modified {
+#last-modified {
+  text-align: right;
   font-style: italic;
+  font-size: 0.7em;
+}
+
+#copyright-notice {
+  max-width: 66%;
+}
+
+#openjsf-links {
+  margin: 0;
+  padding: 0;
+  box-sizing: initial;
+  columns: initial;
+}
+
+#openjsf-links li {
+  display: inline; /* displays list horizontally */
+  border: none;
+  list-style: none;
+  margin: initial;
+  padding: initial;
+}
+
+/* displays each list item with a "|" between */
+#openjsf-links li + li:before {
+  content: ' | ';
 }
 
 .dl-inline dt,
@@ -257,6 +286,27 @@ footer div {
   display: block;
 }
 
+blockquote {
+  border-left: 1px solid #eee;
+  padding: 10px;
+}
+
+@media all and (max-width: 900px) {
+  #copyright-notice {
+    max-width: initial;
+  }
+
+  #openjsf-links {
+    width: 50%;
+    column-count: 2;
+    column-rule: 1px solid #dedede;
+  }
+
+  #openjsf-links li + li:before {
+    content: initial;
+  }
+}
+
 @media all and (max-width: 600px) {
   #tag {
     margin-top: 0;
@@ -272,9 +322,14 @@ footer div {
     margin: 20px -11px;
     padding: 10px;
   }
-}
 
-blockquote {
-  border-left: 1px solid #eee;
-  padding: 10px;
+  /* this list is too long for smaller displays */
+  #openjsf-links {
+    width: 100%;
+    columns: initial;
+  }
+
+  #openjsf-links li {
+    display: block;
+  }
 }


### PR DESCRIPTION
- made footer responsive
- made matomo & openjsf logos responsive
- remove `target="_blank"` since people can decide if they want to open a tab

Ref: #4145