### PR TITLE
Fix leaking global 'uncaughtException' handler

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -800,7 +800,7 @@ Runner.prototype.runSuite = function(suite, fn) {
 };
 
 /**
- * Handle uncaught exceptions.
+ * Handle uncaught exceptions within runner.
  *
  * @param {Error} err
  * @private
@@ -894,6 +894,17 @@ Runner.prototype.uncaught = function(err) {
 };
 
 /**
+ * Handle uncaught exceptions after runner's end event.
+ *
+ * @param {Error} err
+ * @private
+ */
+Runner.prototype.uncaughtEnd = function uncaughtEnd(err) {
+  if (err instanceof Pending) return;
+  throw err;
+};
+
+/**
  * Run the root suite and invoke `fn(failures)`
  * on completion.
  *
@@ -940,16 +951,12 @@ Runner.prototype.run = function(fn) {
   this.on(constants.EVENT_RUN_END, function() {
     debug(constants.EVENT_RUN_END);
     process.removeListener('uncaughtException', uncaught);
-    process.on('uncaughtException', function(err) {
-      if (err instanceof Pending) {
-        return;
-      }
-      throw err;
-    });
+    process.on('uncaughtException', self.uncaughtEnd);
     fn(self.failures);
   });
 
   // uncaught exception
+  process.removeListener('uncaughtException', self.uncaughtEnd);
   process.on('uncaughtException', uncaught);
 
   if (this._delay) {

--- a/test/integration/fixtures/uncaught/listeners.fixture.js
+++ b/test/integration/fixtures/uncaught/listeners.fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const assert = require('assert');
+const mocha = require("../../../../lib/mocha");
+
+for (let i = 0; i < 15; i++) {
+  const r = new mocha.Runner(new mocha.Suite("" + i, undefined));
+  r.run();
+}
+
+assert.equal(process.listenerCount('uncaughtException'), 1);
+assert.equal(process.listeners('uncaughtException')[0].name, 'uncaughtEnd');

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -86,4 +86,16 @@ describe('uncaught exceptions', function() {
       done();
     });
   });
+
+  it('removes uncaught exceptions handlers correctly', function(done) {
+    run('uncaught/listeners.fixture.js', args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res, 'to have passed').and('to have passed test count', 0);
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Description

```js
const mocha = require("mocha");
for (let i = 0; i < 15; i++) {
    const r = new mocha.Runner(new mocha.Suite(""+i, undefined));
    r.run();
}
```
When using Mocha programmatically with multiple runners, a `MaxListenersExceededWarning` is emitted by Node. For every runner instance an `uncaughtException` handler is registered, but never removed.
This is a regression.

### Description of the Change

Remove eventual `uncaughtException` handler before starting a new runner instance.

### Applicable issues

closes #4144