### PR TITLE
Fix backwards compatibility break for `reporterOptions`

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -100,7 +100,10 @@ function Mocha(options) {
   this.grep(options.grep)
     .fgrep(options.fgrep)
     .ui(options.ui)
-    .reporter(options.reporter, options.reporterOption)
+    .reporter(
+      options.reporter,
+      options.reporterOption || options.reporterOptions // reporterOptions was previously the only way to specify options to reporter
+    )
     .slow(options.slow)
     .global(options.global);
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -446,6 +446,30 @@ describe('Mocha', function() {
       var mocha = new Mocha(opts);
       expect(mocha.reporter(), 'to be', mocha);
     });
+
+    it('should keep reporterOption on options', function() {
+      var mocha = new Mocha({
+        reporter: 'spec',
+        reporterOption: {
+          foo: 'bar'
+        }
+      });
+      expect(mocha.options.reporterOption, 'to have property', 'foo', 'bar');
+      // To support the legacy property name that can be used by reporters
+      expect(mocha.options.reporterOptions, 'to have property', 'foo', 'bar');
+    });
+
+    it('should support legacy reporterOptions', function() {
+      var mocha = new Mocha({
+        reporter: 'spec',
+        reporterOptions: {
+          foo: 'bar'
+        }
+      });
+      expect(mocha.options.reporterOption, 'to have property', 'foo', 'bar');
+      // To support the legacy property name that can be used by reporters
+      expect(mocha.options.reporterOptions, 'to have property', 'foo', 'bar');
+    });
   });
 
   describe('#run(fn)', function() {


### PR DESCRIPTION
### Description of the Change

In https://github.com/mochajs/mocha/pull/4004 there was a change to use the documented `reporterOption` in favour of the setting that had always been used in practice called `reporterOptions`. This broke a lot of configurations that used the `reporterOptions`, which was the only way it every worked AFAIK. This is also clear in that all the built-in reporters use this name.

This changes the documentation to specify `reporterOptions` instead and ensure that any one that has switched to `reporterOption` after upgrade, still works.

### Alternate Designs

`reporterOption` could have been chosen as the new preferred way, but objects with options are generally referred to in their plural form in JS. I think the root cause of the confusion comes from the command line option `reporter-option`. I think it makes sense that this is singular, since it is a single option, but it is compiled into a `reporterOptions` object.

### Why should this be in core?

To fix related issues like https://github.com/michaelleeallen/mocha-junit-reporter/issues/106#issuecomment-574015463

### Benefits

Make it easier to upgrade to Mocha 7

### Possible Drawbacks

Slight overhead of supporting two aliases

### Applicable issues
