### PR TITLE
change minimum Node version requirement to 8.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -526,7 +526,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 8.10.0"
   },
   "scripts": {
     "prepublishOnly": "nps test clean build",


### PR DESCRIPTION
### Description of the Change

Mocha’s `package.json` shows that it runs on Node 8.0.0 or higher. But when using Node 8.0.0 it throws an error:

```shell
~/Desktop/node-8.0.0-test.tmp
❯ ./node_modules/.bin/mocha --version
/Users/nate/Desktop/node-8.0.0-test.tmp/node_modules/chokidar/index.js:904
  const options = {type: EV_ALL, alwaysStat: true, lstat: true, ...opts};
                                                                ^^^

SyntaxError: Unexpected token ...
    at createScript (vm.js:74:10)
    at Object.runInThisContext (vm.js:116:10)
    at Module._compile (module.js:533:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/nate/Desktop/node-8.0.0-test.tmp/node_modules/mocha/lib/cli/watch-run.js:4:18)
```

Of Mocha’s direct dependencies, `chokidar` has the highest requirement, at 8.10.0. With 8.10.0, Mocha passes all tests, and I can run it successfully from the CLI.

Therefore this PR changes the `engines` value to `>= 8.10.0`.

### Benefits

Users (both human and automated systems) will know which versions of Node they can successfully use with Mocha.

### Applicable issues

Updating the minimum Node version can be a breaking change, but in this case I don’t think it matters since users of earlier versions were not able to use Mocha in the first place.
