### PR TITLE
Drop node.js v8 support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,7 +28,7 @@ overrides:
       - test/integration/helpers.js
       - lib/growl.js
     parserOptions:
-      ecmaVersion: 2017
+      ecmaVersion: 2018
     env:
       browser: false
 
@@ -76,7 +76,7 @@ overrides:
   - files:
       - test/**/*.mjs
     parserOptions:
-      ecmaVersion: 2017
+      ecmaVersion: 2018
       sourceType: module
 
   - files:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Follow these steps to get going. If you are having trouble, don't be afraid to [
 
 > PRO TIP: After `npm install`, run `npm start` to see a list of commands which can be run with `npm start <command>` (powered by [nps](https://npm.im/nps)).
 
-1. [Install Node.js 8.x or newer](https://nodejs.org/en/download/).
+1. [Install Node.js 10.x or newer](https://nodejs.org/en/download/).
    - If you're new to installing Node, a tool like [nvm](https://github.com/creationix/nvm#install-script) can help you manage multiple version installations.
    - You will need [Google Chrome](https://www.google.com/chrome/) to run browser-based tests locally.
 1. Follow [Github's documentation](https://help.github.com/articles/fork-a-repo/) on setting up Git, forking and cloning.

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,6 @@ jobs:
     - <<: *node
       node_js: '10'
 
-    - <<: *node
-      node_js: '8'
-
     - script: npm start test.bundle test.browser
       # XXX: update when canvas supplies a prebuilt binary for Node.js v12.x
       node_js: 10
@@ -82,9 +79,6 @@ jobs:
 
     - <<: *smoke
       node_js: '10'
-
-    - <<: *smoke
-      node_js: '8'
 
     - stage: precache
       script: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
     - nodejs_version: '13'
     - nodejs_version: '12'
     - nodejs_version: '10'
-    - nodejs_version: '8'
 matrix:
   fast_finish: true
 install:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ _So you wanna build the site?_
 
 ## Prerequisites
 
-- Node.js v8.x or greater
+- Node.js v10.x or greater
 
 ## Development
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ or as a development dependency for your project:
 $ npm install --save-dev mocha
 ```
 
-> As of v7.0.0, Mocha requires Node.js v8.0.0 or newer.
+> As of v8.0.0, Mocha requires Node.js v10.0.0 or newer.
 
 ## Getting Started
 
@@ -1608,17 +1608,17 @@ mocha.setup({
 
 ### Browser-specific Option(s)
 
-Browser Mocha supports many, but not all [cli options](#command-line-usage).  
+Browser Mocha supports many, but not all [cli options](#command-line-usage).
 To use a [cli option](#command-line-usage) that contains a "-", please convert the option to camel-case, (eg. `check-leaks` to `checkLeaks`).
 
 #### Options that differ slightly from [cli options](#command-line-usage):
 
-`reporter` _{string|constructor}_  
+`reporter` _{string|constructor}_
 You can pass a reporter's name or a custom reporter's constructor. You can find **recommended** reporters for the browser [here](#reporting). It is possible to use [built-in reporters](#reporters) as well. Their employment in browsers is neither recommended nor supported, open the console to see the test results.
 
 #### Options that _only_ function in browser context:
 
-`noHighlighting` _{boolean}_  
+`noHighlighting` _{boolean}_
 If set to `true`, do not attempt to use syntax highlighting on output test code.
 
 ### Reporting

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "scripts": {
     "prepublishOnly": "nps test clean build",


### PR DESCRIPTION
### Description of the Change

I removed support to v8 in CI and documentation as explained in #4163


### Alternate Designs

N/A 

### Why should this be in core?

Bump minimum Nodejs version

### Benefits

No need to worry about support for Node v8

### Possible Drawbacks

N/A

### Applicable issues

 Close #4163