### PR TITLE
Fix: Mocha aborts when 'test' is set to 'pending' programmatically  

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -654,7 +654,7 @@ Runner.prototype.runTests = function(suite, fn) {
         self.emit(constants.EVENT_TEST_END, test);
         // skip inner afterEach hooks below errSuite level
         var origSuite = self.suite;
-        self.suite = errSuite;
+        self.suite = errSuite || self.suite;
         return self.hookUp(HOOK_TYPE_AFTER_EACH, function(e, eSuite) {
           self.suite = origSuite;
           next(e, eSuite);

--- a/test/integration/fixtures/pending/programmatic.fixture.js
+++ b/test/integration/fixtures/pending/programmatic.fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+const Mocha = require('../../../../lib/mocha');
+
+const mocha = new Mocha({reporter: 'json'});
+mocha.addFile("./test/integration/fixtures/__default__.fixture.js");
+
+const runner = mocha.run();
+runner.on('test', function (test) { test.pending = true; });

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -143,6 +143,8 @@ module.exports = {
 
   invokeMochaAsync: invokeMochaAsync,
 
+  invokeNode: invokeNode,
+
   /**
    * Resolves the path to a fixture to the full path.
    */
@@ -225,6 +227,19 @@ function invokeMochaAsync(args, opts) {
     );
   });
   return [mochaProcess, resultPromise];
+}
+
+/**
+ * Invokes Node without Mocha binary with the given arguments,
+ * when Mocha is used programmatically.
+ */
+function invokeNode(args, fn, opts) {
+  if (typeof args === 'function') {
+    opts = fn;
+    fn = args;
+    args = [];
+  }
+  return _spawnMochaWithListeners(args, fn, opts);
 }
 
 function invokeSubMocha(args, fn, opts) {

--- a/test/integration/pending.spec.js
+++ b/test/integration/pending.spec.js
@@ -1,9 +1,12 @@
 'use strict';
 
 var assert = require('assert');
-var run = require('./helpers').runMochaJSON;
-var runMocha = require('./helpers').runMocha;
-var splitRegExp = require('./helpers').splitRegExp;
+var helpers = require('./helpers');
+var run = helpers.runMochaJSON;
+var runMocha = helpers.runMocha;
+var splitRegExp = helpers.splitRegExp;
+var invokeNode = helpers.invokeNode;
+var toJSONRunResult = helpers.toJSONRunResult;
 var args = [];
 
 describe('pending', function() {
@@ -320,6 +323,23 @@ describe('pending', function() {
             .and('to have passed test count', 0);
           done();
         });
+      });
+    });
+  });
+
+  describe('programmatic usage', function() {
+    it('should skip the test by listening to test event', function(done) {
+      var path = require.resolve('./fixtures/pending/programmatic.fixture.js');
+      invokeNode([path], function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        var result = toJSONRunResult(res);
+        expect(result, 'to have passed')
+          .and('to have passed test count', 0)
+          .and('to have pending test count', 1)
+          .and('to have pending test order', 'should succeed');
+        done();
       });
     });
   });


### PR DESCRIPTION
### Description

Update for #3741.
When a `test` is conditionally set to `pending` by programmatic means (without using `this.skip()`), `errSuite` is `undefined` and the `runner` crashes.

### Applicable issues

closes #4160 