### PR TITLE
docs: document Node.js' --enable-source-maps flag

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [config file support](#-config-path)
 - [mocha.opts file support](#-opts-path)
-- [source-map support](#-enable-source-maps)
+- [source-map support](#--enable-source-maps)
 - clickable suite titles to filter test execution
 - [node debugger support](#-inspect-inspect-brk-inspect)
 - [node native ES modules support](#nodejs-native-esm-support)

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 - [auto-exit to prevent "hanging" with an active loop](#-exit)
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [config file support](#-config-path)
+- [mocha.opts file support](#-opts-path)
+- [source-map support](#-enable-source-maps)
 - clickable suite titles to filter test execution
 - [node debugger support](#-inspect-inspect-brk-inspect)
 - [node native ES modules support](#nodejs-native-esm-support)
@@ -962,6 +964,19 @@ By default, Mocha will search for a config file if `--config` is not specified; 
 Specify an explicit path to a [`package.json` file](#configuring-mocha-nodejs) (ostensibly containing configuration in a `mocha` property).
 
 By default, Mocha looks for a `package.json` in the current working directory or nearest ancestor, and will use the first file found (regardless of whether it contains a `mocha` property); to suppress `package.json` lookup, use `--no-package`.
+
+### `--enable-source-maps`
+
+> _New in Node.js v12.12.0_
+
+If the [`--enable-source-maps`](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) flag
+is passed to Node.js, source-maps will be collected and used to provide acurate stack traces for transpiled code:
+
+```bash
+Error: cool
+    at Object.<anonymous> (/Users/fake-user/bigco/nodejs-tasks/build/src/index.js:27:7)
+        -> /Users/fake-user/bigco/nodejs-tasks/src/index.ts:24:7
+```
 
 ### `--extension <ext>`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,6 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 - [auto-exit to prevent "hanging" with an active loop](#-exit)
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [config file support](#-config-path)
-- [mocha.opts file support](#-opts-path)
 - [source-map support](#--enable-source-maps)
 - clickable suite titles to filter test execution
 - [node debugger support](#-inspect-inspect-brk-inspect)

--- a/docs/index.md
+++ b/docs/index.md
@@ -970,7 +970,7 @@ By default, Mocha looks for a `package.json` in the current working directory or
 > _New in Node.js v12.12.0_
 
 If the [`--enable-source-maps`](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) flag
-is passed to Node.js, source-maps will be collected and used to provide acurate stack traces for transpiled code:
+is passed to Node.js, source-maps will be collected and used to provide accurate stack traces for transpiled code:
 
 ```bash
 Error: cool

--- a/docs/index.md
+++ b/docs/index.md
@@ -970,7 +970,7 @@ By default, Mocha looks for a `package.json` in the current working directory or
 > _New in Node.js v12.12.0_
 
 If the [`--enable-source-maps`](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) flag
-is passed to Node.js, source-maps will be collected and used to provide accurate stack traces for transpiled code:
+is passed to mocha, source maps will be collected and used to provide accurate stack traces for transpiled code:
 
 ```bash
 Error: cool

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,10 +36,10 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 - [auto-exit to prevent "hanging" with an active loop](#-exit)
 - [easily meta-generate suites](#markdown) & [test-cases](#list)
 - [config file support](#-config-path)
-- [source-map support](#--enable-source-maps)
 - clickable suite titles to filter test execution
 - [node debugger support](#-inspect-inspect-brk-inspect)
 - [node native ES modules support](#nodejs-native-esm-support)
+- [source-map support](#-enable-source-maps)
 - [detects multiple calls to `done()`](#detects-multiple-calls-to-done)
 - [use any assertion library you want](#assertions)
 - [extensible reporting, bundled with 9+ reporters](#reporters)
@@ -964,19 +964,6 @@ Specify an explicit path to a [`package.json` file](#configuring-mocha-nodejs) (
 
 By default, Mocha looks for a `package.json` in the current working directory or nearest ancestor, and will use the first file found (regardless of whether it contains a `mocha` property); to suppress `package.json` lookup, use `--no-package`.
 
-### `--enable-source-maps`
-
-> _New in Node.js v12.12.0_
-
-If the [`--enable-source-maps`](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) flag
-is passed to mocha, source maps will be collected and used to provide accurate stack traces for transpiled code:
-
-```bash
-Error: cool
-    at Object.<anonymous> (/Users/fake-user/bigco/nodejs-tasks/build/src/index.js:27:7)
-        -> /Users/fake-user/bigco/nodejs-tasks/src/index.ts:24:7
-```
-
 ### `--extension <ext>`
 
 Files having this extension will be considered test files. Defaults to `js`.
@@ -1127,6 +1114,19 @@ The `mocha` executable supports all applicable flags which the `node` executable
 These flags vary depending on your version of Node.js.
 
 `node` flags can be defined in Mocha's [configuration](#configuring-mocha-nodejs).
+
+### `--enable-source-maps`
+
+> _New in Node.js v12.12.0_
+
+If the [`--enable-source-maps`](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) flag
+is passed to mocha, source maps will be collected and used to provide accurate stack traces for transpiled code:
+
+```bash
+Error: cool
+    at Object.<anonymous> (/Users/fake-user/bigco/nodejs-tasks/build/src/index.js:27:7)
+        -> /Users/fake-user/bigco/nodejs-tasks/src/index.ts:24:7
+```
 
 ### About V8 Flags
 


### PR DESCRIPTION
## Description of the Change

Newer versions of Node.js introduce the `--enable-source-maps` flag which, when enabled, caches source-maps and provides accurate stack traces to users running transpiled code, e.g., TypeScript.

## Benefits

Many users of Node.js are writing TypeScript, this allows them to receive better stack traces in mocha without installing any dependencies.

## Drawbacks

There's still work to be done to polish this feature in Node.js (would very much appreciate getting feedback).