### PR TITLE
Browser: fix 'allowUncaught' handling 

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -60,7 +60,7 @@ process.on = function(e, fn) {
   if (e === 'uncaughtException') {
     global.onerror = function(err, url, line) {
       fn(new Error(err + ' (' + url + ':' + line + ')'));
-      return !mocha.allowUncaught;
+      return !mocha.options.allowUncaught;
     };
     uncaughtExceptionHandlers.push(fn);
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,6 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 - [javascript API for running tests](#more-information)
 - proper exit status for CI support etc
 - [auto-detects and disables coloring for non-ttys](#reporters)
-- [maps uncaught exceptions to the correct test case](#browser-specific-methods)
 - [async test timeout support](#delayed-root-suite)
 - [test retry support](#retry-tests)
 - [test-specific timeouts](#test-level)
@@ -666,7 +665,7 @@ describe('outer', function() {
 });
 ```
 
-> _Updated in v7.0.0. Skipping a test within an "after all" hook is disallowed and will throw an exception. Use a return statement or other means to abort hook execution._
+> _Updated in v7.0.0:_ skipping a test within an "after all" hook is disallowed and will throw an exception. Use a return statement or other means to abort hook execution.
 
 Before Mocha v3.0.0, `this.skip()` was not supported in asynchronous tests and hooks.
 
@@ -1543,12 +1542,6 @@ Alias: `HTML`, `html`
 
 Mocha runs in the browser. Every release of Mocha will have new builds of `./mocha.js` and `./mocha.css` for use in the browser.
 
-### Browser-specific methods
-
-The following method(s) _only_ function in a browser context:
-
-`mocha.allowUncaught()` : If called, uncaught errors will not be absorbed by the error handler.
-
 A typical setup might look something like the following, where we call `mocha.setup('bdd')` to use the **BDD** interface before loading the test scripts, running them `onload` with `mocha.run()`.
 
 ```html
@@ -1600,6 +1593,7 @@ mocha.setup({
 
 // Examples of options:
 mocha.setup({
+  allowUncaught: true,
   asyncOnly: true,
   bail: true,
   checkLeaks: true,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -800,7 +800,8 @@ Runner.prototype.uncaught = function(err) {
   if (err instanceof Pending) {
     return;
   }
-  if (this.allowUncaught) {
+  // browser does not exit script when throwing in global.onerror()
+  if (this.allowUncaught && !process.browser) {
     throw err;
   }
 

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -709,6 +709,8 @@ describe('Runner', function() {
 
     describe('when allow-uncaught is set to true', function() {
       it('should propagate error and throw', function() {
+        if (process.browser) this.skip();
+
         var err = new Error('should rethrow err');
         runner.allowUncaught = true;
         expect(


### PR DESCRIPTION
### Description

- _mocha/browser-entry.js_: Node's `process.on('uncaughtException', fn)` handler is moved to `global.onerror(fn)` in Browser.
```js
Runner.prototype.uncaught = function(err) {
  if (err instanceof Pending) {
    return;
  }
  // browser does not exit when throwing in global.onerror()
  if (this.allowUncaught && !process.browser) {
    throw err;
  }
[...]
```
- the result is distinct when an Error is thrown in the handler and `allowUncaught: true`
  - **Node**: the process exits and no tests or async tasks are executed anymore.
  - **Browser**: the JS script aborts the handler only, but the script keeps running. There seems no way to kill the entire script with its remaining tests and pending async tasks.
==> **test results are incorrect**, since the entire recovery logic of the handler is skipped.


### Description of the Change

- Node: behavior remains unchanged, the process is aborted upon `uncaughtException` when `allowUncaught` is set.
- Browser: we don't throw anymore inside the `uncaughtException` handler. The script keeps running and the test results are correct. So `allowUncaught` has no effect on the test run, but `uncaughtException`'s are printed in the console.
