### PR TITLE
Remove deprecated methods

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -428,24 +428,6 @@ Mocha.prototype.invert = function() {
 };
 
 /**
- * Enables or disables ignoring global leaks.
- *
- * @deprecated since v7.0.0
- * @public
- * @see {@link Mocha#checkLeaks}
- * @param {boolean} [ignoreLeaks=false] - Whether to ignore global leaks.
- * @return {Mocha} this
- * @chainable
- */
-Mocha.prototype.ignoreLeaks = function(ignoreLeaks) {
-  utils.deprecate(
-    '"ignoreLeaks()" is DEPRECATED, please use "checkLeaks()" instead.'
-  );
-  this.options.checkLeaks = !ignoreLeaks;
-  return this;
-};
-
-/**
  * Enables or disables checking for global variables leaked while running tests.
  *
  * @public
@@ -545,24 +527,6 @@ Mocha.prototype.globals = Mocha.prototype.global;
 /**
  * Enables or disables TTY color output by screen-oriented reporters.
  *
- * @deprecated since v7.0.0
- * @public
- * @see {@link Mocha#color}
- * @param {boolean} colors - Whether to enable color output.
- * @return {Mocha} this
- * @chainable
- */
-Mocha.prototype.useColors = function(colors) {
-  utils.deprecate('"useColors()" is DEPRECATED, please use "color()" instead.');
-  if (colors !== undefined) {
-    this.options.color = colors;
-  }
-  return this;
-};
-
-/**
- * Enables or disables TTY color output by screen-oriented reporters.
- *
  * @public
  * @see [CLI option](../#-color-c-colors)
  * @param {boolean} [color=true] - Whether to enable color output.
@@ -571,25 +535,6 @@ Mocha.prototype.useColors = function(colors) {
  */
 Mocha.prototype.color = function(color) {
   this.options.color = color !== false;
-  return this;
-};
-
-/**
- * Determines if reporter should use inline diffs (rather than +/-)
- * in test failure output.
- *
- * @deprecated since v7.0.0
- * @public
- * @see {@link Mocha#inlineDiffs}
- * @param {boolean} [inlineDiffs=false] - Whether to use inline diffs.
- * @return {Mocha} this
- * @chainable
- */
-Mocha.prototype.useInlineDiffs = function(inlineDiffs) {
-  utils.deprecate(
-    '"useInlineDiffs()" is DEPRECATED, please use "inlineDiffs()" instead.'
-  );
-  this.options.inlineDiffs = inlineDiffs !== undefined && inlineDiffs;
   return this;
 };
 
@@ -605,22 +550,6 @@ Mocha.prototype.useInlineDiffs = function(inlineDiffs) {
  */
 Mocha.prototype.inlineDiffs = function(inlineDiffs) {
   this.options.inlineDiffs = inlineDiffs !== false;
-  return this;
-};
-
-/**
- * Determines if reporter should include diffs in test failure output.
- *
- * @deprecated since v7.0.0
- * @public
- * @see {@link Mocha#diff}
- * @param {boolean} [hideDiff=false] - Whether to hide diffs.
- * @return {Mocha} this
- * @chainable
- */
-Mocha.prototype.hideDiff = function(hideDiff) {
-  utils.deprecate('"hideDiff()" is DEPRECATED, please use "diff()" instead.');
-  this.options.diff = !(hideDiff === true);
   return this;
 };
 

--- a/test/jsapi/index.js
+++ b/test/jsapi/index.js
@@ -5,7 +5,6 @@ var Mocha = require('../../');
 var mocha = new Mocha({
   ui: 'bdd',
   globals: ['okGlobalA', 'okGlobalB', 'okGlobalC', 'callback*'],
-  // ignoreLeaks: true,
   growl: true
 });
 

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -332,56 +332,6 @@ describe('Mocha', function() {
     });
   });
 
-  describe('#hideDiff()', function() {
-    it('should set the diff option to false when param equals true', function() {
-      var mocha = new Mocha(opts);
-      mocha.hideDiff(true);
-      expect(mocha.options, 'to have property', 'diff', false);
-    });
-
-    it('should set the diff option to true when param equals false', function() {
-      var mocha = new Mocha(opts);
-      mocha.hideDiff(false);
-      expect(mocha.options, 'to have property', 'diff', true);
-    });
-
-    it('should set the diff option to true when the param is undefined', function() {
-      var mocha = new Mocha(opts);
-      mocha.hideDiff();
-      expect(mocha.options, 'to have property', 'diff', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.hideDiff(), 'to be', mocha);
-    });
-  });
-
-  describe('#ignoreLeaks()', function() {
-    it('should set the checkLeaks option to false when param equals true', function() {
-      var mocha = new Mocha(opts);
-      mocha.ignoreLeaks(true);
-      expect(mocha.options, 'to have property', 'checkLeaks', false);
-    });
-
-    it('should set the checkLeaks option to true when param equals false', function() {
-      var mocha = new Mocha(opts);
-      mocha.ignoreLeaks(false);
-      expect(mocha.options, 'to have property', 'checkLeaks', true);
-    });
-
-    it('should set the checkLeaks option to true when the param is undefined', function() {
-      var mocha = new Mocha(opts);
-      mocha.ignoreLeaks();
-      expect(mocha.options, 'to have property', 'checkLeaks', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.ignoreLeaks(), 'to be', mocha);
-    });
-  });
-
   describe('#inlineDiffs()', function() {
     it('should set the inlineDiffs option to true', function() {
       var mocha = new Mocha(opts);
@@ -500,50 +450,6 @@ describe('Mocha', function() {
           }
         }, 'not to throw');
       });
-    });
-  });
-
-  describe('#useColors()', function() {
-    it('should set the color option to true', function() {
-      var mocha = new Mocha(opts);
-      mocha.useColors(true);
-      expect(mocha.options, 'to have property', 'color', true);
-    });
-
-    it('should not create the color property', function() {
-      var mocha = new Mocha(opts);
-      mocha.useColors();
-      expect(mocha.options, 'not to have property', 'color');
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.useColors(), 'to be', mocha);
-    });
-  });
-
-  describe('#useInlineDiffs()', function() {
-    it('should set the inlineDiffs option to true when param equals true', function() {
-      var mocha = new Mocha(opts);
-      mocha.useInlineDiffs(true);
-      expect(mocha.options, 'to have property', 'inlineDiffs', true);
-    });
-
-    it('should set the inlineDiffs option to false when param equals false', function() {
-      var mocha = new Mocha(opts);
-      mocha.useInlineDiffs(false);
-      expect(mocha.options, 'to have property', 'inlineDiffs', false);
-    });
-
-    it('should set the inlineDiffs option to false when the param is undefined', function() {
-      var mocha = new Mocha(opts);
-      mocha.useInlineDiffs();
-      expect(mocha.options, 'to have property', 'inlineDiffs', false);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.useInlineDiffs(), 'to be', mocha);
     });
   });
 });


### PR DESCRIPTION
### Test environment 
 - nodeVersion : v10.15.1
 - os : MacOS 

### Description of the Change
I removed deprecated Method and tested it. removing something is difficult like love but it is neccessery
- Mocha.prototype.ignoreLeaks 
- Mocha.prototype.useColors
- Mocha.prototype.useInlineDiffs
- Mocha.prototype.hideDiff

## Mocha.prototype.ignoreLeaks 
Why it is be removed? 
because `Mocha.prototype.checkLeaks` is Take on a role and do better

#### Testing result
After I removed, It is worked
##### index.html
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>Mocha Tests</title>
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
  </head>
  <body>
    <div id="mocha"></div>
    <script src="https://unpkg.com/chai/chai.js"></script>
    <script src="./mocha.js"></script> 
    <script class="mocha-init">
      mocha.setup('bdd');
      mocha.checkLeaks();
    </script>

    <script src="./a.js"></script> 
    <script class="mocha-exec">
      mocha.run();
    </script>
  </body>
</html>
```
##### a.js
```js
const expect = chai.expect;
describe('Leak detection', function() {
  const test = () => {
    a = 1; 
  } 
  it('should not leak', function() {
    test(); 
  }) 
})
```
Testing `npm start build && cp mocha.js ../test/public/`
And it is work! 

## Mocha.prototype.useColors
We use color() instead of useColors().
**Not a base.js - exports.useColors** I removed Mocha.js - Mocha.prototype.useColors
#### Testing result
After I removed, It is worked
`node ../../mocha/bin/mocha a.js --color`
`node ../../mocha/bin/mocha a.js --no-color`

## Mocha.prototype.useInlineDiffs
We use inlinediff() instead of useInlineDiffs();
After I removed, It is worked
`node ../../mocha/bin/mocha a.js --inline-diffs` 

##### a.js
```js
const {expect} = require('chai');  
describe("actual & expected Test", function () { 
  it("should results is same to expected", function () { 
    const results = {
      depth: 2,
      foo: "bar"
    }; 
    const expected = {
      depth: 4,
      foo: "bar",
      hello: "world"
    }; 
    expect(results).to.deep.equal(expected);
  });
});
```

## Mocha.prototype.hideDiff 
We use diff() instead of hideDiff();
After I removed, It is worked
`node ../../mocha/bin/mocha a.js --diff=false` 
`node ../../mocha/bin/mocha a.js --diff` 

##### a.js
```js
const {expect} = require('chai');  
describe("actual & expected Test", function () { 
  it("should results is same to expected", function () { 
    const results = {
      depth: 2,
      foo: "bar"
    }; 
    const expected = {
      depth: 4,
      foo: "bar",
      hello: "world"
    }; 
    expect(results).to.deep.equal(expected);
  });
});
```

Let me know if there is anything I couldn't check. I'll fix it.

### Benefits
Clean up for next version.