### PR TITLE
Fix: programmatic API cannot access retried test objects

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -135,6 +135,11 @@ function Runner(suite, delay) {
   this.total = suite.total();
   this.failures = 0;
   this.on(constants.EVENT_TEST_END, function(test) {
+    if (test.retriedTest() && test.parent) {
+      var idx =
+        test.parent.tests && test.parent.tests.indexOf(test.retriedTest());
+      if (idx > -1) test.parent.tests[idx] = test;
+    }
     self.checkGlobals(test);
   });
   this.on(constants.EVENT_HOOK_END, function(hook) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -36,6 +36,18 @@ function Test(title, fn) {
  */
 utils.inherits(Test, Runnable);
 
+/**
+ * Set or get retried test
+ *
+ * @private
+ */
+Test.prototype.retriedTest = function(n) {
+  if (!arguments.length) {
+    return this._retriedTest;
+  }
+  this._retriedTest = n;
+};
+
 Test.prototype.clone = function() {
   var test = new Test(this.title, this.fn);
   test.timeout(this.timeout());
@@ -43,6 +55,7 @@ Test.prototype.clone = function() {
   test.enableTimeouts(this.enableTimeouts());
   test.retries(this.retries());
   test.currentRetry(this.currentRetry());
+  test.retriedTest(this.retriedTest() || this);
   test.globals(this.globals());
   test.parent = this.parent;
   test.file = this.file;

--- a/test/integration/fixtures/retries/early-pass.fixture.js
+++ b/test/integration/fixtures/retries/early-pass.fixture.js
@@ -1,8 +1,10 @@
 'use strict';
+const assert = require('assert');
 
 describe('retries', function () {
   this.retries(1);
   var times = 0;
+  var self = this;
 
   it('should pass after 1 retry', function () {
     times++;
@@ -10,4 +12,10 @@ describe('retries', function () {
       throw new Error('retry error ' + times);
     }
   });
+  
+  it('check for updated `suite.tests`', function() {
+    assert.equal(self.tests[0]._currentRetry, 1);
+    assert.ok(self.tests[0]._retriedTest);
+    assert.equal(self.tests[0].state, 'passed');
+  })
 });

--- a/test/integration/retries.spec.js
+++ b/test/integration/retries.spec.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert');
 var helpers = require('./helpers');
+var runJSON = helpers.runMochaJSON;
 var args = [];
 var bang = require('../../lib/reporters/base').symbols.bang;
 
@@ -59,25 +60,22 @@ describe('retries', function() {
   });
 
   it('should exit early if test passes', function(done) {
-    helpers.runMochaJSON('retries/early-pass.fixture.js', args, function(
-      err,
-      res
-    ) {
+    runJSON('retries/early-pass.fixture.js', args, function(err, res) {
       if (err) {
-        done(err);
-        return;
+        return done(err);
       }
-      assert.strictEqual(res.stats.passes, 1);
-      assert.strictEqual(res.stats.failures, 0);
-      assert.strictEqual(res.tests[0].currentRetry, 1);
-      assert.strictEqual(res.stats.tests, 1);
-      assert.strictEqual(res.code, 0);
+
+      expect(res, 'to have passed')
+        .and('to have passed test count', 2)
+        .and('to have failed test count', 0)
+        .and('to have retried test', 'should pass after 1 retry', 1);
+
       done();
     });
   });
 
   it('should let test override', function(done) {
-    helpers.runMochaJSON('retries/nested.fixture.js', args, function(err, res) {
+    runJSON('retries/nested.fixture.js', args, function(err, res) {
       if (err) {
         done(err);
         return;

--- a/test/unit/test.spec.js
+++ b/test/unit/test.spec.js
@@ -41,6 +41,12 @@ describe('Test', function() {
       expect(this._test.clone().currentRetry(), 'to be', 1);
     });
 
+    it('should add/keep the retriedTest value', function() {
+      var clone1 = this._test.clone();
+      expect(clone1.retriedTest(), 'to be', this._test);
+      expect(clone1.clone().retriedTest(), 'to be', this._test);
+    });
+
     it('should copy the globals value', function() {
       expect(this._test.clone().globals(), 'not to be empty');
     });


### PR DESCRIPTION
### Description

To re-run a failing test Mocha:
- clones the test for each attempt
- passes the test object of the final attempt to the reporter by emitting an `EVENT_TEST_END`
- DOES NOT: update the original `runner`'s test array `suite.tests` with the latest test object

The result of Mocha's core reporters is correct, since they hook into events and use the latest test object. But third party reporters as _Mochawesome_ relying on `suite.tests` may show incorrect test results.

### Description of the Change

We update `runner`'s `suite.tests` after the final attempt when the `EVENT_TEST_END` is emitted and replace the first failing test by the test object of the last attempt.

### Applicable issues

closes #2188