### PR TITLE
Support .mocharc.cjs

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -22,6 +22,7 @@ const findUp = require('find-up');
  */
 exports.CONFIG_FILES = [
   '.mocharc.js',
+  '.mocharc.cjs',
   '.mocharc.yaml',
   '.mocharc.yml',
   '.mocharc.jsonc',
@@ -75,7 +76,7 @@ exports.loadConfig = filepath => {
   try {
     if (ext === '.yml' || ext === '.yaml') {
       config = parsers.yaml(filepath);
-    } else if (ext === '.js') {
+    } else if (ext === '.js' || ext === '.cjs') {
       config = parsers.js(filepath);
     } else {
       config = parsers.json(filepath);


### PR DESCRIPTION
### Description of the Change

This allows for `"type": "module"` in package.json while also using a
mocha config file, which was previously impossible.
See: https://nodejs.org/api/esm.html

Compare to https://github.com/facebook/jest/issues/9086

### Alternate Designs

N/A

### Why should this be in core?

N/A

### Benefits

`.mocharc.cjs` works

### Possible Drawbacks

N/A

### Applicable issues

https://github.com/mochajs/mocha/pull/4038