### PR TITLE
docs: show Netlify badge on footer

### DIFF
--- a/docs/_includes/default.html
+++ b/docs/_includes/default.html
@@ -90,47 +90,60 @@
         </p>
       </div>
 
-      <ul id="openjsf-links">
-        <li>
-          <a href="https://openjsf.org/" rel="external noopener"
-            >The OpenJS Foundation</a
-          >
-        </li>
-        <li>
-          <a href="https://terms-of-use.openjsf.org/" rel="external noopener"
-            >Terms of Use</a
-          >
-        </li>
-        <li>
-          <a href="https://privacy-policy.openjsf.org/" rel="external noopener"
-            >Privacy Policy</a
-          >
-        </li>
-        <li>
-          <a href="https://bylaws.openjsf.org/" rel="external noopener"
-            >OpenJS Foundation Bylaws</a
-          >
-        </li>
-        <li>
-          <a
-            href="https://trademark-policy.openjsf.org/"
-            rel="external noopener"
-            >Trademark Policy</a
-          >
-        </li>
-        <li>
-          <a href="https://trademark-list.openjsf.org/" rel="external noopener"
-            >Trademark List</a
-          >
-        </li>
-        <li>
-          <a
-            href="https://www.linuxfoundation.org/cookies/"
-            rel="external noopener"
-            >Cookie Policy</a
-          >
-        </li>
-      </ul>
+      <div id="external-links">
+        <ul id="openjsf-links">
+          <li>
+            <a href="https://openjsf.org/" rel="external noopener"
+              >The OpenJS Foundation</a
+            >
+          </li>
+          <li>
+            <a href="https://terms-of-use.openjsf.org/" rel="external noopener"
+              >Terms of Use</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://privacy-policy.openjsf.org/"
+              rel="external noopener"
+              >Privacy Policy</a
+            >
+          </li>
+          <li>
+            <a href="https://bylaws.openjsf.org/" rel="external noopener"
+              >OpenJS Foundation Bylaws</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://trademark-policy.openjsf.org/"
+              rel="external noopener"
+              >Trademark Policy</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://trademark-list.openjsf.org/"
+              rel="external noopener"
+              >Trademark List</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.linuxfoundation.org/cookies/"
+              rel="external noopener"
+              >Cookie Policy</a
+            >
+          </li>
+        </ul>
+        <div class="netlify-badge">
+          <a href="https://www.netlify.com">
+            <img
+              src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"
+            />
+          </a>
+        </div>
+      </div>
       <dl id="last-modified" class="dl-inline">
         <dt>Last updated</dt>
         <dd>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -251,6 +251,10 @@ footer {
   max-width: 66%;
 }
 
+#external-links {
+  position: relative;
+}
+
 #openjsf-links {
   margin: 0;
   padding: 0;
@@ -269,6 +273,12 @@ footer {
 /* displays each list item with a "|" between */
 #openjsf-links li + li:before {
   content: ' | ';
+}
+
+#external-links .netlify-badge {
+  position: absolute;
+  right: 0;
+  bottom: 0;
 }
 
 .dl-inline dt,
@@ -291,7 +301,7 @@ blockquote {
   padding: 10px;
 }
 
-@media all and (max-width: 900px) {
+@media all and (max-width: 960px) {
   #copyright-notice {
     max-width: initial;
   }


### PR DESCRIPTION
### Description of the Change 
To use Netlify's Open Source plan, I added [Netlify badge](https://www.netlify.com/press/#badges) on the footer as [their policy](https://www.netlify.com/legal/open-source-policy/). There are 4 rules but we already met 3 of them.

This PR address 3rd rule.

1. [x] Open Source Initiative approved license
1. [x] Code of Conduct
1. [ ] feature a link to our service
1. [x] must not be a commercial project

##### over 960px width
<img width="1083" alt="스크린샷 2020-02-22 18 21 04" src="https://user-images.githubusercontent.com/390146/75089884-aafc2100-55a0-11ea-80e7-4432663aa865.png">

##### under 960px width
<img width="331" alt="스크린샷 2020-02-22 18 21 54" src="https://user-images.githubusercontent.com/390146/75089906-cf57fd80-55a0-11ea-9e6b-98434f9a18c6.png">


### Alternate Designs
Netlify badge can be next to the OpenJS foundation logo, but I think the footer is better since Netlify badge is much smaller.

### Benefits
We can use Netlify open source plan.