### PR TITLE
fix: check if module.paths really exists

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -30,7 +30,9 @@ const {repository, homepage, version, gitter} = require('../../package.json');
 exports.main = (argv = process.argv.slice(2)) => {
   debug('entered main with raw args', argv);
   // ensure we can require() from current working directory
-  module.paths.push(process.cwd(), path.resolve('node_modules'));
+  if (typeof module.paths !== 'undefined') {
+    module.paths.push(process.cwd(), path.resolve('node_modules'));
+  }
 
   Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -29,7 +29,7 @@ exports = module.exports = Mocha;
  * To require local UIs and reporters when running in node.
  */
 
-if (!process.browser) {
+if (!process.browser && typeof module.paths !== 'undefined') {
   var cwd = process.cwd();
   module.paths.push(cwd, path.join(cwd, 'node_modules'));
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change
`module.paths` was not defined when Mocha was run in an serverless environment. Probably due to the absence of `node_modules` folder. I had bundled the test using a bundler.

I added a check to make sure it doesn't throw an error.

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs
Not sure if there are any other alternatives but open to suggestions.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?
I don't think userland should mock `module.paths`.
<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits
It would not throw an error during the execution of tests in a serverless environment.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
I don't see any.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
Fixes #2505 
This should be a bug fix
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
