### PR TITLE
Reduce unnecessary condition determination

### DIFF
--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -84,8 +84,7 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       return function(event, callback) {
         if (event === ifStr1) {
           callback();
-        }
-        if (event === ifStr2) {
+        } else if (event === ifStr2) {
           callback(test);
         }
       };
@@ -94,11 +93,9 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       return function(event, callback) {
         if (event === ifStr1) {
           callback(expectedSuite);
-        }
-        if (event === ifStr2) {
+        } else if (event === ifStr2) {
           callback();
-        }
-        if (event === ifStr3) {
+        } else if (event === ifStr3) {
           callback();
         }
       };
@@ -107,8 +104,7 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       return function(event, callback) {
         if (event === ifStr1) {
           callback(test);
-        }
-        if (event === ifStr2) {
+        } else if (event === ifStr2) {
           callback();
         }
       };
@@ -118,8 +114,7 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       return function(event, callback) {
         if (event === ifStr1) {
           callback();
-        }
-        if (event === ifStr2) {
+        } else if (event === ifStr2) {
           callback(test, error);
         }
       };
@@ -128,11 +123,9 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
         test = arg1;
         if (event === ifStr1) {
           callback(test, {});
-        }
-        if (event === ifStr2) {
+        } else if (event === ifStr2) {
           callback(test);
-        }
-        if (event === ifStr3) {
+        } else if (event === ifStr3) {
           callback(test);
         }
       };

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -106,7 +106,7 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
           callback();
         }
       };
-    case 'test end fail':
+    case 'end fail':
       test = arg1;
       var error = arg2;
       return function(event, callback) {

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -93,9 +93,7 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
       return function(event, callback) {
         if (event === ifStr1) {
           callback(expectedSuite);
-        } else if (event === ifStr2) {
-          callback();
-        } else if (event === ifStr3) {
+        } else if (event === ifStr2 || event === ifStr3) {
           callback();
         }
       };
@@ -123,9 +121,7 @@ function createRunnerFunction(runStr, ifStr1, ifStr2, ifStr3, arg1, arg2) {
         test = arg1;
         if (event === ifStr1) {
           callback(test, {});
-        } else if (event === ifStr2) {
-          callback(test);
-        } else if (event === ifStr3) {
+        } else if (event === ifStr2 || event === ifStr3) {
           callback(test);
         }
       };

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -126,7 +126,7 @@ describe('TAP reporter', function() {
               message: expectedErrorMessage
             };
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -163,7 +163,7 @@ describe('TAP reporter', function() {
               stack: expectedStack
             };
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -194,7 +194,7 @@ describe('TAP reporter', function() {
               message: expectedErrorMessage
             };
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -230,7 +230,7 @@ describe('TAP reporter', function() {
             var test = createTest();
             var error = {};
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -390,7 +390,7 @@ describe('TAP reporter', function() {
               message: expectedErrorMessage
             };
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -430,7 +430,7 @@ describe('TAP reporter', function() {
               stack: expectedStack
             };
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -464,7 +464,7 @@ describe('TAP reporter', function() {
               message: expectedErrorMessage
             };
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,
@@ -504,7 +504,7 @@ describe('TAP reporter', function() {
             var test = createTest();
             var error = {};
             var runner = createMockRunner(
-              'test end fail',
+              'end fail',
               EVENT_TEST_END,
               EVENT_TEST_FAIL,
               null,


### PR DESCRIPTION
### Description of the Change
In `test/reporters/helpers.js`,
1. Changed some `if` to `else if` for code efficiency.
2. Changed the code by using `||` for code readability.

### Benefits
1. Removing unnecessary discrimination processes.
    * If `event` is `ifStr1`, we no longer need to determine if `event` is `ifStr2` or `ifStr3`. But when `helpers.js` is executed, it goes through all of `if` statements, because they exist independently of each other. By using `else if`, once the preceding callback function is executed, the execution of the latter callback function will be passed **unconditionally**.
2. Minimizing the code length.

### Possible Drawbacks

I think it will not make any side effects.