### PR TITLE
Drop mkdirp and replace it with fs.mkdirSync

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Follow these steps to get going. If you are having trouble, don't be afraid to [
 
 > PRO TIP: After `npm install`, run `npm start` to see a list of commands which can be run with `npm start <command>` (powered by [nps](https://npm.im/nps)).
 
-1. [Install Node.js 10.x or newer](https://nodejs.org/en/download/).
+1. [Install Node.js 10.12.0 or newer](https://nodejs.org/en/download/).
    - If you're new to installing Node, a tool like [nvm](https://github.com/creationix/nvm#install-script) can help you manage multiple version installations.
    - You will need [Google Chrome](https://www.google.com/chrome/) to run browser-based tests locally.
 1. Follow [Github's documentation](https://help.github.com/articles/fork-a-repo/) on setting up Git, forking and cloning.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ _So you wanna build the site?_
 
 ## Prerequisites
 
-- Node.js v10.x or greater
+- Node.js v10.12.0 or greater
 
 ## Development
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ or as a development dependency for your project:
 $ npm install --save-dev mocha
 ```
 
-> As of v8.0.0, Mocha requires Node.js v10.0.0 or newer.
+> As of v8.0.0, Mocha requires Node.js v10.12.0 or newer.
 
 ## Getting Started
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const mkdirp = require('mkdirp');
 const os = require('os');
 const baseBundleDirpath = path.join(__dirname, '.karma');
 
@@ -111,7 +110,7 @@ module.exports = config => {
         console.error('No SauceLabs credentials present');
       }
     }
-    mkdirp.sync(bundleDirpath);
+    fs.mkdirSync(bundleDirpath, {recursive: true});
   } else {
     console.error('CI mode disabled');
   }

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -9,7 +9,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const mkdirp = require('mkdirp');
 
 exports.command = 'init <path>';
 
@@ -24,7 +23,7 @@ exports.builder = yargs =>
 exports.handler = argv => {
   const destdir = argv.path;
   const srcdir = path.join(__dirname, '..', '..');
-  mkdirp.sync(destdir);
+  fs.mkdirSync(destdir, {recursive: true});
   const css = fs.readFileSync(path.join(srcdir, 'mocha.css'));
   const js = fs.readFileSync(path.join(srcdir, 'mocha.js'));
   const tmpl = fs.readFileSync(

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -9,7 +9,6 @@
 var Base = require('./base');
 var utils = require('../utils');
 var fs = require('fs');
-var mkdirp = require('mkdirp');
 var path = require('path');
 var errors = require('../errors');
 var createUnsupportedError = errors.createUnsupportedError;
@@ -62,7 +61,9 @@ function XUnit(runner, options) {
         throw createUnsupportedError('file output not supported in browser');
       }
 
-      mkdirp.sync(path.dirname(options.reporterOptions.output));
+      fs.mkdirSync(path.dirname(options.reporterOptions.output), {
+        recursive: true
+      });
       self.fileStream = fs.createWriteStream(options.reporterOptions.output);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -702,7 +702,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "arch": {
@@ -2227,7 +2227,7 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
     },
     "browser-sync": {
       "version": "2.26.7",
@@ -4739,7 +4739,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -7359,7 +7359,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -12084,7 +12084,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 10.12.0"
   },
   "scripts": {
     "prepublishOnly": "nps test clean build",
@@ -56,7 +56,6 @@
     "js-yaml": "3.13.1",
     "log-symbols": "3.0.0",
     "minimatch": "3.0.4",
-    "mkdirp": "0.5.3",
     "ms": "2.1.1",
     "node-environment-flags": "1.0.6",
     "object.assign": "4.1.0",

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -4,7 +4,6 @@ var utils = require('../../lib/utils');
 var fs = require('fs');
 var path = require('path');
 var os = require('os');
-var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 
 describe('file utils', function() {
@@ -119,7 +118,7 @@ describe('file utils', function() {
   afterEach(removeTempDir);
 
   function makeTempDir() {
-    mkdirp.sync(tmpDir);
+    fs.mkdirSync(tmpDir, {recursive: true});
   }
 
   function removeTempDir() {

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -4,7 +4,6 @@ var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
-var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var sinon = require('sinon');
 var createStatsCollector = require('../../lib/stats-collector');
@@ -51,12 +50,12 @@ describe('XUnit reporter', function() {
     };
 
     describe('when fileStream can be created', function() {
-      var mkdirpSync;
+      var fsMkdirSync;
       var fsCreateWriteStream;
 
       beforeEach(function() {
         sandbox = sinon.createSandbox();
-        mkdirpSync = sandbox.stub(mkdirp, 'sync');
+        fsMkdirSync = sandbox.stub(fs, 'mkdirSync');
         fsCreateWriteStream = sandbox.stub(fs, 'createWriteStream');
       });
 
@@ -67,7 +66,13 @@ describe('XUnit reporter', function() {
         XUnit.call(fakeThis, runner, options);
 
         var expectedDirectory = path.dirname(expectedOutput);
-        expect(mkdirpSync.calledWith(expectedDirectory), 'to be true');
+        expect(
+          fsMkdirSync.calledWith(expectedDirectory, {
+            recursive: true
+          }),
+          'to be true'
+        );
+
         expect(fsCreateWriteStream.calledWith(expectedOutput), 'to be true');
       });
 


### PR DESCRIPTION
### Description of the Change
- Replace `mkdirp` with `fs.mkdirSync` using `{recursive: true}`
- Drop the dependency `mkdirp` from Mocha

### Alternate Designs
There is also a way to update to the latest `mkdirp` version, but Node.js version 10.12.0 has already added a native support for `mkdirSync` to create a directory recursively with `{recursive: true}` option as the following:
```js
fs.mkdirSync(pathname, { recursive: true });
```

So, there is no longer necessary to depend on third-party packages. `fs` module is enough to us.

### Why should this be in core?
`mkdirp` depends on an old version of `minimist`, and it has a prototype pollution vulnerability.

### Benefits
Can create a new directory and any necessary subdirectories at the directory **without mkdirp**.

### Possible Drawbacks
Can't think of any.

### Applicable issues
I think it have to be released with **`semver-major`(maybe v8.0.0)**, because the `{recursive: true}` option of `fs.mkdir` is supported by Node.js v10.12.0 or later.

Closes #4199 