### PR TITLE
Bump version of mkdirp to remove security risk

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-yaml": "3.13.1",
     "log-symbols": "3.0.0",
     "minimatch": "3.0.4",
-    "mkdirp": "0.5.1",
+    "mkdirp": "1.0.3",
     "ms": "2.1.1",
     "node-environment-flags": "1.0.6",
     "object.assign": "4.1.0",


### PR DESCRIPTION

### Description of the Change

This pull request bumps the version of mkdirp to remove the security rist: minimist < 1.2.2.
The latest version of mkdirp do not use this packet at all.

### Alternate Designs

N/A

### Why should this be in core?

It fixes the security risk.
https://github.com/advisories/GHSA-7fhm-mqm4-2wp7

### Benefits

It fixes the security risk.

### Possible Drawbacks

None

### Applicable issues
https://github.com/advisories/GHSA-7fhm-mqm4-2wp7
