### PR TITLE
Fix the description of package.json "type" field

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1732,7 +1732,7 @@ tests as shown below:
 
 Mocha supports configuration files, typical of modern command-line tools, in several formats:
 
-- **JavaScript**: Create a `.mocharc.js` (or `mocharc.cjs` when using [`"type"="module"`](#nodejs-native-esm-support) in your `package.json`)
+- **JavaScript**: Create a `.mocharc.js` (or `mocharc.cjs` when using [`"type": "module"`](#nodejs-native-esm-support) in your `package.json`)
   in your project's root directory, and export an object (`module.exports = {/* ... */}`) containing your configuration.
 - **YAML**: Create a `.mocharc.yaml` (or `.mocharc.yml`) in your project's root directory.
 - **JSON**: Create a `.mocharc.json` (or `.mocharc.jsonc`) in your project's root directory. Comments &mdash; while not valid JSON &mdash; are allowed in this file, and will be ignored by Mocha.


### PR DESCRIPTION
### Description of the Change
I found typo in docs about ["type" field of _package.json_](https://nodejs.org/api/esm.html#esm_package_json_type_field) :
<img src="https://user-images.githubusercontent.com/44132406/76964225-ba834580-6965-11ea-953d-53447ea8c45b.png" width="400px">

So I fixed it.
```diff
- "type"="module"
+ "type": "module"
```

### Applicable issues
For patch release