### PR TITLE
Update mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11588,9 +11588,9 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-yaml": "3.13.1",
     "log-symbols": "3.0.0",
     "minimatch": "3.0.4",
-    "mkdirp": "0.5.3",
+    "mkdirp": "0.5.5",
     "ms": "2.1.1",
     "node-environment-flags": "1.0.6",
     "object.assign": "4.1.0",


### PR DESCRIPTION
We already update mkdirp to 0.5.4 on [6.2.4](https://github.com/mochajs/mocha/releases/tag/v6.2.3). 
But 7.1.1 still have 0.5.3. So update it to 0.5.4.

This PR should land to v7.1.x only because we will use mkdirp on next v8.0.0.

### Applicable issues
Close #4217 