### PR TITLE
Add reporter options example

### DIFF
--- a/example/config/.mocharc.js
+++ b/example/config/.mocharc.js
@@ -1,17 +1,47 @@
 'use strict';
 
-// Here's a JavaScript-based config file.
+// This is a JavaScript-based config file containing every Mocha option plus others.
 // If you need conditional logic, you might want to use this type of config.
 // Otherwise, JSON or YAML is recommended.
 
 module.exports = {
+  'allow-uncaught': false,
+  'async-only': false,
+  bail: false,
+  'check-leaks': false,
+  color: true,
+  delay: false,
   diff: true,
+  exit: false, // could be expressed as "'no-exit': true"
   extension: ['js'],
+  // fgrep: something, // fgrep and grep are mutually exclusive
+  file: ['/path/to/some/file', '/path/to/some/other/file'],
+  'forbid-only': false,
+  'forbid-pending': false,
+  'full-trace': false,
+  global: ['jQuery', '$'],
+  // grep: something, // fgrep and grep are mutually exclusive
+  growl: false,
+  ignore: ['/path/to/some/ignored/file'],
+  'inline-diffs': false,
+  // invert: false, // needs to be used with grep or fgrep
+  jobs: 1,
   package: './package.json',
+  parallel: false,
+  recursive: false,
   reporter: 'spec',
-  slow: 75,
-  timeout: 2000,
+  'reporter-option': ['foo=bar', 'baz=quux'],
+  require: '@babel/register',
+  retries: 1,
+  slow: '75',
+  sort: false,
+  spec: ['test/**/*.spec.js'], // the positional arguments!
+  timeout: '2000', // same as "timeout: '2s'"
+  // timeout: false, // same as "'no-timeout': true" or "timeout: 0"
+  'trace-warnings': true, // node flags ok
   ui: 'bdd',
+  'v8-stack-trace-limit': 100, // V8 flags are prepended with "v8-"
+  watch: false,
   'watch-files': ['lib/**/*.js', 'test/**/*.js'],
   'watch-ignore': ['lib/vendor']
 };

--- a/example/config/.mocharc.json
+++ b/example/config/.mocharc.json
@@ -1,14 +1,13 @@
 // This config file contains Mocha's defaults.
-// As you can see, comments are allowed.
 // This same configuration could be provided in the `mocha` property of your
 // project's `package.json`.
 {
   "diff": true,
-  "extension": ["js"],
+  "extension": ["js", "cjs", "mjs"],
   "package": "./package.json",
   "reporter": "spec",
-  "slow": 75,
-  "timeout": 2000,
+  "slow": "75",
+  "timeout": "2000",
   "ui": "bdd",
   "watch-files": ["lib/**/*.js", "test/**/*.js"],
   "watch-ignore": ["lib/vendor"]

--- a/example/config/.mocharc.jsonc
+++ b/example/config/.mocharc.jsonc
@@ -4,13 +4,12 @@
 // project's `package.json`.
 {
   "diff": true,
-  "extension": ["js"],
+  "extension": ["js","cjs","mjs"],
   "package": /* 📦 */ "./package.json",
   "reporter": /* 📋 */ "spec",
-  "slow": 75,
-  "timeout": 2000,
+  "slow": "75",
+  "timeout": "2000",
   "ui": "bdd",
-  // Camel-casing options are also accepted
-  "watchFiles": ["lib/**/*.js", "test/**/*.js"],
-  "watchIgnore": ["lib/vendor"]
+  "watch-files": ["lib/**/*.js", "test/**/*.js"],
+  "watch-ignore": ["lib/vendor"]
 }

--- a/example/config/.mocharc.yml
+++ b/example/config/.mocharc.yml
@@ -1,4 +1,4 @@
-# This is an example Mocha config containing every Mocha option plus others
+# This is an example Mocha config containing every Mocha option plus others.
 allow-uncaught: false
 async-only: false
 bail: false
@@ -28,6 +28,9 @@ ignore:
 inline-diffs: false
 # needs to be used with grep or fgrep
 # invert: false
+jobs: 1
+package: './package.json'
+parallel: false
 recursive: false
 reporter: 'spec'
 reporter-option:
@@ -35,10 +38,12 @@ reporter-option:
   - 'baz=quux'
 require: '@babel/register'
 retries: 1
-slow: 75
+slow: '75'
 sort: false
-spec: 'test/**/*.spec.js' # the positional arguments!
-timeout: false # same as "no-timeout: true" or "timeout: 0"
+spec:
+  - 'test/**/*.spec.js' # the positional arguments!
+timeout: '2000' # same as "timeout: '2s'"
+# timeout: false # same as "no-timeout: true" or "timeout: 0"
 trace-warnings: true # node flags ok
 ui: 'bdd'
 v8-stack-trace-limit: 100 # V8 flags are prepended with "v8-"


### PR DESCRIPTION
### Description of the Change

I tried to add reporter options as `reporterOptions` or `reporterOption` and failed miserably for quite a while until I accidentally found out that it needs to be specified like in the example below.

### Benefits

I think it's worth adding an example to the documentation to save other people's time.
