### PR TITLE
fix: check process.browser, before access process.stdout

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -25,7 +25,7 @@ exports = module.exports = Base;
  * Check if both stdio streams are associated with a tty.
  */
 
-var isatty = process.stdout.isTTY && process.stderr.isTTY;
+var isatty = !process.browser && process.stdout.isTTY && process.stderr.isTTY;
 
 /**
  * Save log references to avoid tests interfering (see GH-3604).


### PR DESCRIPTION
### Description of the Change

In browser context, `process.stdout` is `undefined`.

I implement a custom reporter, when run macha in browser, as the following code show. Error occur in the first line of code, because of the above reason.

```
const Base = require('mocha/lib/reporters/base');

function MochaReporter(runner, options) {
  ...
  // Call the Base mocha reporter
  Base.call(this, runner);
  ...

  // Process the full suite
  runner.on('end', () => {
    try {
        const rootSuite = mapSuites(this.runner.suite, totalTestsRegistered, this.config);
        const obj = {
          stats: this.stats,
          results: [ rootSuite ],
        };
        // Save the final output to be used in the future
        this.output = obj;
      }
    } catch (e) {
    }
  });
}
```



<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
