### PR TITLE
Remove Runnable#inspect and utils.ngettext

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -223,31 +223,6 @@ Runnable.prototype.clearTimeout = function() {
 };
 
 /**
- * Inspect the runnable void of private properties.
- *
- * @private
- * @return {string}
- */
-Runnable.prototype.inspect = function() {
-  return JSON.stringify(
-    this,
-    function(key, val) {
-      if (key[0] === '_') {
-        return;
-      }
-      if (key === 'parent') {
-        return '#<Suite>';
-      }
-      if (key === 'ctx') {
-        return '#<Context>';
-      }
-      return val;
-    },
-    2
-  );
-};
-
-/**
  * Reset the timeout.
  *
  * @private

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -20,7 +20,6 @@ var STATE_FAILED = Runnable.constants.STATE_FAILED;
 var STATE_PASSED = Runnable.constants.STATE_PASSED;
 var STATE_PENDING = Runnable.constants.STATE_PENDING;
 var dQuote = utils.dQuote;
-var ngettext = utils.ngettext;
 var sQuote = utils.sQuote;
 var stackFilter = utils.stackTraceFilter();
 var stringify = utils.stringify;
@@ -271,12 +270,8 @@ Runner.prototype.checkGlobals = function(test) {
   this._globals = this._globals.concat(leaks);
 
   if (leaks.length) {
-    var format = ngettext(
-      leaks.length,
-      'global leak detected: %s',
-      'global leaks detected: %s'
-    );
-    var error = new Error(util.format(format, leaks.map(sQuote).join(', ')));
+    var msg = 'global leak(s) detected: %s';
+    var error = new Error(util.format(msg, leaks.map(sQuote).join(', ')));
     this.fail(test, error);
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -754,38 +754,6 @@ exports.dQuote = function(str) {
 };
 
 /**
- * Provides simplistic message translation for dealing with plurality.
- *
- * @description
- * Use this to create messages which need to be singular or plural.
- * Some languages have several plural forms, so _complete_ message clauses
- * are preferable to generating the message on the fly.
- *
- * @private
- * @param {number} n - Non-negative integer
- * @param {string} msg1 - Message to be used in English for `n = 1`
- * @param {string} msg2 - Message to be used in English for `n = 0, 2, 3, ...`
- * @returns {string} message corresponding to value of `n`
- * @example
- * var sprintf = require('util').format;
- * var pkgs = ['one', 'two'];
- * var msg = sprintf(
- *   ngettext(
- *     pkgs.length,
- *     'cannot load package: %s',
- *     'cannot load packages: %s'
- *   ),
- *   pkgs.map(sQuote).join(', ')
- * );
- * console.log(msg); // => cannot load packages: 'one', 'two'
- */
-exports.ngettext = function(n, msg1, msg2) {
-  if (typeof n === 'number' && n >= 0) {
-    return n === 1 ? msg1 : msg2;
-  }
-};
-
-/**
  * It's a noop.
  * @public
  */

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -121,7 +121,7 @@ describe('Runner', function() {
       global.foo = 'bar';
       runner.on(EVENT_TEST_FAIL, function(_test, _err) {
         expect(_test, 'to be', test);
-        expect(_err, 'to have message', "global leak detected: 'foo'");
+        expect(_err, 'to have message', "global leak(s) detected: 'foo'");
         delete global.foo;
         done();
       });
@@ -183,7 +183,7 @@ describe('Runner', function() {
       global.bar = 'baz';
       runner.on(EVENT_TEST_FAIL, function(_test, _err) {
         expect(_test, 'to be', test);
-        expect(_err, 'to have message', "global leaks detected: 'foo', 'bar'");
+        expect(_err.message, 'to be', "global leak(s) detected: 'foo', 'bar'");
         delete global.foo;
         delete global.bar;
         done();
@@ -217,7 +217,7 @@ describe('Runner', function() {
       global.bar = 'detect-me';
       runner.on(EVENT_TEST_FAIL, function(_test, _err) {
         expect(_test.title, 'to be', 'im a test about lions');
-        expect(_err, 'to have message', "global leak detected: 'bar'");
+        expect(_err, 'to have message', "global leak(s) detected: 'bar'");
         delete global.foo;
         delete global.bar;
         done();
@@ -229,7 +229,7 @@ describe('Runner', function() {
       global.derp = 'bar';
       runner.on(EVENT_TEST_FAIL, function(_test, _err) {
         expect(_test.title, 'to be', 'herp');
-        expect(_err, 'to have message', "global leak detected: 'derp'");
+        expect(_err, 'to have message', "global leak(s) detected: 'derp'");
         delete global.derp;
         done();
       });

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -724,31 +724,6 @@ describe('lib/utils', function() {
     });
   });
 
-  describe('ngettext', function() {
-    var singular = 'singular';
-    var plural = 'plural';
-
-    it("should return plural string if 'n' is 0", function() {
-      expect(utils.ngettext(0, singular, plural), 'to be', plural);
-    });
-
-    it("should return singular string if 'n' is 1", function() {
-      expect(utils.ngettext(1, singular, plural), 'to be', singular);
-    });
-
-    it("should return plural string if 'n' is greater than 1", function() {
-      var arr = ['aaa', 'bbb'];
-      expect(utils.ngettext(arr.length, singular, plural), 'to be', plural);
-    });
-
-    it("should return undefined if 'n' is not a non-negative integer", function() {
-      expect(utils.ngettext('', singular, plural), 'to be undefined');
-      expect(utils.ngettext(-1, singular, plural), 'to be undefined');
-      expect(utils.ngettext(true, singular, plural), 'to be undefined');
-      expect(utils.ngettext({}, singular, plural), 'to be undefined');
-    });
-  });
-
   describe('createMap', function() {
     it('should return an object with a null prototype', function() {
       expect(Object.getPrototypeOf(utils.createMap()), 'to be', null);


### PR DESCRIPTION
### Description of the Change

- `Runnable#inspect`: this function is never referenced
- `utils.ngettext`: pointless twist-simple-to-complex function, used once