### PR TITLE
fixes some signal handling

### DIFF
--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -98,6 +98,14 @@ function Landing(runner, options) {
     process.stdout.write('\n');
     self.epilogue();
   });
+
+  // if cursor is hidden when we ctrl-C, then it will remain hidden unless...
+  process.once('SIGINT', function() {
+    cursor.show();
+    process.nextTick(function() {
+      process.kill(process.pid, 'SIGINT');
+    });
+  });
 }
 
 /**

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -33,6 +33,7 @@ module.exports = {
    * @param {string[]} args - Extra args to mocha executable
    * @param {Function} fn - Callback
    * @param {Object} [opts] - Options for `spawn()`
+   * @returns {ChildProcess} Mocha process
    */
   runMocha: function(fixturePath, args, fn, opts) {
     if (typeof args === 'function') {
@@ -46,7 +47,7 @@ module.exports = {
     path = resolveFixturePath(fixturePath);
     args = args || [];
 
-    invokeSubMocha(
+    return invokeSubMocha(
       args.concat(['-C', path]),
       function(err, res) {
         if (err) {


### PR DESCRIPTION
- `landing` reporter befouls the terminal up if `SIGINT` is issued
- `--exit` test used an incorrect description, and also did not reliably handle `SIGINT` when running

Ref: #4198
