### PR TITLE
test helper improvements

### DIFF
--- a/test/assertions.js
+++ b/test/assertions.js
@@ -118,6 +118,24 @@ exports.mixinMochaAssertions = function(expect) {
         });
       }
     )
+    .addAssertion(
+      '<RawRunResult> [not] to have failed [test] count <number>',
+      function(expect, result, count) {
+        expect(result.failing, '[not] to be', count);
+      }
+    )
+    .addAssertion(
+      '<RawRunResult> [not] to have passed [test] count <number>',
+      function(expect, result, count) {
+        expect(result.passing, '[not] to be', count);
+      }
+    )
+    .addAssertion(
+      '<RawRunResult> [not] to have pending [test] count <number>',
+      function(expect, result, count) {
+        expect(result.pending, '[not] to be', count);
+      }
+    )
     .addAssertion('<JSONRunResult> [not] to have test count <number>', function(
       expect,
       result,
@@ -315,7 +333,7 @@ exports.mixinMochaAssertions = function(expect) {
       }
     )
     .addAssertion(
-      '<RawRunResult|JSONRunResult> to have [exit] code <number>',
+      '<RawResult|RawRunResult|JSONRunResult> to have [exit] code <number>',
       function(expect, result, code) {
         expect(result.code, 'to be', code);
       }

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -67,120 +67,120 @@ module.exports = {
   runMochaJSONAsync: runMochaJSONAsync
 };
 
-  /**
-   * Invokes the mocha binary for the given fixture with color output disabled.
-   * Accepts an array of additional command line args to pass. The callback is
-   * invoked with a summary of the run, in addition to its output. The summary
-   * includes the number of passing, pending, and failing tests, as well as the
-   * exit code. Useful for testing different reporters.
-   *
-   * By default, `STDERR` is ignored. Pass `{stdio: 'pipe'}` as `opts` if you
-   * want it.
-   * Example response:
-   * {
-   *   pending: 0,
-   *   passing: 0,
-   *   failing: 1,
-   *   code:    1,
-   *   output:  '...'
-   * }
-   *
-   * @param {string} fixturePath - Path to fixture .js file
-   * @param {string[]} args - Extra args to mocha executable
-   * @param {Function} fn - Callback
-   * @param {Object} [opts] - Options for `spawn()`
-   * @returns {ChildProcess} Mocha process
-   */
+/**
+ * Invokes the mocha binary for the given fixture with color output disabled.
+ * Accepts an array of additional command line args to pass. The callback is
+ * invoked with a summary of the run, in addition to its output. The summary
+ * includes the number of passing, pending, and failing tests, as well as the
+ * exit code. Useful for testing different reporters.
+ *
+ * By default, `STDERR` is ignored. Pass `{stdio: 'pipe'}` as `opts` if you
+ * want it.
+ * Example response:
+ * {
+ *   pending: 0,
+ *   passing: 0,
+ *   failing: 1,
+ *   code:    1,
+ *   output:  '...'
+ * }
+ *
+ * @param {string} fixturePath - Path to fixture .js file
+ * @param {string[]} args - Extra args to mocha executable
+ * @param {Function} fn - Callback
+ * @param {Object} [opts] - Options for `spawn()`
+ * @returns {ChildProcess} Mocha process
+ */
 function runMocha(fixturePath, args, fn, opts) {
-    if (typeof args === 'function') {
-      opts = fn;
-      fn = args;
-      args = [];
-    }
+  if (typeof args === 'function') {
+    opts = fn;
+    fn = args;
+    args = [];
+  }
 
-    var path;
+  var path;
 
-    path = resolveFixturePath(fixturePath);
-    args = args || [];
+  path = resolveFixturePath(fixturePath);
+  args = args || [];
 
-    return invokeSubMocha(
+  return invokeSubMocha(
     args.concat(path),
-      function(err, res) {
-        if (err) {
-          return fn(err);
-        }
+    function(err, res) {
+      if (err) {
+        return fn(err);
+      }
 
-        fn(null, getSummary(res));
-      },
-      opts
-    );
+      fn(null, getSummary(res));
+    },
+    opts
+  );
 }
 
-  /**
-   * Invokes the mocha binary for the given fixture using the JSON reporter,
-   * returning the parsed output, as well as exit code.
-   *
-   * By default, `STDERR` is ignored. Pass `{stdio: 'pipe'}` as `opts` if you
-   * want it.
-   * @param {string} fixturePath - Path from __dirname__
-   * @param {string[]} args - Array of args
-   * @param {Function} fn - Callback
-   * @param {Object} [opts] - Opts for `spawn()`
-   * @returns {*} Parsed object
-   */
+/**
+ * Invokes the mocha binary for the given fixture using the JSON reporter,
+ * returning the parsed output, as well as exit code.
+ *
+ * By default, `STDERR` is ignored. Pass `{stdio: 'pipe'}` as `opts` if you
+ * want it.
+ * @param {string} fixturePath - Path from __dirname__
+ * @param {string[]} args - Array of args
+ * @param {Function} fn - Callback
+ * @param {Object} [opts] - Opts for `spawn()`
+ * @returns {*} Parsed object
+ */
 function runMochaJSON(fixturePath, args, fn, opts) {
-    if (typeof args === 'function') {
-      opts = fn;
-      fn = args;
-      args = [];
-    }
+  if (typeof args === 'function') {
+    opts = fn;
+    fn = args;
+    args = [];
+  }
 
-    var path;
+  var path;
 
-    path = resolveFixturePath(fixturePath);
-    args = (args || []).concat('--reporter', 'json', path);
+  path = resolveFixturePath(fixturePath);
+  args = (args || []).concat('--reporter', 'json', path);
 
-    return invokeMocha(
-      args,
-      function(err, res) {
-        if (err) {
-          return fn(err);
-        }
+  return invokeMocha(
+    args,
+    function(err, res) {
+      if (err) {
+        return fn(err);
+      }
 
-        var result;
-        try {
-          // attempt to catch a JSON parsing error *only* here.
-          // previously, the callback was called within this `try` block,
-          // which would result in errors thrown from the callback
-          // getting caught by the `catch` block below.
-          result = toJSONRunResult(res);
-        } catch (err) {
-          return fn(
-            new Error(
-              format(
-                'Failed to parse JSON reporter output. Error:\n%O\nResult:\n%O',
-                err,
-                res
-              )
+      var result;
+      try {
+        // attempt to catch a JSON parsing error *only* here.
+        // previously, the callback was called within this `try` block,
+        // which would result in errors thrown from the callback
+        // getting caught by the `catch` block below.
+        result = toJSONRunResult(res);
+      } catch (err) {
+        return fn(
+          new Error(
+            format(
+              'Failed to parse JSON reporter output. Error:\n%O\nResult:\n%O',
+              err,
+              res
             )
-          );
-        }
-        fn(null, result);
-      },
-      opts
-    );
+          )
+        );
+      }
+      fn(null, result);
+    },
+    opts
+  );
 }
- * Like {@link runMocha}, but returns a `Promise`.
 
-  /**
-   *
+/**
+ *
  * If you need more granular control, try {@link invokeMochaAsync} instead.
-   *
+ *
+ * Like {@link runMocha}, but returns a `Promise`.
  * @param {string} fixturePath - Path to (or name of, or basename of) fixture file
  * @param {Options} [args] - Command-line arguments to the `mocha` executable
  * @param {Object} [opts] - Options for `child_process.spawn`.
  * @returns {Promise<Summary>}
-   */
+ */
 function runMochaAsync(fixturePath, args, opts) {
   return new Promise(function(resolve, reject) {
     runMocha(
@@ -197,12 +197,12 @@ function runMochaAsync(fixturePath, args, opts) {
   });
 }
 
-  /**
+/**
  * Like {@link runMochaJSON}, but returns a `Promise`.
  * @param {string} fixturePath - Path to (or name of, or basename of) fixture file
  * @param {Options} [args] - Command-line args
  * @param {Object} [opts] - Options for `child_process.spawn`
-   */
+ */
 function runMochaJSONAsync(fixturePath, args, opts) {
   return new Promise(function(resolve, reject) {
     runMochaJSON(
@@ -217,7 +217,7 @@ function runMochaJSONAsync(fixturePath, args, opts) {
       opts
     );
   });
-  }
+}
 
 /**
  * Coerce output as returned by _spawnMochaWithListeners using JSON reporter into a JSONRunResult as
@@ -228,9 +228,9 @@ function runMochaJSONAsync(fixturePath, args, opts) {
 function toJSONRunResult(result) {
   var code = result.code;
   try {
-  result = JSON.parse(result.output);
-  result.code = code;
-  return result;
+    result = JSON.parse(result.output);
+    result.code = code;
+    return result;
   } catch (err) {
     throw new Error(
       `Couldn't parse JSON: ${err.message}\n\nOriginal result output: ${result.output}`

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -296,9 +296,9 @@ function runMochaWatch(args, cwd, change) {
     {cwd, stdio: 'pipe'}
   );
 
-  return sleep(1000)
+  return sleep(2000)
     .then(() => change(mochaProcess))
-    .then(() => sleep(1000))
+    .then(() => sleep(2000))
     .then(() => {
       mochaProcess.kill('SIGINT');
       return resultPromise;


### PR DESCRIPTION
### Assertions

- enables `RawResult` (the result of `invokeMocha()` or `invokeMochaAsync()`) to check the exit code via `to have code` assertion
- add passed/failing/pending assertions for `RawRunResult` (the result of `runMocha()` or `runMochaAsync()`)

### Integration test helpers

- expose `getSummary()`, which can be used with a `RawResult` (when not failing)
- reorganize the module a bit
- create `runMochaAsync()` and `runMochaJSONAsync()` which are like `runMocha()` and `runMochaJSON()` except return `Promise`s
- better trapping of JSON parse errors
- better default handling of `STDERR` output in subprocesses (print it instead of suppress it!)
- do not let the `DEBUG` env variable reach subprocesses _unless it was explicitly supplied_
- add an easily copy-paste-able `command` prop to summary
- add some missing docstrings

Ref: #4198
