### PR TITLE
Fix: karma-mocha hangs when there's a exception in a hook

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -134,7 +134,7 @@ function Runner(suite, delay) {
   this.total = suite.total();
   this.failures = 0;
   this.on(constants.EVENT_TEST_END, function(test) {
-    if (test.retriedTest() && test.parent) {
+    if (test.type === 'test' && test.retriedTest() && test.parent) {
       var idx =
         test.parent.tests && test.parent.tests.indexOf(test.retriedTest());
       if (idx > -1) test.parent.tests[idx] = test;


### PR DESCRIPTION
### Description

> If an exception/assert error occurs in a hook, karma-mocha stops immediately due to an unhandled exception.
[...]
karma-mocha is passing a hook object as the param with a 'test end' event.
[...]
The hook doesn't have a retriedTest method, so it throws "Uncaught TypeError: test.retriedTest is not a function"

### Description of the Change

Emitting a `test end` event for a `hook` is wrong. We add a type check before calling `retriedTest()` in order to prevent an uncaught exception.

### Applicable issues

closes #4250 
closes #4227 