### PR TITLE
Mark HTTP 429 responses as allowed failures in hyperlink check

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -267,7 +267,7 @@ module.exports = {
       },
       linkcheck: {
         script:
-          'hyperlink -ri --canonicalroot https://mochajs.org --skip ".js.html#line" docs/_site/index.html'
+          'hyperlink -ri --canonicalroot https://mochajs.org --skip ".js.html#line" docs/_site/index.html --todo "HTTP 429 Too Many Requests"'
       },
       postbuild: {
         script:


### PR DESCRIPTION
We sometimes get HTTP 429 responses from unpkg.com when checking the links to mocha and chai assets we use in a cope/pasteable code reference for how to run mocha in a browser.

These checks should still run, but if we know that we might get HTTP 429 because unpkg is temporarily overloaded we should not fail the build.

Example of such a failure: https://app.netlify.com/sites/mocha/deploys/5ea2e0db7751000007185cf1

Adding a `--todo` match on the error we get in hyperlink allows that particular response to fail without failing the build