### PR TITLE
Remove enableTimeout api + allow overriding a disabled timeout

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -5,6 +5,7 @@
   ],
   "exclude": [
     "coverage/**",
+    "docs/**",
     "packages/*/test{,s}/**",
     "**/*.d.ts",
     "test{,s}/**",

--- a/docs/index.md
+++ b/docs/index.md
@@ -810,7 +810,7 @@ Again, use `this.timeout(0)` to disable the timeout for a hook.
 
 > In v3.0.0 or newer, a parameter passed to `this.timeout()` greater than the [maximum delay value][mdn-settimeout-maxdelay] will cause the timeout to be disabled.
 
-> As of v8.0.0, `enableTimeouts()` has been removed.
+> As of v8.0.0, `this.enableTimeouts()` has been removed.
 
 ## Diffs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -810,6 +810,8 @@ Again, use `this.timeout(0)` to disable the timeout for a hook.
 
 > In v3.0.0 or newer, a parameter passed to `this.timeout()` greater than the [maximum delay value][mdn-settimeout-maxdelay] will cause the timeout to be disabled.
 
+> As of v8.0.0, `enableTimeouts()` has been removed.
+
 ## Diffs
 
 Mocha supports the `err.expected` and `err.actual` properties of any thrown `AssertionError`s from an assertion library. Mocha will attempt to display the difference between what was expected, and what the assertion actually saw. Here's an example of a "string" diff using `--inline-diffs`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -809,8 +809,7 @@ describe('a suite of tests', function() {
 Again, use `this.timeout(0)` to disable the timeout for a hook.
 
 > In v3.0.0 or newer, a parameter passed to `this.timeout()` greater than the [maximum delay value][mdn-settimeout-maxdelay] will cause the timeout to be disabled.
-
-> As of v8.0.0, `this.enableTimeouts()` has been removed.
+> In v8.0.0 or newer, `this.enableTimeouts()` has been removed.
 
 ## Diffs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -810,6 +810,7 @@ Again, use `this.timeout(0)` to disable the timeout for a hook.
 
 > In v3.0.0 or newer, a parameter passed to `this.timeout()` greater than the [maximum delay value][mdn-settimeout-maxdelay] will cause the timeout to be disabled.
 > In v8.0.0 or newer, `this.enableTimeouts()` has been removed.
+> **Warning:** With async tests if you disable timeouts via `this.timeout(0)` and then do not call `done()`, your test will exit silently.
 
 ## Diffs
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -46,21 +46,6 @@ Context.prototype.timeout = function(ms) {
 };
 
 /**
- * Set test timeout `enabled`.
- *
- * @private
- * @param {boolean} enabled
- * @return {Context} self
- */
-Context.prototype.enableTimeouts = function(enabled) {
-  if (!arguments.length) {
-    return this.runnable().enableTimeouts();
-  }
-  this.runnable().enableTimeouts(enabled);
-  return this;
-};
-
-/**
  * Set or get test slowness threshold `ms`.
  *
  * @private

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -627,7 +627,6 @@ Mocha.prototype.diff = function(diff) {
  * @public
  * @see [CLI option](../#-timeout-ms-t-ms)
  * @see [Timeouts](../#timeouts)
- * @see {@link Mocha#enableTimeouts}
  * @param {number|string} msecs - Timeout threshold value.
  * @return {Mocha} this
  * @chainable
@@ -683,22 +682,6 @@ Mocha.prototype.retries = function(n) {
  */
 Mocha.prototype.slow = function(msecs) {
   this.suite.slow(msecs);
-  return this;
-};
-
-/**
- * Enables or disables timeouts.
- *
- * @public
- * @see [CLI option](../#-timeout-ms-t-ms)
- * @param {boolean} enableTimeouts - Whether to enable timeouts.
- * @return {Mocha} this
- * @chainable
- */
-Mocha.prototype.enableTimeouts = function(enableTimeouts) {
-  this.suite.enableTimeouts(
-    arguments.length && enableTimeouts !== undefined ? enableTimeouts : true
-  );
   return this;
 };
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -208,7 +208,7 @@ Runnable.prototype.clearTimeout = function() {
  */
 Runnable.prototype.resetTimeout = function() {
   var self = this;
-  var ms = this.timeout() >= 0 ? this.timeout() : 1e9;
+  var ms = this.timeout();
 
   if (ms === 0) {
     return;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -35,7 +35,6 @@ function Runnable(title, fn) {
   this.sync = !this.async;
   this._timeout = 2000;
   this._slow = 75;
-  this._enableTimeouts = true;
   this.timedOut = false;
   this._retries = -1;
   this._currentRetry = 0;
@@ -81,13 +80,6 @@ Runnable.prototype.timeout = function(ms) {
   var range = [0, INT_MAX];
   ms = utils.clamp(ms, range);
 
-  // see #1652 for reasoning
-  if (ms === range[0] || ms === range[1]) {
-    this.enableTimeouts(false);
-  } else {
-    // Reset now that a new timeout limit has been set
-    this.enableTimeouts(true);
-  }
   debug('timeout %d', ms);
   this._timeout = ms;
   if (this.timer) {
@@ -112,22 +104,6 @@ Runnable.prototype.slow = function(ms) {
   }
   debug('slow %d', ms);
   this._slow = ms;
-  return this;
-};
-
-/**
- * Set and get whether timeout is `enabled`.
- *
- * @private
- * @param {boolean} enabled
- * @return {Runnable|boolean} enabled or Runnable instance.
- */
-Runnable.prototype.enableTimeouts = function(enabled) {
-  if (!arguments.length) {
-    return this._enableTimeouts;
-  }
-  debug('enableTimeouts %s', enabled);
-  this._enableTimeouts = enabled;
   return this;
 };
 
@@ -234,12 +210,16 @@ Runnable.prototype.resetTimeout = function() {
   var self = this;
   var ms = this.timeout() || 1e9;
 
-  if (!this._enableTimeouts) {
+  var timeoutIsDisabled = function() {
+    return ms === 0;
+  };
+
+  if (timeoutIsDisabled()) {
     return;
   }
   this.clearTimeout();
   this.timer = setTimeout(function() {
-    if (!self._enableTimeouts) {
+    if (timeoutIsDisabled()) {
       return;
     }
     self.callback(self._timeoutError(ms));
@@ -309,7 +289,7 @@ Runnable.prototype.run = function(fn) {
     self.clearTimeout();
     self.duration = new Date() - start;
     finished = true;
-    if (!err && self.duration > ms && self._enableTimeouts) {
+    if (!err && self.duration > ms && ms > 0) {
       err = self._timeoutError(ms);
     }
     fn(err);

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -80,8 +80,14 @@ Runnable.prototype.timeout = function(ms) {
   var range = [0, INT_MAX];
   ms = utils.clamp(ms, range);
 
-  debug('timeout %d', ms);
-  this._timeout = ms;
+  // see #1652 for reasoning
+  if (ms === range[0] || ms === range[1]) {
+    this._timeout = 0;
+  } else {
+    this._timeout = ms;
+  }
+  debug('timeout %d', this._timeout);
+
   if (this.timer) {
     this.resetTimeout();
   }

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -83,9 +83,10 @@ Runnable.prototype.timeout = function(ms) {
 
   // see #1652 for reasoning
   if (ms === range[0] || ms === range[1]) {
-    this._enableTimeouts = false;
+    this.enableTimeouts(false);
   } else {
-    this._enableTimeouts = true;
+    // Reset now that a new timeout limit has been set
+    this.enableTimeouts(true);
   }
   debug('timeout %d', ms);
   this._timeout = ms;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -208,7 +208,7 @@ Runnable.prototype.clearTimeout = function() {
  */
 Runnable.prototype.resetTimeout = function() {
   var self = this;
-  var ms = this.timeout() || 1e9;
+  var ms = this.timeout() >= 0 ? this.timeout() : 1e9;
 
   var timeoutIsDisabled = function() {
     return ms === 0;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -210,16 +210,12 @@ Runnable.prototype.resetTimeout = function() {
   var self = this;
   var ms = this.timeout() >= 0 ? this.timeout() : 1e9;
 
-  var timeoutIsDisabled = function() {
-    return ms === 0;
-  };
-
-  if (timeoutIsDisabled()) {
+  if (ms === 0) {
     return;
   }
   this.clearTimeout();
   this.timer = setTimeout(function() {
-    if (timeoutIsDisabled()) {
+    if (self.timeout() === 0) {
       return;
     }
     self.callback(self._timeoutError(ms));

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -84,6 +84,8 @@ Runnable.prototype.timeout = function(ms) {
   // see #1652 for reasoning
   if (ms === range[0] || ms === range[1]) {
     this._enableTimeouts = false;
+  } else {
+    this._enableTimeouts = true;
   }
   debug('timeout %d', ms);
   this._timeout = ms;

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -68,7 +68,6 @@ function Suite(title, parentContext, isRoot) {
   this._afterAll = [];
   this.root = isRoot === true;
   this._timeout = 2000;
-  this._enableTimeouts = true;
   this._slow = 75;
   this._bail = false;
   this._retries = -1;
@@ -105,7 +104,6 @@ Suite.prototype.clone = function() {
   suite.root = this.root;
   suite.timeout(this.timeout());
   suite.retries(this.retries());
-  suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
   suite.bail(this.bail());
   return suite;
@@ -122,9 +120,6 @@ Suite.prototype.clone = function() {
 Suite.prototype.timeout = function(ms) {
   if (!arguments.length) {
     return this._timeout;
-  }
-  if (ms.toString() === '0') {
-    this._enableTimeouts = false;
   }
   if (typeof ms === 'string') {
     ms = milliseconds(ms);
@@ -147,22 +142,6 @@ Suite.prototype.retries = function(n) {
   }
   debug('retries %d', n);
   this._retries = parseInt(n, 10) || 0;
-  return this;
-};
-
-/**
- * Set or get timeout to `enabled`.
- *
- * @private
- * @param {boolean} enabled
- * @return {Suite|boolean} self or enabled
- */
-Suite.prototype.enableTimeouts = function(enabled) {
-  if (!arguments.length) {
-    return this._enableTimeouts;
-  }
-  debug('enableTimeouts %s', enabled);
-  this._enableTimeouts = enabled;
   return this;
 };
 
@@ -222,7 +201,6 @@ Suite.prototype._createHook = function(title, fn) {
   hook.parent = this;
   hook.timeout(this.timeout());
   hook.retries(this.retries());
-  hook.enableTimeouts(this.enableTimeouts());
   hook.slow(this.slow());
   hook.ctx = this.ctx;
   hook.file = this.file;
@@ -337,7 +315,6 @@ Suite.prototype.addSuite = function(suite) {
   suite.root = false;
   suite.timeout(this.timeout());
   suite.retries(this.retries());
-  suite.enableTimeouts(this.enableTimeouts());
   suite.slow(this.slow());
   suite.bail(this.bail());
   this.suites.push(suite);
@@ -356,7 +333,6 @@ Suite.prototype.addTest = function(test) {
   test.parent = this;
   test.timeout(this.timeout());
   test.retries(this.retries());
-  test.enableTimeouts(this.enableTimeouts());
   test.slow(this.slow());
   test.ctx = this.ctx;
   this.tests.push(test);

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -124,6 +124,12 @@ Suite.prototype.timeout = function(ms) {
   if (typeof ms === 'string') {
     ms = milliseconds(ms);
   }
+
+  // Clamp to range
+  var INT_MAX = Math.pow(2, 31) - 1;
+  var range = [0, INT_MAX];
+  ms = utils.clamp(ms, range);
+
   debug('timeout %d', ms);
   this._timeout = parseInt(ms, 10);
   return this;

--- a/lib/test.js
+++ b/lib/test.js
@@ -61,7 +61,6 @@ Test.prototype.clone = function() {
   var test = new Test(this.title, this.fn);
   test.timeout(this.timeout());
   test.slow(this.slow());
-  test.enableTimeouts(this.enableTimeouts());
   test.retries(this.retries());
   test.currentRetry(this.currentRetry());
   test.retriedTest(this.retriedTest() || this);

--- a/test/integration/fixtures/timeout-override.fixture.js
+++ b/test/integration/fixtures/timeout-override.fixture.js
@@ -2,7 +2,7 @@
 
 describe('timeout override', function() {
   it('should fail async test due to re-enable', function(done) {
-    this.enableTimeouts(false);
+    this.timeout(0);
     this.timeout(1);
     setTimeout(done, 2);
   });

--- a/test/integration/fixtures/timeout-override.fixture.js
+++ b/test/integration/fixtures/timeout-override.fixture.js
@@ -1,0 +1,9 @@
+'use strict';
+
+describe('timeout override', function() {
+  it('should fail async test due to re-enable', function(done) {
+    this.enableTimeouts(false);
+    this.timeout(1);
+    setTimeout(done, 2);
+  });
+});

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -18,4 +18,15 @@ describe('this.timeout()', function() {
       done();
     });
   });
+
+  it('should allow overriding per-test', function(done) {
+    run('timeout-override.fixture.js', args, function(err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+      assert.strictEqual(res.stats.failures, 1);
+      done();
+    });
+  });
 });

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -25,7 +25,7 @@ describe('this.timeout()', function() {
         done(err);
         return;
       }
-      assert.strictEqual(res.stats.failures, 1);
+      expect(res.stats.failures, 'to be', 1);
       done();
     });
   });

--- a/test/integration/timeout.spec.js
+++ b/test/integration/timeout.spec.js
@@ -19,7 +19,7 @@ describe('this.timeout()', function() {
     });
   });
 
-  it('should allow overriding per-test', function(done) {
+  it('should allow overriding if disabled per-test', function(done) {
     run('timeout-override.fixture.js', args, function(err, res) {
       if (err) {
         done(err);

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -90,12 +90,6 @@ describe('methods', function() {
     });
   });
 
-  describe('enableTimeouts()', function() {
-    it('should return the enableTimeouts', function() {
-      expect(this.enableTimeouts(), 'to be', true);
-    });
-  });
-
   describe('retries', function() {
     it('should return the number of retries', function() {
       expect(this.retries(), 'to be', -1);

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -159,19 +159,6 @@ describe('Mocha', function() {
     });
   });
 
-  describe('#enableTimeouts()', function() {
-    it('should set the suite._enableTimeouts to true if no argument', function() {
-      var mocha = new Mocha(opts);
-      mocha.enableTimeouts();
-      expect(mocha.suite._enableTimeouts, 'to be', true);
-    });
-
-    it('should be chainable', function() {
-      var mocha = new Mocha(opts);
-      expect(mocha.enableTimeouts(), 'to be', mocha);
-    });
-  });
-
   describe('#diff()', function() {
     it('should set the diff option to true', function() {
       var mocha = new Mocha(opts);

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -74,14 +74,8 @@ describe('Runnable(title, fn)', function() {
         run.timeout(MAX_TIMEOUT);
       });
       describe('given numeric value', function() {
-        it('should set the timeout value', function() {
-          expect(run.timeout(), 'to be', MAX_TIMEOUT);
-        });
-      });
-
-      describe('given string timestamp', function() {
-        it('should set the timeout value', function() {
-          expect(run.timeout(), 'to be', MAX_TIMEOUT);
+        it('should set the disabled timeout value', function() {
+          expect(run.timeout(), 'to be', 0);
         });
       });
     });
@@ -96,14 +90,8 @@ describe('Runnable(title, fn)', function() {
       });
 
       describe('given numeric value', function() {
-        it('should clamp the value to max timeout', function() {
-          expect(run.timeout(), 'to be', MAX_TIMEOUT);
-        });
-      });
-
-      describe('given string timestamp', function() {
-        it('should clamp the value to max timeout', function() {
-          expect(run.timeout(), 'to be', MAX_TIMEOUT);
+        it('should set the disabled timeout value', function() {
+          expect(run.timeout(), 'to be', 0);
         });
       });
     });

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -8,19 +8,19 @@ var STATE_FAILED = Runnable.constants.STATE_FAILED;
 
 describe('Runnable(title, fn)', function() {
   describe('#timeout(ms)', function() {
-    var MIN_TIMEOUT = 0;
+    var DISABLED_TIMEOUTS = 0;
     var MAX_TIMEOUT = 2147483647; // INT_MAX (32-bit signed integer)
 
     describe('when value is less than lower bound', function() {
       it('should clamp to lower bound given numeric', function() {
         var run = new Runnable();
         run.timeout(-1);
-        expect(run.timeout(), 'to be', MIN_TIMEOUT);
+        expect(run.timeout(), 'to be', DISABLED_TIMEOUTS);
       });
       it('should clamp to lower bound given timestamp', function() {
         var run = new Runnable();
         run.timeout('-1 ms');
-        expect(run.timeout(), 'to be', MIN_TIMEOUT);
+        expect(run.timeout(), 'to be', DISABLED_TIMEOUTS);
       });
     });
 
@@ -29,25 +29,17 @@ describe('Runnable(title, fn)', function() {
 
       beforeEach(function() {
         run = new Runnable();
-        run.timeout(MIN_TIMEOUT);
+        run.timeout(DISABLED_TIMEOUTS);
       });
       describe('given numeric value', function() {
-        it('should set the timeout value', function() {
-          expect(run.timeout(), 'to be', MIN_TIMEOUT);
-        });
-
-        it('should disable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be false');
+        it('should set the timeout value to disabled', function() {
+          expect(run.timeout(), 'to be', DISABLED_TIMEOUTS);
         });
       });
 
       describe('given string timestamp', function() {
-        it('should set the timeout value', function() {
-          expect(run.timeout(), 'to be', MIN_TIMEOUT);
-        });
-
-        it('should disable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be false');
+        it('should set the timeout value to disabled', function() {
+          expect(run.timeout(), 'to be', DISABLED_TIMEOUTS);
         });
       });
     });
@@ -65,19 +57,11 @@ describe('Runnable(title, fn)', function() {
         it('should set the timeout value', function() {
           expect(run.timeout(), 'to be', timeout);
         });
-
-        it('should enable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be true');
-        });
       });
 
       describe('given string timestamp', function() {
         it('should set the timeout value', function() {
           expect(run.timeout(), 'to be', timeout);
-        });
-
-        it('should enable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be true');
         });
       });
     });
@@ -93,19 +77,11 @@ describe('Runnable(title, fn)', function() {
         it('should set the timeout value', function() {
           expect(run.timeout(), 'to be', MAX_TIMEOUT);
         });
-
-        it('should disable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be false');
-        });
       });
 
       describe('given string timestamp', function() {
         it('should set the timeout value', function() {
           expect(run.timeout(), 'to be', MAX_TIMEOUT);
-        });
-
-        it('should disable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be false');
         });
       });
     });
@@ -123,29 +99,13 @@ describe('Runnable(title, fn)', function() {
         it('should clamp the value to max timeout', function() {
           expect(run.timeout(), 'to be', MAX_TIMEOUT);
         });
-
-        it('should enable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be false');
-        });
       });
 
       describe('given string timestamp', function() {
         it('should clamp the value to max timeout', function() {
           expect(run.timeout(), 'to be', MAX_TIMEOUT);
         });
-
-        it('should enable timeouts', function() {
-          expect(run.enableTimeouts(), 'to be false');
-        });
       });
-    });
-  });
-
-  describe('#enableTimeouts(enabled)', function() {
-    it('should set enabled', function() {
-      var run = new Runnable();
-      run.enableTimeouts(false);
-      expect(run.enableTimeouts(), 'to be false');
     });
   });
 
@@ -314,7 +274,7 @@ describe('Runnable(title, fn)', function() {
           }, 2);
         });
         runnable.timeout(1);
-        runnable.enableTimeouts(false);
+        runnable.timeout(0);
         runnable.run(function(err) {
           expect(err, 'to be falsy');
           done();
@@ -721,7 +681,7 @@ describe('Runnable(title, fn)', function() {
       var runnable = new Runnable('foo', function() {});
       runnable.timeout(10);
       runnable.resetTimeout();
-      runnable.enableTimeouts(false);
+      runnable.timeout(0);
       setTimeout(function() {
         expect(runnable.timedOut, 'to be', false);
         done();

--- a/test/unit/test.spec.js
+++ b/test/unit/test.spec.js
@@ -10,7 +10,6 @@ describe('Test', function() {
       this._test = new Test('To be cloned', function() {});
       this._test._timeout = 3043;
       this._test._slow = 101;
-      this._test._enableTimeouts = true;
       this._test._retries = 3;
       this._test._currentRetry = 1;
       this._test._allowedGlobals = ['foo'];
@@ -28,10 +27,6 @@ describe('Test', function() {
 
     it('should copy the slow value', function() {
       expect(this._test.clone().slow(), 'to be', 101);
-    });
-
-    it('should copy the enableTimeouts value', function() {
-      expect(this._test.clone().enableTimeouts(), 'to be', true);
     });
 
     it('should copy the retries value', function() {

--- a/test/unit/timeout.spec.js
+++ b/test/unit/timeout.spec.js
@@ -46,13 +46,13 @@ describe('timeouts', function() {
       });
     });
 
-    describe('using enableTimeouts(false)', function() {
+    describe('using timeout(0)', function() {
       this.timeout(4);
 
       it('should suppress timeout(4)', function(done) {
         this.slow(100);
         // The test is in the before() call.
-        this.enableTimeouts(false);
+        this.timeout(0);
         setTimeout(done, 50);
       });
     });

--- a/test/unit/timeout.spec.js
+++ b/test/unit/timeout.spec.js
@@ -21,12 +21,6 @@ describe('timeouts', function() {
   });
 
   describe('disabling', function() {
-    it('should allow overriding per-test', function(done) {
-      this.enableTimeouts(false);
-      this.timeout(1);
-      setTimeout(done, 2);
-    });
-
     it('should work with timeout(0)', function(done) {
       this.timeout(0);
       setTimeout(done, 1);


### PR DESCRIPTION
# Description of the Change 

Removed `enableTimeout` stuff. Use the latest `timeout` value to determine if enabled/disabled + its value. (disabled is value of 0, else is enabled).

Also fixes issue of tests not timing out when timeout is re-enabled. See associating issue https://github.com/mochajs/mocha/issues/4254.

Fixes https://github.com/mochajs/mocha/issues/4254

### Alternate Designs 

Could remove `enableTimeouts` from public-facing and use it internally, however it is easiest to have a **single source of truth** (the value) and mirror what the user uses. Having 2 different states which are very similar gets confusing.

### Why should this be in core? 

Simplify the codebase. 

There are use-cases where it is useful to be able to re-enable and make use of a previously disabled timeout. Also seems pretty important that the feature behaves as a user would expect.

### Possible Drawbacks

You can no longer restore a previously set timeout if disabled (`enableTimeout(true)` did) and must always explicitly set it again.

The default timeout value will now never be used as the user has to set a value to re-enable it anyway. That could be a good thing.

Anyone relying on `enableTimeout` to disable or re-enable timeouts will have to swap to using the explicit `timeout`. However if it is the correct behaviour and goes into the next major release, then should be fine.

### Applicable issues

Fixes https://github.com/mochajs/mocha/issues/4254