### PR TITLE
adds a bunch of keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,15 @@
     "test",
     "bdd",
     "tdd",
-    "tap"
+    "tap",
+    "testing",
+    "chai",
+    "assertion",
+    "ava",
+    "jest",
+    "tape",
+    "jasmine",
+    "karma"
   ],
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
Did you know that if you click on the "testing" icon on npmjs.com, Mocha is completely absent?

It wants the keyword `testing`, which we do not have.  So I added that and a bunch more.  Since all of
the other major test frameworks seem to use keywords of others, might as well join that arms race.
