### PR TITLE
Netlify environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,6 @@
 [build]
   publish = "docs/_dist/"
   command = "npm start docs"
+
+[build.environment]
+  NODE_VERSION = "12"

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -271,7 +271,7 @@ module.exports = {
       },
       postbuild: {
         script:
-          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
+          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts --browsers ">0%, not ie <= 8" && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
         description: 'Post-process docs after build',
         hiddenFromHelp: true
       },


### PR DESCRIPTION
clean up Netlify environment and try to improve docs build time

### Use Node.js v12
Previously, [Netlify is using Node.js v8.17.0](https://app.netlify.com/sites/mocha/deploys/5ea52b482af4780007585058). Node.js 8 is now end-of-lie and assetgraph v8.0.0 droped node.js 8 support.

```
3:34:08 PM: v8.17.0 is already installed.
3:34:08 PM: Now using node v8.17.0 (npm v6.13.4)
```

Using Node.js v12 needs an additional step to download lastest Node.js, it doesn't take too long.

```
7:04:54 PM: Downloading and installing node v12.16.3...
7:04:54 PM: Downloading https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-x64.tar.xz...
7:04:54 PM: Computing checksum with sha256sum
7:04:54 PM: Checksums matched!
7:04:57 PM: Now using node v12.16.3 (npm v6.14.4)
```

### Exclude IE8 from target browsers
As [assetgraph-builder's README](https://github.com/assetgraph/assetgraph-builder#specifying-which-browsers-to-support), I excluded IE8 from assetgraph's build target(`--browsers ">0%, not ie <= 8"`). 
[In our analytics](https://mochajs.matomo.cloud/index.php?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#?idSite=1&period=year&date=2020-04-17&segment=&category=General_Visitors&subcategory=DevicesDetection_Software). IE is only 0.2% of our visitors. 
Build time is vary whenever I run `npm start docs.postbuild` up to 40 secs, So, I am not sure how much it reduce our docs build time. But we doesn't need support IE8 on our website. 