### PR TITLE
Consistent handling of --forbid-only for suites and tests

### DIFF
--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -94,6 +94,9 @@ module.exports = function(suites, context, mocha) {
        * @returns {Suite}
        */
       only: function only(opts) {
+        if (mocha.options.forbidOnly) {
+          throw createForbiddenExclusivityError(mocha);
+        }
         opts.isOnly = true;
         return this.create(opts);
       },
@@ -130,12 +133,14 @@ module.exports = function(suites, context, mocha) {
           if (mocha.options.forbidOnly && shouldBeTested(suite)) {
             throw createForbiddenExclusivityError(mocha);
           }
-          suite.parent.appendOnlySuite(suite);
+          suite.markOnly();
         }
-        if (suite.pending) {
-          if (mocha.options.forbidPending && shouldBeTested(suite)) {
-            throw createUnsupportedError('Pending test forbidden');
-          }
+        if (
+          suite.pending &&
+          mocha.options.forbidPending &&
+          shouldBeTested(suite)
+        ) {
+          throw createUnsupportedError('Pending test forbidden');
         }
         if (typeof opts.fn === 'function') {
           opts.fn.call(suite);

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -130,9 +130,6 @@ module.exports = function(suites, context, mocha) {
         suite.file = opts.file;
         suites.unshift(suite);
         if (opts.isOnly) {
-          if (mocha.options.forbidOnly && shouldBeTested(suite)) {
-            throw createForbiddenExclusivityError(mocha);
-          }
           suite.markOnly();
         }
         if (

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -492,6 +492,15 @@ Suite.prototype.appendOnlySuite = function(suite) {
 };
 
 /**
+ * Marks a suite to be `only`.
+ *
+ * @private
+ */
+Suite.prototype.markOnly = function() {
+  this.parent && this.parent.appendOnlySuite(this);
+};
+
+/**
  * Adds a test to the list of tests marked `only`.
  *
  * @private

--- a/test/integration/options/forbidOnly.spec.js
+++ b/test/integration/options/forbidOnly.spec.js
@@ -92,32 +92,37 @@ describe('--forbid-only', function() {
     );
   });
 
-  it('should succeed if suite marked only does not match grep', function(done) {
+  it('should fail if suite marked only does not match grep', function(done) {
     var fixture = path.join('options', 'forbid-only', 'only-suite');
-    runMochaJSON(fixture, args.concat('--fgrep', 'bumble bees'), function(
-      err,
-      res
-    ) {
-      if (err) {
-        return done(err);
-      }
-      expect(res, 'to have passed');
-      done();
-    });
+    var spawnOpts = {stdio: 'pipe'};
+    runMocha(
+      fixture,
+      args.concat('--fgrep', 'bumble bees'),
+      function(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, 'to have failed with output', new RegExp(onlyErrorMessage));
+        done();
+      },
+      spawnOpts
+    );
   });
 
-  it('should succeed if suite marked only does not match inverted grep', function(done) {
+  it('should fail if suite marked only does not match inverted grep', function(done) {
     var fixture = path.join('options', 'forbid-only', 'only-suite');
-    runMochaJSON(
+    var spawnOpts = {stdio: 'pipe'};
+    runMocha(
       fixture,
       args.concat('--fgrep', 'suite marked with only', '--invert'),
       function(err, res) {
         if (err) {
           return done(err);
         }
-        expect(res, 'to have passed');
+        expect(res, 'to have failed with output', new RegExp(onlyErrorMessage));
         done();
-      }
+      },
+      spawnOpts
     );
   });
 

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -682,8 +682,6 @@ describe('Suite', function() {
   });
 
   describe('.markOnly()', function() {
-    var sandbox;
-
     beforeEach(function() {
       sandbox = sinon.createSandbox();
     });

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -680,6 +680,31 @@ describe('Suite', function() {
       });
     });
   });
+
+  describe('.markOnly()', function() {
+    var sandbox;
+
+    beforeEach(function() {
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should call appendOnlySuite on parent', function() {
+      var suite = new Suite('foo');
+      var spy = sandbox.spy();
+      suite.parent = {
+        appendOnlySuite: spy
+      };
+      suite.markOnly();
+
+      expect(spy, 'to have a call exhaustively satisfying', [suite]).and(
+        'was called once'
+      );
+    });
+  });
 });
 
 describe('Test', function() {

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -682,14 +682,6 @@ describe('Suite', function() {
   });
 
   describe('.markOnly()', function() {
-    beforeEach(function() {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(function() {
-      sandbox.restore();
-    });
-
     it('should call appendOnlySuite on parent', function() {
       var suite = new Suite('foo');
       var spy = sandbox.spy();


### PR DESCRIPTION
### Description of the Change

The handling of the `--forbid-only` option is currently inconsistent for the`Test` and `Suite` classes. Suites that are marked as only and excluded by `--grep`  or `--fgrep` don't throw an error. Test that are marked as only but excluded by `grep` or `f-grep` do throw an error. 

Following the discussion in #4256 it was suggested that due to the nature of the `--forbid-only` option it should not matter if a suite or test is excluded by a grep. An error should be thrown either way to protect the user from forgetting to remove `.only()` statements from his test code. I moved the changes concerning this inconsistency, including a refactoring of the Suite class to use a `markOnly()` instance method, into this PR to separate them from the fix #4256 for bug #3840.

### Alternate Designs

An alternative to make it consistent would be to adapt the logic so it will be checked if test cases are excluded by `grep` or `fgrep` as well. (see discussion in #4256)

### Why should this be in core?

It improves the consistency of the `--forbid-only` option and improves encapsulation between classes.

### Benefits

It improves the consistency of the `--forbid-only` option and improves encapsulation between classes.

### Possible Drawbacks

If the `--forbid-only` option is set and a test or suite is marked only but excluded by grep it will now throw an error.

### Applicable issues

#4256 
#3840 

