### PR TITLE
fix test/unit/hook.spec.js

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -192,15 +192,18 @@ Runner.prototype._addEventListener = function(target, eventName, listener) {
  * @param fn {function}
  */
 Runner.prototype._removeEventListener = function(target, eventName, listener) {
-  var eventListenerIndex = this._eventListeners.findIndex(function(
-    eventListenerDescriptor
-  ) {
-    return (
+  var eventListenerIndex = -1;
+  for (var i = 0; i < this._eventListeners.length; i++) {
+    var eventListenerDescriptor = this._eventListeners[i];
+    if (
       eventListenerDescriptor[0] === target &&
       eventListenerDescriptor[1] === eventName &&
       eventListenerDescriptor[2] === listener
-    );
-  });
+    ) {
+      eventListenerIndex = i;
+      break;
+    }
+  }
   if (eventListenerIndex !== -1) {
     var removedListener = this._eventListeners.splice(eventListenerIndex, 1)[0];
     removedListener[0].removeListener(removedListener[1], removedListener[2]);

--- a/test/unit/hook.spec.js
+++ b/test/unit/hook.spec.js
@@ -4,7 +4,7 @@ var Mocha = require('../../lib/mocha');
 var Hook = Mocha.Hook;
 var Runnable = Mocha.Runnable;
 
-describe(Hook.name, function() {
+describe('Hook', function() {
   var hook;
 
   beforeEach(function() {


### PR DESCRIPTION
`Function.prototype.name` is not available in IE11, and will cause the browser tests to fail.

Ideally, we could catch this with ESLint, but here's hoping we don't need to do that.

cc @nicojs 