### PR TITLE
Support --require of ESM; closes #4281

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -56,6 +56,8 @@ overrides:
       browser: false
   - files:
       - test/**/*.{js,mjs}
+    parserOptions:
+      ecmaVersion: 2018
     env:
       mocha: true
     globals:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -56,8 +56,6 @@ overrides:
       browser: false
   - files:
       - test/**/*.{js,mjs}
-    parserOptions:
-      ecmaVersion: 2018
     env:
       mocha: true
     globals:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1007,6 +1007,8 @@ Modules required in this manner are expected to do work synchronously; Mocha won
 
 Note you cannot use `--require` to set a global `beforeEach()` hook, for example &mdash; use `--file` instead, which allows you to specify an explicit order in which test files are loaded.
 
+> As of v7.3.0, Mocha supports `--require` for [NodeJS native ESM](#nodejs-native-esm-support). There is no separate `--import` flag.
+
 ### `--sort, -S`
 
 Sort test files (by absolute path) using [Array.prototype.sort][mdn-array-sort].

--- a/docs/index.md
+++ b/docs/index.md
@@ -1450,7 +1450,6 @@ Node.JS native ESM support still has status: **Stability: 1 - Experimental**
 - [Watch mode](#-watch-w) does not support ES Module test files
 - [Custom reporters](#third-party-reporters) and [custom interfaces](#interfaces)
   can only be CommonJS files
-- [Required modules](#-require-module-r-module) can only be CommonJS files
 - [Configuration file](#configuring-mocha-nodejs) can only be a CommonJS file (`.mocharc.js` or `.mocharc.cjs`)
 - When using module-level mocks via libs like `proxyquire`, `rewiremock` or `rewire`, hold off on using ES modules for your test files
 - Node.JS native ESM support does not work with [esm][npm-esm] module

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -92,7 +92,10 @@ exports.handleRequires = async (requires = []) => {
       debug('resolved required file %s to %s', mod, modpath);
     }
     const requiredModule = await requireOrImport(modpath);
-    if (type(requiredModule) === 'object' && requiredModule.mochaHooks) {
+    if (
+      ['object', 'module'].includes(type(requiredModule)) &&
+      requiredModule.mochaHooks
+    ) {
       const mochaHooksType = type(requiredModule.mochaHooks);
       if (/function$/.test(mochaHooksType) || mochaHooksType === 'object') {
         debug('found root hooks in required file %s', mod);

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -15,6 +15,7 @@ const collectFiles = require('./collect-files');
 const {type} = require('../utils');
 const {format} = require('util');
 const {createInvalidPluginError, createUnsupportedError} = require('../errors');
+const {requireOrImport} = require('../esm-utils');
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
@@ -81,15 +82,16 @@ exports.list = str =>
  * @returns {Promise<MochaRootHookObject|MochaRootHookFunction>} Any root hooks
  * @private
  */
-exports.handleRequires = async (requires = []) =>
-  requires.reduce((acc, mod) => {
+exports.handleRequires = async (requires = []) => {
+  const acc = [];
+  for (const mod of requires) {
     let modpath = mod;
     // this is relative to cwd
     if (fs.existsSync(mod) || fs.existsSync(`${mod}.js`)) {
       modpath = path.resolve(mod);
       debug('resolved required file %s to %s', mod, modpath);
     }
-    const requiredModule = require(modpath);
+    const requiredModule = await requireOrImport(modpath);
     if (type(requiredModule) === 'object' && requiredModule.mochaHooks) {
       const mochaHooksType = type(requiredModule.mochaHooks);
       if (/function$/.test(mochaHooksType) || mochaHooksType === 'object') {
@@ -102,8 +104,9 @@ exports.handleRequires = async (requires = []) =>
       }
     }
     debug('loaded required module "%s"', mod);
-    return acc;
-  }, []);
+  }
+  return acc;
+};
 
 /**
  * Loads root hooks as exported via `mochaHooks` from required files.

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -93,7 +93,8 @@ exports.handleRequires = async (requires = []) => {
     }
     const requiredModule = await requireOrImport(modpath);
     if (
-      ['object', 'module'].includes(type(requiredModule)) &&
+      requiredModule &&
+      typeof requiredModule === 'object' &&
       requiredModule.mochaHooks
     ) {
       const mochaHooksType = type(requiredModule.mochaHooks);

--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -1,8 +1,16 @@
 const path = require('path');
+const url = require('url');
+
+const formattedImport = async file => {
+  if (path.isAbsolute(file)) {
+    return import(url.pathToFileURL(file));
+  }
+  return import(file);
+};
 
 exports.requireOrImport = async file => {
   if (path.extname(file) === '.mjs') {
-    return import(file);
+    return formattedImport(file);
   }
   // This is currently the only known way of figuring out whether a file is CJS or ESM.
   // If Node.js or the community establish a better procedure for that, we can fix this code.
@@ -12,7 +20,7 @@ exports.requireOrImport = async file => {
     return require(file);
   } catch (err) {
     if (err.code === 'ERR_REQUIRE_ESM') {
-      return import(file);
+      return formattedImport(file);
     } else {
       throw err;
     }

--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -1,11 +1,8 @@
-const url = require('url');
 const path = require('path');
 
-const requireOrImport = async file => {
-  file = path.resolve(file);
-
+exports.requireOrImport = async file => {
   if (path.extname(file) === '.mjs') {
-    return import(url.pathToFileURL(file));
+    return import(file);
   }
   // This is currently the only known way of figuring out whether a file is CJS or ESM.
   // If Node.js or the community establish a better procedure for that, we can fix this code.
@@ -15,7 +12,7 @@ const requireOrImport = async file => {
     return require(file);
   } catch (err) {
     if (err.code === 'ERR_REQUIRE_ESM') {
-      return import(url.pathToFileURL(file));
+      return import(file);
     } else {
       throw err;
     }
@@ -25,7 +22,7 @@ const requireOrImport = async file => {
 exports.loadFilesAsync = async (files, preLoadFunc, postLoadFunc) => {
   for (const file of files) {
     preLoadFunc(file);
-    const result = await requireOrImport(file);
+    const result = await exports.requireOrImport(path.resolve(file));
     postLoadFunc(file, result);
   }
 };

--- a/test/integration/fixtures/options/require/esm/package.json
+++ b/test/integration/fixtures/options/require/esm/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/test/integration/fixtures/options/require/esm/root-hook-defs-esm.fixture.js
+++ b/test/integration/fixtures/options/require/esm/root-hook-defs-esm.fixture.js
@@ -1,0 +1,8 @@
+export const mochaHooks = () => ({
+  beforeEach() {
+    console.log('esm beforeEach');
+  },
+  afterEach() {
+    console.log('esm afterEach');
+  },
+});

--- a/test/integration/fixtures/options/require/root-hook-defs-esm.fixture.mjs
+++ b/test/integration/fixtures/options/require/root-hook-defs-esm.fixture.mjs
@@ -1,0 +1,8 @@
+export const mochaHooks = {
+  beforeAll() {
+    console.log('mjs beforeAll');
+  },
+  afterAll() {
+    console.log('mjs afterAll');
+  },
+};

--- a/test/integration/options/require.spec.js
+++ b/test/integration/options/require.spec.js
@@ -74,16 +74,11 @@ describe('--require', function() {
               require.resolve(
                 '../fixtures/options/require/root-hook-test.fixture.js'
               )
-            ],
-            {
-              env: {
-                ...process.env,
-                NODE_OPTIONS:
-                  +process.versions.node.split('.')[0] >= 13
-                    ? ''
-                    : '--experimental-modules'
-              }
-            }
+            ].concat(
+              +process.versions.node.split('.')[0] >= 13
+                ? []
+                : '--experimental-modules'
+            )
           )[1],
           'when fulfilled',
           'to contain output',

--- a/test/integration/options/require.spec.js
+++ b/test/integration/options/require.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var invokeMochaAsync = require('../helpers').invokeMochaAsync;
+var utils = require('../../../lib/utils');
 
 describe('--require', function() {
   describe('when mocha run in serial mode', function() {
@@ -44,6 +45,51 @@ describe('--require', function() {
         'to contain output',
         /beforeAll[\s\S]+?beforeAll array 1[\s\S]+?beforeAll array 2[\s\S]+?beforeEach[\s\S]+?beforeEach array 1[\s\S]+?beforeEach array 2[\s\S]+?afterEach[\s\S]+?afterEach array 1[\s\S]+?afterEach array 2[\s\S]+?afterAll[\s\S]+?afterAll array 1[\s\S]+?afterAll array 2/
       );
+    });
+
+    describe('support ESM when style=module or .mjs extension', function() {
+      before(function() {
+        if (!utils.supportsEsModules()) this.skip();
+      });
+
+      it('should run root hooks when provided via mochaHooks', function() {
+        return expect(
+          invokeMochaAsync(
+            [
+              '--require=' +
+                require.resolve(
+                  // as object
+                  '../fixtures/options/require/root-hook-defs-esm.fixture.mjs'
+                ),
+              '--require=' +
+                require.resolve(
+                  // as function
+                  '../fixtures/options/require/esm/root-hook-defs-esm.fixture.js'
+                ),
+              '--require=' +
+                require.resolve(
+                  // mixed with commonjs
+                  '../fixtures/options/require/root-hook-defs-a.fixture.js'
+                ),
+              require.resolve(
+                '../fixtures/options/require/root-hook-test.fixture.js'
+              )
+            ],
+            {
+              env: {
+                ...process.env,
+                NODE_OPTIONS:
+                  +process.versions.node.split('.')[0] >= 13
+                    ? ''
+                    : '--experimental-modules'
+              }
+            }
+          )[1],
+          'when fulfilled',
+          'to contain output',
+          /mjs beforeAll[\s\S]+?beforeAll[\s\S]+?esm beforeEach[\s\S]+?beforeEach[\s\S]+?esm afterEach[\s\S]+?afterEach[\s\S]+?mjs afterAll[\s\S]+?afterAll/
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Allow files/modules specified in `--require` to be ESM.

CommonJS loading is still supported and the default.

closes https://github.com/mochajs/mocha/issues/4281

### Description of the Change

Support `--require`ing ESM files in config. Current behavior is to fail on `ERR_REQUIRE_ESM`.

Re-use existing "require or import" logic for loading test files to load required files.

### Alternate Designs

Pipe requiring the ESM file through something like [esm](https://www.npmjs.com/package/esm) or [ts-node](https://www.npmjs.com/package/ts-node). Although that seems much more complicated and overkill.

### Why should this be in core?

Requiring JS files before the test suite is a core part of Mocha's functionality. This extends that support to ESM-first codebases, which is natively supported via `"type":"module"`, or `--exerimental-module`.

### Benefits

Allows developers more freedom in choosing to write ESM or CommonJS.

### Possible Drawbacks

Native ESM in NodeJS is still labeled as experimental (although an `--experimental` flag is no longer needed). It is possible the usage will change, but that is justification for re-using existing "require or import" functionality.

### Applicable issues

This should be an "enhancement" (minor release). `--require`ing CommonJS is still the default and fully supported, this will just allow additional support for ESM.