### PR TITLE
Remove Node v13 from CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,6 @@ jobs:
       name: 'Latest Node.js (with coverage)'
     - script: MOCHA_PARALLEL=0 npm start test.node.unit
       name: 'Latest Node.js (unit tests in serial mode)'
-    - &node
-      script: npm start test.node
-      node_js: '13'
-      name: 'Node.js v13'
 
     - &node
       script: npm start test.node

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ clone_depth: 1
 environment:
   matrix:
     - nodejs_version: '14'
-    - nodejs_version: '13'
     - nodejs_version: '12'
     - nodejs_version: '10'
 matrix:


### PR DESCRIPTION
### Description

Node v13 is end-of-life: June 1st / 2020