### PR TITLE
fix unfriendly error; add ESM examples for root hook plugins; closes #4310

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1277,9 +1277,11 @@ A _Root Hook Plugin_ is a JavaScript file loaded via [`--require`](#-require-mod
 
 ### Defining a Root Hook Plugin
 
-A Root Hook Plugin file is a script which exports (via `module.exports`) a `mochaHooks` property.
+A Root Hook Plugin file is a script which exports (via `module.exports`) a `mochaHooks` property. It is loaded via `--require <file>`.
 
-Here's a simple example, which defines a root hook. Use it via `--require test/hooks.js`:
+Here's a simple example which defines a root hook, written using CJS and ESM syntax.
+
+#### With CommonJS
 
 ```js
 // test/hooks.js
@@ -1292,7 +1294,24 @@ exports.mochaHooks = {
 };
 ```
 
-`beforeEach`--as you may have guessed--corresponds to a `beforeEach` in the default [`bdd`](#bdd) interface.
+#### With ES Modules
+
+We're using the `.mjs` extension in these examples.
+
+> _Tip: If you're having trouble getting ES modules to work, refer to [the Node.js documentation](https://nodejs.org/api/esm.html)._
+
+```js
+// test/hooks.mjs
+
+export const mochaHooks = {
+  beforeEach(done) {
+    // do something before every test
+    done();
+  }
+};
+```
+
+> _Note: Further examples will use ESM syntax._
 
 ### Available Root Hooks
 
@@ -1313,10 +1332,12 @@ Available root hooks and their behavior:
 
 {:.single-column}
 
-The root hook callbacks run in the usual context, so `this` is available:
+As with other hooks, `this` refers to to the current context object:
 
 ```js
-exports.mochaHooks = {
+// test/hooks.mjs
+
+export const mochaHooks = {
   beforeAll() {
     // skip all tests for bob
     if (require('os').userInfo().username === 'bob') {
@@ -1331,7 +1352,9 @@ exports.mochaHooks = {
 Multiple root hooks can be defined in a single plugin, for organizational purposes. For example:
 
 ```js
-exports.mochaHooks = {
+// test/hooks.mjs
+
+export const mochaHooks = {
   beforeEach: [
     function(done) {
       // do something before every test,
@@ -1349,7 +1372,9 @@ exports.mochaHooks = {
 If you need to perform some logic--such as choosing a root hook conditionally, based on the environment--`mochaHooks` can be a _function_ which returns the expected object.
 
 ```js
-exports.mochaHooks = () => {
+// test/hooks.mjs
+
+export const mochaHooks = () => {
   if (process.env.CI) {
     // root hooks object
     return {
@@ -1375,7 +1400,9 @@ exports.mochaHooks = () => {
 If you need to perform an async operation, `mochaHooks` can be `Promise`-returning:
 
 ```js
-exports.mochaHooks = async () => {
+// test/hooks.mjs
+
+export const mochaHooks = async () => {
   const result = await checkSomething();
   // only use a root hook if `result` is truthy
   if (result) {
@@ -1423,7 +1450,7 @@ describe('my test suite', function() {
 });
 ```
 
-Your `test/hooks.js` should contain:
+Your `test/hooks.js` (for this example, a CJS module) should contain:
 
 ```js
 // test/hooks.js

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -49,10 +49,10 @@ exports.main = (argv = process.argv.slice(2)) => {
       'Commands:': 'Commands'
     })
     .fail((msg, err, yargs) => {
-      debug(err);
+      debug('caught error sometime before command handler: %O', err);
       yargs.showHelp();
       console.error(`\n${symbols.error} ${ansi.red('ERROR:')} ${msg}`);
-      process.exit(1);
+      yargs.exit(1);
     })
     .help('help', 'Show usage information & exit')
     .alias('help', 'h')

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -7,6 +7,8 @@
  * @private
  */
 
+const symbols = require('log-symbols');
+const ansi = require('ansi-colors');
 const Mocha = require('../mocha');
 const {
   createUnsupportedError,
@@ -333,14 +335,21 @@ exports.builder = yargs =>
 
       return true;
     })
-    .middleware(async argv => {
-      // load requires first, because it can impact "plugin" validation
-      const rawRootHooks = await handleRequires(argv.require);
-      validatePlugin(argv, 'reporter', Mocha.reporters);
-      validatePlugin(argv, 'ui', Mocha.interfaces);
+    .middleware(async (argv, yargs) => {
+      // currently a failing middleware does not work nicely with yargs' `fail()`.
+      try {
+        // load requires first, because it can impact "plugin" validation
+        const rawRootHooks = await handleRequires(argv.require);
+        validatePlugin(argv, 'reporter', Mocha.reporters);
+        validatePlugin(argv, 'ui', Mocha.interfaces);
 
-      if (rawRootHooks.length) {
-        argv.rootHooks = await loadRootHooks(rawRootHooks);
+        if (rawRootHooks && rawRootHooks.length) {
+          argv.rootHooks = await loadRootHooks(rawRootHooks);
+        }
+      } catch (err) {
+        // this could be a bad --require, bad reporter, ui, etc.
+        console.error(`\n${symbols.error} ${ansi.red('ERROR:')}`, err);
+        yargs.exit(1);
       }
     })
     .array(types.array)

--- a/test/integration/fixtures/options/require/root-hook-defs-esm-broken.fixture.js
+++ b/test/integration/fixtures/options/require/root-hook-defs-esm-broken.fixture.js
@@ -1,0 +1,8 @@
+export const mochaHooks = {
+  beforeAll() {
+    console.log('mjs beforeAll');
+  },
+  afterAll() {
+    console.log('mjs afterAll');
+  },
+};


### PR DESCRIPTION
This PR conflates two things, and I apologize.  

I've updated the docs to show how to use ESM with root hook plugins.

I've also added a fix in the case that the `middleware` fails.  It looks like yargs does not handle async middleware rejections properly--it fails to trap any error, and instead prints an unrelated problem.  So, if `handleRequires` or `validatePlugin` fails, we need to trap that error ourself and print it, then force yargs to exit before the `fail` handler can take over.

Also contains refactors of `test/integration/options/require.spec.js`, which was driving me nuts due to the nondeterministic parallel tests.  It was also confusing as hell _anyway_, so hopefully the result is a little easier to stomach (it's still a hack).