### PR TITLE
closes issue #4303 - update tests by removing method call to createSa…

### DIFF
--- a/test/node-unit/buffered-runner.spec.js
+++ b/test/node-unit/buffered-runner.spec.js
@@ -13,11 +13,10 @@ const BUFFERED_RUNNER_PATH = require.resolve(
 );
 const Suite = require('../../lib/suite');
 const Runner = require('../../lib/runner');
-const {createSandbox} = require('sinon');
+var sinon = require('sinon');
 
 describe('buffered-runner', function() {
   describe('BufferedRunner', function() {
-    let sandbox;
     let run;
     let BufferedWorkerPool;
     let terminate;
@@ -27,19 +26,18 @@ describe('buffered-runner', function() {
     let cpuCount;
 
     beforeEach(function() {
-      sandbox = createSandbox();
       cpuCount = 1;
       suite = new Suite('a root suite', {}, true);
-      warn = sandbox.stub();
+      warn = sinon.stub();
 
       // tests will want to further define the behavior of these.
-      run = sandbox.stub();
-      terminate = sandbox.stub();
+      run = sinon.stub();
+      terminate = sinon.stub();
       BufferedWorkerPool = {
-        create: sandbox.stub().returns({
+        create: sinon.stub().returns({
           run,
           terminate,
-          stats: sandbox.stub().returns({})
+          stats: sinon.stub().returns({})
         })
       };
       BufferedRunner = rewiremock.proxy(BUFFERED_RUNNER_PATH, r => ({
@@ -47,7 +45,7 @@ describe('buffered-runner', function() {
           BufferedWorkerPool
         },
         os: {
-          cpus: sandbox.stub().callsFake(() => new Array(cpuCount))
+          cpus: sinon.stub().callsFake(() => new Array(cpuCount))
         },
         '../../lib/utils': r.with({warn}).callThrough()
       }));
@@ -157,7 +155,7 @@ describe('buffered-runner', function() {
 
           it('should delegate to Runner#uncaught', function(done) {
             const options = {};
-            sandbox.spy(runner, 'uncaught');
+            sinon.spy(runner, 'uncaught');
             const err = new Error('whoops');
             run.withArgs('some-file.js', options).rejects(new Error('whoops'));
             run.withArgs('some-other-file.js', options).resolves({

--- a/test/node-unit/buffered-runner.spec.js
+++ b/test/node-unit/buffered-runner.spec.js
@@ -13,7 +13,7 @@ const BUFFERED_RUNNER_PATH = require.resolve(
 );
 const Suite = require('../../lib/suite');
 const Runner = require('../../lib/runner');
-var sinon = require('sinon');
+const sinon = require('sinon');
 
 describe('buffered-runner', function() {
   describe('BufferedRunner', function() {

--- a/test/node-unit/buffered-worker-pool.spec.js
+++ b/test/node-unit/buffered-worker-pool.spec.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const rewiremock = require('rewiremock/node');
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 
 describe('class BufferedWorkerPool', function() {
   let BufferedWorkerPool;
-  let sandbox;
   let pool;
   let stats;
   let serializeJavascript;
@@ -13,24 +12,23 @@ describe('class BufferedWorkerPool', function() {
   let result;
 
   beforeEach(function() {
-    sandbox = createSandbox();
     stats = {totalWorkers: 10, busyWorkers: 8, idleWorkers: 2, pendingTasks: 3};
     result = {failures: 0, events: []};
     pool = {
-      terminate: sandbox.stub().resolves(),
-      exec: sandbox.stub().resolves(result),
-      stats: sandbox.stub().returns(stats)
+      terminate: sinon.stub().resolves(),
+      exec: sinon.stub().resolves(result),
+      stats: sinon.stub().returns(stats)
     };
     serializer = {
-      deserialize: sandbox.stub()
+      deserialize: sinon.stub()
     };
 
-    serializeJavascript = sandbox.spy(require('serialize-javascript'));
+    serializeJavascript = sinon.spy(require('serialize-javascript'));
     BufferedWorkerPool = rewiremock.proxy(
       require.resolve('../../lib/nodejs/buffered-worker-pool'),
       {
         workerpool: {
-          pool: sandbox.stub().returns(pool),
+          pool: sinon.stub().returns(pool),
           cpus: 8
         },
         '../../lib/nodejs/serializer': serializer,
@@ -43,7 +41,7 @@ describe('class BufferedWorkerPool', function() {
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('static method', function() {

--- a/test/node-unit/cli/config.spec.js
+++ b/test/node-unit/cli/config.spec.js
@@ -1,18 +1,13 @@
 'use strict';
 
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 const rewiremock = require('rewiremock/node');
 
 describe('cli/config', function() {
-  let sandbox;
   const phonyConfigObject = {ok: true};
 
-  beforeEach(function() {
-    sandbox = createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('loadConfig()', function() {
@@ -29,9 +24,9 @@ describe('cli/config', function() {
 
     describe('when parsing succeeds', function() {
       beforeEach(function() {
-        sandbox.stub(parsers, 'yaml').returns(phonyConfigObject);
-        sandbox.stub(parsers, 'json').returns(phonyConfigObject);
-        sandbox.stub(parsers, 'js').returns(phonyConfigObject);
+        sinon.stub(parsers, 'yaml').returns(phonyConfigObject);
+        sinon.stub(parsers, 'json').returns(phonyConfigObject);
+        sinon.stub(parsers, 'js').returns(phonyConfigObject);
       });
 
       describe('when supplied a filepath with ".yaml" extension', function() {
@@ -103,7 +98,7 @@ describe('cli/config', function() {
 
     describe('when supplied a filepath with unsupported extension', function() {
       beforeEach(function() {
-        sandbox.stub(parsers, 'json').returns(phonyConfigObject);
+        sinon.stub(parsers, 'json').returns(phonyConfigObject);
       });
 
       it('should use the JSON parser', function() {
@@ -114,7 +109,7 @@ describe('cli/config', function() {
 
     describe('when config file parsing fails', function() {
       beforeEach(function() {
-        sandbox.stub(parsers, 'yaml').throws();
+        sinon.stub(parsers, 'yaml').throws();
       });
 
       it('should throw', function() {
@@ -129,7 +124,7 @@ describe('cli/config', function() {
     let CONFIG_FILES;
 
     beforeEach(function() {
-      findup = {sync: sandbox.stub().returns('/some/path/.mocharc.js')};
+      findup = {sync: sinon.stub().returns('/some/path/.mocharc.js')};
       const config = rewiremock.proxy(
         require.resolve('../../../lib/cli/config'),
         r => ({

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 const rewiremock = require('rewiremock/node');
 const {ONE_AND_DONE_ARGS} = require('../../../lib/cli/one-and-dones');
 
@@ -31,19 +31,14 @@ const defaults = {
 };
 
 describe('options', function() {
-  let sandbox;
   let readFileSync;
   let findupSync;
   let loadOptions;
   let findConfig;
   let loadConfig;
 
-  beforeEach(function() {
-    sandbox = createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   /**
@@ -57,11 +52,11 @@ describe('options', function() {
     describe('when no parameter provided', function() {
       beforeEach(function() {
         this.timeout(1000);
-        readFileSync = sandbox.stub();
+        readFileSync = sinon.stub();
         readFileSync.onFirstCall().returns('{}');
-        findConfig = sandbox.stub().returns('/some/.mocharc.json');
-        loadConfig = sandbox.stub().returns({});
-        findupSync = sandbox.stub().returns('/some/package.json');
+        findConfig = sinon.stub().returns('/some/.mocharc.json');
+        loadConfig = sinon.stub().returns({});
+        findupSync = sinon.stub().returns('/some/package.json');
 
         loadOptions = proxyLoadOptions({
           readFileSync,
@@ -91,12 +86,12 @@ describe('options', function() {
 
           beforeEach(function() {
             const filepath = '/some/package.json';
-            readFileSync = sandbox.stub();
+            readFileSync = sinon.stub();
             // package.json
             readFileSync.onFirstCall().returns('{"mocha": {"retries": 3}}');
-            findConfig = sandbox.stub().returns('/some/.mocharc.json');
-            loadConfig = sandbox.stub().returns({});
-            findupSync = sandbox.stub();
+            findConfig = sinon.stub().returns('/some/.mocharc.json');
+            loadConfig = sinon.stub().returns({});
+            findupSync = sinon.stub();
             loadOptions = proxyLoadOptions({
               readFileSync,
               findConfig,
@@ -135,12 +130,12 @@ describe('options', function() {
 
         describe('when path to package.json (`--package <path>`) is invalid', function() {
           beforeEach(function() {
-            readFileSync = sandbox.stub();
+            readFileSync = sinon.stub();
             // package.json
             readFileSync.onFirstCall().throws('yikes');
-            findConfig = sandbox.stub().returns('/some/.mocharc.json');
-            loadConfig = sandbox.stub().returns({});
-            findupSync = sandbox.stub();
+            findConfig = sinon.stub().returns('/some/.mocharc.json');
+            loadConfig = sinon.stub().returns({});
+            findupSync = sinon.stub();
             loadOptions = proxyLoadOptions({
               readFileSync,
               findConfig,
@@ -165,14 +160,14 @@ describe('options', function() {
 
           beforeEach(function() {
             const filepath = '/some/package.json';
-            readFileSync = sandbox.stub();
+            readFileSync = sinon.stub();
             // package.json
             readFileSync
               .onFirstCall()
               .returns('{"mocha": {"retries": 3, "_": ["foobar.spec.js"]}}');
-            findConfig = sandbox.stub().returns('/some/.mocharc.json');
-            loadConfig = sandbox.stub().returns({});
-            findupSync = sandbox.stub().returns(filepath);
+            findConfig = sinon.stub().returns('/some/.mocharc.json');
+            loadConfig = sinon.stub().returns({});
+            findupSync = sinon.stub().returns(filepath);
             loadOptions = proxyLoadOptions({
               readFileSync,
               findConfig,
@@ -208,11 +203,11 @@ describe('options', function() {
         describe('when called with package = false (`--no-package`)', function() {
           let result;
           beforeEach(function() {
-            readFileSync = sandbox.stub();
+            readFileSync = sinon.stub();
             readFileSync.onFirstCall().returns('{}');
-            findConfig = sandbox.stub().returns('/some/path/to/.mocharc.json');
-            loadConfig = sandbox.stub().returns({'check-leaks': true});
-            findupSync = sandbox.stub().returns('/some/package.json');
+            findConfig = sinon.stub().returns('/some/path/to/.mocharc.json');
+            loadConfig = sinon.stub().returns({'check-leaks': true});
+            findupSync = sinon.stub().returns('/some/package.json');
 
             loadOptions = proxyLoadOptions({
               readFileSync,
@@ -251,15 +246,15 @@ describe('options', function() {
         describe('when called with config = false (`--no-config`)', function() {
           let result;
           beforeEach(function() {
-            readFileSync = sandbox.stub();
+            readFileSync = sinon.stub();
             readFileSync
               .onFirstCall()
               .returns(
                 '{"mocha": {"check-leaks": true, "_": ["foobar.spec.js"]}}'
               );
-            findConfig = sandbox.stub();
-            loadConfig = sandbox.stub();
-            findupSync = sandbox.stub().returns('/some/package.json');
+            findConfig = sinon.stub();
+            loadConfig = sinon.stub();
+            findupSync = sinon.stub().returns('/some/package.json');
 
             loadOptions = proxyLoadOptions({
               readFileSync,
@@ -301,12 +296,12 @@ describe('options', function() {
           let config;
 
           beforeEach(function() {
-            readFileSync = sandbox.stub();
+            readFileSync = sinon.stub();
             config = '/some/.mocharc.json';
             readFileSync.onFirstCall().returns('{}');
-            findConfig = sandbox.stub();
-            loadConfig = sandbox.stub().throws('Error', 'failed to parse');
-            findupSync = sandbox.stub().returns('/some/package.json');
+            findConfig = sinon.stub();
+            loadConfig = sinon.stub().throws('Error', 'failed to parse');
+            findupSync = sinon.stub().returns('/some/package.json');
 
             loadOptions = proxyLoadOptions({
               readFileSync,
@@ -346,12 +341,12 @@ describe('options', function() {
             let result;
 
             beforeEach(function() {
-              readFileSync = sandbox.stub();
+              readFileSync = sinon.stub();
               readFileSync.onFirstCall().returns('{}');
               readFileSync.onSecondCall().throws();
-              findConfig = sandbox.stub().returns('/some/.mocharc.json');
-              loadConfig = sandbox.stub().returns({});
-              findupSync = sandbox.stub().returns('/some/package.json');
+              findConfig = sinon.stub().returns('/some/.mocharc.json');
+              loadConfig = sinon.stub().returns({});
+              findupSync = sinon.stub().returns('/some/package.json');
 
               loadOptions = proxyLoadOptions({
                 readFileSync,
@@ -382,12 +377,12 @@ describe('options', function() {
             let result;
 
             beforeEach(function() {
-              readFileSync = sandbox.stub();
+              readFileSync = sinon.stub();
               readFileSync.onFirstCall().returns('{}');
               readFileSync.onSecondCall().throws();
-              findConfig = sandbox.stub().returns(null);
-              loadConfig = sandbox.stub().returns({});
-              findupSync = sandbox.stub().returns('/some/package.json');
+              findConfig = sinon.stub().returns(null);
+              loadConfig = sinon.stub().returns({});
+              findupSync = sinon.stub().returns('/some/package.json');
 
               loadOptions = proxyLoadOptions({
                 readFileSync,
@@ -417,15 +412,15 @@ describe('options', function() {
 
     describe('config priority', function() {
       it('should prioritize package.json over defaults', function() {
-        readFileSync = sandbox.stub();
+        readFileSync = sinon.stub();
         readFileSync
           .onFirstCall()
           .returns(
             '{"mocha": {"timeout": 700, "require": "bar", "extension": "ts"}}'
           );
-        findConfig = sandbox.stub().returns('/some/.mocharc.json');
-        loadConfig = sandbox.stub().returns({});
-        findupSync = sandbox.stub().returns('/some/package.json');
+        findConfig = sinon.stub().returns('/some/.mocharc.json');
+        loadConfig = sinon.stub().returns({});
+        findupSync = sinon.stub().returns('/some/package.json');
 
         loadOptions = proxyLoadOptions({
           readFileSync,
@@ -442,12 +437,12 @@ describe('options', function() {
       });
 
       it('should prioritize rc file over package.json', function() {
-        readFileSync = sandbox.stub();
+        readFileSync = sinon.stub();
         readFileSync.onFirstCall().returns('{"mocha": {"timeout": 700}}');
         readFileSync.onSecondCall().returns('--timeout 800');
-        findConfig = sandbox.stub().returns('/some/.mocharc.json');
-        loadConfig = sandbox.stub().returns({timeout: 600});
-        findupSync = sandbox.stub().returns('/some/package.json');
+        findConfig = sinon.stub().returns('/some/.mocharc.json');
+        loadConfig = sinon.stub().returns({timeout: 600});
+        findupSync = sinon.stub().returns('/some/package.json');
 
         loadOptions = proxyLoadOptions({
           readFileSync,
@@ -460,12 +455,12 @@ describe('options', function() {
       });
 
       it('should prioritize args over rc file', function() {
-        readFileSync = sandbox.stub();
+        readFileSync = sinon.stub();
         readFileSync.onFirstCall().returns('{"mocha": {"timeout": 700}}');
         readFileSync.onSecondCall().returns('--timeout 800');
-        findConfig = sandbox.stub().returns('/some/.mocharc.json');
-        loadConfig = sandbox.stub().returns({timeout: 600});
-        findupSync = sandbox.stub().returns('/some/package.json');
+        findConfig = sinon.stub().returns('/some/.mocharc.json');
+        loadConfig = sinon.stub().returns({timeout: 600});
+        findupSync = sinon.stub().returns('/some/package.json');
 
         loadOptions = proxyLoadOptions({
           readFileSync,
@@ -485,10 +480,10 @@ describe('options', function() {
 
     describe('when called with a one-and-done arg', function() {
       beforeEach(function() {
-        readFileSync = sandbox.stub();
-        findConfig = sandbox.stub();
-        loadConfig = sandbox.stub();
-        findupSync = sandbox.stub();
+        readFileSync = sinon.stub();
+        findConfig = sinon.stub();
+        loadConfig = sinon.stub();
+        findupSync = sinon.stub();
         loadOptions = proxyLoadOptions({
           readFileSync,
           findConfig,
@@ -511,11 +506,11 @@ describe('options', function() {
         let result;
 
         beforeEach(function() {
-          readFileSync = sandbox.stub();
+          readFileSync = sinon.stub();
           readFileSync.onFirstCall().throws();
-          findConfig = sandbox.stub().returns('/some/.mocharc.json');
-          loadConfig = sandbox.stub().returns({extension: ['tsx']});
-          findupSync = sandbox.stub();
+          findConfig = sinon.stub().returns('/some/.mocharc.json');
+          loadConfig = sinon.stub().returns({extension: ['tsx']});
+          findupSync = sinon.stub();
           loadOptions = proxyLoadOptions({
             readFileSync,
             findConfig,
@@ -534,11 +529,11 @@ describe('options', function() {
         let result;
 
         beforeEach(function() {
-          readFileSync = sandbox.stub();
+          readFileSync = sinon.stub();
           readFileSync.onFirstCall().throws();
-          findConfig = sandbox.stub().returns('/some/.mocharc.json');
-          loadConfig = sandbox.stub().returns({});
-          findupSync = sandbox.stub();
+          findConfig = sinon.stub().returns('/some/.mocharc.json');
+          loadConfig = sinon.stub().returns({});
+          findupSync = sinon.stub();
           loadOptions = proxyLoadOptions({
             readFileSync,
             findConfig,
@@ -559,13 +554,11 @@ describe('options', function() {
         let result;
 
         beforeEach(function() {
-          readFileSync = sandbox.stub();
+          readFileSync = sinon.stub();
           readFileSync.onFirstCall().throws();
-          findConfig = sandbox.stub().returns('/some/.mocharc.json');
-          loadConfig = sandbox
-            .stub()
-            .returns({spec: '{dirA,dirB}/**/*.spec.js'});
-          findupSync = sandbox.stub();
+          findConfig = sinon.stub().returns('/some/.mocharc.json');
+          loadConfig = sinon.stub().returns({spec: '{dirA,dirB}/**/*.spec.js'});
+          findupSync = sinon.stub();
           loadOptions = proxyLoadOptions({
             readFileSync,
             findConfig,
@@ -588,13 +581,11 @@ describe('options', function() {
       let result;
 
       beforeEach(function() {
-        readFileSync = sandbox.stub();
+        readFileSync = sinon.stub();
         readFileSync.onFirstCall().throws();
-        findConfig = sandbox.stub().returns('/some/.mocharc.json');
-        loadConfig = sandbox
-          .stub()
-          .returns({ignore: '{dirA,dirB}/**/*.spec.js'});
-        findupSync = sandbox.stub();
+        findConfig = sinon.stub().returns('/some/.mocharc.json');
+        loadConfig = sinon.stub().returns({ignore: '{dirA,dirB}/**/*.spec.js'});
+        findupSync = sinon.stub();
         loadOptions = proxyLoadOptions({
           readFileSync,
           findConfig,

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const rewiremock = require('rewiremock/node');
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 const {EventEmitter} = require('events');
 
 const MODULE_PATH = require.resolve('../../lib/mocha.js');
@@ -15,41 +15,39 @@ describe('Mocha', function() {
   let stubs;
   let opts;
   let Mocha;
-  let sandbox;
 
   beforeEach(function() {
-    sandbox = createSandbox();
-    opts = {reporter: sandbox.stub()};
+    opts = {reporter: sinon.stub()};
 
     stubs = {};
     stubs.utils = {
-      supportsEsModules: sandbox.stub().returns(false),
-      warn: sandbox.stub(),
-      isString: sandbox.stub(),
-      noop: sandbox.stub(),
-      cwd: sandbox.stub().returns(process.cwd()),
-      isBrowser: sandbox.stub().returns(false)
+      supportsEsModules: sinon.stub().returns(false),
+      warn: sinon.stub(),
+      isString: sinon.stub(),
+      noop: sinon.stub(),
+      cwd: sinon.stub().returns(process.cwd()),
+      isBrowser: sinon.stub().returns(false)
     };
-    stubs.suite = Object.assign(sandbox.createStubInstance(EventEmitter), {
-      slow: sandbox.stub(),
-      timeout: sandbox.stub(),
-      bail: sandbox.stub(),
-      reset: sandbox.stub(),
-      dispose: sandbox.stub()
+    stubs.suite = Object.assign(sinon.createStubInstance(EventEmitter), {
+      slow: sinon.stub(),
+      timeout: sinon.stub(),
+      bail: sinon.stub(),
+      reset: sinon.stub(),
+      dispose: sinon.stub()
     });
-    stubs.Suite = sandbox.stub().returns(stubs.suite);
+    stubs.Suite = sinon.stub().returns(stubs.suite);
     stubs.Suite.constants = {};
-    stubs.BufferedRunner = sandbox.stub().returns({});
-    const runner = Object.assign(sandbox.createStubInstance(EventEmitter), {
-      run: sandbox
+    stubs.BufferedRunner = sinon.stub().returns({});
+    const runner = Object.assign(sinon.createStubInstance(EventEmitter), {
+      run: sinon
         .stub()
         .callsArgAsync(0)
         .returnsThis(),
-      globals: sandbox.stub(),
-      grep: sandbox.stub(),
-      dispose: sandbox.stub()
+      globals: sinon.stub(),
+      grep: sinon.stub(),
+      dispose: sinon.stub()
     });
-    stubs.Runner = sandbox.stub().returns(runner);
+    stubs.Runner = sinon.stub().returns(runner);
     // the Runner constructor is the main export, and constants is a static prop.
     // we don't need the constants themselves, but the object cannot be undefined
     stubs.Runner.constants = {};
@@ -67,7 +65,7 @@ describe('Mocha', function() {
   afterEach(function() {
     delete require.cache[DUMB_FIXTURE_PATH];
     delete require.cache[DUMBER_FIXTURE_PATH];
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('instance method', function() {
@@ -211,7 +209,7 @@ describe('Mocha', function() {
     describe('unloadFiles()', function() {
       it('should delegate Mocha.unloadFile() for each item in its list of files', function() {
         mocha.files = [DUMB_FIXTURE_PATH, DUMBER_FIXTURE_PATH];
-        sandbox.stub(Mocha, 'unloadFile');
+        sinon.stub(Mocha, 'unloadFile');
         mocha.unloadFiles();
         expect(Mocha.unloadFile, 'to have a call exhaustively satisfying', [
           DUMB_FIXTURE_PATH

--- a/test/node-unit/reporters/parallel-buffered.spec.js
+++ b/test/node-unit/reporters/parallel-buffered.spec.js
@@ -19,16 +19,14 @@ const {
   EVENT_RUN_END
 } = require('../../../lib/runner').constants;
 const {EventEmitter} = require('events');
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 const rewiremock = require('rewiremock/node');
 
 describe('ParallelBuffered', function() {
-  let sandbox;
   let runner;
   let ParallelBuffered;
 
   beforeEach(function() {
-    sandbox = createSandbox();
     runner = new EventEmitter();
     ParallelBuffered = rewiremock.proxy(
       require.resolve('../../../lib/nodejs/reporters/parallel-buffered'),
@@ -56,15 +54,15 @@ describe('ParallelBuffered', function() {
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('constructor', function() {
     it('should listen for Runner events', function() {
       // EventEmitter#once calls thru to EventEmitter#on, which
       // befouls our assertion below.
-      sandbox.stub(runner, 'once');
-      sandbox.stub(runner, 'on');
+      sinon.stub(runner, 'once');
+      sinon.stub(runner, 'on');
       // eslint-disable-next-line no-new
       new ParallelBuffered(runner);
       expect(runner.on, 'to have calls satisfying', [
@@ -83,7 +81,7 @@ describe('ParallelBuffered', function() {
     });
 
     it('should listen for Runner events expecting to occur once', function() {
-      sandbox.stub(runner, 'once');
+      sinon.stub(runner, 'once');
       // eslint-disable-next-line no-new
       new ParallelBuffered(runner);
       expect(runner.once, 'to have calls satisfying', [
@@ -172,7 +170,7 @@ describe('ParallelBuffered', function() {
         runner.emit(EVENT_TEST_PASS, test);
         runner.emit(EVENT_TEST_END, test);
         runner.emit(EVENT_SUITE_END, suite);
-        const cb = sandbox.stub();
+        const cb = sinon.stub();
         reporter.done(0, cb);
         expect(cb, 'to have a call satisfying', [
           {
@@ -221,7 +219,7 @@ describe('ParallelBuffered', function() {
         runner.emit(EVENT_TEST_PASS, test);
         runner.emit(EVENT_TEST_END, test);
         runner.emit(EVENT_SUITE_END, suite);
-        const cb = sandbox.stub();
+        const cb = sinon.stub();
         reporter.done(0, cb);
         expect(reporter.events, 'to be empty');
       });

--- a/test/node-unit/serializer.spec.js
+++ b/test/node-unit/serializer.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 const {
   serialize,
   deserialize,
@@ -9,14 +9,8 @@ const {
 } = require('../../lib/nodejs/serializer');
 
 describe('serializer', function() {
-  let sandbox;
-
-  beforeEach(function() {
-    sandbox = createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('function', function() {
@@ -38,7 +32,7 @@ describe('serializer', function() {
         describe('having a `serialize` method', function() {
           it('should return the result of the `serialize` method', function() {
             const serializedObj = {foo: 'bar'};
-            const obj = {serialize: sandbox.stub().returns(serializedObj)};
+            const obj = {serialize: sinon.stub().returns(serializedObj)};
             expect(serialize(obj), 'to be', serializedObj);
           });
         });
@@ -76,9 +70,7 @@ describe('serializer', function() {
 
         it('should return the result of `SerializableWorkerResult.deserialize` called on the value', function() {
           const obj = Object.assign({}, SerializableWorkerResult.create());
-          sandbox
-            .stub(SerializableWorkerResult, 'deserialize')
-            .returns('butts');
+          sinon.stub(SerializableWorkerResult, 'deserialize').returns('butts');
           deserialize(obj);
           expect(
             SerializableWorkerResult.deserialize,
@@ -133,7 +125,7 @@ describe('serializer', function() {
         describe('when passed an object with a `serialize` method', function() {
           it('should call the `serialize` method', function() {
             const obj = {
-              serialize: sandbox.stub()
+              serialize: sinon.stub()
             };
             SerializableEvent.create('some-event', obj).serialize();
             expect(obj.serialize, 'was called once');
@@ -142,7 +134,7 @@ describe('serializer', function() {
 
         describe('when passed an object containing an object with a `serialize` method', function() {
           it('should call the `serialize` method', function() {
-            const stub = sandbox.stub();
+            const stub = sinon.stub();
             const obj = {
               nested: {
                 serialize: stub
@@ -400,7 +392,7 @@ describe('serializer', function() {
 
         describe('when the value data contains a prop with an array value', function() {
           beforeEach(function() {
-            sandbox.spy(SerializableEvent, '_deserializeObject');
+            sinon.spy(SerializableEvent, '_deserializeObject');
           });
 
           it('should deserialize each prop', function() {
@@ -480,7 +472,7 @@ describe('serializer', function() {
 
       describe('deserialize', function() {
         beforeEach(function() {
-          sandbox.stub(SerializableEvent, 'deserialize');
+          sinon.stub(SerializableEvent, 'deserialize');
         });
 
         it('should call SerializableEvent#deserialize on each item in its `events` prop', function() {
@@ -525,7 +517,7 @@ describe('serializer', function() {
         });
 
         it('should call `SerializableEvent#serialize` of each of its events', function() {
-          sandbox.spy(SerializableEvent.prototype, 'serialize');
+          sinon.spy(SerializableEvent.prototype, 'serialize');
           const events = [
             SerializableEvent.create('foo'),
             SerializableEvent.create('bar')

--- a/test/node-unit/worker.spec.js
+++ b/test/node-unit/worker.spec.js
@@ -3,24 +3,22 @@
 const serializeJavascript = require('serialize-javascript');
 const rewiremock = require('rewiremock/node');
 const {SerializableWorkerResult} = require('../../lib/nodejs/serializer');
-const {createSandbox} = require('sinon');
+const sinon = require('sinon');
 
 const WORKER_PATH = require.resolve('../../lib/nodejs/worker.js');
 
 describe('worker', function() {
   let worker;
-  let sandbox;
   let stubs;
 
   beforeEach(function() {
-    sandbox = createSandbox();
     stubs = {
       workerpool: {
         isMainThread: false,
-        worker: sandbox.stub()
+        worker: sinon.stub()
       }
     };
-    sandbox.spy(process, 'removeAllListeners');
+    sinon.spy(process, 'removeAllListeners');
   });
 
   describe('when run as main process', function() {
@@ -41,24 +39,24 @@ describe('worker', function() {
 
     beforeEach(function() {
       mocha = {
-        addFile: sandbox.stub().returnsThis(),
-        loadFilesAsync: sandbox.stub().resolves(),
-        run: sandbox.stub().callsArgAsync(0),
-        unloadFiles: sandbox.stub().returnsThis()
+        addFile: sinon.stub().returnsThis(),
+        loadFilesAsync: sinon.stub().resolves(),
+        run: sinon.stub().callsArgAsync(0),
+        unloadFiles: sinon.stub().returnsThis()
       };
-      stubs.Mocha = Object.assign(sandbox.stub().returns(mocha), {
-        bdd: sandbox.stub(),
+      stubs.Mocha = Object.assign(sinon.stub().returns(mocha), {
+        bdd: sinon.stub(),
         interfaces: {}
       });
 
       stubs.serializer = {
-        serialize: sandbox.stub()
+        serialize: sinon.stub()
       };
 
       stubs.runHelpers = {
-        handleRequires: sandbox.stub(),
-        validatePlugin: sandbox.stub(),
-        loadRootHooks: sandbox.stub().resolves()
+        handleRequires: sinon.stub(),
+        validatePlugin: sinon.stub(),
+        loadRootHooks: sinon.stub().resolves()
       };
 
       worker = rewiremock.proxy(WORKER_PATH, {
@@ -216,7 +214,7 @@ describe('worker', function() {
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
     // this is needed due to `require.cache` getting dumped in watch mode
     process.removeAllListeners('beforeExit');
   });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -12,14 +12,13 @@ var createElements = helpers.createElements;
 var makeTest = helpers.makeTest;
 
 describe('Base reporter', function() {
-  var sandbox;
   var stdout;
 
   function list(tests) {
     try {
       Base.list(tests);
     } finally {
-      sandbox.restore();
+      sinon.restore();
     }
   }
 
@@ -29,7 +28,7 @@ describe('Base reporter', function() {
     try {
       diffStr = Base.generateDiff(actual, expected);
     } finally {
-      sandbox.restore();
+      sinon.restore();
     }
 
     return diffStr;
@@ -40,14 +39,13 @@ describe('Base reporter', function() {
   };
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(Base, 'useColors').value(false);
-    sandbox.stub(process.stdout, 'write').callsFake(gather);
+    sinon.stub(Base, 'useColors').value(false);
+    sinon.stub(process.stdout, 'write').callsFake(gather);
     stdout = [];
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('showDiff', function() {
@@ -103,7 +101,7 @@ describe('Base reporter', function() {
     it("should not show diffs if 'hideDiff' is true", function() {
       var test = makeTest(err);
 
-      sandbox.stub(Base, 'hideDiff').value(true);
+      sinon.stub(Base, 'hideDiff').value(true);
       list([test]);
 
       var errOut = stdout.join('\n');
@@ -136,7 +134,7 @@ describe('Base reporter', function() {
     var inlineDiffsStub;
 
     beforeEach(function() {
-      inlineDiffsStub = sandbox.stub(Base, 'inlineDiffs');
+      inlineDiffsStub = sinon.stub(Base, 'inlineDiffs');
     });
 
     it("should generate unified diffs if 'inlineDiffs' is false", function() {
@@ -170,7 +168,7 @@ describe('Base reporter', function() {
 
   describe('inline strings diff', function() {
     beforeEach(function() {
-      sandbox.stub(Base, 'inlineDiffs').value(true);
+      sinon.stub(Base, 'inlineDiffs').value(true);
     });
 
     it("should show single line diff if 'inlineDiffs' is true", function() {
@@ -213,7 +211,7 @@ describe('Base reporter', function() {
 
   describe('unified diff', function() {
     beforeEach(function() {
-      sandbox.stub(Base, 'inlineDiffs').value(false);
+      sinon.stub(Base, 'inlineDiffs').value(false);
     });
 
     it('should separate diff hunks by two dashes', function() {
@@ -426,13 +424,11 @@ describe('Base reporter', function() {
   });
 
   describe('when reporter output immune to user test changes', function() {
-    var sandbox;
     var baseConsoleLog;
 
     beforeEach(function() {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(console, 'log');
-      baseConsoleLog = sandbox.stub(Base, 'consoleLog');
+      sinon.stub(console, 'log');
+      baseConsoleLog = sinon.stub(Base, 'consoleLog');
     });
 
     it('should let you stub out console.log without effecting reporters output', function() {
@@ -444,7 +440,7 @@ describe('Base reporter', function() {
     });
 
     afterEach(function() {
-      sandbox.restore();
+      sinon.restore();
     });
   });
 });

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -17,22 +17,20 @@ var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
 var EVENT_TEST_PENDING = events.EVENT_TEST_PENDING;
 
 describe('Dot reporter', function() {
-  var sandbox;
   var windowWidthStub;
   var runReporter = makeRunReporter(Dot);
   var noop = function() {};
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    windowWidthStub = sandbox.stub(Base.window, 'width').value(0);
-    sandbox.stub(Base, 'useColors').value(false);
-    sandbox.stub(Base, 'color').callsFake(function(type, str) {
+    windowWidthStub = sinon.stub(Base.window, 'width').value(0);
+    sinon.stub(Base, 'useColors').value(false);
+    sinon.stub(Base, 'color').callsFake(function(type, str) {
       return type.replace(/ /g, '-') + '_' + str;
     });
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('event handlers', function() {
@@ -41,7 +39,7 @@ describe('Dot reporter', function() {
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
         var stdout = runReporter({epilogue: noop}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedArray = ['\n'];
         expect(stdout, 'to equal', expectedArray);
@@ -58,7 +56,7 @@ describe('Dot reporter', function() {
           var runner = createMockRunner('pending', EVENT_TEST_PENDING);
           var options = {};
           var stdout = runReporter({epilogue: noop}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedArray = ['\n  ', 'pending_' + Base.symbols.comma];
           expect(stdout, 'to equal', expectedArray);
@@ -70,7 +68,7 @@ describe('Dot reporter', function() {
           var runner = createMockRunner('pending', EVENT_TEST_PENDING);
           var options = {};
           var stdout = runReporter({epilogue: noop}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedArray = ['pending_' + Base.symbols.comma];
           expect(stdout, 'to equal', expectedArray);
@@ -102,7 +100,7 @@ describe('Dot reporter', function() {
             );
             var options = {};
             var stdout = runReporter({epilogue: noop}, runner, options);
-            sandbox.restore();
+            sinon.restore();
 
             expect(test.speed, 'to equal', 'fast');
             var expectedArray = ['\n  ', 'fast_' + Base.symbols.dot];
@@ -123,7 +121,7 @@ describe('Dot reporter', function() {
             );
             var options = {};
             var stdout = runReporter({epilogue: noop}, runner, options);
-            sandbox.restore();
+            sinon.restore();
 
             expect(test.speed, 'to equal', 'fast');
             var expectedArray = ['fast_' + Base.symbols.dot];
@@ -143,7 +141,7 @@ describe('Dot reporter', function() {
             );
             var options = {};
             var stdout = runReporter({epilogue: noop}, runner, options);
-            sandbox.restore();
+            sinon.restore();
 
             expect(test.speed, 'to equal', 'medium');
             var expectedArray = ['medium_' + Base.symbols.dot];
@@ -163,7 +161,7 @@ describe('Dot reporter', function() {
             );
             var options = {};
             var stdout = runReporter({epilogue: noop}, runner, options);
-            sandbox.restore();
+            sinon.restore();
 
             expect(test.speed, 'to equal', 'slow');
             var expectedArray = ['bright-yellow_' + Base.symbols.dot];
@@ -195,7 +193,7 @@ describe('Dot reporter', function() {
           );
           var options = {};
           var stdout = runReporter({epilogue: noop}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedArray = ['\n  ', 'fail_' + Base.symbols.bang];
           expect(stdout, 'to equal', expectedArray);
@@ -213,7 +211,7 @@ describe('Dot reporter', function() {
           );
           var options = {};
           var stdout = runReporter({epilogue: noop}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedArray = ['fail_' + Base.symbols.bang];
           expect(stdout, 'to equal', expectedArray);
@@ -229,7 +227,7 @@ describe('Dot reporter', function() {
         };
         var options = {};
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(fakeThis.epilogue.called, 'to be true');
       });

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -7,7 +7,6 @@ var Runner = Mocha.Runner;
 var Test = Mocha.Test;
 
 describe('JSON reporter', function() {
-  var sandbox;
   var suite;
   var runner;
   var testTitle = 'json test 1';
@@ -26,12 +25,11 @@ describe('JSON reporter', function() {
   });
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(process.stdout, 'write').callsFake(noop);
+    sinon.stub(process.stdout, 'write').callsFake(noop);
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   it('should have 1 test failure', function(done) {
@@ -45,7 +43,7 @@ describe('JSON reporter', function() {
     suite.addTest(test);
 
     runner.run(function(failureCount) {
-      sandbox.restore();
+      sinon.restore();
       expect(runner, 'to satisfy', {
         testResults: {
           failures: [
@@ -70,7 +68,7 @@ describe('JSON reporter', function() {
     suite.addTest(test);
 
     runner.run(function(failureCount) {
-      sandbox.restore();
+      sinon.restore();
       expect(runner, 'to satisfy', {
         testResults: {
           pending: [
@@ -102,7 +100,7 @@ describe('JSON reporter', function() {
     suite.addTest(test);
 
     runner.run(function(failureCount) {
-      sandbox.restore();
+      sinon.restore();
       expect(runner, 'to satisfy', {
         testResults: {
           failures: [

--- a/test/reporters/landing.spec.js
+++ b/test/reporters/landing.spec.js
@@ -19,7 +19,6 @@ var STATE_FAILED = states.STATE_FAILED;
 var STATE_PASSED = states.STATE_PASSED;
 
 describe('Landing reporter', function() {
-  var sandbox;
   var runReporter = makeRunReporter(Landing);
   var resetCode = '\u001b[0m';
   var expectedArray = [
@@ -34,35 +33,34 @@ describe('Landing reporter', function() {
   ];
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(Base, 'useColors').value(false);
-    sandbox.stub(Base.window, 'width').value(1);
+    sinon.stub(Base, 'useColors').value(false);
+    sinon.stub(Base.window, 'width').value(1);
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('event handlers', function() {
     describe("on 'start' event", function() {
       it('should write newlines', function() {
-        sandbox.stub(Base.cursor, 'hide');
+        sinon.stub(Base.cursor, 'hide');
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
         var stdout = runReporter({}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(stdout[0], 'to equal', '\n\n\n  ');
       });
 
       it('should call cursor hide', function() {
-        var hideCursorStub = sandbox.stub(Base.cursor, 'hide');
+        var hideCursorStub = sinon.stub(Base.cursor, 'hide');
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
         runReporter({}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(hideCursorStub.called, 'to be true');
       });
@@ -83,7 +81,7 @@ describe('Landing reporter', function() {
           );
           var options = {};
           var stdout = runReporter({}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           expect(stdout, 'to equal', expectedArray);
         });
@@ -104,7 +102,7 @@ describe('Landing reporter', function() {
           runner.total = 12;
           var options = {};
           var stdout = runReporter({}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           expect(stdout, 'to equal', expectedArray);
         });
@@ -113,7 +111,7 @@ describe('Landing reporter', function() {
 
     describe("on 'end' event", function() {
       it('should call cursor show and epilogue', function() {
-        var showCursorStub = sandbox.stub(Base.cursor, 'show');
+        var showCursorStub = sinon.stub(Base.cursor, 'show');
 
         var fakeThis = {
           epilogue: sinon.spy()
@@ -121,7 +119,7 @@ describe('Landing reporter', function() {
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(fakeThis.epilogue.calledOnce, 'to be true');
         expect(showCursorStub.called, 'to be true');

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -18,7 +18,6 @@ var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
 var EVENT_TEST_PENDING = events.EVENT_TEST_PENDING;
 
 describe('List reporter', function() {
-  var sandbox;
   var runReporter = makeRunReporter(List);
   var expectedTitle = 'some title';
   var expectedDuration = 100;
@@ -32,12 +31,11 @@ describe('List reporter', function() {
   };
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(Base, 'useColors').value(false);
+    sinon.stub(Base, 'useColors').value(false);
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('event handlers', function() {
@@ -55,7 +53,7 @@ describe('List reporter', function() {
           epilogue: noop
         };
         var stdout = runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         var startString = '\n';
         var testString = '    ' + expectedTitle + ': ';
@@ -78,7 +76,7 @@ describe('List reporter', function() {
           epilogue: noop
         };
         var stdout = runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(stdout[0], 'to equal', '  - ' + expectedTitle + '\n');
       });
@@ -88,7 +86,7 @@ describe('List reporter', function() {
       var crStub;
 
       beforeEach(function() {
-        crStub = sandbox.stub(Base.cursor, 'CR').callsFake(noop);
+        crStub = sinon.stub(Base.cursor, 'CR').callsFake(noop);
       });
 
       it('should call cursor CR', function() {
@@ -104,14 +102,14 @@ describe('List reporter', function() {
           epilogue: noop
         };
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(crStub.called, 'to be true');
       });
 
       it('should write expected symbol, title, and duration', function() {
         var expectedOkSymbol = 'OK';
-        sandbox.stub(Base.symbols, 'ok').value(expectedOkSymbol);
+        sinon.stub(Base.symbols, 'ok').value(expectedOkSymbol);
 
         var runner = createMockRunner(
           'pass',
@@ -125,7 +123,7 @@ describe('List reporter', function() {
           epilogue: noop
         };
         var stdout = runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(
           stdout[0],
@@ -145,7 +143,7 @@ describe('List reporter', function() {
       var crStub;
 
       beforeEach(function() {
-        crStub = sandbox.stub(Base.cursor, 'CR').callsFake(noop);
+        crStub = sinon.stub(Base.cursor, 'CR').callsFake(noop);
       });
 
       it('should call cursor CR', function() {
@@ -161,7 +159,7 @@ describe('List reporter', function() {
           epilogue: noop
         };
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(crStub.called, 'to be true');
       });
@@ -180,7 +178,7 @@ describe('List reporter', function() {
           epilogue: noop
         };
         var stdout = runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(
           stdout[0],
@@ -222,7 +220,7 @@ describe('List reporter', function() {
           epilogue: noop
         };
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(typeof err.actual, 'to be', 'string');
         expect(typeof err.expected, 'to be', 'string');
@@ -237,7 +235,7 @@ describe('List reporter', function() {
           epilogue: sinon.spy()
         };
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(fakeThis.epilogue.calledOnce, 'to be true');
       });

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -17,15 +17,10 @@ var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
 var EVENT_TEST_PENDING = events.EVENT_TEST_PENDING;
 
 describe('Nyan reporter', function() {
-  var sandbox;
   var noop = function() {};
 
-  beforeEach(function() {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('event handlers', function() {
@@ -144,7 +139,7 @@ describe('Nyan reporter', function() {
       });
 
       it('should call Base show', function() {
-        var showCursorStub = sandbox.stub(Base.cursor, 'show');
+        var showCursorStub = sinon.stub(Base.cursor, 'show');
         var fakeThis = {
           draw: noop,
           epilogue: noop,
@@ -153,7 +148,7 @@ describe('Nyan reporter', function() {
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(showCursorStub.called, 'to be true');
       });
@@ -165,7 +160,7 @@ describe('Nyan reporter', function() {
     var stdout;
 
     beforeEach(function() {
-      stdoutWriteStub = sandbox.stub(process.stdout, 'write');
+      stdoutWriteStub = sinon.stub(process.stdout, 'write');
       stdoutWriteStub.callsFake(function(chunk, encoding, cb) {
         stdout.push(chunk);
       });
@@ -194,7 +189,7 @@ describe('Nyan reporter', function() {
         try {
           nyanCat.draw.call(fakeThis);
         } finally {
-          sandbox.restore();
+          sinon.restore();
         }
 
         var expectedArray = [
@@ -237,7 +232,7 @@ describe('Nyan reporter', function() {
         try {
           nyanCat.draw.call(fakeThis);
         } finally {
-          sandbox.restore();
+          sinon.restore();
         }
 
         var expectedArray = [
@@ -264,7 +259,7 @@ describe('Nyan reporter', function() {
     var stdout;
 
     beforeEach(function() {
-      stdoutWriteStub = sandbox.stub(process.stdout, 'write');
+      stdoutWriteStub = sinon.stub(process.stdout, 'write');
       stdoutWriteStub.callsFake(function(chunk, encoding, cb) {
         stdout.push(chunk);
       });
@@ -280,7 +275,7 @@ describe('Nyan reporter', function() {
       try {
         nyanCat.cursorDown(expectedNumber);
       } finally {
-        sandbox.restore();
+        sinon.restore();
       }
 
       var expectedArray = ['\u001b[' + expectedNumber + 'B'];
@@ -293,7 +288,7 @@ describe('Nyan reporter', function() {
     var stdout;
 
     beforeEach(function() {
-      stdoutWriteStub = sandbox.stub(process.stdout, 'write');
+      stdoutWriteStub = sinon.stub(process.stdout, 'write');
       stdoutWriteStub.callsFake(function(chunk, encoding, cb) {
         stdout.push(chunk);
       });
@@ -309,7 +304,7 @@ describe('Nyan reporter', function() {
       try {
         nyanCat.cursorUp(expectedNumber);
       } finally {
-        sandbox.restore();
+        sinon.restore();
       }
 
       var expectedArray = ['\u001b[' + expectedNumber + 'A'];
@@ -321,11 +316,11 @@ describe('Nyan reporter', function() {
     var useColorsStub;
 
     beforeEach(function() {
-      useColorsStub = sandbox.stub(Base, 'useColors');
+      useColorsStub = sinon.stub(Base, 'useColors');
     });
 
     afterEach(function() {
-      sandbox.restore();
+      sinon.restore();
     });
 
     describe("when 'useColors' is false", function() {
@@ -340,7 +335,7 @@ describe('Nyan reporter', function() {
 
         var inputString = 'hello';
         var outputString = nyanCat.rainbowify(inputString);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedString = inputString;
         expect(outputString, 'to be', expectedString);
@@ -364,7 +359,7 @@ describe('Nyan reporter', function() {
           colorIndex: 0
         };
         var outputString = nyanCat.rainbowify.call(fakeThis, inputString);
-        sandbox.restore();
+        sinon.restore();
 
         var startCode = '\u001b[38;5;';
         var endCode = '\u001b[0m';
@@ -453,10 +448,10 @@ describe('Nyan reporter', function() {
     var stdout;
 
     beforeEach(function() {
-      sandbox.stub(Base, 'color').callsFake(function(type, n) {
+      sinon.stub(Base, 'color').callsFake(function(type, n) {
         return type + n;
       });
-      var stdoutWriteStub = sandbox.stub(process.stdout, 'write');
+      var stdoutWriteStub = sinon.stub(process.stdout, 'write');
       stdoutWriteStub.callsFake(function(chunk, encoding, cb) {
         stdout.push(chunk);
       });
@@ -481,7 +476,7 @@ describe('Nyan reporter', function() {
       try {
         nyanCat.drawScoreboard.call(fakeThis);
       } finally {
-        sandbox.restore();
+        sinon.restore();
       }
 
       var expectedArray = [
@@ -514,7 +509,7 @@ describe('Nyan reporter', function() {
       try {
         nyanCat.drawScoreboard.call(fakeThis);
       } finally {
-        sandbox.restore();
+        sinon.restore();
       }
 
       expect(fakeThis.cursorUp.calledWith(expectedNumberOfLines), 'to be true');
@@ -525,7 +520,7 @@ describe('Nyan reporter', function() {
     var stdout;
 
     beforeEach(function() {
-      var stdoutWriteStub = sandbox.stub(process.stdout, 'write');
+      var stdoutWriteStub = sinon.stub(process.stdout, 'write');
       stdoutWriteStub.callsFake(function(chunk, encoding, cb) {
         stdout.push(chunk);
       });
@@ -551,7 +546,7 @@ describe('Nyan reporter', function() {
       try {
         nyanCat.drawRainbow.call(fakeThis);
       } finally {
-        sandbox.restore();
+        sinon.restore();
       }
 
       var expectedArray = [
@@ -581,7 +576,7 @@ describe('Nyan reporter', function() {
       try {
         nyanCat.drawRainbow.call(fakeThis);
       } finally {
-        sandbox.restore();
+        sinon.restore();
       }
 
       expect(expectedCursorArgument, 'to be', expectedNumberOfLines);

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -15,27 +15,22 @@ var EVENT_RUN_END = events.EVENT_RUN_END;
 var EVENT_TEST_END = events.EVENT_TEST_END;
 
 describe('Progress reporter', function() {
-  var sandbox;
   var runReporter = makeRunReporter(Progress);
   var noop = function() {};
 
-  beforeEach(function() {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('event handlers', function() {
     describe("on 'start' event", function() {
       it('should call cursor hide', function() {
-        var hideCursorStub = sandbox.stub(Base.cursor, 'hide');
+        var hideCursorStub = sinon.stub(Base.cursor, 'hide');
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
         runReporter({}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(hideCursorStub.called, 'to be true');
       });
@@ -44,9 +39,9 @@ describe('Progress reporter', function() {
     describe("on 'test end' event", function() {
       describe('when line has changed', function() {
         it('should write expected progress of open and close options', function() {
-          var crCursorStub = sandbox.stub(Base.cursor, 'CR').callsFake(noop);
-          sandbox.stub(Base, 'useColors').value(false);
-          sandbox.stub(Base.window, 'width').value(5);
+          var crCursorStub = sinon.stub(Base.cursor, 'CR').callsFake(noop);
+          sinon.stub(Base, 'useColors').value(false);
+          sinon.stub(Base.window, 'width').value(5);
 
           var expectedTotal = 12;
           var expectedOpen = 'OpEn';
@@ -65,7 +60,7 @@ describe('Progress reporter', function() {
             reporterOptions: expectedOptions
           };
           var stdout = runReporter({}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedArray = [
             '\u001b[J',
@@ -82,16 +77,16 @@ describe('Progress reporter', function() {
 
       describe('when line has not changed', function() {
         it('should not write anything', function() {
-          sandbox.stub(Base, 'useColors').value(false);
-          sandbox.stub(Base.cursor, 'CR').callsFake(noop);
-          sandbox.stub(Base.window, 'width').value(-3);
+          sinon.stub(Base, 'useColors').value(false);
+          sinon.stub(Base.cursor, 'CR').callsFake(noop);
+          sinon.stub(Base.window, 'width').value(-3);
 
           var expectedTotal = 1;
           var runner = createMockRunner('test end', EVENT_TEST_END);
           runner.total = expectedTotal;
           var options = {};
           var stdout = runReporter({}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           expect(stdout, 'to equal', []);
         });
@@ -100,14 +95,14 @@ describe('Progress reporter', function() {
 
     describe("on 'end' event", function() {
       it('should call cursor show and epilogue', function() {
-        var showCursorStub = sandbox.stub(Base.cursor, 'show');
+        var showCursorStub = sinon.stub(Base.cursor, 'show');
         var fakeThis = {
           epilogue: sinon.spy()
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
         runReporter(fakeThis, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         expect(fakeThis.epilogue.calledOnce, 'to be true');
         expect(showCursorStub.called, 'to be true');

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -19,15 +19,13 @@ describe('Spec reporter', function() {
   var runReporter = makeRunReporter(Spec);
   var expectedTitle = 'expectedTitle';
   var noop = function() {};
-  var sandbox;
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(Base, 'useColors').value(false);
+    sinon.stub(Base, 'useColors').value(false);
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('event handlers', function() {
@@ -45,7 +43,7 @@ describe('Spec reporter', function() {
         );
         var options = {};
         var stdout = runReporter({epilogue: noop}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedArray = [expectedTitle + '\n'];
         expect(stdout, 'to equal', expectedArray);
@@ -66,7 +64,7 @@ describe('Spec reporter', function() {
         );
         var options = {};
         var stdout = runReporter({epilogue: noop}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedArray = ['  - ' + expectedTitle + '\n'];
         expect(stdout, 'to equal', expectedArray);
@@ -93,7 +91,7 @@ describe('Spec reporter', function() {
           );
           var options = {};
           var stdout = runReporter({epilogue: noop}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedString =
             '  ' +
@@ -127,7 +125,7 @@ describe('Spec reporter', function() {
           );
           var options = {};
           var stdout = runReporter({epilogue: noop}, runner, options);
-          sandbox.restore();
+          sinon.restore();
 
           var expectedString =
             '  ' + Base.symbols.ok + ' ' + expectedTitle + '\n';
@@ -151,7 +149,7 @@ describe('Spec reporter', function() {
         );
         var options = {};
         var stdout = runReporter({epilogue: noop}, runner, options);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedArray = [
           '  ' + functionCount + ') ' + expectedTitle + '\n'

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -24,7 +24,6 @@ var STATE_FAILED = states.STATE_FAILED;
 var STATE_PASSED = states.STATE_PASSED;
 
 describe('XUnit reporter', function() {
-  var sandbox;
   var runner;
   var noop = function() {};
 
@@ -54,9 +53,8 @@ describe('XUnit reporter', function() {
       var fsCreateWriteStream;
 
       beforeEach(function() {
-        sandbox = sinon.createSandbox();
-        fsMkdirSync = sandbox.stub(fs, 'mkdirSync');
-        fsCreateWriteStream = sandbox.stub(fs, 'createWriteStream');
+        fsMkdirSync = sinon.stub(fs, 'mkdirSync');
+        fsCreateWriteStream = sinon.stub(fs, 'createWriteStream');
       });
 
       it('should open given file for writing, recursively creating directories in pathname', function() {
@@ -77,7 +75,7 @@ describe('XUnit reporter', function() {
       });
 
       afterEach(function() {
-        sandbox.restore();
+        sinon.restore();
       });
     });
 
@@ -127,8 +125,7 @@ describe('XUnit reporter', function() {
 
       describe('when run in browser', function() {
         beforeEach(function() {
-          sandbox = sinon.createSandbox();
-          sandbox.stub(fs, 'createWriteStream').value(false);
+          sinon.stub(fs, 'createWriteStream').value(false);
         });
 
         it('should throw unsupported error', function() {
@@ -141,7 +138,7 @@ describe('XUnit reporter', function() {
         });
 
         afterEach(function() {
-          sandbox.restore();
+          sinon.restore();
         });
       });
     });
@@ -198,14 +195,13 @@ describe('XUnit reporter', function() {
     var callback;
 
     beforeEach(function() {
-      sandbox = sinon.createSandbox();
-      callback = sandbox.spy();
+      callback = sinon.spy();
     });
 
     afterEach(function() {
       callback = null;
       xunit = null;
-      sandbox.restore();
+      sinon.restore();
     });
 
     describe('when output directed to file', function() {
@@ -309,12 +305,11 @@ describe('XUnit reporter', function() {
     };
 
     beforeEach(function() {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(Base, 'useColors').value(false);
+      sinon.stub(Base, 'useColors').value(false);
     });
 
     afterEach(function() {
-      sandbox.restore();
+      sinon.restore();
       expectedWrite = null;
     });
 
@@ -339,7 +334,7 @@ describe('XUnit reporter', function() {
         };
 
         xunit.test.call(fakeThis, expectedTest);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedTag =
           '<testcase classname="' +
@@ -378,13 +373,13 @@ describe('XUnit reporter', function() {
           }
         };
 
-        sandbox.stub(xunit, 'write').callsFake(function(str) {
+        sinon.stub(xunit, 'write').callsFake(function(str) {
           expectedWrite += str;
         });
 
         runner.emit(EVENT_TEST_FAIL, expectedTest, expectedTest.err);
         runner.emit(EVENT_RUN_END);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedDiff =
           '\n      + expected - actual\n\n      -1\n      +2\n      ';
@@ -410,7 +405,7 @@ describe('XUnit reporter', function() {
         };
 
         xunit.test.call(fakeThis, expectedTest);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedTag =
           '<testcase classname="' +
@@ -439,7 +434,7 @@ describe('XUnit reporter', function() {
         };
 
         xunit.test.call(fakeThis, expectedTest);
-        sandbox.restore();
+        sinon.restore();
 
         var expectedTag =
           '<testcase classname="' +
@@ -490,7 +485,7 @@ describe('XUnit reporter', function() {
       createStatsCollector(runner);
       var xunit = new XUnit(runner);
       expectedWrite = '';
-      sandbox.stub(xunit, 'write').callsFake(function(str) {
+      sinon.stub(xunit, 'write').callsFake(function(str) {
         expectedWrite += str;
       });
 
@@ -503,7 +498,7 @@ describe('XUnit reporter', function() {
       runner.emit(EVENT_TEST_END);
       runner.emit(EVENT_RUN_END);
 
-      sandbox.restore();
+      sinon.restore();
 
       var expectedNumPass = 1;
       var expectedNumFail = 2;

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -12,12 +12,6 @@ describe('Mocha', function() {
   var opts;
 
   /**
-   * Sinon sandbox
-   * @see https://sinonjs.org/releases/v9.0.2/sandbox/
-   */
-  var sandbox;
-
-  /**
    * Stub `Runner` constructor; returns a stubbed `EventEmitter`
    */
   var Runner;
@@ -48,61 +42,60 @@ describe('Mocha', function() {
   var reporterInstance;
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
     reporterInstance = {};
-    opts = {reporter: sandbox.stub().returns(reporterInstance)};
+    opts = {reporter: sinon.stub().returns(reporterInstance)};
 
     // NOTE: calling `stub(someObject, someFunction)` where `someFunction` has
     // its own static properties WILL NOT blast those static properties!
-    Base = sandbox.stub(Mocha.reporters, 'Base').returns({});
-    sandbox.stub(Mocha.reporters, 'base').returns({});
-    sandbox.stub(Mocha.reporters, 'spec').returns({});
+    Base = sinon.stub(Mocha.reporters, 'Base').returns({});
+    sinon.stub(Mocha.reporters, 'base').returns({});
+    sinon.stub(Mocha.reporters, 'spec').returns({});
 
-    runner = utils.assign(sandbox.createStubInstance(EventEmitter), {
-      run: sandbox
+    runner = utils.assign(sinon.createStubInstance(EventEmitter), {
+      run: sinon
         .stub()
         .callsArgAsync(0)
         .returnsThis(),
-      globals: sandbox.stub(),
-      grep: sandbox.stub(),
-      dispose: sandbox.stub()
+      globals: sinon.stub(),
+      grep: sinon.stub(),
+      dispose: sinon.stub()
     });
-    Runner = sandbox.stub(Mocha, 'Runner').returns(runner);
+    Runner = sinon.stub(Mocha, 'Runner').returns(runner);
     // the Runner constructor is the main export, and constants is a static prop.
     // we don't need the constants themselves, but the object cannot be undefined
     Runner.constants = {};
-    suite = utils.assign(sandbox.createStubInstance(EventEmitter), {
-      slow: sandbox.stub(),
-      timeout: sandbox.stub(),
-      bail: sandbox.stub(),
-      dispose: sandbox.stub(),
-      reset: sandbox.stub()
+    suite = utils.assign(sinon.createStubInstance(EventEmitter), {
+      slow: sinon.stub(),
+      timeout: sinon.stub(),
+      bail: sinon.stub(),
+      dispose: sinon.stub(),
+      reset: sinon.stub()
     });
-    Suite = sandbox.stub(Mocha, 'Suite').returns(suite);
+    Suite = sinon.stub(Mocha, 'Suite').returns(suite);
     Suite.constants = {};
 
-    sandbox.stub(utils, 'supportsEsModules').returns(false);
-    sandbox.stub(utils, 'warn');
-    sandbox.stub(utils, 'isString');
-    sandbox.stub(utils, 'noop');
+    sinon.stub(utils, 'supportsEsModules').returns(false);
+    sinon.stub(utils, 'warn');
+    sinon.stub(utils, 'isString');
+    sinon.stub(utils, 'noop');
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('constructor', function() {
     var mocha;
 
     beforeEach(function() {
-      mocha = sandbox.createStubInstance(Mocha);
+      mocha = sinon.createStubInstance(Mocha);
       mocha.timeout.returnsThis();
       mocha.retries.returnsThis();
-      sandbox.stub(Mocha.prototype, 'timeout').returnsThis();
-      sandbox.stub(Mocha.prototype, 'global').returnsThis();
-      sandbox.stub(Mocha.prototype, 'retries').returnsThis();
-      sandbox.stub(Mocha.prototype, 'rootHooks').returnsThis();
-      sandbox.stub(Mocha.prototype, 'parallelMode').returnsThis();
+      sinon.stub(Mocha.prototype, 'timeout').returnsThis();
+      sinon.stub(Mocha.prototype, 'global').returnsThis();
+      sinon.stub(Mocha.prototype, 'retries').returnsThis();
+      sinon.stub(Mocha.prototype, 'rootHooks').returnsThis();
+      sinon.stub(Mocha.prototype, 'parallelMode').returnsThis();
     });
 
     it('should set _cleanReferencesAfterRun to true', function() {
@@ -326,7 +319,7 @@ describe('Mocha', function() {
       });
 
       it('should unload the files', function() {
-        var unloadFilesStub = sandbox.stub(mocha, 'unloadFiles');
+        var unloadFilesStub = sinon.stub(mocha, 'unloadFiles');
         mocha.dispose();
         expect(unloadFilesStub, 'was called once');
       });
@@ -553,7 +546,7 @@ describe('Mocha', function() {
     describe('run()', function() {
       describe('when files have been added to the Mocha instance', function() {
         beforeEach(function() {
-          sandbox.stub(mocha, 'loadFiles');
+          sinon.stub(mocha, 'loadFiles');
           mocha.addFile('some-file.js');
         });
 
@@ -633,7 +626,7 @@ describe('Mocha', function() {
       describe('when "growl" option is present', function() {
         beforeEach(function() {
           mocha.options.growl = true;
-          sandbox.stub(Mocha.prototype, '_growl').returnsThis();
+          sinon.stub(Mocha.prototype, '_growl').returnsThis();
         });
 
         it('should initialize growl support', function(done) {
@@ -693,7 +686,7 @@ describe('Mocha', function() {
 
       describe('when a reporter instance has a "done" method', function() {
         beforeEach(function() {
-          reporterInstance.done = sandbox.stub().callsArgAsync(1);
+          reporterInstance.done = sinon.stub().callsArgAsync(1);
         });
 
         it('should call the reporter "done" method', function(done) {
@@ -837,7 +830,7 @@ describe('Mocha', function() {
     describe('parallelMode()', function() {
       describe('when `Mocha` is running in a browser', function() {
         beforeEach(function() {
-          sandbox.stub(utils, 'isBrowser').returns(true);
+          sinon.stub(utils, 'isBrowser').returns(true);
         });
 
         it('should throw', function() {

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -23,7 +23,6 @@ var STATE_RUNNING = Runner.constants.STATE_RUNNING;
 var STATE_STOPPED = Runner.constants.STATE_STOPPED;
 
 describe('Runner', function() {
-  var sandbox;
   var suite;
   var runner;
 
@@ -31,11 +30,10 @@ describe('Runner', function() {
     suite = new Suite('Suite', 'root');
     runner = new Runner(suite, {cleanReferencesAfterRun: true});
     runner.checkLeaks = true;
-    sandbox = sinon.createSandbox();
   });
 
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('.grep()', function() {
@@ -511,7 +509,7 @@ describe('Runner', function() {
 
     it('should clean references after a run', function() {
       runner = new Runner(suite, {delay: false, cleanReferencesAfterRun: true});
-      var cleanReferencesStub = sandbox.stub(suite, 'cleanReferences');
+      var cleanReferencesStub = sinon.stub(suite, 'cleanReferences');
       runner.run();
       runner.emit(EVENT_SUITE_END, suite);
       expect(cleanReferencesStub, 'was called once');
@@ -522,7 +520,7 @@ describe('Runner', function() {
         delay: false,
         cleanReferencesAfterRun: false
       });
-      var cleanReferencesStub = sandbox.stub(suite, 'cleanReferences');
+      var cleanReferencesStub = sinon.stub(suite, 'cleanReferences');
       runner.run();
       runner.emit(EVENT_SUITE_END, suite);
       expect(cleanReferencesStub, 'was not called');
@@ -557,7 +555,7 @@ describe('Runner', function() {
     });
 
     it('should remove "error" listeners from a test', function() {
-      var fn = sandbox.stub();
+      var fn = sinon.stub();
       runner.test = new Test('test for dispose', fn);
       runner.runTest(noop);
       // sanity check
@@ -846,7 +844,7 @@ describe('Runner', function() {
 
   describe('uncaught()', function() {
     beforeEach(function() {
-      sandbox.stub(runner, 'fail');
+      sinon.stub(runner, 'fail');
     });
 
     describe('when allow-uncaught is set to true', function() {
@@ -988,19 +986,19 @@ describe('Runner', function() {
           beforeEach(function() {
             runnable = new Runnable();
             runnable.parent = runner.suite;
-            sandbox.stub(runnable, 'clearTimeout');
+            sinon.stub(runnable, 'clearTimeout');
             runner.currentRunnable = runnable;
           });
 
           it('should clear any pending timeouts', function() {
-            runnable.callback = sandbox.fake();
+            runnable.callback = sinon.fake();
             runner.uncaught(err);
             expect(runnable.clearTimeout, 'was called times', 1);
           });
 
           describe('when current Runnable has already failed', function() {
             beforeEach(function() {
-              sandbox.stub(runnable, 'isFailed').returns(true);
+              sinon.stub(runnable, 'isFailed').returns(true);
             });
 
             it('should not attempt to fail again', function() {
@@ -1011,7 +1009,7 @@ describe('Runner', function() {
 
           describe('when current Runnable has been marked pending', function() {
             beforeEach(function() {
-              sandbox.stub(runnable, 'isPending').returns(true);
+              sinon.stub(runnable, 'isPending').returns(true);
             });
 
             it('should attempt to fail', function() {
@@ -1022,7 +1020,7 @@ describe('Runner', function() {
 
           describe('when the current Runnable has already passed', function() {
             beforeEach(function() {
-              sandbox.stub(runnable, 'isPassed').returns(true);
+              sinon.stub(runnable, 'isPassed').returns(true);
             });
 
             it('should fail with the current Runnable and the error', function() {
@@ -1053,7 +1051,7 @@ describe('Runner', function() {
                 runnable = new Test('goomba', noop);
                 runnable.parent = runner.suite;
                 runner.currentRunnable = runnable;
-                runnable.callback = sandbox.fake();
+                runnable.callback = sinon.fake();
               });
 
               it('should run callback(err) to handle failing and hooks', function() {
@@ -1093,7 +1091,7 @@ describe('Runner', function() {
                 runnable = new Hook();
                 runnable.parent = runner.suite;
                 runner.currentRunnable = runnable;
-                runnable.callback = sandbox.fake();
+                runnable.callback = sinon.fake();
               });
 
               it('should run callback(err) to handle failing hook pattern', function() {

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -12,13 +12,8 @@ function supportsFunctionNames() {
 }
 
 describe('Suite', function() {
-  var sandbox;
-  beforeEach(function() {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('.clone()', function() {
@@ -96,8 +91,8 @@ describe('Suite', function() {
       var test = new Test('test', function() {});
       this.suite.addSuite(childSuite);
       this.suite.addTest(test);
-      var testResetStub = sandbox.stub(test, 'reset');
-      var suiteResetStub = sandbox.stub(childSuite, 'reset');
+      var testResetStub = sinon.stub(test, 'reset');
+      var suiteResetStub = sinon.stub(childSuite, 'reset');
       this.suite.reset();
       expect(testResetStub, 'was called once');
       expect(suiteResetStub, 'was called once');
@@ -556,7 +551,7 @@ describe('Suite', function() {
 
   describe('constructor', function() {
     beforeEach(function() {
-      sandbox.stub(utils, 'deprecate');
+      sinon.stub(utils, 'deprecate');
     });
 
     /* eslint no-new: off */
@@ -684,7 +679,7 @@ describe('Suite', function() {
   describe('.markOnly()', function() {
     it('should call appendOnlySuite on parent', function() {
       var suite = new Suite('foo');
-      var spy = sandbox.spy();
+      var spy = sinon.spy();
       suite.parent = {
         appendOnlySuite: spy
       };

--- a/test/unit/test.spec.js
+++ b/test/unit/test.spec.js
@@ -6,17 +6,8 @@ var Test = mocha.Test;
 var Runnable = mocha.Runnable;
 
 describe('Test', function() {
-  /**
-   * @type {sinon.SinonSandbox}
-   */
-  var sandbox;
-
-  beforeEach(function() {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('.clone()', function() {
@@ -82,7 +73,7 @@ describe('Test', function() {
     });
 
     it('should call Runnable.reset', function() {
-      var runnableResetStub = sandbox.stub(Runnable.prototype, 'reset');
+      var runnableResetStub = sinon.stub(Runnable.prototype, 'reset');
       this._test.reset();
       expect(runnableResetStub, 'was called once');
     });
@@ -113,19 +104,13 @@ describe('Test', function() {
   });
 
   describe('.markOnly()', function() {
-    var sandbox;
-
-    beforeEach(function() {
-      sandbox = sinon.createSandbox();
-    });
-
     afterEach(function() {
-      sandbox.restore();
+      sinon.restore();
     });
 
     it('should call appendOnlyTest on parent', function() {
       var test = new Test('foo');
-      var spy = sandbox.spy();
+      var spy = sinon.spy();
       test.parent = {
         appendOnlyTest: spy
       };

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -4,14 +4,8 @@ var utils = require('../../lib/utils');
 var sinon = require('sinon');
 
 describe('lib/utils', function() {
-  var sandbox;
-
-  beforeEach(function() {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(function() {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('clean()', function() {
@@ -640,9 +634,9 @@ describe('lib/utils', function() {
     beforeEach(function() {
       if (process.emitWarning) {
         emitWarning = process.emitWarning;
-        sandbox.stub(process, 'emitWarning');
+        sinon.stub(process, 'emitWarning');
       } else {
-        process.emitWarning = sandbox.spy();
+        process.emitWarning = sinon.spy();
       }
       utils.deprecate.cache = {};
     });
@@ -680,9 +674,9 @@ describe('lib/utils', function() {
     beforeEach(function() {
       if (process.emitWarning) {
         emitWarning = process.emitWarning;
-        sandbox.stub(process, 'emitWarning');
+        sinon.stub(process, 'emitWarning');
       } else {
-        process.emitWarning = sandbox.spy();
+        process.emitWarning = sinon.spy();
       }
     });
 


### PR DESCRIPTION
…ndbox as sinon is a sandbox by default

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

The change made in the PR is to use `sinon@5.0.0` which is a sandbox by default. Previously, we were creating a sandbox and using it across tests. This change would remove the intermediate layer of creating sandbox as it is no longer needed.
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

No alternatives
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

`Sinon` is a sandbox by default in `sinon@5.0.0`
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

No side-effects.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

Fixes the issue - https://github.com/mochajs/mocha/issues/4303

It's not a major or minor release. 
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
