### PR TITLE
Fix glob pattern support: no comma splitting for 'spec' and 'ignore' options

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -54,16 +54,19 @@ const configuration = Object.assign({}, YARGS_PARSER_CONFIG, {
 
 /**
  * This is a really fancy way to:
- * - ensure unique values for `array`-type options
- * - use its array's last element for `boolean`/`number`/`string`- options given multiple times
+ * - `array`-type options: ensure unique values and evtl. split comma-delimited lists
+ * - `boolean`/`number`/`string`- options: use last element when given multiple times
  * This is passed as the `coerce` option to `yargs-parser`
  * @private
  * @ignore
  */
+const globOptions = ['spec', 'ignore'];
 const coerceOpts = Object.assign(
   types.array.reduce(
     (acc, arg) =>
-      Object.assign(acc, {[arg]: v => Array.from(new Set(list(v)))}),
+      Object.assign(acc, {
+        [arg]: v => Array.from(new Set(globOptions.includes(arg) ? v : list(v)))
+      }),
     {}
   ),
   types.boolean

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -562,7 +562,9 @@ describe('options', function() {
           readFileSync = sandbox.stub();
           readFileSync.onFirstCall().throws();
           findConfig = sandbox.stub().returns('/some/.mocharc.json');
-          loadConfig = sandbox.stub().returns({spec: '*.spec.js'});
+          loadConfig = sandbox
+            .stub()
+            .returns({spec: '{dirA,dirB}/**/*.spec.js'});
           findupSync = sandbox.stub();
           loadOptions = proxyLoadOptions({
             readFileSync,
@@ -573,9 +575,40 @@ describe('options', function() {
           result = loadOptions(['*.test.js']);
         });
 
-        it('should place both into the positional arguments array', function() {
-          expect(result, 'to have property', '_', ['*.test.js', '*.spec.js']);
+        it('should place both - unsplitted - into the positional arguments array', function() {
+          expect(result, 'to have property', '_', [
+            '*.test.js',
+            '{dirA,dirB}/**/*.spec.js'
+          ]);
         });
+      });
+    });
+
+    describe('"ignore" handling', function() {
+      let result;
+
+      beforeEach(function() {
+        readFileSync = sandbox.stub();
+        readFileSync.onFirstCall().throws();
+        findConfig = sandbox.stub().returns('/some/.mocharc.json');
+        loadConfig = sandbox
+          .stub()
+          .returns({ignore: '{dirA,dirB}/**/*.spec.js'});
+        findupSync = sandbox.stub();
+        loadOptions = proxyLoadOptions({
+          readFileSync,
+          findConfig,
+          loadConfig,
+          findupSync
+        });
+        result = loadOptions(['--ignore', '*.test.js']);
+      });
+
+      it('should not split option values by comma', function() {
+        expect(result, 'to have property', 'ignore', [
+          '*.test.js',
+          '{dirA,dirB}/**/*.spec.js'
+        ]);
       });
     });
   });


### PR DESCRIPTION
### Description

Currently we can pass test files via CLI:
- `node mocha test1 test2`
- `node mocha -- test1 test2`
- `node mocha --spec test1 --spec test2`
- `node mocha --spec test1,test2`

via configuration files:
- `spec: ['test1', 'test2']`
- `spec: ['test1,test2']`

The last option (comma-delimited list) is neither documented nor provided in our _Yargs_ configuration. But it does break Mocha's glob pattern support in certain cases, e.g.
`{controllers,test}/**/*.test.js` ==> `['{controllers', 'test}/**/*.test.js']`

### Description of the Change

For options `spec` and `ignore`:
- _yars-parser:_ we remove splitting by comma
- _yargs:_ no changes necessary

### Applicable issues

closes #4307