### PR TITLE
disable parallel mode by default

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -5,7 +5,6 @@ global:
   - 'okGlobalC'
   - 'callback*'
 timeout: 1000
-parallel: true
 watch-ignore:
   - '.*'
   - 'docs/_dist/**'

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -139,7 +139,7 @@ module.exports = {
         integration: {
           script: test(
             'integration',
-            '--timeout 10000 --slow 3750 "test/integration/**/*.spec.js"'
+            '--parallel --timeout 10000 --slow 3750 "test/integration/**/*.spec.js"'
           ),
           description: 'Run Node.js integration tests',
           hiddenFromHelp: true


### PR DESCRIPTION
Having run benchmarks against our unit tests and integration tests, I've found that the unit tests do not benefit from parallel mode--and in fact, they run more slowly.  Integration tests still see a 50% performance boost, so we will use parallel tests for those only.
