### PR TITLE
trigger netlify deploy nightly

### DIFF
--- a/.github/workflows/nightly-site-deploy.yml
+++ b/.github/workflows/nightly-site-deploy.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Webhook Action
-        uses: joelwmale/webhook-action@1
+        uses: joelwmale/webhook-action@1.0.0
         env:
           WEBHOOK_URL: ${{ secrets.NETLIFY_NIGHTLY_DEPLOY_URL }}

--- a/.github/workflows/nightly-site-deploy.yml
+++ b/.github/workflows/nightly-site-deploy.yml
@@ -3,10 +3,8 @@
 
 name: Nightly mochajs.org Deploy
 on:
-  push:
-    branches: [boneskull/netlify-nightly-deploy]
-  #  schedule:
-  #  - cron: '0 0 * * *'
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-site-deploy.yml
+++ b/.github/workflows/nightly-site-deploy.yml
@@ -3,8 +3,10 @@
 
 name: Nightly mochajs.org Deploy
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches: [boneskull/netlify-nightly-deploy]
+  #  schedule:
+  #  - cron: '0 0 * * *'
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -13,4 +15,3 @@ jobs:
         uses: joelwmale/webhook-action@1
         env:
           WEBHOOK_URL: ${{ secrets.NETLIFY_NIGHTLY_DEPLOY_URL }}
-          

--- a/.github/workflows/nightly-site-deploy.yml
+++ b/.github/workflows/nightly-site-deploy.yml
@@ -14,4 +14,5 @@ jobs:
       - name: Webhook Action
         uses: joelwmale/webhook-action@1.0.0
         env:
+          data: ''
           WEBHOOK_URL: ${{ secrets.NETLIFY_NIGHTLY_DEPLOY_URL }}

--- a/.github/workflows/nightly-site-deploy.yml
+++ b/.github/workflows/nightly-site-deploy.yml
@@ -1,0 +1,16 @@
+# Deploy `mochajs.org` branch nightly by hitting a netlify build URL.
+# This updates the list of supporters
+
+name: Nightly mochajs.org Deploy
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Webhook Action
+        uses: joelwmale/webhook-action@1
+        env:
+          WEBHOOK_URL: ${{ secrets.NETLIFY_NIGHTLY_DEPLOY_URL }}
+          


### PR DESCRIPTION
This sets up a job to run at 00:00 UTC every day, which rebuilds the site from the `mochajs.org` branch.  This keeps the list of supporters up-to-date.  It relies on a secret env var to do its thing.

Will try to figure out how to test this...