### PR TITLE
Move removal of `uncaughtException` handler into `end` callback

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -989,6 +989,7 @@ Runner.prototype.run = function(fn, opts) {
   fn = fn || function() {};
 
   function start() {
+    self._addEventListener(process, 'uncaughtException', self.uncaught);
     debug('run(): starting');
     // If there is an `only` filter
     if (rootSuite.hasOnly()) {
@@ -1027,10 +1028,8 @@ Runner.prototype.run = function(fn, opts) {
     debug(constants.EVENT_RUN_END);
     debug('run(): emitted %s', constants.EVENT_RUN_END);
     fn(self.failures);
+    self._removeEventListener(process, 'uncaughtException', self.uncaught);
   });
-
-  self._removeEventListener(process, 'uncaughtException', self.uncaught);
-  self._addEventListener(process, 'uncaughtException', self.uncaught);
 
   if (this._delay) {
     // for reporters, I guess.


### PR DESCRIPTION
And only attach it initially within `start`. Since `self.uncaught` is a bound function, "removing" it immediately before adding it only prevents the same instance from leaking multiple handles - it still allows multiple runners to leak handles forever, even when those runners runs have ended (resulting in an issue akin to #4144).

### Description of the Change

Essentially, it _seems like_ mocha 8 regressed #4144, but the test added in #4147 didn't seem to catch it, I'm guessing because now the process of of attaching the handlers during `.run` was deferred in some fashion by another change.
