### PR TITLE
Fix wrong sponsors images from OC

### DIFF
--- a/docs/_data/supporters.js
+++ b/docs/_data/supporters.js
@@ -128,7 +128,7 @@ module.exports = async () => {
   await Promise.all(
     supporters.sponsors.map(async sponsor => {
       const filePath = resolve(supporterImagePath, sponsor.id + '.png');
-      const {body} = await needle('get', sponsor.avatar);
+      const {body} = await needle('get', encodeURI(sponsor.avatar));
       sponsor.dimensions = imageSize(body);
       await writeFile(filePath, body);
     })
@@ -138,7 +138,7 @@ module.exports = async () => {
   await Promise.all(
     supporters.backers.map(async backer => {
       const filePath = resolve(supporterImagePath, backer.id + '.png');
-      const {body} = await needle('get', backer.avatar);
+      const {body} = await needle('get', encodeURI(backer.avatar));
       await writeFile(filePath, body);
     })
   );


### PR DESCRIPTION
After merging #4318 , building our docs are failed with `Error: Unsupported image type`. See [here](https://app.netlify.com/sites/mocha/deploys/5ee47f8ed28ad60008aa8f19) or [here](https://app.netlify.com/sites/mocha/deploys/5ee3de46550b6a0008874fc1)

One of our backers(id is `7mywxoz3-409rl6ka-anpvenbd-j7gk85ag`)'s avatar URL is <https://images.opencollective.com/andréleifeld/97285d0/avatar/32.png>. Because `é` character in path, cloudflare return blocked HTML page instead avatar image.

<img width="474" alt="스크린샷 2020-06-13 20 26 53" src="https://user-images.githubusercontent.com/390146/84568935-d3ad5e00-adbd-11ea-8292-c9131faf27fa.png">

This HTML page is `Sorry, you have been blocked. You are unable to access opencollective.com`. So, the image has `png` extension but it is not an image. 

I'm not sure whether it is [needle](https://www.npmjs.com/package/needle)'s problem or cloudflare's problem.

But, we should encode avatar URL before request it. 