### PR TITLE
Browser usage issues with `delay` option

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -139,7 +139,7 @@ mocha.setup = function(opts) {
   if (typeof opts === 'string') {
     opts = {ui: opts};
   }
-  if ('delay' in opts && opts['delay'] === true) {
+  if ('delay' in opts && opts.delay === true) {
     this.delay();
   }
   var self = this;

--- a/browser-entry.js
+++ b/browser-entry.js
@@ -139,7 +139,7 @@ mocha.setup = function(opts) {
   if (typeof opts === 'string') {
     opts = {ui: opts};
   }
-  if ('delay' in opts && opts.delay === true) {
+  if (opts.delay === true) {
     this.delay();
   }
   var self = this;

--- a/browser-entry.js
+++ b/browser-entry.js
@@ -139,11 +139,19 @@ mocha.setup = function(opts) {
   if (typeof opts === 'string') {
     opts = {ui: opts};
   }
-  for (var opt in opts) {
-    if (Object.prototype.hasOwnProperty.call(opts, opt)) {
-      this[opt](opts[opt]);
-    }
+  if ('delay' in opts && opts['delay'] === true) {
+    this.delay();
   }
+  var self = this;
+  Object.keys(opts)
+    .filter(function(opt) {
+      return opt !== 'delay';
+    })
+    .forEach(function(opt) {
+      if (Object.prototype.hasOwnProperty.call(opts, opt)) {
+        self[opt](opts[opt]);
+      }
+    });
   return this;
 };
 


### PR DESCRIPTION
There seem to be 2 issues currently with the `delay` option in the browser usage.

1. setting `mocha.setup({delay: false})` actually enables the delay - this is because `delay` does not work with an argument.
2. calling `ui` before `delay` does not apply the delay  (see issue). 

```javascript
// this does not work
mocha.setup({ui: 'bdd', delay: true});
```

This fix runs `delay` flag separately to the others.

### Alternative designs

Could update `delay` to work with an argument. Thought it was slightly better to apply a fix just to the browser-based code. Also that would not have been enough to fix the issue with the ordering.

Could not see a way to get it to work like the CLI as mocha handles options differently for cli + browser (e.g. whats available for the constructor).

### Possible Drawbacks

Currently no HTML reporter tests so is currently not covered. 
**Looking for recommendations.**

### Applicable issues

https://github.com/mochajs/mocha/issues/1799