### PR TITLE
Remove GLOBALS in api docs

### DIFF
--- a/lib/browser/progress.js
+++ b/lib/browser/progress.js
@@ -1,6 +1,10 @@
 'use strict';
 
 /**
+ @module Progress
+*/
+
+/**
  * Expose `Progress`.
  */
 

--- a/lib/browser/progress.js
+++ b/lib/browser/progress.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- @module Progress
+ @module browser/Progress
 */
 
 /**

--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -81,6 +81,7 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
 
 /**
  * An object to configure how Mocha gathers test files
+ * @private
  * @typedef {Object} FileCollectionOptions
  * @property {string[]} extension - File extensions to use
  * @property {string[]} spec - Files, dirs, globs to run

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ @module common
+*/
+
 var Suite = require('../suite');
 var errors = require('../errors');
 var createMissingArgumentError = errors.createMissingArgumentError;
@@ -9,6 +13,7 @@ var createForbiddenExclusivityError = errors.createForbiddenExclusivityError;
 /**
  * Functions common to more than one interface.
  *
+ * @private
  * @param {Suite[]} suites
  * @param {Context} context
  * @param {Mocha} mocha

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- @module common
+ @module interfaces/common
 */
 
 var Suite = require('../suite');

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -35,23 +35,28 @@ exports = module.exports = Mocha;
 /**
  * A Mocha instance is a finite state machine.
  * These are the states it can be in.
+ * @private
  */
 var mochaStates = utils.defineConstants({
   /**
    * Initial state of the mocha instance
+   * @private
    */
   INIT: 'init',
   /**
    * Mocha instance is running tests
+   * @private
    */
   RUNNING: 'running',
   /**
    * Mocha instance is done running tests and references to test functions and hooks are cleaned.
    * You can reset this state by unloading the test files.
+   * @private
    */
   REFERENCES_CLEANED: 'referencesCleaned',
   /**
    * Mocha instance is disposed and can no longer be used.
+   * @private
    */
   DISPOSED: 'disposed'
 });
@@ -67,6 +72,7 @@ if (!utils.isBrowser() && typeof module.paths !== 'undefined') {
 
 /**
  * Expose internals.
+ * @private
  */
 
 exports.utils = utils;
@@ -921,6 +927,7 @@ Object.defineProperty(Mocha.prototype, 'version', {
 /**
  * Callback to be invoked when test execution is complete.
  *
+ * @private
  * @callback DoneCB
  * @param {number} failures - Number of failures that occurred.
  */
@@ -1091,6 +1098,7 @@ Mocha.prototype.lazyLoadFiles = function lazyLoadFiles(enable) {
 
 /**
  * An alternative way to define root hooks that works with parallel runs.
+ * @private
  * @typedef {Object} MochaRootHookObject
  * @property {Function|Function[]} [beforeAll] - "Before all" hook(s)
  * @property {Function|Function[]} [beforeEach] - "Before each" hook(s)
@@ -1100,6 +1108,7 @@ Mocha.prototype.lazyLoadFiles = function lazyLoadFiles(enable) {
 
 /**
  * An function that returns a {@link MochaRootHookObject}, either sync or async.
+ * @private
  * @callback MochaRootHookFunction
  * @returns {MochaRootHookObject|Promise<MochaRootHookObject>}
  */

--- a/lib/nodejs/parallel-buffered-runner.js
+++ b/lib/nodejs/parallel-buffered-runner.js
@@ -281,12 +281,14 @@ module.exports = ParallelBufferedRunner;
 
 /**
  * Listener function intended to be bound to `Process.SIGINT` event
+ * @private
  * @callback SigIntListener
  * @returns {Promise<void>}
  */
 
 /**
  * A function accepting a test file path and returning the results of a test run
+ * @private
  * @callback FileRunner
  * @param {string} filename - File to run
  * @returns {Promise<SerializedWorkerResult>}

--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -387,6 +387,7 @@ exports.SerializableWorkerResult = SerializableWorkerResult;
 /**
  * The result of calling `SerializableEvent.serialize`, as received
  * by the deserializer.
+ * @private
  * @typedef {Object} SerializedEvent
  * @property {object?} data - Optional serialized data
  * @property {object?} error - Optional serialized `Error`
@@ -395,6 +396,7 @@ exports.SerializableWorkerResult = SerializableWorkerResult;
 /**
  * The result of calling `SerializableWorkerResult.serialize` as received
  * by the deserializer.
+ * @private
  * @typedef {Object} SerializedWorkerResult
  * @property {number} failureCount - Number of failures
  * @property {SerializedEvent[]} events - Serialized events

--- a/lib/pending.js
+++ b/lib/pending.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ @module Pending
+*/
+
 module.exports = Pending;
 
 /**

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ @module Runnable
+*/
+
 var EventEmitter = require('events').EventEmitter;
 var Pending = require('./pending');
 var debug = require('debug')('mocha:runnable');

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -1,9 +1,5 @@
 'use strict';
 
-/**
- @module Runnable
-*/
-
 var EventEmitter = require('events').EventEmitter;
 var Pending = require('./pending');
 var debug = require('debug')('mocha:runnable');
@@ -15,6 +11,7 @@ var createMultipleDoneError = errors.createMultipleDoneError;
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
+ * @private
  */
 var Date = global.Date;
 var setTimeout = global.setTimeout;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,10 @@
 'use strict';
 
 /**
+ @module Runner
+*/
+
+/**
  * Module dependencies.
  */
 var util = require('util');

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,11 +1,8 @@
 'use strict';
 
 /**
- @module Runner
-*/
-
-/**
  * Module dependencies.
+ * @private
  */
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
@@ -35,6 +32,7 @@ var createFatalError = errors.createFatalError;
 
 /**
  * Non-enumerable globals.
+ * @private
  * @readonly
  */
 var globals = [

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -1,6 +1,10 @@
 'use strict';
 
 /**
+ @module Suite
+*/
+
+/**
  * Module dependencies.
  */
 var EventEmitter = require('events').EventEmitter;

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -1,11 +1,8 @@
 'use strict';
 
 /**
- @module Suite
-*/
-
-/**
  * Module dependencies.
+ * @private
  */
 var EventEmitter = require('events').EventEmitter;
 var Hook = require('./hook');


### PR DESCRIPTION
We should not document any globals in the context of programmatic usage, which is the target for the api docs.
The **Members** and **Methods** we have listed live are currently mostly wrong and sometimes sending people down the wrong path. By removing them we remove confusion.

I have given an explicit module directive name to fix the **Methods**, the other half of **Members** were manual tags.

## Alternative design

We could remove the module directive from the "interfaces/common" module, which leaves just the hooks (after/afterEach/before/beforeEach). 
But I decided it was better to have either ALL of the available globals given, or none of them.

## Screens

### On live
<img width="236" alt="Screenshot 2020-06-07 at 16 33 15" src="https://user-images.githubusercontent.com/3532787/83973180-9ab44b80-a8dc-11ea-9aab-b646d1c1387a.png">

### On local - section gone

<img width="215" alt="Screenshot 2020-06-23 at 15 02 14" src="https://user-images.githubusercontent.com/3532787/85413310-9174e100-b562-11ea-85e3-3526256eea14.png">


### Applicable issues

https://github.com/mochajs/mocha/issues/4317
