### PR TITLE
do not run production build on netlify for PRs; closes #4356

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,12 @@
 
 [build]
   publish = "docs/_dist/"
-  command = "npm start docs"
+  command = "npm start docs.production"
 
 [build.environment]
   NODE_VERSION = "12"
+  RUBY_VERSION = "2.7.1"
+
+[context.deploy-preview]
+  command = "npm start docs"
+  publish = "docs/_site/"

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -288,8 +288,12 @@ module.exports = {
     docs: {
       default: {
         script:
-          'nps docs.prebuild && nps docs.api && eleventy && nps docs.linkcheck && nps docs.postbuild',
+          'nps docs.prebuild && nps docs.api && eleventy && nps docs.linkcheck && node scripts/netlify-headers.js docs/_site >> docs/_site/_headers',
         description: 'Build documentation'
+      },
+      production: {
+        script: 'nps docs && nps docs.postbuild',
+        description: 'Build docs for production'
       },
       prebuild: {
         script: 'rimraf docs/_dist docs/_site',
@@ -302,7 +306,7 @@ module.exports = {
       },
       postbuild: {
         script:
-          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
+          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js docs/_dist >> docs/_dist/_headers',
         description: 'Post-process docs after build',
         hiddenFromHelp: true
       },

--- a/scripts/netlify-headers.js
+++ b/scripts/netlify-headers.js
@@ -2,6 +2,14 @@
 
 const AssetGraph = require('assetgraph');
 
+const dest = process.argv[2];
+
+if (!dest) {
+  console.error('usage: node netlify-headers.js <docs-output-dir>');
+  console.error('example: node netlify-headers.js docs/_dist');
+  process.exit(1);
+}
+
 const headers = ['Content-Security-Policy'];
 
 const resourceHintTypeMap = {
@@ -25,7 +33,7 @@ function getHeaderForRelation(rel) {
 
 console.error('Generating optimal netlify headers...');
 
-new AssetGraph({root: 'docs/_dist'})
+new AssetGraph({root: dest})
   .loadAssets('*.html')
   .populate({
     followRelations: {type: 'HtmlAnchor', crossorigin: false}
@@ -112,8 +120,7 @@ new AssetGraph({root: 'docs/_dist'})
       });
 
       console.log('');
-
-      console.error('netlify headers done!');
     });
+    console.error('netlify headers done!');
   })
   .run();


### PR DESCRIPTION
- non-production builds will now publish from `docs/_site`
- branches and production contexts will use production build
- `npm start docs` now does _not_ run in production build
- use `npm start docs.production` for production build
- `scripts/netlify-headers.js` now requires a path
- fixed duplicate message in `scripts/netlify-headers.js`
- add `RUBY_VERSION` to netlify env
