### PR TITLE
fixes failure output in mocha init w/o target

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -52,7 +52,7 @@ exports.main = (argv = process.argv.slice(2)) => {
       debug('caught error sometime before command handler: %O', err);
       yargs.showHelp();
       console.error(`\n${symbols.error} ${ansi.red('ERROR:')} ${msg}`);
-      yargs.exit(1);
+      process.exitCode = 1;
     })
     .help('help', 'Show usage information & exit')
     .alias('help', 'h')

--- a/test/integration/init.spec.js
+++ b/test/integration/init.spec.js
@@ -23,19 +23,39 @@ describe('init command', function() {
     } catch (ignored) {}
   });
 
-  it('should break if no path supplied', function(done) {
-    invokeMocha(
-      ['init'],
-      function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result, 'to have failed');
-        expect(result.output, 'to match', /not enough non-option arguments/i);
-        done();
-      },
-      {stdio: 'pipe'}
-    );
+  describe('when no path is supplied', function() {
+    it('should fail', function(done) {
+      invokeMocha(
+        ['init'],
+        function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(
+            result,
+            'to have failed with output',
+            /not enough non-option arguments/i
+          );
+          done();
+        },
+        {stdio: 'pipe'}
+      );
+    });
+    it('should not throw', function(done) {
+      invokeMocha(
+        ['init'],
+        function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result, 'to have failed').and('not to satisfy', {
+            output: /throw/i
+          });
+          done();
+        },
+        {stdio: 'pipe'}
+      );
+    });
   });
 
   it('should create some files in the dest dir', function(done) {


### PR DESCRIPTION
`yargs.exit()` is not always present, apparently. it will throw in this case--we don't need to be calling it anyway.

before this change, you see the following when running `mocha init` w/o the `<path>`

```
mocha init <path>

create a client-side Mocha setup at <path>

Positional Arguments
  path                                                       [string] [required]

Other Options
  --help, -h     Show usage information & exit                         [boolean]
  --version, -V  Show version number & exit                            [boolean]

✖ ERROR: Not enough non-option arguments: got 0, need at least 1
/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/yargs.js:1172
      else throw err
           ^

TypeError: yargs.exit is not a function
    at Array.<anonymous> (/Users/boneskull/projects/mochajs/mocha/lib/cli/cli.js:55:13)
    at Object.fail (/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/lib/usage.js:41:17)
    at Object.positionalCount (/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/lib/validation.js:51:13)
    at populatePositionals (/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/lib/command.js:301:16)
    at Object.runCommand (/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/lib/command.js:225:23)
    at Object.parseArgs [as _parseArgs] (/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/yargs.js:1087:30)
    at Object.parse (/Users/boneskull/projects/mochajs/mocha/node_modules/yargs/yargs.js:575:25)
    at Object.exports.main (/Users/boneskull/projects/mochajs/mocha/lib/cli/cli.js:71:6)
    at Object.<anonymous> (/Users/boneskull/projects/mochajs/mocha/bin/mocha:153:29)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
```