### PR TITLE
Exclude jsdoc pages from bundling and optimization

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -302,7 +302,7 @@ module.exports = {
       },
       postbuild: {
         script:
-          'buildProduction docs/_site/index.html --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
+          'buildProduction docs/_site/index.html --exclude docs/_site/api/ --outroot docs/_dist --canonicalroot https://mochajs.org/ --optimizeimages --svgo --inlinehtmlimage 9400 --inlinehtmlscript 0 --asyncscripts && cp -r docs/_site/api docs/_dist/api && cp docs/_headers docs/_dist/_headers && node scripts/netlify-headers.js >> docs/_dist/_headers',
         description: 'Post-process docs after build',
         hiddenFromHelp: true
       },


### PR DESCRIPTION
By excluding the jsdoc output from being handled by assetgraph-builder we gain a significant speed improvement on postprocessing the docs.

Downside: API docs aren't as optimized. But I think the speed increase is worth the trade-off

Relates to #4356


**Latest build on `master`:**
> Build time: 5m 39s. Total deploy time: 5m 41s

**PR preview build from this branch:**
> Build time: 2m 36s. Total deploy time: 2m 38s