### PR TITLE
Replace utils constants and map functions with native versions

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -37,7 +37,7 @@ exports = module.exports = Mocha;
  * These are the states it can be in.
  * @private
  */
-var mochaStates = utils.defineConstants({
+var mochaStates = Object.freeze({
   /**
    * Initial state of the mocha instance
    * @private

--- a/lib/nodejs/parallel-buffered-runner.js
+++ b/lib/nodejs/parallel-buffered-runner.js
@@ -12,7 +12,6 @@ const {EVENT_RUN_BEGIN, EVENT_RUN_END} = Runner.constants;
 const debug = require('debug')('mocha:parallel:parallel-buffered-runner');
 const {BufferedWorkerPool} = require('./buffered-worker-pool');
 const {setInterval, clearInterval} = global;
-const {createMap} = require('../utils');
 
 /**
  * Outputs a debug statement with worker stats
@@ -43,15 +42,15 @@ const BAILING = 'BAILING';
 const BAILED = 'BAILED';
 const COMPLETE = 'COMPLETE';
 
-const states = createMap({
-  [IDLE]: new Set([RUNNING, ABORTING]),
-  [RUNNING]: new Set([COMPLETE, BAILING, ABORTING]),
-  [COMPLETE]: new Set(),
-  [ABORTED]: new Set(),
-  [ABORTING]: new Set([ABORTED]),
-  [BAILING]: new Set([BAILED, ABORTING]),
-  [BAILED]: new Set([COMPLETE, ABORTING])
-});
+const states = new Map([
+  [IDLE, new Set([RUNNING, ABORTING])],
+  [RUNNING, new Set([COMPLETE, BAILING, ABORTING])],
+  [COMPLETE, new Set()],
+  [ABORTED, new Set()],
+  [ABORTING, new Set([ABORTED])],
+  [BAILING, new Set([BAILED, ABORTING])],
+  [BAILED, new Set([COMPLETE, ABORTING])]
+]);
 
 /**
  * This `Runner` delegates tests runs to worker threads.  Does not execute any
@@ -68,7 +67,7 @@ class ParallelBufferedRunner extends Runner {
         return state;
       },
       set(newState) {
-        if (states[state].has(newState)) {
+        if (states.get(state).has(newState)) {
           state = newState;
         } else {
           throw new Error(`invalid state transition: ${state} => ${newState}`);

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -426,7 +426,7 @@ Runnable.prototype._timeoutError = function(ms) {
   return new Error(msg);
 };
 
-var constants = utils.defineConstants(
+var constants = Object.freeze(
   /**
    * {@link Runnable}-related constants.
    * @public

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -46,7 +46,7 @@ var globals = [
   'clearImmediate'
 ];
 
-var constants = utils.defineConstants(
+var constants = Object.freeze(
   /**
    * {@link Runner}-related constants.
    * @public

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -77,7 +77,7 @@ function Suite(title, parentContext, isRoot) {
   this.reset();
 
   this.on('newListener', function(event) {
-    if (deprecatedEvents[event]) {
+    if (deprecatedEvents.has(event)) {
       utils.deprecate(
         'Event "' +
           event +
@@ -659,18 +659,17 @@ var constants = Object.freeze(
 
 /**
  * @summary There are no known use cases for these events.
- * @desc This is a `Set`-like object having all keys being the constant's string value and the value being `true`.
+ * @desc This is a `Set` containg deprecated constant's string values.
  * @todo Remove eventually
- * @type {Object<string,boolean>}
+ * @type {Set<string>}
  * @ignore
  */
-var deprecatedEvents = Object.keys(constants)
-  .filter(function(constant) {
-    return constant.substring(0, 15) === 'EVENT_SUITE_ADD';
-  })
-  .reduce(function(acc, constant) {
-    acc[constants[constant]] = true;
-    return acc;
-  }, utils.createMap());
+var deprecatedEvents = new Set();
+
+for (const constant of Object.keys(constants)) {
+  if (constant.substring(0, 15) === 'EVENT_SUITE_ADD') {
+    deprecatedEvents.add(constants[constant]);
+  }
+}
 
 Suite.constants = constants;

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -583,7 +583,7 @@ Suite.prototype.serialize = function serialize() {
   };
 };
 
-var constants = utils.defineConstants(
+var constants = Object.freeze(
   /**
    * {@link Suite}-related constants.
    * @public

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -582,25 +582,6 @@ exports.createMap = function(obj) {
 };
 
 /**
- * Creates a read-only map-like object.
- *
- * @description
- * This differs from {@link module:utils.createMap createMap} only in that
- * the argument must be non-empty, because the result is frozen.
- *
- * @see {@link module:utils.createMap createMap}
- * @param {...*} [obj] - Arguments to `Object.assign()`.
- * @returns {Object} A frozen object with no prototype, having `...obj` properties
- * @throws {TypeError} if argument is not a non-empty object.
- */
-exports.defineConstants = function(obj) {
-  if (type(obj) !== 'object' || !Object.keys(obj).length) {
-    throw new TypeError('Invalid argument; expected a non-empty object');
-  }
-  return Object.freeze(exports.createMap(obj));
-};
-
-/**
  * Whether current version of Node support ES modules
  *
  * @description

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ var path = require('path');
 var util = require('util');
 var he = require('he');
 
-var assign = (exports.assign = require('object.assign').getPolyfill());
+exports.assign = require('object.assign').getPolyfill();
 
 /**
  * Inherit the prototype methods from one constructor into another.
@@ -558,28 +558,6 @@ exports.dQuote = function(str) {
  * @public
  */
 exports.noop = function() {};
-
-/**
- * Creates a map-like object.
- *
- * @description
- * A "map" is an object with no prototype, for our purposes. In some cases
- * this would be more appropriate than a `Map`, especially if your environment
- * doesn't support it. Recommended for use in Mocha's public APIs.
- *
- * @public
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|MDN:Map}
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Custom_and_Null_objects|MDN:Object.create - Custom objects}
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign|MDN:Object.assign}
- * @param {...*} [obj] - Arguments to `Object.assign()`.
- * @returns {Object} An object with no prototype, having `...obj` properties
- */
-exports.createMap = function(obj) {
-  return assign.apply(
-    null,
-    [Object.create(null)].concat(Array.prototype.slice.call(arguments))
-  );
-};
 
 /**
  * Whether current version of Node support ES modules

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -701,26 +701,6 @@ describe('lib/utils', function() {
     });
   });
 
-  describe('createMap()', function() {
-    it('should return an object with a null prototype', function() {
-      expect(Object.getPrototypeOf(utils.createMap()), 'to be', null);
-    });
-
-    it('should add props to the object', function() {
-      expect(utils.createMap({foo: 'bar'}), 'to exhaustively satisfy', {
-        foo: 'bar'
-      });
-    });
-
-    it('should add props from all object parameters to the object', function() {
-      expect(
-        utils.createMap({foo: 'bar'}, {bar: 'baz'}),
-        'to exhaustively satisfy',
-        {foo: 'bar', bar: 'baz'}
-      );
-    });
-  });
-
   describe('slug()', function() {
     it('should convert the string to lowercase', function() {
       expect(utils.slug('FOO'), 'to be', 'foo');


### PR DESCRIPTION
This replaces `utils.defineConstants` with `Object.freeze` and `utils. createMap` with actual map usage.