### PR TITLE
[WIP] Yield fixtures

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -32,6 +32,11 @@ module.exports = Runnable;
 function Runnable(title, fn) {
   this.title = title;
   this.fn = fn;
+  if (this.isGenerator()) {
+    if (!this.yieldsOnce()) {
+      throw new Error('Yield fixture must yield exactly once.');
+    }
+  }
   this.body = (fn || '').toString();
   this.async = fn && fn.length;
   this.sync = !this.async;
@@ -55,6 +60,9 @@ Runnable.prototype.reset = function() {
   this.pending = false;
   delete this.state;
   delete this.err;
+  delete this.iterable;
+  delete this.teardownAdded;
+  delete this.readyForReset;
 };
 
 /**
@@ -133,6 +141,46 @@ Runnable.prototype.slow = function(ms) {
 Runnable.prototype.skip = function() {
   this.pending = true;
   throw new Pending('sync skip; aborting execution');
+};
+
+/**
+ * Check if this runnable is a generator function.
+ * @return {boolean}
+ * @private
+ */
+Runnable.prototype.isGenerator = function() {
+  if (!this.fn) {
+    return false;
+  }
+  return ['GeneratorFunction', 'AsyncGeneratorFunction'].includes(
+    this.fn.constructor.name
+  );
+};
+
+/**
+ * Checks if the generator function only yields once. A fixture yielding more
+ * than once will result in code that never runs.
+ * @return {boolean}
+ * @private
+ */
+Runnable.prototype.yieldsOnce = function() {
+  if (!this.isGenerator) {
+    throw new TypeError("Non-generator functions can't yield.");
+  }
+  var count = 0;
+  var pos = 0;
+  var token = 'yield';
+  var stringifiedFn = this.fn.toString();
+  while (true) {
+    pos = stringifiedFn.indexOf(token, pos);
+    if (pos >= 0) {
+      count++;
+      pos += token.length;
+    } else {
+      break;
+    }
+  }
+  return count === 1;
 };
 
 /**
@@ -327,7 +375,7 @@ Runnable.prototype.run = function(fn) {
     };
 
     try {
-      callFnAsync(this.fn);
+      callFnAsync(this);
     } catch (err) {
       // handles async runnables which actually run synchronously
       errorWasHandled = true;
@@ -343,7 +391,7 @@ Runnable.prototype.run = function(fn) {
 
   // sync or promise-returning
   try {
-    callFn(this.fn);
+    callFn(this);
   } catch (err) {
     errorWasHandled = true;
     if (err instanceof Pending) {
@@ -354,8 +402,21 @@ Runnable.prototype.run = function(fn) {
     done(Runnable.toValueOrError(err));
   }
 
-  function callFn(fn) {
-    var result = fn.call(ctx);
+  function callFn(runnable) {
+    var result;
+    if (!runnable.iterable) {
+      // The runnable should only be called if the runnable isn't a
+      // generator, or it's a generator that hasn't been called yet.
+      result = runnable.fn.call(ctx);
+    }
+    if (runnable.isGenerator()) {
+      // The result of calling the generator would be the iterable object, but
+      // the result of the runnable is still needed. This will provide the
+      // result of both the setup and teardown parts of a generator fixture.
+      runnable.iterable = runnable.iterable || result;
+      result = runnable.iterable.next();
+      runnable.readyForReset = result.done;
+    }
     if (result && typeof result.then === 'function') {
       self.resetTimeout();
       result.then(
@@ -382,8 +443,8 @@ Runnable.prototype.run = function(fn) {
     }
   }
 
-  function callFnAsync(fn) {
-    var result = fn.call(ctx, function(err) {
+  function callFnAsync(runnable) {
+    var callback = function(err) {
       if (err instanceof Error || toString.call(err) === '[object Error]') {
         return done(err);
       }
@@ -404,7 +465,22 @@ Runnable.prototype.run = function(fn) {
       }
 
       done();
-    });
+    };
+    var result;
+    if (!runnable.iterable) {
+      // The runnable should only be called if the runnable isn't a
+      // generator, or it's a generator that hasn't been called yet.
+      result = runnable.fn.call(ctx, callback);
+    }
+    if (runnable.isGenerator()) {
+      // The result of calling the generator would be the iterable object, but
+      // the result of the runnable is still needed. This will provide the
+      // result of both the setup and teardown parts of a generator fixture.
+      runnable.iterable = runnable.iterable || result;
+      result = result.next();
+      runnable.readyForReset = result.done;
+    }
+    // result = runnable.fn.call(ctx, callback);
   }
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -478,6 +478,13 @@ Runner.prototype.hook = function(name, fn) {
       var testError = hook.error();
       if (testError) {
         self.fail(self.test, testError);
+      } else if (hook.isGenerator() && !hook.teardownAdded) {
+        if (hook.parent._beforeAll.includes(hook)) {
+          hook.parent._afterAll.push(hook);
+        } else if (hook.parent._beforeEach.includes(hook)) {
+          hook.parent._afterEach.push(hook);
+        }
+        hook.teardownAdded = true;
       }
       // conditional skip
       if (hook.pending) {
@@ -514,6 +521,29 @@ Runner.prototype.hook = function(name, fn) {
       }
       self.emit(constants.EVENT_HOOK_END, hook);
       delete hook.ctx.currentTest;
+      if (hook.readyForReset) {
+        // Reset the generator hook as it's run its course and may need to be
+        // executed again. After resetting the hook, remove it from the relevant
+        // teardown array so it can only be torn down again if it successfully
+        // executes again. Otherwise it may result in an infinite loop.
+        hook.reset();
+        var teardownArray;
+        switch (name) {
+          case HOOK_TYPE_AFTER_ALL:
+            teardownArray = hook.parent._afterAll;
+            break;
+          case HOOK_TYPE_AFTER_EACH:
+            teardownArray = hook.parent._afterEach;
+            break;
+          default:
+            throw Error(
+              `Unrecognized hook. Was expecting ${HOOK_TYPE_AFTER_ALL} or ${HOOK_TYPE_AFTER_EACH}`
+            );
+        }
+        if (teardownArray.includes(hook)) {
+          teardownArray.splice(teardownArray.indexOf(hook), 1);
+        }
+      }
       next(++i);
     });
   }

--- a/test/integration/fixtures/uncaught/yield.fixture.js
+++ b/test/integration/fixtures/uncaught/yield.fixture.js
@@ -1,0 +1,49 @@
+'use strict';
+
+function throwSomething() {
+  throw new Error('fixture setup gone wrong');
+}
+
+describe('yield fixture exceptions', () => {
+  var x = 0;
+
+  before(function*(){
+    x++;
+    yield;
+    x--;
+  });
+  it('x is 1', () => {
+    expect(x, 'to equal', 1);
+  });
+  describe('describe layer with exception', () => {
+    before(function*() {
+      x += 3;
+      yield;
+      x -= 3;
+    });
+    before(function*() {
+      throwSomething();
+      yield;
+      x -= 30;
+    });
+    before('should not run at all', () => {
+      x += 20;
+    });
+    it('should not bother running this', () => {
+      expect(x, 'to equal', 24);
+    });
+  });
+  describe('describe layer without exception', () => {
+    before(function*() {
+      x += 3;
+      yield;
+      x -= 3;
+    });
+    before('should be fine', () => {
+      x += 20;
+    });
+    it('x is 24', () => {
+      expect(x, 'to equal', 24);
+    });
+  });
+});

--- a/test/integration/yield-fixture.spec.js
+++ b/test/integration/yield-fixture.spec.js
@@ -1,0 +1,112 @@
+'use strict';
+
+var helpers = require('../integration/helpers');
+var run = helpers.runMochaJSON;
+var args = [];
+
+describe('yield fixtures', () => {
+  var x;
+
+  before('first before', function*() {
+    x = 0;
+    yield;
+    x = undefined;
+  });
+
+  before('second before', function*() {
+    x++;
+    yield;
+    x--;
+  });
+
+  beforeEach('before each', function*() {
+    x += 2;
+    yield;
+    x -= 2;
+  });
+
+  it('x is 3', () => {
+    expect(x, 'to equal', 3);
+  });
+
+  describe('inner describe', () => {
+    before('inner before', function*() {
+      x += 6;
+      yield;
+      x -= 6;
+    });
+
+    it('x is 9', () => {
+      expect(x, 'to equal', 9);
+    });
+  });
+
+  describe('another inner describe', () => {
+    before('inner before', function*() {
+      x += 10;
+      yield;
+      x -= 10;
+    });
+
+    it('x is 13', () => {
+      expect(x, 'to equal', 13);
+    });
+  });
+});
+
+describe('uncaught errors', function() {
+  it('only successful fixtures are torn down', function(done) {
+    run('uncaught/yield.fixture.js', args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res, 'to have failed with error', 'fixture setup gone wrong')
+        .and('to have passed test count', 2)
+        .and('to have pending test count', 0)
+        .and('to have failed test count', 1)
+        .and(
+          'to have failed test',
+          '"before all" hook for "should not bother running this"'
+        );
+
+      done();
+    });
+  });
+});
+
+describe('yield beforeEach', () => {
+  var x = 0;
+
+  beforeEach(function*() {
+    x++;
+    yield;
+    x--;
+  });
+
+  it('x is 1', () => {
+    expect(x, 'to equal', 1);
+  });
+
+  it('x is still 1', () => {
+    expect(x, 'to equal', 1);
+  });
+
+  describe('yield beforeEach nested', () => {
+    // var x = 0;
+
+    beforeEach(function*() {
+      x += 2;
+      yield;
+      x -= 2;
+    });
+
+    it('x is 3', () => {
+      expect(x, 'to equal', 3);
+    });
+
+    it('x is still 3', () => {
+      expect(x, 'to equal', 3);
+    });
+  });
+});


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Tl;dr: Added ability to use yield in `before` and `beforeEach` to separate setup and teardown logic. Teardowns will then only get executed if the setup doesn't have any issues.

(copied from [issue](https://github.com/mochajs/mocha/issues/4368))

## Example scenario

An e2e test needs to instantiate a client to interact with the admin API, use that client to create a user, launch a web browser session, use that session to go to a login page, and then login using the created user. In order to properly tear down after this test, the browser session must be quit, and the user must be deleted.

### The challenge introduced

While some parts of this setup process are independent of each other, there must be some serializable order to them; certain fixtures will have to execute/resolve before others. There is a chance that an error can occur in an earlier fixture that would prevent further fixtures from setting up.

Mocha currently handles this part just fine, as it will just stop executing `before` and `beforeEach` functions for that test.

The challenge is introduced with how teardowns can get handled. When mocha reaches a given `describe` layer for a test without any errors popping up before then, if a `before`/`beforeEach` throws an error, mocha will still try to execute all the `after`/`afterEach` for that layer, no matter how many `before`/`beforeEach` succeeded in that later. This presents a risk in that mocha could still attempt to tear down a fixture even if its setup wasn't completed.

Here's a quick mockup demonstrating the risks of this if the engineer assumes the setups won't have issues:

```javascript
describe('loggin in', () => {
  var driver;
  var loginPage;
  var landingPage;
  var adminClient;
  var user;

  before('create user', () => {
    user = User({ name = 'Jimmy', email = `test+${uuidv4()}@example.com`, password = 'P4$$w0rd!' });
    adminClient = AdminClient();
    adminClient.createUser(user);
  });

  before('launch driver', () => {
    driver = Chrome();
  });

  before('go to login page', () => {
    driver.get("https://mysite.com/login");
    loginPage = LoginPage(driver);
  });

  before('login', () => {
    loginPage.login(user);
    landingPage = LandingPage(driver);
  });

  it('should show user name in header', () => {
    expect(landingPage.header.text, 'to equal', user.name);
  });

  after('quit driver', () => {
    driver.quit();
  });

  after('delete user', () => {
    adminClient.deleteUser(user);
  });
});
```

If creating the user throws an error, the driver will never be launched, but mocha would still attempt to quit it in the first `after`. What's worse, is that if the driver `before` was the one to have the error, the `driver.quit()` call would also throw an error, as there's no driver to actually quit, and, as a result, mocha would not attempt to finish the remaining teardowns, which means the user wouldn't get deleted.

There is no _guaranteed_ solution for the latter risk, as even if the driver had launched successfully, it's still possible (however unlikely) that quitting that driver session could throw an error.

The prior risk, though, is at least manageable. By doing a preliminary check in the `after`/`afterEach` to see if there is something that needs to be torn down would mitigate this risk. The `before` for user creation would have to be modified to this:

```javascript
  before('create user', () => {
    let _user = User({ name = 'Jimmy', email = `test+${uuidv4()}@example.com`, password = 'P4$$w0rd!' });
    adminClient = AdminClient();
    adminClient.createUser(_user);
    // necessary to delay assignment until user creation completion for simpler teardown logic
    user = _user;
  });
```

and the `after` for the driver and user creation would look like this:

```javascript
  after('quit driver', () => {
    if (driver) {
      driver.quit();
    }
  });

  after('delete user', () => {
    if (user) {
      adminClient.deleteUser(user);
    }
  });
```

This, however, increases the [complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) of the tests, which would be ideal to avoid. Depending on how complex it is to either check for a need to teardown a fixture, or to do the teardown itself, this can drastically increase the complexity and the surface area for bugs in the test code (although, ideally for maximum safety/simplicity, each fixture would be atomic so the resulting complexity would be minimal).

## Proposed solution

Rather than having increased complexity in the test code to handle conditionally tearing down, it would be beneficial to not have the conditional at all, thus reducing complexity. Going one step further, it would also be beneficial to explicitly tie the teardown logic for a fixture to its setup logic in such a way that the teardown logic _can't_ be executed if the associated setup logic had a problem, thus reducing complexity further and increasing teardown safety.

By making fixtures into generators this can be easily achieved. I'm told generators aren't widely used for JavaScript development, but in this use case, they become more like context managers than generators.

Here's what the above example would look like using them:

```javascript
describe('loggin in', () => {
  var driver;
  var loginPage;
  var landingPage;
  var adminClient;
  var user;

  before('create user', function*() {
    user = User({ name = 'Jimmy', email = `test+${uuidv4()}@example.com`, password = 'P4$$w0rd!' });
    adminClient = AdminClient();
    adminClient.createUser(u);
    yield;
    adminClient.deleteUser(user);
  });

  before('launch driver', function*() {
    driver = Chrome();
    yield;
    driver.quit();
  });

  before('go to login page', () => {
    driver.get("https://mysite.com/login");
    loginPage = LoginPage(driver);
  });

  before('login', () => {
    loginPage.login(user);
    landingPage = LandingPage(driver);
  });

  it('should show user name in header', () => {
    expect(landingPage.header.text, 'to equal', user.name);
  });
});
```

In my implementation, mocha evaluates a hook's result after executing it initially and calling `next()` on it once. If the hook made it through to the `yield` successfully, then it is appended to the relevant `after`/`afterEach` array for that `describe` layer. Because they are executed sequentially (assuming the fixtures are executed in a serializable fashion), then the teardowns for them will be executed in the reverse order, effectively creating a fixture stack. So because the user was created _before_ the driver was launched, the user would be deleted _after_ the driver was quit.

If a hook throws an error during its setup logic, it will not be added the the relevant `after`/`afterEach` array, and as a result, mocha won't try to execute its teardown code, but any hooks that had already been setup successfully will still be torn down.

There's also the bonus of not having to worry about the order of the `after`/`afterEach` definitions. for a given layer, which increases test code maintainability/extensibility/reusability.

### Alternate Designs

Callbacks were considered, but they introduced more complexity than the `yield` option, and, depending on the implementation, could mean that setup error still wouldn't prevent teardown execution. 

### Why should this be in core?

It would apply to any use case where a teardown is needed, provides increased safety and simplicity for mocha users in a standard way (there is precedent in pytest), and requires the changes be made to the core logic of mocha's runner. Their use is also completely optional.

### Benefits

Increased teardown simplicity and safety, and test maintainability/extensibility/reusability.

### Possible drawbacks

None that I can identify.

It works interchangeably with other hook types. The only quirk is that the yield hook is always appended to the _end_ of the relevant teardown array, so it would always be executed after the relevant `after`/`afterEach` definitions that already exist in that describe layer.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

This would be purely an enhancement with no backwards compatibility issues. One thing I haven't added yet is documentation, but I wanted to ask where it would be best to put it.

[Here's the related issue.](https://github.com/mochajs/mocha/issues/4368)