### PR TITLE
mark Runnable#retries and Runnable#currentRetry methods as public

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -165,7 +165,9 @@ Runnable.prototype.isPassed = function() {
 /**
  * Set or get number of retries.
  *
- * @private
+ * @memberof Mocha.Runnable
+ * @public
+ * @returns {number|void}
  */
 Runnable.prototype.retries = function(n) {
   if (!arguments.length) {
@@ -177,7 +179,9 @@ Runnable.prototype.retries = function(n) {
 /**
  * Set or get current retry
  *
- * @private
+ * @memberof Mocha.Runnable
+ * @public
+ * @returns {number|void}
  */
 Runnable.prototype.currentRetry = function(n) {
   if (!arguments.length) {


### PR DESCRIPTION
This change makes it easier for Mocha reporters to report retriable and regular tests differently, should they choose to do so.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

I'd like the [Serenity/JS Mocha reporter](https://serenity-js.org/modules/mocha) to be able to report differently on regular and retriable Mocha scenarios. In order to do so, a Mocha reporter needs to be able to tell the difference between the two.

The easiest way to do it is to mark the already existing [`Runnable#retries`](https://github.com/mochajs/mocha/blob/7c8896c70faf58d942249190df1343f7349cf946/lib/runnable.js#L177-L187) and [`Runnable#currentRetry`](https://github.com/mochajs/mocha/blob/7c8896c70faf58d942249190df1343f7349cf946/lib/runnable.js#L177-L187) methods as public to expose the required information.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Any alternative designs would require marking at least [`Runnable#currentRetry`](https://github.com/mochajs/mocha/blob/7c8896c70faf58d942249190df1343f7349cf946/lib/runnable.js#L177-L187) as public, so changing the JSDoc seems like the most efficient way to reach my objective.

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->
This functionality can't be implemented in an external module.

### Benefits

<!-- What benefits will be realized by the code change? -->

This change allows any Mocha reporter to treat retriable and regular scenarios differently and therefore provide better quality information to developers using them. If the PR makes it to core, I'm also planning to raise another one for [`@types/mocha`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mocha/index.d.ts)


### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Marking those APIs as public might encourage developers to use them in their tests, which they probably shouldn't be doing. Having said that, they can do that already.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

N/A
