### PR TITLE
Update javascript-serialize 3.1.0 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19327,7 +19327,7 @@
     "serialize-javascript": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "requires": {
         "randombytes": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19325,8 +19325,8 @@
       }
     },
     "serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
       "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
       "requires": {
         "randombytes": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ms": "2.1.2",
     "object.assign": "4.1.0",
     "promise.allsettled": "1.0.2",
-    "serialize-javascript": "3.1.0",
+    "serialize-javascript": "4.0.0",
     "strip-json-comments": "3.0.1",
     "supports-color": "7.1.0",
     "which": "2.0.2",


### PR DESCRIPTION

### Description of the Change
package.json's javascript-serialize 3.1.0 to 4.0.0
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

--> 
### Benefits
Mocha can prepare for serializing bigint later.
https://github.com/yahoo/serialize-javascript/releases/tag/v4.0.0 

related to #4375 