### PR TITLE
Fix #4347 | Ensure root level hooks are called when running in watch mode

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -59,6 +59,10 @@ exports.watchParallelRun = (
       // in `createRerunner`), we need to call `mocha.ui()` again to set up the context/globals.
       newMocha.ui(newMocha.options.ui);
 
+      // we need to call `newMocha.rootHooks` to set up rootHooks for the new
+      // suite
+      newMocha.rootHooks(newMocha.options.rootHooks);
+
       // in parallel mode, the main Mocha process doesn't actually load the
       // files. this flag prevents `mocha.run()` from autoloading.
       newMocha.lazyLoadFiles(true);
@@ -117,6 +121,10 @@ exports.watchRun = (mocha, {watchFiles, watchIgnore}, fileCollectParams) => {
       // because we've swapped out the root suite (see the `run` inner function
       // in `createRerunner`), we need to call `mocha.ui()` again to set up the context/globals.
       newMocha.ui(newMocha.options.ui);
+
+      // we need to call `newMocha.rootHooks` to set up rootHooks for the new
+      // suite
+      newMocha.rootHooks(newMocha.options.rootHooks);
 
       return newMocha;
     },

--- a/test/integration/fixtures/options/watch/hook.fixture.js
+++ b/test/integration/fixtures/options/watch/hook.fixture.js
@@ -1,0 +1,7 @@
+module.exports = {
+  mochaHooks: {
+    ["<hook>"]: function() {
+      throw new Error("<hook> Hook Error");
+    },
+  },
+};

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -275,6 +275,43 @@ describe('--watch', function() {
         expect(results[1].tests, 'to have length', 2);
       });
     });
+
+    describe('with required hooks', function() {
+      /**
+       * Helper for setting up hook tests
+       *
+       * @param {string} hookName name of hook to test
+       * @return {function}
+       */
+      function setupHookTest(hookName) {
+        return function() {
+          const testFile = path.join(tempDir, 'test.js');
+          const hookFile = path.join(tempDir, 'hook.js');
+
+          copyFixture('__default__', testFile);
+          copyFixture('options/watch/hook', hookFile);
+
+          replaceFileContents(hookFile, '<hook>', hookName);
+
+          return runMochaWatch(
+            [testFile, '--require', hookFile],
+            tempDir,
+            () => {
+              touchFile(testFile);
+            }
+          ).then(results => {
+            expect(results.length, 'to equal', 2);
+            expect(results[0].failures, 'to have length', 1);
+            expect(results[1].failures, 'to have length', 1);
+          });
+        };
+      }
+
+      it('mochaHooks.beforeAll runs as expected', setupHookTest('beforeAll'));
+      it('mochaHooks.beforeEach runs as expected', setupHookTest('beforeEach'));
+      it('mochaHooks.afterAll runs as expected', setupHookTest('afterAll'));
+      it('mochaHooks.afterEach runs as expected', setupHookTest('afterEach'));
+    });
   });
 });
 


### PR DESCRIPTION
## Rationale
Tests with root level hooks are ignored when running in watch mode.
This occurs on initial & subsequent runs.

## Description of the Change

- updated `lib/cli/run-watch` to re-initialise rootHooks

As we have swapped out the root suite it is necessary to re-initialize
root level hooks again.

- Extended integration tests for watch to take into consideration
  hooks

## Refs

- mochajs/mocha/issues/4347