### PR TITLE
Refactoring: Consuming log-symbols alternate to code for win32 in reporters/base.

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -10,6 +10,7 @@ var diff = require('diff');
 var milliseconds = require('ms');
 var utils = require('../utils');
 var supportsColor = require('supports-color');
+var symbols = require('log-symbols');
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
@@ -88,19 +89,12 @@ exports.colors = {
  */
 
 exports.symbols = {
-  ok: '✓',
-  err: '✖',
-  dot: '․',
+  ok: symbols.success,
+  err: symbols.err,
+  dot: '.',
   comma: ',',
   bang: '!'
 };
-
-// With node.js on Windows: use symbols available in terminal default fonts
-if (process.platform === 'win32') {
-  exports.symbols.ok = '\u221A';
-  exports.symbols.err = '\u00D7';
-  exports.symbols.dot = '.';
-}
 
 /**
  * Color `str` with the given `type`,


### PR DESCRIPTION
### Description of the Change

I used the `log-symbols` instead of the code for win32.

### Alternate Designs

No alternate designs

### Benefits

Mocha already uses `log-symbols`, so we can remove duplicated code and maintain consistency.

### Possible Drawbacks

I also deleted the `dot` case, But I don't know if the size difference between dot for win32(`.`) and dot for the others(`․`) is a problem.

So I think this might be a problem.

### Applicable issues

* Enter any applicable Issues here.
https://github.com/mochajs/mocha/issues/4353

The above issue is not directly related to the PR.

But I think you may want to use alphabets rather than `log-symbols` to resolve the issue.

like this

```
success : v or o
fail : x
```

Please leave a good comment or question at any time :)

* Is this a breaking change (major release)? no
* Is it an enhancement (minor release)?  maybe, yes
* Is it a bug fix, or does it not impact production code (patch release)? no


