### PR TITLE
fix(base): if message and stacktrace overlap remove duplicates

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -15,7 +15,7 @@ var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 
 const isBrowser = utils.isBrowser();
-var stackFilter = utils.stackTraceFilter();
+const stackFilter = utils.stackTraceFilter();
 
 function getBrowserWindowSize() {
   if ('innerHeight' in global) {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -15,6 +15,7 @@ var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 
 const isBrowser = utils.isBrowser();
+var stackFilter = utils.stackTraceFilter();
 
 function getBrowserWindowSize() {
   if ('innerHeight' in global) {
@@ -249,6 +250,8 @@ exports.list = function(failures) {
     } else {
       message = '';
     }
+
+    message = test.fullStackTrace ? message : stackFilter(message);
     var stack = err.stack || message;
     var index = message ? stack.indexOf(message) : -1;
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -402,6 +402,7 @@ Runner.prototype.fail = function(test, err, force) {
   }
 
   try {
+    test.fullStackTrace = this.fullStackTrace;
     err.stack =
       this.fullStackTrace || !err.stack ? err.stack : stackFilter(err.stack);
   } catch (ignore) {

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -444,7 +444,7 @@ describe('Base reporter', function() {
     });
   });
 
-  describe.only('When there is StackTrace in the error message', function() {
+  describe('When there is StackTrace in the error message', function() {
     var baseConsoleLog;
     var err;
     var test;

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -443,4 +443,40 @@ describe('Base reporter', function() {
       sinon.restore();
     });
   });
+
+  describe.only('When there is StackTrace in the error message', function() {
+    var baseConsoleLog;
+    var err;
+    var test;
+
+    beforeEach(function() {
+      baseConsoleLog = sinon.spy(Base, 'consoleLog');
+      err = {
+        message:
+          'AssertionError: foo bar\n' +
+          'at EventEmitter.<anonymous> (/usr/local/dev/test.js:16:12)',
+        stack:
+          'AssertionError: foo bar\n' +
+          'at EventEmitter.<anonymous> (/usr/local/dev/test.js:16:12)\n' +
+          'at Context.<anonymous> (/usr/local/dev/test.js:19:5)'
+      };
+      test = makeTest(err);
+    });
+
+    it('You should be able to remove the overlap between the message and the stacktrace.', function() {
+      var expected = [
+        '  %s) %s:\n     %s\n%s\n',
+        1,
+        'test title',
+        'AssertionError: foo bar\nat EventEmitter.<anonymous> (/usr/local/dev/test.js:16:12)',
+        '  at Context.<anonymous> (/usr/local/dev/test.js:19:5)'
+      ];
+      Base.list([test]);
+      assert.deepEqual(baseConsoleLog.lastCall.args, expected);
+    });
+
+    afterEach(function() {
+      baseConsoleLog.restore();
+    });
+  });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -444,13 +444,11 @@ describe('Base reporter', function() {
     });
   });
 
-  describe('When there is StackTrace in the error message', function() {
-    var baseConsoleLog;
-    var err;
-    var test;
+  describe.only('When there is StackTrace in the error message', function() {
+    let err;
+    let test;
 
     beforeEach(function() {
-      baseConsoleLog = sinon.spy(Base, 'consoleLog');
       err = {
         message:
           'AssertionError: foo bar\n' +
@@ -464,7 +462,7 @@ describe('Base reporter', function() {
     });
 
     it('You should be able to remove the overlap between the message and the stacktrace.', function() {
-      var expected = [
+      const expected = [
         '  %s) %s:\n     %s\n%s\n',
         1,
         'test title',
@@ -472,11 +470,7 @@ describe('Base reporter', function() {
         '  at Context.<anonymous> (/usr/local/dev/test.js:19:5)'
       ];
       Base.list([test]);
-      assert.deepEqual(baseConsoleLog.lastCall.args, expected);
-    });
-
-    afterEach(function() {
-      baseConsoleLog.restore();
+      expect(Base.consoleLog, 'when called with', expected);
     });
   });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -444,7 +444,7 @@ describe('Base reporter', function() {
     });
   });
 
-  describe.only('When there is StackTrace in the error message', function() {
+  describe('When there is StackTrace in the error message', function() {
     let err;
     let test;
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

The problem was that the message of the issue contained a stacktrace.
There is a logic to remove the existing duplicates.
The stacktrace received as a message and the internally created stacktrace are not the same.
We can consider how to make the shape of the internally generated stack trace and the trace passed to the message the same.
So I used utils.stackTraceFilter.
Through stackTraceFilter, we have worked to secure the efficiency of the existing deduplication logic.

### Alternate Designs

If possible, it would be nice to consider ignoring the stacktrace if there is a stacktrace in the error message.

### Why should this be in core?

if message and stackTrace overlap, remove duplicate message or stacktrace.

### Benefits

You can get a cleaner error report.

### Possible Drawbacks

I don't think it will be a problem because all of the existing tests have passed.

### Applicable issues

#3992 