### PR TITLE
fix: add Mocha to global variable

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,8 @@ const config = {
     file: './mocha.js',
     format: 'umd',
     sourcemap: true,
-    name: 'mocha'
+    name: 'mocha',
+    footer: 'window.Mocha = window.mocha.Mocha;'
   },
   plugins: [
     json(),

--- a/test/browser-specific/esm.spec.mjs
+++ b/test/browser-specific/esm.spec.mjs
@@ -3,3 +3,7 @@ import './fixtures/esm.fixture.mjs';
 it('should register a global if it did not fail', function() {
   expect(window.MOCHA_IS_OK, 'to be ok');
 });
+
+it('should has global Mocha', function() {
+  expect(window.Mocha, 'not to be', undefined);
+});


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

To apply UMD pattern, Mocha module was located in `mocha` as module name. But browsers are be able to access Mocha as global variable with this change.

I added *rollup config* `footer` to assign Mocha module to global variable. I hope that this would be the alias to acutal Mocha module,  not deep cloning another Mocha.

### Alternate Designs

in `browser-entry.js` from line `213`

```javascript
mocha.Mocha = Mocha;
mocha.mocha = mocha;
```

I would like to suggest like next

```javascript
global.Mocha = Mocha;
global.mocha = mocha;
```

OR,

```javascript
mocha.Mocha = Mocha;
mocha.mocha = mocha;

(function(currentGlobal) {
  currentGlobal.Mocha = mocha.Mocha;
})(global);
```

anyway, I was afraid of any side-effects and then I selected this version as PR.

### Benefits

- Users who used mocha for browsers could update the latest mocha
- Other third party modules with global variable Mocha could update the latest mocha

### Possible Drawbacks

There would be duplicated Mocha modules on browser.
IMHO, an alias for this module would be better than assign object but I would like to avoid to modify core code.

### Applicable issues

#4395
 
### Versioning Info

* Is this a breaking change (major release)? No
* Is it an enhancement (minor release)? No
* Is it a bug fix, or does it not impact production code (patch release)? Yes

