### PR TITLE
fix: the number of concurrent job with --parallel option in mocha:cli:run:helpers

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -173,11 +173,7 @@ const singleRun = async (mocha, {exit}, fileCollectParams) => {
  */
 const parallelRun = async (mocha, options, fileCollectParams) => {
   const files = collectFiles(fileCollectParams);
-  debug(
-    'executing %d test file(s) across %d concurrent jobs',
-    files.length,
-    options.jobs ? options.jobs : workerpool.cpus - 1
-  );
+  debug('executing %d test file(s) in parallel mode', files.length);
   mocha.files = files;
 
   // note that we DO NOT load any files here; this is handled by the worker

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -9,6 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const workerpool = require('workerpool');
 const debug = require('debug')('mocha:cli:run:helpers');
 const {watchRun, watchParallelRun} = require('./watch-run');
 const collectFiles = require('./collect-files');
@@ -175,7 +176,7 @@ const parallelRun = async (mocha, options, fileCollectParams) => {
   debug(
     'executing %d test file(s) across %d concurrent jobs',
     files.length,
-    options.jobs
+    options.jobs ? options.jobs : workerpool.cpus - 1
   );
   mocha.files = files;
 

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -9,7 +9,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const workerpool = require('workerpool');
 const debug = require('debug')('mocha:cli:run:helpers');
 const {watchRun, watchParallelRun} = require('./watch-run');
 const collectFiles = require('./collect-files');


### PR DESCRIPTION

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

When users run mocha with ```--parallel``` option wihtout ```--jobs``` option, ```undefined``` was passed to the parallelRun method.

I changed options.jobs to the number of CPU cores less 1 when options.jobs was false.

**AS-IS**
<img width="994" alt="스크린샷 2020-08-25 오후 6 09 07" src="https://user-images.githubusercontent.com/29244798/91155771-401dd500-e6fe-11ea-85a2-29b811f7c309.png">

**TO-BE**
<img width="903" alt="스크린샷 2020-08-25 오후 6 08 37" src="https://user-images.githubusercontent.com/29244798/91155779-42802f00-e6fe-11ea-90cd-78a70a36287b.png">

### Alternate Designs

in ```lib/cli/run-helpers.js``` from line ```179```

**AS-iS**
```javascript
options.jobs
```

**TO-BE**
```javascript
options.jobs ? options.jobs : workerpool.cpus - 1
```

### Why should this be in core?

It's a confirmed bug as described in #4415. 

### Benefits

Users can know exact current concurrent job count instead NaN.

### Possible Drawbacks

N/A

### Applicable issues

#4415
