### PR TITLE
prefer all mocha flags over node flags; closes #4417

### DIFF
--- a/lib/cli/node-flags.js
+++ b/lib/cli/node-flags.js
@@ -7,6 +7,7 @@
  */
 
 const nodeFlags = process.allowedNodeEnvironmentFlags;
+const {isMochaFlag} = require('./run-option-metadata');
 const unparse = require('yargs-unparser');
 
 /**
@@ -43,16 +44,14 @@ exports.isNodeFlag = (flag, bareword = true) => {
     flag = flag.replace(/^--?/, '');
   }
   return (
-    // treat --require/-r as Mocha flag even though it's also a node flag
-    !(flag === 'require' || flag === 'r') &&
     // check actual node flags from `process.allowedNodeEnvironmentFlags`,
     // then historical support for various V8 and non-`NODE_OPTIONS` flags
     // and also any V8 flags with `--v8-` prefix
-    ((nodeFlags && nodeFlags.has(flag)) ||
-      debugFlags.has(flag) ||
-      /(?:preserve-symlinks(?:-main)?|harmony(?:[_-]|$)|(?:trace[_-].+$)|gc(?:[_-]global)?$|es[_-]staging$|use[_-]strict$|v8[_-](?!options).+?$)/.test(
-        flag
-      ))
+    (!isMochaFlag(flag) && nodeFlags && nodeFlags.has(flag)) ||
+    debugFlags.has(flag) ||
+    /(?:preserve-symlinks(?:-main)?|harmony(?:[_-]|$)|(?:trace[_-].+$)|gc(?:[_-]global)?$|es[_-]staging$|use[_-]strict$|v8[_-](?!options).+?$)/.test(
+      flag
+    )
   );
 };
 

--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -12,7 +12,7 @@
  * @type {{string:string[]}}
  * @private
  */
-exports.types = {
+const TYPES = (exports.types = {
   array: [
     'extension',
     'file',
@@ -58,7 +58,7 @@ exports.types = {
     'slow',
     'timeout'
   ]
-};
+});
 
 /**
  * Option aliases keyed by canonical option name.
@@ -87,4 +87,27 @@ exports.aliases = {
   timeout: ['t', 'timeouts'],
   ui: ['u'],
   watch: ['w']
+};
+
+const ALL_MOCHA_FLAGS = Object.keys(TYPES).reduce((acc, key) => {
+  // gets all flags from each of the fields in `types`, adds those,
+  // then adds aliases of each flag (if any)
+  TYPES[key].forEach(flag => {
+    acc.add(flag);
+    const aliases = exports.aliases[flag] || [];
+    aliases.forEach(alias => {
+      acc.add(alias);
+    });
+  });
+  return acc;
+}, new Set());
+
+/**
+ * Returns `true` if the provided `flag` is known to Mocha.
+ * @param {string} flag - Flag to check
+ * @returns {boolean} If `true`, this is a Mocha flag
+ * @private
+ */
+exports.isMochaFlag = flag => {
+  return ALL_MOCHA_FLAGS.has(flag.replace(/^--?/, ''));
 };


### PR DESCRIPTION
- no more `require` special-case
- future-proofs `mocha` against the introduction of conflicting flags in `node`

Fixes #4417 
Ref: https://github.com/nodejs/node/pull/34852