### PR TITLE
update @mocha/docdash to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,9 +3111,9 @@
       "dev": true
     },
     "@mocha/docdash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mocha/docdash/-/docdash-3.0.0.tgz",
-      "integrity": "sha512-k/mjHfHe6shnj7gUH3wjVqFyWPiJqiV1IXxn9kzS85mzljS45VB+8zsUKOrKpXtX5YdI6DJmHfqDrR0oHGFNMA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@mocha/docdash/-/docdash-3.0.1.tgz",
+      "integrity": "sha512-gzdsI+iJeOqgD01pHILKinuV1rvoWRzUfDCmadamefAMXXhWvdldDTVLWQrTDOMRQ3/zssISpSb+dbeNFflg9A==",
       "dev": true,
       "requires": {
         "taffydb": "^2.7.3"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@11ty/eleventy": "^0.11.0",
     "@11ty/eleventy-plugin-inclusive-language": "^1.0.0",
     "@babel/preset-env": "^7.11.0",
-    "@mocha/docdash": "^3.0.0",
+    "@mocha/docdash": "^3.0.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
See #4412.  Changes made by @sujin-park were published in `@mocha/docdash` v3.0.1, which this PR pulls in.