### PR TITLE
Fix parallel feature: disable parallel automatically/ add command line option

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -217,13 +217,12 @@ exports.runMocha = async (mocha, options) => {
   };
 
   const files = collectFiles(fileCollectParams);
-  if(files.length===1) {
-    if(options.parallel && !options.parallelForce) {
+  if (files.length === 1) {
+    if (parallel && !parallelForce) {
       mocha.parallelMode(false);
-      parallel=false;
+      parallel = false;
     }
   }
-  
   let run;
   if (watch) {
     run = parallel ? watchParallelRun : watchRun;

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -203,7 +203,8 @@ exports.runMocha = async (mocha, options) => {
     parallel = false,
     recursive = false,
     sort = false,
-    spec = []
+    spec = [],
+    parallelForce = false
   } = options;
 
   const fileCollectParams = {

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -195,17 +195,17 @@ const parallelRun = async (mocha, options, fileCollectParams) => {
  * @returns {Promise<Runner>}
  */
 exports.runMocha = async (mocha, options) => {
-  let {
+  const {
     watch = false,
     extension = [],
     ignore = [],
     file = [],
-    parallel = false,
     recursive = false,
     sort = false,
     spec = [],
     parallelForce = false
   } = options;
+  let {parallel} = options;
 
   const fileCollectParams = {
     ignore,
@@ -223,6 +223,7 @@ exports.runMocha = async (mocha, options) => {
       parallel = false;
     }
   }
+
   let run;
   if (watch) {
     run = parallel ? watchParallelRun : watchRun;

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -195,7 +195,7 @@ const parallelRun = async (mocha, options, fileCollectParams) => {
  * @returns {Promise<Runner>}
  */
 exports.runMocha = async (mocha, options) => {
-  const {
+  let {
     watch = false,
     extension = [],
     ignore = [],
@@ -215,6 +215,14 @@ exports.runMocha = async (mocha, options) => {
     spec
   };
 
+  const files = collectFiles(fileCollectParams);
+  if(files.length===1) {
+    if(options.parallel && !options.parallelForce) {
+      mocha.parallelMode(false);
+      parallel=false;
+    }
+  }
+  
   let run;
   if (watch) {
     run = parallel ? watchParallelRun : watchRun;

--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -45,7 +45,8 @@ const TYPES = (exports.types = {
     'parallel',
     'recursive',
     'sort',
-    'watch'
+    'watch',
+    'parallelForce'
   ],
   number: ['retries', 'jobs'],
   string: [

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -263,7 +263,7 @@ exports.builder = yargs =>
       },
       parallelForce: {
         description: 'Force Mocha to quit after tests complete',
-        group: GROUPS.RULES,
+        group: GROUPS.RULES
       }
     })
     .positional('spec', {

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -260,6 +260,10 @@ exports.builder = yargs =>
         requiresArg: true,
         coerce: list,
         default: defaults['watch-ignore']
+      },
+      parallelForce: {
+        description: 'Force Mocha to quit after tests complete',
+        group: GROUPS.RULES,
       }
     })
     .positional('spec', {

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -123,6 +123,7 @@ exports.Test = require('./test');
  * @param {number|string} [options.timeout] - Timeout threshold value.
  * @param {string} [options.ui] - Interface name.
  * @param {boolean} [options.parallel] - Run jobs in parallel
+ * @param {boolean} [options.parallelForce] - Run jobs in parallel
  * @param {number} [options.jobs] - Max number of worker processes for parallel runs
  * @param {MochaRootHookObject} [options.rootHooks] - Hooks to bootstrap the root
  * suite with


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

This PR comes from the idea #4322
AS-IS
[single run]
![parallelrun](https://user-images.githubusercontent.com/70261569/91636597-d1fa4a80-ea3c-11ea-8fe0-13c4dda05c5e.PNG)
[parallel run]
![singlerun](https://user-images.githubusercontent.com/70261569/91636598-d32b7780-ea3c-11ea-9592-f60f9a577d24.PNG)


(1) fix parallel feature : When running a single file, disable parallel mode automatically.

If we run only a single file in parallel mode, it is much slower.
So I added a feature to automate swap from parallel mode to single mode when we're running a single file.

(2) Added Command Line Option: added an option to FORCE PARALLEL MODE in (1) situation


### Alternate Designs


### Why should this be in core?


### Benefits

When running a single file, Mocha automatically run in a faster way.

### Possible Drawbacks

There must be a way to force parallel mode when running a single file if needed.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
