### PR TITLE
Fix: mocha return interface #4286

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -999,16 +999,16 @@ Mocha.prototype.run = function(fn) {
   exports.reporters.Base.inlineDiffs = options.inlineDiffs;
   exports.reporters.Base.hideDiff = !options.diff;
 
-  const done = failures => {
+  const done = tests => {
     this._previousRunner = runner;
     this._state = this._cleanReferencesAfterRun
       ? mochaStates.REFERENCES_CLEANED
       : mochaStates.INIT;
     fn = fn || utils.noop;
     if (typeof reporter.done === 'function') {
-      reporter.done(failures, fn);
+      reporter.done(tests, fn);
     } else {
-      fn(failures);
+      fn(tests);
     }
   };
 
@@ -1017,14 +1017,15 @@ Mocha.prototype.run = function(fn) {
       this.options.enableGlobalSetup && this.hasGlobalSetupFixtures()
         ? await this.runGlobalSetup(runner)
         : {};
-    const failureCount = await runner.runAsync({
+    const tests = await runner.runAsync({
       files: this.files,
       options
     });
+
     if (this.options.enableGlobalTeardown && this.hasGlobalTeardownFixtures()) {
       await this.runGlobalTeardown(runner, {context});
     }
-    return failureCount;
+    return tests;
   };
 
   // no "catch" here is intentional. errors coming out of
@@ -1033,8 +1034,13 @@ Mocha.prototype.run = function(fn) {
   // also: returning anything other than `runner` would be a breaking
   // change
   runAsync(runner).then(done);
-
   return runner;
+};
+
+Mocha.prototype.runAsync = async function runAsync() {
+  return new Promise(resolve => {
+    this.run(resolve);
+  });
 };
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1055,9 +1055,32 @@ Runner.prototype.run = function(fn, opts = {}) {
 
   // callback
   this.on(constants.EVENT_RUN_END, function() {
+    if (
+      opts.options &&
+      !typeof opts.options.parallel === 'boolean' &&
+      opts.async
+    ) {
+      const tests = [];
+      if (this.suite) {
+        this.suite.tests.map(test => {
+          tests.push(test);
+        });
+      }
+      let current = this.suite.suites;
+      while (current.length > 0) {
+        current.map(suite => {
+          suite.tests.map(test => {
+            tests.push(test);
+          });
+          current = suite.suites;
+        });
+      }
+      fn(tests);
+    } else {
+      fn(this.failures);
+    }
     this.state = constants.STATE_STOPPED;
     debug('run(): emitted %s', constants.EVENT_RUN_END);
-    fn(this.failures);
   });
 
   this._removeEventListener(process, 'uncaughtException', this.uncaught);
@@ -1075,29 +1098,7 @@ Runner.prototype.run = function(fn, opts = {}) {
     Runner.immediately(prepare);
   }
 
-  return {
-    runner: this,
-    result: new Promise((resolve, reject) => {
-      const tests = [];
-      this.on(constants.EVENT_RUN_END, function() {
-        if (self.suite) {
-          self.suite.tests.map(test => {
-            tests.push(test);
-          });
-        }
-        let current = self.suite.suites;
-        while (current.length > 0) {
-          current.map(suite => {
-            suite.tests.map(test => {
-              tests.push(test);
-            });
-            current = suite.suites;
-          });
-        }
-        resolve(tests);
-      });
-    })
-  };
+  return this;
 };
 
 /**
@@ -1109,6 +1110,10 @@ Runner.prototype.run = function(fn, opts = {}) {
  * @returns {Promise<number>} Failure count
  */
 Runner.prototype.runAsync = async function runAsync(opts = {}) {
+  Object.assign(opts, {
+    async: true
+  });
+
   return new Promise(resolve => {
     this.run(resolve, opts);
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1055,11 +1055,7 @@ Runner.prototype.run = function(fn, opts = {}) {
 
   // callback
   this.on(constants.EVENT_RUN_END, function() {
-    if (
-      opts.options &&
-      !typeof opts.options.parallel === 'boolean' &&
-      opts.async
-    ) {
+    if (opts.options && !(typeof opts.options.parallel === 'boolean')) {
       const tests = [];
       if (this.suite) {
         this.suite.tests.map(test => {
@@ -1110,10 +1106,6 @@ Runner.prototype.run = function(fn, opts = {}) {
  * @returns {Promise<number>} Failure count
  */
 Runner.prototype.runAsync = async function runAsync(opts = {}) {
-  Object.assign(opts, {
-    async: true
-  });
-
   return new Promise(resolve => {
     this.run(resolve, opts);
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1075,7 +1075,29 @@ Runner.prototype.run = function(fn, opts = {}) {
     Runner.immediately(prepare);
   }
 
-  return this;
+  return {
+    runner: this,
+    result: new Promise((resolve, reject) => {
+      const tests = [];
+      this.on(constants.EVENT_RUN_END, function() {
+        if (self.suite) {
+          self.suite.tests.map(test => {
+            tests.push(test);
+          });
+        }
+        let current = self.suite.suites;
+        while (current.length > 0) {
+          current.map(suite => {
+            suite.tests.map(test => {
+              tests.push(test);
+            });
+            current = suite.suites;
+          });
+        }
+        resolve(tests);
+      });
+    })
+  };
 };
 
 /**

--- a/test/integration/fixtures/pending/programmatic.fixture.js
+++ b/test/integration/fixtures/pending/programmatic.fixture.js
@@ -4,5 +4,5 @@ const Mocha = require('../../../../lib/mocha');
 const mocha = new Mocha({reporter: 'json'});
 mocha.addFile("./test/integration/fixtures/__default__.fixture.js");
 
-const runner = mocha.run().runner;
+const runner = mocha.run();
 runner.on('test', function (test) { test.pending = true; });

--- a/test/integration/fixtures/pending/programmatic.fixture.js
+++ b/test/integration/fixtures/pending/programmatic.fixture.js
@@ -4,5 +4,5 @@ const Mocha = require('../../../../lib/mocha');
 const mocha = new Mocha({reporter: 'json'});
 mocha.addFile("./test/integration/fixtures/__default__.fixture.js");
 
-const runner = mocha.run();
+const runner = mocha.run().runner;
 runner.on('test', function (test) { test.pending = true; });

--- a/test/integration/fixtures/simple.fixture.js
+++ b/test/integration/fixtures/simple.fixture.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var assert = require('assert');
+
+it('success test1', function () {
+    assert(true);
+});
+
+describe('suite1', function () {
+  it('success test 1-1', function () {
+    assert(true);
+  });
+
+  it('success test 1-2', function () {
+    assert(true);
+  });
+});
+
+describe('suite2', function () {
+    it('success test 2-1', function () {
+      assert(true);
+    });
+  
+    it('fail test 2-2', function () {
+      assert(false);
+    });
+});
+  
+describe('suite3', function () {
+    describe('suite3-1', function () {
+        it('success test 3-1-1', function () {
+            assert(true);
+          });
+        it('fail test 3-1-2', function () {
+            assert(false);
+        });
+    });
+});
+  
+

--- a/test/integration/mocha-return.spec.js
+++ b/test/integration/mocha-return.spec.js
@@ -10,7 +10,7 @@ describe('diffs', function() {
     const resultTests = await result.result;
     const successTests = resultTests.filter(test => test.state === 'passed');
     const failedTests = resultTests.filter(test => test.state === 'failed');
-    expect(successTests.length === 5, 'to be true');
-    expect(failedTests.length === 2, 'to be true');
+    expect(successTests, 'to have length', 5);
+    expect(failedTests, 'to have length', 2);
   });
 });

--- a/test/integration/mocha-return.spec.js
+++ b/test/integration/mocha-return.spec.js
@@ -3,13 +3,12 @@
 var Mocha = require('../../lib/mocha');
 
 describe('diffs', function() {
-  it('test', async () => {
+  it.skip('test', async () => {
     const mocha = new Mocha();
     mocha.addFile('./test/integration/fixtures/simple.fixture.js');
-    const result = mocha.run();
-    const resultTests = await result.result;
-    const successTests = resultTests.filter(test => test.state === 'passed');
-    const failedTests = resultTests.filter(test => test.state === 'failed');
+    const result = await mocha.runAsync();
+    const successTests = result.filter(test => test.state === 'passed');
+    const failedTests = result.filter(test => test.state === 'failed');
     expect(successTests, 'to have length', 5);
     expect(failedTests, 'to have length', 2);
   });

--- a/test/integration/mocha-return.spec.js
+++ b/test/integration/mocha-return.spec.js
@@ -10,7 +10,7 @@ describe('diffs', function() {
     const resultTests = await result.result;
     const successTests = resultTests.filter(test => test.state === 'passed');
     const failedTests = resultTests.filter(test => test.state === 'failed');
-    console.log('successTests', successTests.length);
-    console.log('failedTests', failedTests.length);
+    expect(successTests.length === 5, 'to be true');
+    expect(failedTests.length === 2, 'to be true');
   });
 });

--- a/test/integration/mocha-return.spec.js
+++ b/test/integration/mocha-return.spec.js
@@ -3,7 +3,7 @@
 var Mocha = require('../../lib/mocha');
 
 describe('diffs', function() {
-  it.skip('test', async () => {
+  it('test', async () => {
     const mocha = new Mocha();
     mocha.addFile('./test/integration/fixtures/simple.fixture.js');
     const result = await mocha.runAsync();

--- a/test/integration/mocha-return.spec.js
+++ b/test/integration/mocha-return.spec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var Mocha = require('../../lib/mocha');
+
+describe('diffs', function() {
+  it('test', async () => {
+    const mocha = new Mocha();
+    mocha.addFile('./test/integration/fixtures/simple.fixture.js');
+    const result = mocha.run();
+    const resultTests = await result.result;
+    const successTests = resultTests.filter(test => test.state === 'passed');
+    const failedTests = resultTests.filter(test => test.state === 'failed');
+    console.log('successTests', successTests.length);
+    console.log('failedTests', failedTests.length);
+  });
+});


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

`mocha.run` return `{Runner: runner, Promise<Test[]>}`

To be precise, `runner.run` return this.


### Alternate Designs

Before
mocha.run() : runner

After
mocha.run() : {Runner: runner, Promise<Test[]>}

### Why should this be in core?

https://github.com/mochajs/mocha/issues/4286

### Benefits

It can provide an easier interface to consumers running Mocha programmatically.

### Possible Drawbacks

I was careful because it was a modification of the interface of the core function.

the callback is deprecated, but it couldn't be deleted for existing users using callback.
And I think it could be a bit slow in the process of putting the tests into an array.
Finally, since I don't have enough background on Mocha, I desperately need your help to prevent side-effect.

### Applicable issues

https://github.com/mochajs/mocha/issues/4286
