### PR TITLE
Fix: Broken wallaby logo on mochajs.org #4430

### DIFF
--- a/docs/_includes/default.liquid
+++ b/docs/_includes/default.liquid
@@ -52,7 +52,7 @@
         title="Mocha is sponsored by Wallaby"
       >
         <figure id="wallaby-logo">
-          <img src="images/wallaby-logo.png?trim" loading="lazy" alt="Wallaby logo" />
+          <img src="images/wallaby-logo.png" loading="lazy" alt="Wallaby logo" />
           <figcaption>Wallaby</figcaption>
         </figure>
       </a>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

After executing ```docs.production``` script without ```trim``` on ```wallaby-logo```, the logo  takes 126 bytes.
However, with ```trim```, the logo takes 271bytes and it is not shown properly.
So I think it is better to remove trim operation option on ```wallaby-logo.png``` in ```default.liquid```

The reason why the logo is not shown properly after ```trim``` is a bug with ```impro``` used by ```assetgraph-builder``` that execute ```trim``` operation with ```gm```, not ```sharp```. So, it is actually a bug with ```gm```. I created another pr on ```impro``` to fix this as well.
https://github.com/papandreou/impro/pull/4

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

X

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

#4430 

### Benefits

<!-- What benefits will be realized by the code change? -->

The size of wallaby-logo after production build will decrease and it will appear properly.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

X

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

#4430 
