### PR TITLE
Add speed in -R json option (#4226)

### DIFF
--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -84,7 +84,8 @@ function clean(test) {
     fullTitle: test.fullTitle(),
     file: test.file,
     duration: test.duration,
-    currentRetry: test.currentRetry()
+    currentRetry: test.currentRetry(),
+    speed: test.speed
   };
 }
 

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -90,6 +90,7 @@ function clean(test) {
     file: test.file,
     duration: test.duration,
     currentRetry: test.currentRetry(),
+    speed: test.speed,
     err: cleanCycles(err)
   };
 }

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -29,7 +29,7 @@ describe('JSON Stream reporter', function() {
     expectedFullTitle,
     expectedFile,
     expectedDuration,
-    currentRetry, 
+    currentRetry,
     expectedSpeed
   );
   var expectedErrorMessage = 'error message';
@@ -81,7 +81,7 @@ describe('JSON Stream reporter', function() {
             ',"currentRetry":' +
             currentRetry +
             ',"speed":' +
-            dQuote(expectedSpeed) + 
+            dQuote(expectedSpeed) +
             '}]\n'
         );
       });
@@ -116,7 +116,7 @@ describe('JSON Stream reporter', function() {
               ',"currentRetry":' +
               currentRetry +
               ',"speed":' +
-              dQuote(expectedSpeed) + 
+              dQuote(expectedSpeed) +
               ',"err":' +
               dQuote(expectedErrorMessage) +
               ',"stack":' +
@@ -154,7 +154,7 @@ describe('JSON Stream reporter', function() {
               ',"currentRetry":' +
               currentRetry +
               ',"speed":' +
-              dQuote(expectedSpeed) + 
+              dQuote(expectedSpeed) +
               ',"err":' +
               dQuote(expectedErrorMessage) +
               ',"stack":null}]\n'

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -23,12 +23,14 @@ describe('JSON Stream reporter', function() {
   var expectedFile = 'someTest.spec.js';
   var expectedDuration = 1000;
   var currentRetry = 1;
+  var expectedSpeed = 'fast';
   var expectedTest = makeExpectedTest(
     expectedTitle,
     expectedFullTitle,
     expectedFile,
     expectedDuration,
-    currentRetry
+    currentRetry, 
+    expectedSpeed
   );
   var expectedErrorMessage = 'error message';
   var expectedErrorStack = 'error stack';
@@ -78,6 +80,8 @@ describe('JSON Stream reporter', function() {
             expectedDuration +
             ',"currentRetry":' +
             currentRetry +
+            ',"speed":' +
+            dQuote(expectedSpeed) + 
             '}]\n'
         );
       });
@@ -111,6 +115,8 @@ describe('JSON Stream reporter', function() {
               expectedDuration +
               ',"currentRetry":' +
               currentRetry +
+              ',"speed":' +
+              dQuote(expectedSpeed) + 
               ',"err":' +
               dQuote(expectedErrorMessage) +
               ',"stack":' +
@@ -147,6 +153,8 @@ describe('JSON Stream reporter', function() {
               expectedDuration +
               ',"currentRetry":' +
               currentRetry +
+              ',"speed":' +
+              dQuote(expectedSpeed) + 
               ',"err":' +
               dQuote(expectedErrorMessage) +
               ',"stack":null}]\n'

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -11,7 +11,6 @@ describe('JSON reporter', function() {
   var runner;
   var testTitle = 'json test 1';
   var testFile = 'someTest.spec.js';
-  var testSpeed = 'fast';
   var noop = function() {};
 
   beforeEach(function() {

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -98,7 +98,7 @@ describe('JSON reporter', function() {
             {
               title: testTitle,
               file: testFile,
-              speed: testSpeed
+              speed: /(slow|medium|fast)/
             }
           ]
         }

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -92,7 +92,6 @@ describe('JSON reporter', function() {
     suite.addTest(test);
 
     runner.run(function(failureCount) {
-      sinon.restore();
       expect(runner, 'to satisfy', {
         testResults: {
           passes: [

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -86,9 +86,7 @@ describe('JSON reporter', function() {
   });
 
   it('should have 1 test pass', function(done) {
-    var test = new Test(testTitle, function(done) {
-      done();
-    });
+    const test = new Test(testTitle, () => {});
 
     test.file = testFile;
     suite.addTest(test);

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -11,6 +11,7 @@ describe('JSON reporter', function() {
   var runner;
   var testTitle = 'json test 1';
   var testFile = 'someTest.spec.js';
+  var testSpeed = 'fast';
   var noop = function() {};
 
   beforeEach(function() {
@@ -75,6 +76,32 @@ describe('JSON reporter', function() {
             {
               title: testTitle,
               file: testFile
+            }
+          ]
+        }
+      });
+      expect(failureCount, 'to be', 0);
+      done();
+    });
+  });
+
+  it('should have 1 test pass', function(done) {
+    var test = new Test(testTitle, function(done) {
+      done();
+    });
+
+    test.file = testFile;
+    suite.addTest(test);
+
+    runner.run(function(failureCount) {
+      sinon.restore();
+      expect(runner, 'to satisfy', {
+        testResults: {
+          passes: [
+            {
+              title: testTitle,
+              file: testFile,
+              speed: testSpeed
             }
           ]
         }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

I modified the ` -R json` option to show speed.

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

N/A

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

#4226 

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

You can see speed result in `json reporter `

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

N/A

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
Fixes #4226 

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
