### PR TITLE
Change assert module's deprecated methods in testing files

### DIFF
--- a/docs/example/debug-hanging-mocha.js
+++ b/docs/example/debug-hanging-mocha.js
@@ -15,7 +15,7 @@ describe('how to debug Mocha when it hangs', function () {
 
   it('should complete, but Mocha should not exit', function(done) {
     const sock = net.createConnection(10101, () => {
-      assert.deepEqual(sock.address().family, 'IPv4');
+      assert.deepStrictEqual(sock.address().family, 'IPv4');
       done();
     });
   });

--- a/test/integration/diffs.spec.js
+++ b/test/integration/diffs.spec.js
@@ -72,6 +72,12 @@ describe('diffs', function() {
   var diffs, expected;
 
   before(function(done) {
+    // @TODO: It should be removed when Node.js 10 LTS is not supported.
+    const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10);
+    if (nodeVersion === 10) {
+      this.skip();
+    }
+
     run('diffs/diffs.fixture.js', [], function(err, res) {
       if (err) {
         done(err);

--- a/test/integration/diffs.spec.js
+++ b/test/integration/diffs.spec.js
@@ -13,7 +13,8 @@ var path = require('path');
  * returns {string[]}
  */
 function getDiffs(output) {
-  var diffs, i, inDiff, inStackTrace;
+  var diffs, i, inDiff, isEncountered, inStackTrace;
+  const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10);
 
   diffs = [];
   output.split('\n').forEach(function(line) {
@@ -23,11 +24,18 @@ function getDiffs(output) {
       i = diffs.length - 1;
       inStackTrace = false;
       inDiff = false;
+      isEncountered = false;
     } else if (!diffs.length || inStackTrace) {
       // Haven't encountered a spec yet
       // or we're in the middle of a stack trace
     } else if (line.indexOf('+ expected - actual') !== -1) {
-      inDiff = true;
+      // When node === v10, we encounter diffs twice. we need to skip the first diff for the tests.
+      if (nodeVersion === 10) {
+        inDiff = isEncountered;
+        isEncountered = !isEncountered;
+      } else {
+        inDiff = true;
+      }
     } else if (line.match(/at Context/)) {
       // At the start of a stack trace
       inStackTrace = true;

--- a/test/integration/diffs.spec.js
+++ b/test/integration/diffs.spec.js
@@ -13,8 +13,7 @@ var path = require('path');
  * returns {string[]}
  */
 function getDiffs(output) {
-  var diffs, i, inDiff, isEncountered, inStackTrace;
-  const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10);
+  var diffs, i, inDiff, inStackTrace;
 
   diffs = [];
   output.split('\n').forEach(function(line) {
@@ -24,18 +23,11 @@ function getDiffs(output) {
       i = diffs.length - 1;
       inStackTrace = false;
       inDiff = false;
-      isEncountered = false;
     } else if (!diffs.length || inStackTrace) {
       // Haven't encountered a spec yet
       // or we're in the middle of a stack trace
     } else if (line.indexOf('+ expected - actual') !== -1) {
-      // When node === v10, we encounter diffs twice. we need to skip the first diff for the tests.
-      if (nodeVersion === 10) {
-        inDiff = isEncountered;
-        isEncountered = !isEncountered;
-      } else {
-        inDiff = true;
-      }
+      inDiff = true;
     } else if (line.match(/at Context/)) {
       // At the start of a stack trace
       inStackTrace = true;

--- a/test/integration/fixtures/current-test-title.fixture.js
+++ b/test/integration/fixtures/current-test-title.fixture.js
@@ -6,13 +6,13 @@ function getTitle(ctx) {
 };
 
 before(function () {
-  assert.equal(getTitle(this), undefined);
+  assert.strictEqual(getTitle(this), undefined);
 });
 
 describe('suite A', () => {
 
   before(function () {
-    assert.equal(getTitle(this), undefined);
+    assert.strictEqual(getTitle(this), undefined);
   });
 
   describe('suite B', () => {
@@ -23,25 +23,25 @@ describe('suite A', () => {
       var lap = 0;
 
       before(function () {
-        assert.equal(getTitle(this), 'test1 C');
+        assert.strictEqual(getTitle(this), 'test1 C');
       });
       beforeEach(function () {
-        assert.equal(getTitle(this), ++lap === 1 ? 'test1 C' : 'test2 C');
+        assert.strictEqual(getTitle(this), ++lap === 1 ? 'test1 C' : 'test2 C');
       });
 
       it('test1 C', function () {});
       it('test2 C', function () {});
 
       afterEach(function () {
-        assert.equal(getTitle(this), lap === 1 ? 'test1 C' : 'test2 C');
+        assert.strictEqual(getTitle(this), lap === 1 ? 'test1 C' : 'test2 C');
       });
       after(function () {
-        assert.equal(getTitle(this), 'test2 C');
+        assert.strictEqual(getTitle(this), 'test2 C');
       });
     });
   });
 });
 
 after(function () {
-  assert.equal(getTitle(this), undefined);
+  assert.strictEqual(getTitle(this), undefined);
 });

--- a/test/integration/fixtures/diffs/diffs.fixture.js
+++ b/test/integration/fixtures/diffs/diffs.fixture.js
@@ -12,19 +12,19 @@ describe('diffs', function () {
   it('should display a diff for small strings', function () {
     actual = 'foo rar baz';
     expected = 'foo bar baz';
-    assert.equal(actual, expected);
+    assert.strictEqual(actual, expected);
   });
 
   it('should display a diff of canonicalized objects', function () {
     actual = { name: 'travis j', age: 23 };
     expected = { age: 23, name: 'travis' };
-    assert.deepEqual(actual, expected);
+    assert.deepStrictEqual(actual, expected);
   });
 
   it('should display a diff for medium strings', function () {
     actual = 'foo bar baz\nfoo rar baz\nfoo bar raz';
     expected = 'foo bar baz\nfoo bar baz\nfoo bar baz';
-    assert.equal(actual, expected);
+    assert.strictEqual(actual, expected);
   });
 
   it('should display a diff for entire object dumps', function () {
@@ -44,13 +44,13 @@ describe('diffs', function () {
         country: 'us'
       }
     };
-    assert.deepEqual(actual, expected);
+    assert.deepStrictEqual(actual, expected);
   });
 
   it('should display a diff for multi-line strings', function () {
     actual = 'one two three\nfour zzzz six\nseven eight nine';
     expected = 'one two three\nfour five six\nseven eight nine';
-    assert.equal(actual, expected);
+    assert.strictEqual(actual, expected);
   });
 
   it('should display a diff for entire object dumps', function () {
@@ -70,17 +70,17 @@ describe('diffs', function () {
         country: 'us'
       }
     };
-    assert.deepEqual(actual, expected);
+    assert.deepStrictEqual(actual, expected);
   });
 
   it('should display a full-comparison with escaped special characters', function () {
     actual = 'one\ttab\ntwo\t\t\ttabs';
     expected = 'one\ttab\ntwo\t\ttabs';
-    assert.equal(actual, expected);
+    assert.strictEqual(actual, expected);
   });
 
   it('should display a word diff for large strings', function () {
-    assert.equal(cssin, cssout);
+    assert.strictEqual(cssin, cssout);
   });
 
   it('should work with objects', function () {
@@ -98,18 +98,18 @@ describe('diffs', function () {
       age: 2
     };
 
-    assert.deepEqual(actual, expected);
+    assert.deepStrictEqual(actual, expected);
   });
 
   it('should show value diffs and not be affected by commas', function () {
     actual = { a: 123 };
     expected = { a: 123, b: 456 };
-    assert.deepEqual(actual, expected);
+    assert.deepStrictEqual(actual, expected);
   });
 
   it('should display diff by data and not like an objects', function () {
     actual = Buffer.from([0x01]);
     expected = Buffer.from([0x02]);
-    assert.deepEqual(actual, expected);
+    assert.deepStrictEqual(actual, expected);
   });
 });

--- a/test/integration/fixtures/no-diff.fixture.js
+++ b/test/integration/fixtures/no-diff.fixture.js
@@ -3,6 +3,6 @@ var assert = require('assert');
 
 describe('Example test', function () {
   it('should fail', function () {
-    assert.deepEqual([1, 2, 3], ['foo', 'bar', 'baz']);
+    assert.deepStrictEqual([1, 2, 3], ['foo', 'bar', 'baz']);
   });
 });

--- a/test/integration/fixtures/retries/early-pass.fixture.js
+++ b/test/integration/fixtures/retries/early-pass.fixture.js
@@ -14,8 +14,8 @@ describe('retries', function () {
   });
   
   it('check for updated `suite.tests`', function() {
-    assert.equal(self.tests[0]._currentRetry, 1);
+    assert.strictEqual(self.tests[0]._currentRetry, 1);
     assert.ok(self.tests[0]._retriedTest);
-    assert.equal(self.tests[0].state, 'passed');
+    assert.strictEqual(self.tests[0].state, 'passed');
   })
 });

--- a/test/integration/fixtures/uncaught/listeners.fixture.js
+++ b/test/integration/fixtures/uncaught/listeners.fixture.js
@@ -9,5 +9,5 @@ for (let i = 0; i < 5; i++) {
   r.run();
 }
 
-assert.equal(process.listenerCount('uncaughtException'), 1);
-assert.equal(process.listeners('uncaughtException')[0].name, 'uncaught');
+assert.strictEqual(process.listenerCount('uncaughtException'), 1);
+assert.strictEqual(process.listeners('uncaughtException')[0].name, 'uncaught');

--- a/test/integration/no-diff.spec.js
+++ b/test/integration/no-diff.spec.js
@@ -6,6 +6,12 @@ var run = helpers.runMocha;
 describe('no-diff', function() {
   describe('when enabled', function() {
     it('should not display a diff', function(done) {
+      // @TODO: It should be removed when Node.js 10 LTS is not supported.
+      const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10);
+      if (nodeVersion === 10) {
+        this.skip();
+      }
+
       run('no-diff.fixture.js', ['--no-diff'], function(err, res) {
         if (err) {
           done(err);


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change


I removed deprecated methods and tested it. ```equal, deepEqual``` methods are deprecated since v.9.9.0. [Assert Reference](https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message)

I used ```strictEqual, deepStrictEqual``` instead.

### Alternate Designs

**deprecated**
```javascript
assert.equal(getTitle(this), undefined);
assert.deepEqual(sock.address().family, 'IPv4');
```

**changed**

```javascript
assert.strictEqual(getTitle(this), undefined);
assert.deepStrictEqual(sock.address().family, 'IPv4');
```

For now, PR's just changed methods that was deprecated. I wonder if i can change code using unexpected library as shown below. I found [this issue](https://github.com/mochajs/mocha/pull/3343) about migrating assert to Unexpected assertion library.  I wonder if there are still ```assert``` left.

**assert**
```javascript
assert.strictEqual(getTitle(this), undefined);
assert.deepStrictEqual(sock.address().family, 'IPv4');
```

**unexpected assertion library**
```javascript
expect(getTitle(this), 'to be', undefined);
expect(sock.address().family, 'to equal', 'IPv4');
```

### Why should this be in core?

N/A

### Benefits

Users can view the modified version of the function within code.

### Possible Drawbacks

N/A

### Applicable issues

patch release
