### PR TITLE
redirect webpack test output to a temp dir

### DIFF
--- a/test/browser-specific/fixtures/webpack/webpack.config.js
+++ b/test/browser-specific/fixtures/webpack/webpack.config.js
@@ -1,9 +1,18 @@
 'use strict';
 
 const FailOnErrorsPlugin = require('fail-on-errors-webpack-plugin');
+const {tmpdir} = require('os');
+const {join} = require('path');
+
+const outputPath = join(tmpdir(), 'mocha-test-webpack');
+
+console.error('output dir: %s', outputPath);
 
 module.exports = {
   entry: require.resolve('./webpack.fixture.mjs'),
+  output: {
+    path: outputPath
+  },
   plugins: [
     new FailOnErrorsPlugin({
       failOnErrors: true,


### PR DESCRIPTION
Right now `npm start test.browser.webpack` creates `dist/main.js` which is likely to be accidentally committed.  Put the output in a temp dir