### PR TITLE
Add support for node v8 option 'prof' parameter (#4433)

### DIFF
--- a/lib/cli/node-flags.js
+++ b/lib/cli/node-flags.js
@@ -27,6 +27,7 @@ const debugFlags = new Set(['inspect', 'inspect-brk']);
  *   - `--trace-*`
  *   - `--es-staging`
  *   - `--use-strict`
+ *   - '--prof'
  *   - `--v8-*` (but *not* `--v8-options`)
  * @summary Whether or not to pass a flag along to the `node` executable.
  * @param {string} flag - Flag to test
@@ -49,7 +50,7 @@ exports.isNodeFlag = (flag, bareword = true) => {
     // and also any V8 flags with `--v8-` prefix
     (!isMochaFlag(flag) && nodeFlags && nodeFlags.has(flag)) ||
     debugFlags.has(flag) ||
-    /(?:preserve-symlinks(?:-main)?|harmony(?:[_-]|$)|(?:trace[_-].+$)|gc(?:[_-]global)?$|es[_-]staging$|use[_-]strict$|v8[_-](?!options).+?$)/.test(
+    /(?:preserve-symlinks(?:-main)?|harmony(?:[_-]|$)|(?:trace[_-].+$)|gc(?:[_-]global)?$|es[_-]staging$|use[_-]strict$|prof$|v8[_-](?!options).+?$)/.test(
       flag
     )
   );

--- a/test/node-unit/cli/node-flags.spec.js
+++ b/test/node-unit/cli/node-flags.spec.js
@@ -82,6 +82,10 @@ describe('node-flags', function() {
         expect(isNodeFlag('use_strict'), 'to be true');
       });
 
+      it('should return true for "prof" itself', function() {
+        expect(isNodeFlag('prof'), 'to be true');
+      });
+
       it('should return true for flags starting with "--v8-"', function() {
         expect(isNodeFlag('v8-'), 'to be false');
         expect(isNodeFlag('v8-options'), 'to be false');


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

I modified `--prof` to be considered as a 'Node' flag so that Node can handle it.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

N/A

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

#4433 

### Benefits

<!-- What benefits will be realized by the code change? -->

Users can pass `--prof` argument to mocha and Node can handle it by profiling.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

N/A

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

#4433 
