### PR TITLE
Support multipart extensions like ".test.js"

### DIFF
--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -45,9 +45,8 @@ function isHiddenOnUnix(pathname) {
  * hasMatchingExtname('foo.html', ['js', 'css']); // => false
  */
 function hasMatchingExtname(pathname, exts) {
-  var suffix = path.extname(pathname).slice(1);
   return exts.some(function(element) {
-    return suffix === element;
+    return pathname.endsWith(element);
   });
 }
 

--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -46,7 +46,7 @@ function isHiddenOnUnix(pathname) {
  */
 function hasMatchingExtname(pathname, exts) {
   return exts.some(function(element) {
-    return pathname.endsWith(element);
+    return pathname.endsWith('.' + element);
   });
 }
 

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -93,6 +93,20 @@ describe('file utils', function() {
       ).and('to have length', 2);
     });
 
+    it('should return ".test.js" files', function() {
+      fs.writeFileSync(
+        tmpFile('mocha-utils.test.js'),
+        'i have a multipart extension'
+      );
+      var res = lookupFiles(tmpDir, ['test.js'], false).map(
+        path.normalize.bind(path)
+      );
+      expect(res, 'to contain', tmpFile('mocha-utils.test.js')).and(
+        'to have length',
+        1
+      );
+    });
+
     it('should require the extensions parameter when looking up a file', function() {
       var dirLookup = function() {
         return lookupFiles(tmpFile('mocha-utils'), undefined, false);

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -107,6 +107,20 @@ describe('file utils', function() {
       );
     });
 
+    it('should return not return "*test.js" files', function() {
+      fs.writeFileSync(
+        tmpFile('mocha-utils-test.js'),
+        'i do not have a multipart extension'
+      );
+      var res = lookupFiles(tmpDir, ['test.js'], false).map(
+        path.normalize.bind(path)
+      );
+      expect(res, 'not to contain', tmpFile('mocha-utils-test.js')).and(
+        'to have length',
+        0
+      );
+    });
+
     it('should require the extensions parameter when looking up a file', function() {
       var dirLookup = function() {
         return lookupFiles(tmpFile('mocha-utils'), undefined, false);


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Allow `extensions` configuration option to support multipart extensions, ex: `test.js`. extension matching support is currently implemented by matching against [node's `path.extname`](https://nodejs.org/api/path.html#path_path_extname_path) which

> returns the extension of the path, from the last occurrence of the . (period) character to end of string in the last portion of the path.

This prevents support for multipart extensions like `.test.js`.

By instead using [`String.prototype.endsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith), we can support the existing behavior while also enabling support for multipart extensions.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
You could have also accomplished this by using a RegExp, I suppose, but `endsWith` is simpler.

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

Even without adding support for multipart extensions, I think this implementation is simpler than the existing one for the currently supported use-case. But because multipart extensions are relatively common, and the `extensions` configuration is the only way I can see to support restricting input to these files without resorting to more intricate globbing, I think opening up support for this is also a benefit.

### Benefits

<!-- What benefits will be realized by the code change? -->

Support for multipart extensions, simpler implementation.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I don't see any from here.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

I looked for relevant issues and was surprised that not to find any. If I have overlooked something, let me know.

Thanks!