### PR TITLE
refactor: utils.type()

### DIFF
--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -190,7 +190,8 @@ class SerializableEvent {
       parent[key] = Object.create(null);
       return;
     }
-    if (type(value) === 'error') {
+    let _type = type(value);
+    if (_type === 'error') {
       // we need to reference the stack prop b/c it's lazily-loaded.
       // `__type` is necessary for deserialization to create an `Error` later.
       // `message` is apparently not enumerable, so we must handle it specifically.
@@ -200,10 +201,11 @@ class SerializableEvent {
         __type: 'Error'
       });
       parent[key] = value;
-      // after this, the result of type(value) will be `object`, and we'll throw
+      // after this, set the result of type(value) to be `object`, and we'll throw
       // whatever other junk is in the original error into the new `value`.
+      _type = 'object';
     }
-    switch (type(value)) {
+    switch (_type) {
       case 'object':
         if (type(value.serialize) === 'function') {
           parent[key] = value.serialize();

--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const {canonicalType: type} = require('../utils');
+const {type} = require('../utils');
 const {createInvalidArgumentTypeError} = require('../errors');
 // this is not named `mocha:parallel:serializer` because it's noisy and it's
 // helpful to be able to write `DEBUG=mocha:parallel*` and get everything else.
@@ -190,7 +190,7 @@ class SerializableEvent {
       parent[key] = Object.create(null);
       return;
     }
-    if (type(value) === 'error' || value instanceof Error) {
+    if (type(value) === 'error') {
       // we need to reference the stack prop b/c it's lazily-loaded.
       // `__type` is necessary for deserialization to create an `Error` later.
       // `message` is apparently not enumerable, so we must handle it specifically.

--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const {type} = require('../utils');
+const {canonicalType: type} = require('../utils');
 const {createInvalidArgumentTypeError} = require('../errors');
 // this is not named `mocha:parallel:serializer` because it's noisy and it's
 // helpful to be able to write `DEBUG=mocha:parallel*` and get everything else.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -23,7 +23,7 @@ var dQuote = utils.dQuote;
 var sQuote = utils.sQuote;
 var stackFilter = utils.stackTraceFilter();
 var stringify = utils.stringify;
-var type = utils.type;
+
 var errors = require('./errors');
 var createInvalidExceptionError = errors.createInvalidExceptionError;
 var createUnsupportedError = errors.createUnsupportedError;
@@ -1171,7 +1171,11 @@ function isError(err) {
  */
 function thrown2Error(err) {
   return new Error(
-    'the ' + type(err) + ' ' + stringify(err) + ' was thrown, throw an Error :)'
+    'the ' +
+      utils.canonicalType(err) +
+      ' ' +
+      stringify(err) +
+      ' was thrown, throw an Error :)'
   );
 }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1171,11 +1171,9 @@ function isError(err) {
  */
 function thrown2Error(err) {
   return new Error(
-    'the ' +
-      utils.canonicalType(err) +
-      ' ' +
-      stringify(err) +
-      ' was thrown, throw an Error :)'
+    `the ${utils.canonicalType(err)} ${stringify(
+      err
+    )} was thrown, throw an Error :)`
   );
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -126,19 +126,21 @@ function emptyRepresentation(value, typeHint) {
  * @param {*} value The value to test.
  * @returns {string} Computed type
  * @example
- * type({}) // 'object'
- * type([]) // 'array'
- * type(1) // 'number'
- * type(false) // 'boolean'
- * type(Infinity) // 'number'
- * type(null) // 'null'
- * type(new Date()) // 'date'
- * type(/foo/) // 'regexp'
- * type('type') // 'string'
- * type(global) // 'global'
- * type(new String('foo') // 'object'
+ * canonicalType({}) // 'object'
+ * canonicalType([]) // 'array'
+ * canonicalType(1) // 'number'
+ * canonicalType(false) // 'boolean'
+ * canonicalType(Infinity) // 'number'
+ * canonicalType(null) // 'null'
+ * canonicalType(new Date()) // 'date'
+ * canonicalType(/foo/) // 'regexp'
+ * canonicalType('type') // 'string'
+ * canonicalType(global) // 'global'
+ * canonicalType(new String('foo') // 'object'
+ * canonicalType(async function() {}) // 'asyncfunction'
+ * canonicalType(await import(name)) // 'module'
  */
-var type = (exports.type = function type(value) {
+var canonicalType = (exports.canonicalType = function canonicalType(value) {
   if (value === undefined) {
     return 'undefined';
   } else if (value === null) {
@@ -151,6 +153,52 @@ var type = (exports.type = function type(value) {
     .replace(/^\[.+\s(.+?)]$/, '$1')
     .toLowerCase();
 });
+
+/**
+ *
+ * Returns a general type or data structure of a variable
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures
+ * @param {*} value The value to test.
+ * @returns {string} Computed type
+ * @example
+ * type({}) // 'object'
+ * type([]) // 'array'
+ * type(1) // 'number'
+ * type(false) // 'boolean'
+ * type(Infinity) // 'number'
+ * type(null) // 'null'
+ * type(new Date()) // 'date'
+ * type(/foo/) // 'regexp'
+ * type('type') // 'string'
+ * type(global) // 'global'
+ * type(new String('foo') // 'object'
+ */
+exports.type = function type(value) {
+  // Null is special
+  if (value === null) return 'null';
+  var primitives = [
+    'undefined',
+    'boolean',
+    'number',
+    'string',
+    'bigint',
+    'symbol'
+  ];
+  var _type = typeof value;
+  if (_type === 'function') return _type;
+  for (var i = 0; i++; i < primitives.length) {
+    if (_type === primitives[i]) return _type;
+  }
+  if (Buffer.isBuffer(value)) return 'buffer'; // otherwise it returns uint8array
+  if (value && typeof value.constructor === 'object')
+    return value.constructor.name.toLowerCase();
+
+  return Object.prototype.toString
+    .call(value)
+    .replace(/^\[.+\s(.+?)]$/, '$1')
+    .toLowerCase();
+};
 
 /**
  * Stringify `value`. Different behavior depending on type of value:
@@ -168,7 +216,7 @@ var type = (exports.type = function type(value) {
  * @return {string}
  */
 exports.stringify = function(value) {
-  var typeHint = type(value);
+  var typeHint = canonicalType(value);
 
   if (!~['object', 'array', 'function'].indexOf(typeHint)) {
     if (typeHint === 'buffer') {
@@ -234,7 +282,7 @@ function jsonStringify(object, spaces, depth) {
   }
 
   function _stringify(val) {
-    switch (type(val)) {
+    switch (canonicalType(val)) {
       case 'null':
       case 'undefined':
         val = '[' + val + ']';
@@ -315,7 +363,7 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
   /* eslint-disable no-unused-vars */
   var prop;
   /* eslint-enable no-unused-vars */
-  typeHint = typeHint || type(value);
+  typeHint = typeHint || canonicalType(value);
   function withStack(value, fn) {
     stack.push(value);
     fn();
@@ -549,7 +597,7 @@ exports.createMap = function(obj) {
  * @throws {TypeError} if argument is not a non-empty object.
  */
 exports.defineConstants = function(obj) {
-  if (type(obj) !== 'object' || !Object.keys(obj).length) {
+  if (canonicalType(obj) !== 'object' || !Object.keys(obj).length) {
     throw new TypeError('Invalid argument; expected a non-empty object');
   }
   return Object.freeze(exports.createMap(obj));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -157,7 +157,7 @@ var canonicalType = (exports.canonicalType = function canonicalType(value) {
 /**
  *
  * Returns a general type or data structure of a variable
- *
+ * @private
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures
  * @param {*} value The value to test.
  * @returns {string} One of undefined, boolean, number, string, bigint, symbol, object
@@ -177,19 +177,17 @@ var canonicalType = (exports.canonicalType = function canonicalType(value) {
 exports.type = function type(value) {
   // Null is special
   if (value === null) return 'null';
-  var primitives = [
+  const primitives = new Set([
     'undefined',
     'boolean',
     'number',
     'string',
     'bigint',
     'symbol'
-  ];
-  var _type = typeof value;
+  ]);
+  const _type = typeof value;
   if (_type === 'function') return _type;
-  for (var i = 0; i++; i < primitives.length) {
-    if (_type === primitives[i]) return _type;
-  }
+  if (primitives.has(_type)) return _type;
   if (value instanceof String) return 'string';
   if (value instanceof Error) return 'error';
   if (Array.isArray(value)) return 'array';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,7 +160,7 @@ var canonicalType = (exports.canonicalType = function canonicalType(value) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures
  * @param {*} value The value to test.
- * @returns {string} Computed type
+ * @returns {string} One of undefined, boolean, number, string, bigint, symbol, object
  * @example
  * type({}) // 'object'
  * type([]) // 'array'
@@ -168,11 +168,11 @@ var canonicalType = (exports.canonicalType = function canonicalType(value) {
  * type(false) // 'boolean'
  * type(Infinity) // 'number'
  * type(null) // 'null'
- * type(new Date()) // 'date'
- * type(/foo/) // 'regexp'
+ * type(new Date()) // 'object'
+ * type(/foo/) // 'object'
  * type('type') // 'string'
- * type(global) // 'global'
- * type(new String('foo') // 'object'
+ * type(global) // 'object'
+ * type(new String('foo') // 'string'
  */
 exports.type = function type(value) {
   // Null is special
@@ -190,9 +190,9 @@ exports.type = function type(value) {
   for (var i = 0; i++; i < primitives.length) {
     if (_type === primitives[i]) return _type;
   }
+  if (value instanceof String) return 'string';
   if (value instanceof Error) return 'error';
   if (Array.isArray(value)) return 'array';
-  if (Buffer.isBuffer(value)) return 'buffer';
 
   return _type;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -190,14 +190,11 @@ exports.type = function type(value) {
   for (var i = 0; i++; i < primitives.length) {
     if (_type === primitives[i]) return _type;
   }
-  if (Buffer.isBuffer(value)) return 'buffer'; // otherwise it returns uint8array
-  if (value && typeof value.constructor === 'object')
-    return value.constructor.name.toLowerCase();
+  if (value instanceof Error) return 'error';
+  if (Array.isArray(value)) return 'array';
+  if (Buffer.isBuffer(value)) return 'buffer';
 
-  return Object.prototype.toString
-    .call(value)
-    .replace(/^\[.+\s(.+?)]$/, '$1')
-    .toLowerCase();
+  return _type;
 };
 
 /**

--- a/test/node-unit/utils.spec.js
+++ b/test/node-unit/utils.spec.js
@@ -18,9 +18,6 @@ describe('utils', function() {
     });
 
     describe('type()', function() {
-      it('should return "buffer" if the parameter is a Buffer', function() {
-        expect(utils.type(Buffer.from('ff', 'hex')), 'to be', 'buffer');
-      });
       it('should return "function" if the parameter is an async function', function() {
         expect(
           utils.type(async () => {}),

--- a/test/node-unit/utils.spec.js
+++ b/test/node-unit/utils.spec.js
@@ -28,6 +28,9 @@ describe('utils', function() {
           'function'
         );
       });
+      it('should return "error" if the parameter is an Error', function() {
+        expect(utils.type(new Error('err')), 'to be', 'error');
+      });
     });
     describe('canonicalType()', function() {
       it('should return "buffer" if the parameter is a Buffer', function() {

--- a/test/node-unit/utils.spec.js
+++ b/test/node-unit/utils.spec.js
@@ -18,9 +18,28 @@ describe('utils', function() {
     });
 
     describe('type()', function() {
-      it('should return "asyncfunction" if the parameter is an async function', function() {
+      it('should return "buffer" if the parameter is a Buffer', function() {
+        expect(utils.type(Buffer.from('ff', 'hex')), 'to be', 'buffer');
+      });
+      it('should return "function" if the parameter is an async function', function() {
         expect(
           utils.type(async () => {}),
+          'to be',
+          'function'
+        );
+      });
+    });
+    describe('canonicalType()', function() {
+      it('should return "buffer" if the parameter is a Buffer', function() {
+        expect(
+          utils.canonicalType(Buffer.from('ff', 'hex')),
+          'to be',
+          'buffer'
+        );
+      });
+      it('should return "asyncfunction" if the parameter is an async function', function() {
+        expect(
+          utils.canonicalType(async () => {}),
           'to be',
           'asyncfunction'
         );

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -543,18 +543,18 @@ describe('lib/utils', function() {
       expect(type(Infinity), 'to be', 'number');
       expect(type(null), 'to be', 'null');
       expect(type(undefined), 'to be', 'undefined');
-      expect(type(new Date()), 'to be', 'date');
-      expect(type(/foo/), 'to be', 'regexp');
+      expect(type(new Date()), 'to be', 'object');
+      expect(type(/foo/), 'to be', 'object');
       expect(type('type'), 'to be', 'string');
-      expect(type(global), 'to be', 'domwindow');
+      expect(type(new Error()), 'to be', 'error');
+      expect(type(global), 'to be', 'object');
       expect(type(true), 'to be', 'boolean');
       expect(type(Buffer.from('ff', 'hex')), 'to be', 'buffer');
-      expect(type(new Uint8Array()), 'to be', 'uint8array');
       expect(type(Symbol.iterator), 'to be', 'symbol');
-      expect(type(new Map()), 'to be', 'map');
-      expect(type(new WeakMap()), 'to be', 'weakmap');
-      expect(type(new Set()), 'to be', 'set');
-      expect(type(new WeakSet()), 'to be', 'weakset');
+      expect(type(new Map()), 'to be', 'object');
+      expect(type(new WeakMap()), 'to be', 'object');
+      expect(type(new Set()), 'to be', 'object');
+      expect(type(new WeakSet()), 'to be', 'object');
       expect(
         type(async () => {}),
         'to be',

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -548,6 +548,60 @@ describe('lib/utils', function() {
       expect(type('type'), 'to be', 'string');
       expect(type(global), 'to be', 'domwindow');
       expect(type(true), 'to be', 'boolean');
+      expect(type(Buffer.from('ff', 'hex')), 'to be', 'buffer');
+      expect(type(new Uint8Array()), 'to be', 'uint8array');
+      expect(type(Symbol.iterator), 'to be', 'symbol');
+      expect(type(new Map()), 'to be', 'map');
+      expect(type(new WeakMap()), 'to be', 'weakmap');
+      expect(type(new Set()), 'to be', 'set');
+      expect(type(new WeakSet()), 'to be', 'weakset');
+      expect(
+        type(async () => {}),
+        'to be',
+        'function'
+      );
+    });
+
+    describe('when toString on null or undefined stringifies window', function() {
+      it('should recognize null and undefined', function() {
+        expect(type(null), 'to be', 'null');
+        expect(type(undefined), 'to be', 'undefined');
+      });
+    });
+
+    afterEach(function() {
+      Object.prototype.toString = toString;
+    });
+  });
+
+  describe('canonicalType()', function() {
+    /* eslint no-extend-native: off */
+
+    var type = utils.canonicalType;
+    var toString = Object.prototype.toString;
+
+    beforeEach(function() {
+      // some JS engines such as PhantomJS 1.x exhibit this behavior
+      Object.prototype.toString = function() {
+        if (this === global) {
+          return '[object DOMWindow]';
+        }
+        return toString.call(this);
+      };
+    });
+
+    it('should recognize various types', function() {
+      expect(type({}), 'to be', 'object');
+      expect(type([]), 'to be', 'array');
+      expect(type(1), 'to be', 'number');
+      expect(type(Infinity), 'to be', 'number');
+      expect(type(null), 'to be', 'null');
+      expect(type(undefined), 'to be', 'undefined');
+      expect(type(new Date()), 'to be', 'date');
+      expect(type(/foo/), 'to be', 'regexp');
+      expect(type('type'), 'to be', 'string');
+      expect(type(global), 'to be', 'domwindow');
+      expect(type(true), 'to be', 'boolean');
     });
 
     describe('when toString on null or undefined stringifies window', function() {

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -549,7 +549,7 @@ describe('lib/utils', function() {
       expect(type(new Error()), 'to be', 'error');
       expect(type(global), 'to be', 'object');
       expect(type(true), 'to be', 'boolean');
-      expect(type(Buffer.from('ff', 'hex')), 'to be', 'buffer');
+      expect(type(Buffer.from('ff', 'hex')), 'to be', 'object');
       expect(type(Symbol.iterator), 'to be', 'symbol');
       expect(type(new Map()), 'to be', 'object');
       expect(type(new WeakMap()), 'to be', 'object');


### PR DESCRIPTION
## Description of the Change
- Existing `utils.type()` is renamed to `utils.canonicalType()`
- Call from `utils.canonise()` is changed to `canonicalType()`
- New function `type()`added to the `utils` implementing generic type retrieval based on [MDN:DataStructures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures) and several additional cases: Error => 'error' and String = > 'string', aiming to replace `Array.isArray()`, `typeof` and `Buffer.isBuffer`.

### Alternate Designs
Diff functionality, as suggested in the related issue, should be separated in its own module. 
The only difference is that this PR implies incremental changes.

An alternative could be to instead implement `isType(value, type)` due to the use intentions.


### Why should this be in core?
- It is part of the core functionality

### Benefits
- Lays foundation for future `utils` refactoring
- Adds ability to perform strict and generic type comparisons
- 

### Possible Drawbacks
- The only file that uses new `utils.type()` is `lib/node/serializer.js`

### Applicable issues
https://github.com/mochajs/mocha/issues/4306
