### PR TITLE
adding a MOCHA_WORKER_ID environment variable, unique for each worker

### DIFF
--- a/lib/nodejs/buffered-worker-pool.js
+++ b/lib/nodejs/buffered-worker-pool.js
@@ -79,7 +79,7 @@ class BufferedWorkerPool {
 
     this.options = Object.assign({}, WORKER_POOL_DEFAULT_OPTS, opts, {
       maxWorkers,
-      forkOpts: Object.assign({}, WORKER_POOL_DEFAULT_OPTS || {}, {
+      forkOpts: Object.assign({}, WORKER_POOL_DEFAULT_OPTS.forkOpts || {}, {
         env: Object.defineProperties({ ...process.env }, {
           MOCHA_WORKER_ID: {
             enumerable: true,

--- a/lib/nodejs/buffered-worker-pool.js
+++ b/lib/nodejs/buffered-worker-pool.js
@@ -75,9 +75,20 @@ class BufferedWorkerPool {
       process.execArgv.join(' ')
     );
 
+    let count = 0;
+
     this.options = Object.assign({}, WORKER_POOL_DEFAULT_OPTS, opts, {
-      maxWorkers
+      maxWorkers,
+      forkOpts: Object.assign({}, WORKER_POOL_DEFAULT_OPTS || {}, {
+        env: Object.defineProperties({ ...process.env }, {
+          MOCHA_WORKER_ID: {
+            enumerable: true,
+            get: () => ++count
+          }
+        })
+      })
     });
+
     this._pool = workerpool.pool(WORKER_PATH, this.options);
   }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

This change addresses #4456. It adds a `MOCHA_WORKER_ID` environment variable that is unique for each worker, so that it may be used for by any test resources that need to use global resources (network ports, filesystem paths, etc.) but ensure that these are unique in order to avoid conflicts during parallel tests.

### Alternate Designs

I considered using `forkArgs` instead of an environment variable, so that an ID may be accessed using `process.argv[2]`. I did not want to do this in case adding arguments was necessary for internal uses in the future.

### Why should this be in core?

It is common for tests to use global resources like network ports, which can conflict during parallel testing. Without a feature like this in core, users would be left on their own to create a home-brewed solution (using filesystem files as signals, sockets that elect a leader in the cluster so that one process hands out all global data, a standalone cluster orchestration system), all of which add a lot of complication to writing tests. This would also be a difference when writing tests that run in series vs. parallel, as this concern would not exist (and potentially needs to be turned off) for test in series, and would add pain points when taking existing serial tests and having them run in parallel. This makes using mocha significantly less fun.

This feature takes that pain point away. For example, allocating ports would once again be trivial, using `const port = 1234 + Number(process.env.MOCHA_WORKER_ID || 0)`.

Other parallel testing frameworks, like jest, already use this approach: https://github.com/facebook/jest/issues/2284

### Benefits

This solves common pain points for developers writing tests.

### Possible Drawbacks

Other than more complexity, I can't think of a drawback for the feature itself.

Since `workerpool` does not itself provide an option for worker-specific options or to execute code deterministically in a specific worker (only an option to add to the queue to execute on any available worker), I had to use a workaround in the implementation. This workaround could make internal updates more difficult and adds extra requirements to replacing `workerpool` if a need arises to use a different implementation internally. I personally believe that this tradeoff is worth it, though I am probably biased here.

### Applicable issues

* Enter any applicable Issues here.
#4456

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)? **No**
* Is it an enhancement (minor release)? **Yes**
* Is it a bug fix, or does it not impact production code (patch release)? **No**
