### PR TITLE
Change serializer errors to use error codes

### DIFF
--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -7,7 +7,10 @@
 'use strict';
 
 const {type} = require('../utils');
-const {createInvalidArgumentTypeError} = require('../errors');
+const {
+  createInvalidArgumentTypeError,
+  createInvalidArgumentValueError
+} = require('../errors');
 // this is not named `mocha:parallel:serializer` because it's noisy and it's
 // helpful to be able to write `DEBUG=mocha:parallel*` and get everything else.
 const debug = require('debug')('mocha:serializer');
@@ -131,7 +134,12 @@ class SerializableEvent {
    */
   constructor(eventName, originalValue, originalError) {
     if (!eventName) {
-      throw new Error('expected a non-empty `eventName` string argument');
+      throw createInvalidArgumentValueError(
+        'Empty `eventName` string argument',
+        'eventName',
+        eventName,
+        'is empty'
+      );
     }
     /**
      * The event name.
@@ -140,8 +148,10 @@ class SerializableEvent {
     this.eventName = eventName;
     const originalValueType = type(originalValue);
     if (originalValueType !== 'object' && originalValueType !== 'undefined') {
-      throw new Error(
-        `expected object, received [${originalValueType}]: ${originalValue}`
+      throw createInvalidArgumentTypeError(
+        `Expected object but received ${originalValueType}`,
+        'originalValue',
+        'object'
       );
     }
     /**

--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -7,10 +7,7 @@
 'use strict';
 
 const {type} = require('../utils');
-const {
-  createInvalidArgumentTypeError,
-  createInvalidArgumentValueError
-} = require('../errors');
+const {createInvalidArgumentTypeError} = require('../errors');
 // this is not named `mocha:parallel:serializer` because it's noisy and it's
 // helpful to be able to write `DEBUG=mocha:parallel*` and get everything else.
 const debug = require('debug')('mocha:serializer');
@@ -134,11 +131,10 @@ class SerializableEvent {
    */
   constructor(eventName, originalValue, originalError) {
     if (!eventName) {
-      throw createInvalidArgumentValueError(
+      throw createInvalidArgumentTypeError(
         'Empty `eventName` string argument',
         'eventName',
-        eventName,
-        'is empty'
+        'string'
       );
     }
     /**

--- a/test/node-unit/serializer.spec.js
+++ b/test/node-unit/serializer.spec.js
@@ -90,7 +90,7 @@ describe('serializer', function() {
       describe('when called without `eventName`', function() {
         it('should throw "invalid arg value" error', function() {
           expect(() => new SerializableEvent(), 'to throw', {
-            code: 'ERR_MOCHA_INVALID_ARG_VALUE'
+            code: 'ERR_MOCHA_INVALID_ARG_TYPE'
           });
         });
       });

--- a/test/node-unit/serializer.spec.js
+++ b/test/node-unit/serializer.spec.js
@@ -88,22 +88,18 @@ describe('serializer', function() {
   describe('SerializableEvent', function() {
     describe('constructor', function() {
       describe('when called without `eventName`', function() {
-        it('should throw', function() {
-          expect(
-            () => new SerializableEvent(),
-            'to throw',
-            /expected a non-empty `eventName`/
-          );
+        it('should throw "invalid arg value" error', function() {
+          expect(() => new SerializableEvent(), 'to throw', {
+            code: 'ERR_MOCHA_INVALID_ARG_VALUE'
+          });
         });
       });
 
       describe('when called with a non-object `rawObject`', function() {
-        it('should throw', function() {
-          expect(
-            () => new SerializableEvent('blub', 'glug'),
-            'to throw',
-            /expected object, received \[string\]/
-          );
+        it('should throw "invalid arg type" error', function() {
+          expect(() => new SerializableEvent('blub', 'glug'), 'to throw', {
+            code: 'ERR_MOCHA_INVALID_ARG_TYPE'
+          });
         });
       });
     });


### PR DESCRIPTION
### Description of the Change

After the implementations of https://github.com/mochajs/mocha/pull/3467 and https://github.com/mochajs/mocha/pull/3666, there are a few instances in the code that do not use error codes yet. This PR addresses the instances in the serializer code and does not cover all remaining instances of lack of error codes (I mainly wanted to make sure I was on the right track here before trying to change as many remaining errors as possible). 

### Alternate Designs

N/A

### Why should this be in core?

Using codes is a best practice like in Node.js, codes help identify errors as mocha errors at a glance

### Benefits

Using codes is a best practice like in Node.js, codes help identify errors as mocha errors at a glance

### Possible Drawbacks

None I'm aware of

### Applicable issues

Contributes to https://github.com/mochajs/mocha/issues/3656, semver-patch
