### PR TITLE
support leading dots in --extension

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -984,7 +984,11 @@ Files having this extension will be considered test files. Defaults to `js`.
 
 Specifying `--extension` will _remove_ `.js` as a test file extension; use `--extension js` to re-add it. For example, to load `.mjs` and `.js` test files, you must supply `--extension mjs --extension js`.
 
-The option can be given multiple times. The option accepts a comma-delimited list: `--extension a,b` is equivalent to `--extension a --extension b`
+The option can be given multiple times. The option accepts a comma-delimited list: `--extension a,b` is equivalent to `--extension a --extension b`.
+
+> _New in v8.2.0._
+
+`--extension` now supports multipart extensions (e.g., `spec.js`), leading dots (`.js`) and combinations thereof (`.spec.js`);
 
 ### `--file <file|directory|glob>`
 

--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -1,5 +1,4 @@
 'use strict';
-
 /**
  * Contains `lookupFiles`, which takes some globs/dirs/options and returns a list of files.
  * @module
@@ -14,6 +13,7 @@ var errors = require('../errors');
 var createNoFilesMatchPatternError = errors.createNoFilesMatchPatternError;
 var createMissingArgumentError = errors.createMissingArgumentError;
 var {sQuote, dQuote} = require('../utils');
+const debug = require('debug')('mocha:cli:lookup-files');
 
 /**
  * Determines if pathname would be a "hidden" file (or directory) on UN*X.
@@ -30,25 +30,26 @@ var {sQuote, dQuote} = require('../utils');
  * @example
  * isHiddenOnUnix('.profile'); // => true
  */
-function isHiddenOnUnix(pathname) {
-  return path.basename(pathname)[0] === '.';
-}
+const isHiddenOnUnix = pathname => path.basename(pathname).startsWith('.');
 
 /**
  * Determines if pathname has a matching file extension.
  *
+ * Supports multi-part extensions.
+ *
  * @private
  * @param {string} pathname - Pathname to check for match.
- * @param {string[]} exts - List of file extensions (sans period).
- * @return {boolean} whether file extension matches.
+ * @param {string[]} exts - List of file extensions, w/-or-w/o leading period
+ * @return {boolean} `true` if file extension matches.
  * @example
- * hasMatchingExtname('foo.html', ['js', 'css']); // => false
+ * hasMatchingExtname('foo.html', ['js', 'css']); // false
+ * hasMatchingExtname('foo.js', ['.js']); // true
+ * hasMatchingExtname('foo.js', ['js']); // ture
  */
-function hasMatchingExtname(pathname, exts) {
-  return exts.some(function(element) {
-    return pathname.endsWith('.' + element);
-  });
-}
+const hasMatchingExtname = (pathname, exts = []) =>
+  exts
+    .map(ext => (ext.startsWith('.') ? ext : `.${ext}`))
+    .some(ext => pathname.endsWith(ext));
 
 /**
  * Lookup file names at the given `path`.
@@ -66,27 +67,28 @@ function hasMatchingExtname(pathname, exts) {
  * @throws {Error} if no files match pattern.
  * @throws {TypeError} if `filepath` is directory and `extensions` not provided.
  */
-module.exports = function lookupFiles(filepath, extensions, recursive) {
-  extensions = extensions || [];
-  recursive = recursive || false;
-  var files = [];
-  var stat;
+module.exports = function lookupFiles(
+  filepath,
+  extensions = [],
+  recursive = false
+) {
+  const files = [];
+  let stat;
 
   if (!fs.existsSync(filepath)) {
-    var pattern;
+    let pattern;
     if (glob.hasMagic(filepath)) {
       // Handle glob as is without extensions
       pattern = filepath;
     } else {
       // glob pattern e.g. 'filepath+(.js|.ts)'
-      var strExtensions = extensions
-        .map(function(v) {
-          return '.' + v;
-        })
+      const strExtensions = extensions
+        .map(ext => (ext.startsWith('.') ? ext : `.${ext}`))
         .join('|');
-      pattern = filepath + '+(' + strExtensions + ')';
+      pattern = `${filepath}+(${strExtensions})`;
+      debug('looking for files using glob pattern: %s', pattern);
     }
-    files = glob.sync(pattern, {nodir: true});
+    files.push(...glob.sync(pattern, {nodir: true}));
     if (!files.length) {
       throw createNoFilesMatchPatternError(
         'Cannot find any files matching pattern ' + dQuote(filepath),
@@ -108,20 +110,19 @@ module.exports = function lookupFiles(filepath, extensions, recursive) {
   }
 
   // Handle directory
-  fs.readdirSync(filepath).forEach(function(dirent) {
-    var pathname = path.join(filepath, dirent);
-    var stat;
+  fs.readdirSync(filepath).forEach(dirent => {
+    const pathname = path.join(filepath, dirent);
+    let stat;
 
     try {
       stat = fs.statSync(pathname);
       if (stat.isDirectory()) {
         if (recursive) {
-          files = files.concat(lookupFiles(pathname, extensions, recursive));
+          files.push(...lookupFiles(pathname, extensions, recursive));
         }
         return;
       }
-    } catch (err) {
-      // ignore error
+    } catch (ignored) {
       return;
     }
     if (!extensions.length) {

--- a/test/integration/options/extension.spec.js
+++ b/test/integration/options/extension.spec.js
@@ -28,4 +28,28 @@ describe('--extension', function() {
       done();
     });
   });
+
+  it('should allow extensions beginning with a dot', function(done) {
+    var args = [
+      '--require',
+      'coffee-script/register',
+      '--require',
+      './test/setup',
+      '--reporter',
+      'json',
+      '--extension',
+      '.js',
+      'test/integration/fixtures/options/extension'
+    ];
+    invokeMocha(args, function(err, res) {
+      if (err) {
+        return done(err);
+      }
+      expect(toJSONResult(res), 'to have passed').and(
+        'to have passed test count',
+        1
+      );
+      done();
+    });
+  });
 });


### PR DESCRIPTION
- update documentation for the feature and multipart extensions
- rename integration test `file-utils.spec.js` to `lookup-files.spec.js` and "modernize" it

Ref: #4442 