### PR TITLE
chore(deps): chokidar@3.4.3, pin @ungap/promise-all-settled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4959,9 +4959,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -4970,7 +4970,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
       }
     },
     "chownr": {
@@ -17318,9 +17318,9 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "requires": {
         "picomatch": "^2.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "test:smoke": "node ./bin/mocha --no-config test/smoke/smoke.spec.js"
   },
   "dependencies": {
-    "@ungap/promise-all-settled": "^1.1.2",
+    "@ungap/promise-all-settled": "1.1.2",
     "ansi-colors": "4.1.1",
     "browser-stdout": "1.3.1",
-    "chokidar": "3.4.2",
+    "chokidar": "3.4.3",
     "debug": "4.2.0",
     "diff": "4.0.2",
     "escape-string-regexp": "4.0.0",


### PR DESCRIPTION
### Description of the Change

- Upgrade to `chokidar@3.4.3`.
- Pinned `@ungap/promise-all-settled` for consistency.

### Alternate Designs

Perhaps use `^` in dependencies as well.

### Why should this be in core?

New chokidar version fixes infinite loops on circular symlinks: https://github.com/paulmillr/chokidar/blob/master/.github/full_changelog.md

### Benefits

Better deduping in consumer projects, as most of the ecosystem uses ^ and picks up the latest of that major.

### Possible Drawbacks

New versions always have the possibility of a regression.

### Applicable issues

None.