### PR TITLE
Correct global fixtures release version in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1533,7 +1533,7 @@ If you're a library maintainer, and your library uses root hooks, you can migrat
 
 ## Global Fixtures
 
-> New in v9.0.0
+> New in v8.2.0
 
 At first glance, _global fixtures_ seem similar to [root hooks](#root-hook-plugins). However, unlike root hooks, global fixtures:
 


### PR DESCRIPTION
Minor documentation update.

https://mochajs.org/#global-fixtures shows
> New in v9.0.0

Whereas global fixtures was recently introduced in v8.2.0 https://github.com/mochajs/mocha/blob/v8.2.0/CHANGELOG.md

This pr corrects this nit.

