### PR TITLE
properly dispose Mocha instance in watch mode; closes #4495

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -41,6 +41,9 @@ exports.watchParallelRun = (
       // I don't know why we're cloning the root suite.
       const rootSuite = mocha.suite.clone();
 
+      // ensure we aren't leaking event listeners
+      mocha.dispose();
+
       // this `require` is needed because the require cache has been cleared.  the dynamic
       // exports set via the below call to `mocha.ui()` won't work properly if a
       // test depends on this module (see `required-tokens.spec.js`).
@@ -99,6 +102,9 @@ exports.watchRun = (mocha, {watchFiles, watchIgnore}, fileCollectParams) => {
 
       // I don't know why we're cloning the root suite.
       const rootSuite = mocha.suite.clone();
+
+      // ensure we aren't leaking event listeners
+      mocha.dispose();
 
       // this `require` is needed because the require cache has been cleared.  the dynamic
       // exports set via the below call to `mocha.ui()` won't work properly if a

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -415,8 +415,12 @@ async function runMochaWatchAsync(args, opts, change) {
   if (typeof opts === 'string') {
     opts = {cwd: opts};
   }
-  opts = {sleepMs: 2000, ...opts, fork: process.platform === 'win32'};
-  opts.stdio = ['pipe', 'pipe', 'inherit'];
+  opts = {
+    sleepMs: 2000,
+    stdio: ['pipe', 'pipe', 'inherit'],
+    ...opts,
+    fork: process.platform === 'win32'
+  };
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, '--watch'],
     opts
@@ -539,24 +543,25 @@ function sleep(time) {
 module.exports = {
   DEFAULT_FIXTURE,
   SPLIT_DOT_REPORTER_REGEXP,
+  copyFixture,
 
   createTempDir,
+  escapeRegExp,
+  getSummary,
   invokeMocha,
   invokeMochaAsync,
   invokeNode,
-  getSummary,
+  replaceFileContents,
   resolveFixturePath,
-  toJSONResult,
-  escapeRegExp,
   runMocha,
-  runMochaJSON,
   runMochaAsync,
+  runMochaJSON,
   runMochaJSONAsync,
   runMochaWatchAsync,
   runMochaWatchJSONAsync,
-  copyFixture,
-  touchFile,
-  replaceFileContents
+  sleep,
+  toJSONResult,
+  touchFile
 };
 
 /**


### PR DESCRIPTION
- Mocha instance needed a `dispose()` call before re-instantiation
- Exposed `sleep()` in integration test helpers

Ref: #4495