### PR TITLE
fix for issue 4047

### DIFF
--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -4,8 +4,11 @@ const path = require('path');
 const ansi = require('ansi-colors');
 const debug = require('debug')('mocha:cli:run:helpers');
 const minimatch = require('minimatch');
-const {NO_FILES_MATCH_PATTERN} = require('../errors').constants;
+const { NO_FILES_MATCH_PATTERN } = require('../errors').constants;
 const lookupFiles = require('./lookup-files');
+const { createNoFilesMatchPatternError } = require('../errors').createNoFilesMatchPatternError;
+const fs = require('fs');
+
 
 /**
  * Exports a function that collects test files from CLI parameters.
@@ -21,7 +24,7 @@ const lookupFiles = require('./lookup-files');
  * @returns {string[]} List of files to test
  * @private
  */
-module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
+module.exports = ({ ignore, extension, file, recursive, sort, spec } = {}) => {
   let files = [];
   const unmatched = [];
   spec.forEach(arg => {
@@ -30,7 +33,7 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
       newFiles = lookupFiles(arg, extension, recursive);
     } catch (err) {
       if (err.code === NO_FILES_MATCH_PATTERN) {
-        unmatched.push({message: err.message, pattern: err.pattern});
+        unmatched.push({ message: err.message, pattern: err.pattern });
         return;
       }
 
@@ -49,7 +52,16 @@ module.exports = ({ignore, extension, file, recursive, sort, spec} = {}) => {
     files = files.concat(newFiles);
   });
 
-  const fileArgs = file.map(filepath => path.resolve(filepath));
+  // const fileArgs = file.map(filepath => path.resolve(filepath));
+  const fileArgs = file
+    .map(filepath => path.resolve(filepath))
+    .filter(filename => {
+      const exists = fs.existsSync(filename);
+      if (!exists) {
+        throw createNoFilesMatchPatternError("File ${filename} not found.")
+      }
+      return exists;
+    });
   files = files.map(filepath => path.resolve(filepath));
 
   // ensure we don't sort the stuff from fileArgs; order is important!


### PR DESCRIPTION
CLI will verify if args passed with --file exists and if not, throws error createNoFilesMatchPatternError("File ${FileName} not found")
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
