### PR TITLE
Change CLI file parsing errors to use an error code

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('mocha:cli:config');
 const findUp = require('find-up');
+const {createUnparsableFileError} = require('../errors');
 const utils = require('../utils');
 
 /**
@@ -81,7 +82,7 @@ exports.loadConfig = filepath => {
       config = parsers.json(filepath);
     }
   } catch (err) {
-    throw new Error(`failed to parse config "${filepath}": ${err}`);
+    throw createUnparsableFileError(err, filepath);
   }
   return config;
 };

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -82,7 +82,10 @@ exports.loadConfig = filepath => {
       config = parsers.json(filepath);
     }
   } catch (err) {
-    throw createUnparsableFileError(err, filepath);
+    throw createUnparsableFileError(
+      `Unable to read/parse ${filepath}: ${err}`,
+      filepath
+    );
   }
   return config;
 };

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -18,6 +18,7 @@ const {loadConfig, findConfig} = require('./config');
 const findUp = require('find-up');
 const debug = require('debug')('mocha:cli:options');
 const {isNodeFlag} = require('./node-flags');
+const {createUnparsableFileError} = require('../errors');
 
 /**
  * The `yargs-parser` namespace
@@ -190,7 +191,7 @@ const loadPkgRc = (args = {}) => {
       }
     } catch (err) {
       if (args.package) {
-        throw new Error(`Unable to read/parse ${filepath}: ${err}`);
+        throw createUnparsableFileError(err, filepath);
       }
       debug('failed to read default package.json at %s; ignoring', filepath);
     }

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -191,7 +191,10 @@ const loadPkgRc = (args = {}) => {
       }
     } catch (err) {
       if (args.package) {
-        throw createUnparsableFileError(err, filepath);
+        throw createUnparsableFileError(
+          `Unable to read/parse ${filepath}: ${err}`,
+          filepath
+        );
       }
       debug('failed to read default package.json at %s; ignoring', filepath);
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -163,7 +163,12 @@ var constants = {
    * @constant
    * @default
    */
-  TIMEOUT: 'ERR_MOCHA_TIMEOUT'
+  TIMEOUT: 'ERR_MOCHA_TIMEOUT',
+
+  /**
+   * Input file is not able to be parsed
+   */
+  UNPARSABLE_FILE: 'ERR_MOCHA_UNPARSABLE_FILE'
 };
 
 /**
@@ -496,6 +501,21 @@ function createTimeoutError(msg, timeout, file) {
 }
 
 /**
+* Creates an error object to be thrown when file is unparsable
+*
+* @public
+* @param {string} message - Error message to be displayed.
+* @param {string} filename - File name
+* @param {string} [reason] - Why the filename is unparsable.
+*/
+function createUnparsableFileError(message, filename, reason) {
+   var err = new Error(message);
+   err.code = constants.UNPARSABLE_FILE;
+   err.reason = typeof reason !== 'undefined' ? reason : `${filename} is unparsable`;
+   return err;
+ }
+
+/**
  * Returns `true` if an error came out of Mocha.
  * _Can suffer from false negatives, but not false positives._
  * @static
@@ -525,6 +545,7 @@ module.exports = {
   createMultipleDoneError,
   createNoFilesMatchPatternError,
   createTimeoutError,
+  createUnparsableFileError,
   createUnsupportedError,
   deprecate,
   isMochaError,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -501,19 +501,18 @@ function createTimeoutError(msg, timeout, file) {
 }
 
 /**
-* Creates an error object to be thrown when file is unparsable
-*
-* @public
-* @param {string} message - Error message to be displayed.
-* @param {string} filename - File name
-* @param {string} [reason] - Why the filename is unparsable.
-*/
-function createUnparsableFileError(message, filename, reason) {
-   var err = new Error(message);
-   err.code = constants.UNPARSABLE_FILE;
-   err.reason = typeof reason !== 'undefined' ? reason : `${filename} is unparsable`;
-   return err;
- }
+ * Creates an error object to be thrown when file is unparsable
+ * @public
+ * @static
+ * @param {string} message - Error message to be displayed.
+ * @param {string} filename - File name
+ * @returns {Error} Error with code {@link constants.UNPARSABLE_FILE}
+ */
+function createUnparsableFileError(message, filename) {
+  var err = new Error(message);
+  err.code = constants.UNPARSABLE_FILE;
+  return err;
+}
 
 /**
  * Returns `true` if an error came out of Mocha.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -167,6 +167,8 @@ var constants = {
 
   /**
    * Input file is not able to be parsed
+   * @constant
+   * @default
    */
   UNPARSABLE_FILE: 'ERR_MOCHA_UNPARSABLE_FILE'
 };

--- a/test/node-unit/cli/config.spec.js
+++ b/test/node-unit/cli/config.spec.js
@@ -109,11 +109,15 @@ describe('cli/config', function() {
 
     describe('when config file parsing fails', function() {
       beforeEach(function() {
-        sinon.stub(parsers, 'yaml').throws();
+        sinon.stub(parsers, 'yaml').throws('goo.yaml is unparsable');
       });
 
       it('should throw', function() {
-        expect(() => loadConfig('goo.yaml'), 'to throw', /failed to parse/);
+        expect(
+          () => loadConfig('goo.yaml'),
+          'to throw',
+          'goo.yaml is unparsable'
+        );
       });
     });
   });

--- a/test/node-unit/cli/config.spec.js
+++ b/test/node-unit/cli/config.spec.js
@@ -116,7 +116,7 @@ describe('cli/config', function() {
         expect(
           () => loadConfig('goo.yaml'),
           'to throw',
-          'goo.yaml is unparsable'
+          'Unable to read/parse goo.yaml: goo.yaml is unparsable'
         );
       });
     });

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -130,7 +130,7 @@ describe('options', function() {
           beforeEach(function() {
             readFileSync = sinon.stub();
             // package.json
-            readFileSync.onFirstCall().throws('yikes');
+            readFileSync.onFirstCall().throws('bad file message');
             findConfig = sinon.stub().returns('/some/.mocharc.json');
             loadConfig = sinon.stub().returns({});
             findupSync = sinon.stub();
@@ -148,7 +148,7 @@ describe('options', function() {
                 loadOptions('--package /something/wherever --require butts');
               },
               'to throw',
-              /unable to read\/parse/i
+              'bad file message'
             );
           });
         });

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -148,7 +148,7 @@ describe('options', function() {
                 loadOptions('--package /something/wherever --require butts');
               },
               'to throw',
-              'bad file message'
+              'Unable to read/parse /something/wherever: bad file message'
             );
           });
         });

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -76,8 +76,7 @@ describe('Errors', function() {
         'to satisfy',
         {
           message: message,
-          code: 'ERR_MOCHA_UNPARSABLE_FILE',
-          reason: 'badFilePath is unparsable'
+          code: 'ERR_MOCHA_UNPARSABLE_FILE'
         }
       );
     });

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -69,6 +69,20 @@ describe('Errors', function() {
     });
   });
 
+  describe('createUnparsableFileError()', function() {
+    it('should include expected code in thrown unparsable file errors', function() {
+      expect(
+        errors.createUnparsableFileError(message, 'badFilePath'),
+        'to satisfy',
+        {
+          message: message,
+          code: 'ERR_MOCHA_UNPARSABLE_FILE',
+          reason: 'badFilePath is unparsable'
+        }
+      );
+    });
+  });
+
   describe('deprecate()', function() {
     var emitWarning;
 


### PR DESCRIPTION
## Description of the Change

After the implementations of https://github.com/mochajs/mocha/pull/3467 and https://github.com/mochajs/mocha/pull/3666 and https://github.com/mochajs/mocha/pull/4464, there are a few instances in the code that do not use error codes yet.

### Alternate Designs

Open to other names for this error code

### Why should this be in core?

Using codes is a best practice like in Node.js, codes help identify errors as mocha errors at a glance

### Benefits

Using codes is a best practice like in Node.js, codes help identify errors as mocha errors at a glance

### Possible Drawbacks

None I'm aware of

### Applicable issues

Contributes to https://github.com/mochajs/mocha/issues/3656, semver-minor
