### PR TITLE
chore(deps): debug@4.3.1, karma-sauce-launcher@4.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6335,9 +6335,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,6 +1908,21 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@types/archiver": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-TzVZ9204sH1TuFylfr1cw/AA/3/VldAAXswEwKLXUOzA9mDg+m6gHF9EaqKNlozcjc6knX5m1KAqJzksPLSEfw==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*"
+      }
+    },
+    "@types/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==",
+      "dev": true
+    },
     "@types/babel-types": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
@@ -1941,6 +1956,25 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.4.tgz",
+      "integrity": "sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
@@ -1963,10 +1997,28 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.161",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "version": "4.14.165",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
+      "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
       "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/lodash.merge": {
       "version": "4.6.6",
@@ -2002,12 +2054,21 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.2.tgz",
-      "integrity": "sha512-JRuHPSbHZBadOxxFwpyZPeRlpPTTeMbQneMdpFd8LXdyNfFSiX950CGewdm69g/ipzEAXAmMyFF1WOWJOL/nKw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.0.tgz",
+      "integrity": "sha512-zTYDLjnHjgzokrwKt7N0rgn7oZPYo1J0m8Ghu+gXqzLCEn8RWbELa2uprE2UFJ0jU/Sk0x9jXXdOH/5QQLFHhQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/puppeteer-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz",
+      "integrity": "sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==",
+      "dev": true,
+      "requires": {
+        "@types/puppeteer": "*"
       }
     },
     "@types/q": {
@@ -2034,10 +2095,22 @@
         "@types/node": "*"
       }
     },
+    "@types/ua-parser-js": {
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+      "dev": true
+    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yauzl": {
@@ -2056,20 +2129,20 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
     },
     "@wdio/config": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.6.0.tgz",
-      "integrity": "sha512-7yQds6v1q9oGD+xwDcAmc6klSj1EpjhrgwRXXyVaDxnjyD18Ln03/FOgrpxK5Kr5ra94nvQhA+JkfwlT0k+RdQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.0.tgz",
+      "integrity": "sha512-Wl+OzX8X1kRRE2oymqleLTQIaWkj04AGLGNpg1f3dolwelQK/5RMPG4oUnnnB1jZhkywMkAqvw/yf3u+zl/G0Q==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.6.0",
+        "@wdio/logger": "6.8.0",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       }
     },
     "@wdio/logger": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.6.0.tgz",
-      "integrity": "sha512-BAvXcnlWdQC93MLWObetpcjHUEGR8niW2mH2KAwLPQhXwJkKxXjhlMKH/DmUn5uQ4/S7iySLlMq9EEEg9KuCwA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.8.0.tgz",
+      "integrity": "sha512-IvRnp2gTU1z6L+snMrKLrRDqYFq9yzcqXp7i6+Q/bxewxkgcpitm4hSs+13KS4fmbeBmhT5UeUeumnTZBYkhBQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -2079,27 +2152,27 @@
       }
     },
     "@wdio/protocols": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.6.0.tgz",
-      "integrity": "sha512-0wWSZTB4sBzr9HG3hT9a0jaO+xPhz+eFdE/qMLvM8b1yPOOgHieGPSoTXPjkBaks0CZpqeimbT4myYoim2JK1w==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.0.tgz",
+      "integrity": "sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==",
       "dev": true
     },
     "@wdio/repl": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.6.0.tgz",
-      "integrity": "sha512-i6Ss+0S4G6Q/3xsvF8uV1WR4mvrVnO0hKmXSfH5ewPHd67MroqemyURmNNoX0R/euHwG3U7tBZQyaK2JGPI0GA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.8.0.tgz",
+      "integrity": "sha512-unFnItXq6+V8JNfAtPtuEza047r2dLdcFXPN4exq7+O/kPJTzsTGOAQTlSLPJGMrfy5axTk90KOl08gpJvzjOA==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "6.6.0"
+        "@wdio/utils": "6.8.0"
       }
     },
     "@wdio/utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.6.0.tgz",
-      "integrity": "sha512-2BcpNRlsaNEx+UvWay04i3+MS92dL+dMn0K/mi9/5XIgZDIHP+K0FISaZFaERzL/j7inyqjkyZu6xAeYup2O2g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.8.0.tgz",
+      "integrity": "sha512-2vGwkaqP2e876o3NDTWz021aLTBrbZfCLHETuS+e/J0IXMR3FQ8et01BY/bjwyz6EP1I3vVtP2ZVC1dV2yIIVQ==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.6.0"
+        "@wdio/logger": "6.8.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -2582,9 +2655,9 @@
       }
     },
     "archiver": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz",
-      "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
+      "integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -2593,7 +2666,7 @@
         "readable-stream": "^3.6.0",
         "readdir-glob": "^1.0.0",
         "tar-stream": "^2.1.4",
-        "zip-stream": "^4.0.0"
+        "zip-stream": "^4.0.4"
       },
       "dependencies": {
         "async": {
@@ -3793,9 +3866,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
       "dev": true
     },
     "boxen": {
@@ -5515,13 +5588,13 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
-      "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
       "dev": true,
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.0",
+        "crc32-stream": "^4.0.1",
         "normalize-path": "^3.0.0",
         "readable-stream": "^3.6.0"
       },
@@ -5926,22 +5999,23 @@
         "request": "^2.88.2"
       }
     },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.1.0"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "crc32-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
-      "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+      "integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
+        "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "dependencies": {
@@ -6118,6 +6192,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+      "dev": true
+    },
+    "css-shorthand-properties": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
       "dev": true
     },
     "css-tree": {
@@ -6724,15 +6804,18 @@
       "dev": true
     },
     "devtools": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.6.2.tgz",
-      "integrity": "sha512-iogAMiD5lHyEm5Fq+rSHBmfYT0rmmeyJmbbuDKb5vguynM5PHuaH/TIxumJMnhyMqpfuLMkJB/HCt340VQA+UQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.2.tgz",
+      "integrity": "sha512-I7uwrlX4kxVkWM3KZKHSaHwt5m8XOrK4/sToY0LGPq6VHt1RQlI8TJEvoc3wUqxDt0DHeTl1YU9RwZMuhX3y3w==",
       "dev": true,
       "requires": {
-        "@wdio/config": "6.6.0",
-        "@wdio/logger": "6.6.0",
-        "@wdio/protocols": "6.6.0",
-        "@wdio/utils": "6.6.0",
+        "@types/puppeteer-core": "^2.0.0",
+        "@types/ua-parser-js": "^0.7.33",
+        "@types/uuid": "^8.3.0",
+        "@wdio/config": "6.10.0",
+        "@wdio/logger": "6.8.0",
+        "@wdio/protocols": "6.10.0",
+        "@wdio/utils": "6.8.0",
         "chrome-launcher": "^0.13.1",
         "edge-paths": "^2.1.0",
         "puppeteer-core": "^5.1.0",
@@ -6741,9 +6824,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.799653",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.799653.tgz",
-      "integrity": "sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg==",
+      "version": "0.0.818844",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
       "dev": true
     },
     "di": {
@@ -8052,6 +8135,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/exif-reader/-/exif-reader-1.0.3.tgz",
       "integrity": "sha512-tWMBj1+9jUSibgR/kv/GQ/fkR0biaN9GEZ5iPdf7jFeH//d2bSzgPoaWf1OfMv4MXFD4upwvpCCyeMvSyLWSfA==",
+      "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
       "dev": true
     },
     "expand-brackets": {
@@ -12287,14 +12376,15 @@
       "dev": true
     },
     "karma-sauce-launcher": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-4.1.5.tgz",
-      "integrity": "sha512-X6/1IaUTOhbSuw+Y8ea8/1fAHsIbitDosJVnxqC0ZxIlDQMM4/U0WbETtCIbwUDoa89jwM3alfDs5RTRUW5mJw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-4.3.3.tgz",
+      "integrity": "sha512-t9t4RYGXKF1md3EutXb59r4gWOFi67jfUDHdfEssSXsjNlmMZ43qGFupUFbpBO6iebSbwf+KqLcwhDx/bxzbuQ==",
       "dev": true,
       "requires": {
-        "global-agent": "^2.1.8",
-        "saucelabs": "^4.3.0",
-        "webdriverio": "^6.1.9"
+        "fs-extra": "^9.0.1",
+        "global-agent": "^2.1.12",
+        "saucelabs": "^4.5.1",
+        "webdriverio": "^6.7.0"
       }
     },
     "keyv": {
@@ -13076,9 +13166,9 @@
       }
     },
     "loglevel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
-      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
     },
     "loglevel-plugin-prefix": {
@@ -14111,6 +14201,12 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -16653,6 +16749,12 @@
         "parse-ms": "^0.1.0"
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "dev": true
+    },
     "prismjs": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
@@ -17000,15 +17102,16 @@
       }
     },
     "puppeteer-core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.3.1.tgz",
-      "integrity": "sha512-YE6c6FvHAFKQUyNTqFs78SgGmpcqOPhhmVfEVNYB4abv7bV2V+B3r72T3e7vlJkEeTloy4x9bQLrGbHHoKSg1w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.799653",
+        "devtools-protocol": "0.0.818844",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
+        "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
@@ -17065,9 +17168,9 @@
           }
         },
         "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
           "dev": true
         }
       }
@@ -17850,9 +17953,9 @@
       }
     },
     "resq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.8.0.tgz",
-      "integrity": "sha512-VObcnfPcE6/EKfHqsi5qoJ0+BF9qfl5181CytP1su3HgzilqF03DrQ+Y7kZQrd+5myfmantl9W3/5uUcpwvKeg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
+      "integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1"
@@ -17917,9 +18020,9 @@
       "dev": true
     },
     "rgb2hex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.0.tgz",
-      "integrity": "sha512-cHdNTwmTMPu/TpP1bJfdApd6MbD+Kzi4GNnM6h35mdFChhQPSi9cAI8J7DMn5kQDKX8NuBaQXAyo360Oa7tOEA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
+      "integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
       "dev": true
     },
     "rgba-regex": {
@@ -18252,24 +18355,24 @@
       "dev": true
     },
     "saucelabs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.5.0.tgz",
-      "integrity": "sha512-xPMYLLOJMnWRunZKiu92h4cKCR/SCTYBIvAHTlHYtDA09oebnwEOf7cjrv/+R0TuXgSYO85pll0mOXDIKUTB3Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.6.0.tgz",
+      "integrity": "sha512-GAytkfq2QTVzwMS4/A99YQ79wqZvq29hO1r7+JYvfExRD9UipuvzvqhzsAfS8fKg+OuRIbIDTk0Rd7aWXa06zw==",
       "dev": true,
       "requires": {
         "bin-wrapper": "^4.1.0",
         "change-case": "^4.1.1",
         "form-data": "^3.0.0",
-        "got": "^11.1.4",
+        "got": "^11.7.0",
         "hash.js": "^1.1.7",
         "tunnel": "0.0.6",
-        "yargs": "^15.3.1"
+        "yargs": "^16.0.3"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
           "dev": true
         },
         "cacheable-request": {
@@ -18288,14 +18391,14 @@
           }
         },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "wrap-ansi": "^7.0.0"
           }
         },
         "decompress-response": {
@@ -18313,15 +18416,11 @@
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
+        "escalade": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+          "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+          "dev": true
         },
         "form-data": {
           "version": "3.0.0",
@@ -18344,12 +18443,12 @@
           }
         },
         "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.0.tgz",
+          "integrity": "sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^3.1.1",
+            "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
             "@types/cacheable-request": "^6.0.1",
             "@types/responselike": "^1.0.0",
@@ -18389,15 +18488,6 @@
             "json-buffer": "3.0.1"
           }
         },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -18422,24 +18512,6 @@
           "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
           "dev": true
         },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
         "responselike": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
@@ -18461,9 +18533,9 @@
           }
         },
         "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -18471,34 +18543,32 @@
             "strip-ansi": "^6.0.0"
           }
         },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "dev": true
+        },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "16.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
+          "integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
           "dev": true,
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
         }
       }
     },
@@ -22794,24 +22864,24 @@
       }
     },
     "webdriver": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.6.2.tgz",
-      "integrity": "sha512-Xv4ber+2aKkgDtDqweNiEp4whiIO14Me67exHdfwvgOJb2sqrlW8SAz+e8oGI2s0pYZ2LBfHsNGLNcos/xEB/w==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.0.tgz",
+      "integrity": "sha512-73WQqtLlQGXR+mJ1AWMAJ6ENR3hu0bM94uVOYx+SlzOAXucPa+VT7vMyz8IfIlLAAhN84QdIgvYY0VundDMUgA==",
       "dev": true,
       "requires": {
         "@types/lodash.merge": "^4.6.6",
-        "@wdio/config": "6.6.0",
-        "@wdio/logger": "6.6.0",
-        "@wdio/protocols": "6.6.0",
-        "@wdio/utils": "6.6.0",
+        "@wdio/config": "6.10.0",
+        "@wdio/logger": "6.8.0",
+        "@wdio/protocols": "6.10.0",
+        "@wdio/utils": "6.8.0",
         "got": "^11.0.2",
         "lodash.merge": "^4.6.1"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
           "dev": true
         },
         "cacheable-request": {
@@ -22848,12 +22918,12 @@
           }
         },
         "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.0.tgz",
+          "integrity": "sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^3.1.1",
+            "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
             "@types/cacheable-request": "^6.0.1",
             "@types/responselike": "^1.0.0",
@@ -22923,20 +22993,26 @@
       }
     },
     "webdriverio": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.6.2.tgz",
-      "integrity": "sha512-tBnAIS5B2/G+50h1+jR5uqahb8qfeh6JF0K9s//gpmv8NJ1X5npOUzJN38G3LtobTbpDMLMOD9LQgeqHknDnkA==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.2.tgz",
+      "integrity": "sha512-XnodmNkql/R+EwZVJ5lXTK9VfthJ9xTAs7S1qJATcOdIeBDYvuvFePrG3h+O5rzinR561MM5cYbZeJYH1tzZvQ==",
       "dev": true,
       "requires": {
-        "@types/puppeteer": "^3.0.1",
-        "@wdio/config": "6.6.0",
-        "@wdio/logger": "6.6.0",
-        "@wdio/repl": "6.6.0",
-        "@wdio/utils": "6.6.0",
+        "@types/archiver": "^3.1.1",
+        "@types/atob": "^2.1.2",
+        "@types/fs-extra": "^9.0.2",
+        "@types/lodash.clonedeep": "^4.5.6",
+        "@types/lodash.isplainobject": "^4.0.6",
+        "@types/puppeteer-core": "^2.0.0",
+        "@wdio/config": "6.10.0",
+        "@wdio/logger": "6.8.0",
+        "@wdio/repl": "6.8.0",
+        "@wdio/utils": "6.8.0",
         "archiver": "^5.0.0",
         "atob": "^2.1.2",
+        "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "6.6.2",
+        "devtools": "6.10.2",
         "fs-extra": "^9.0.1",
         "get-port": "^5.1.1",
         "grapheme-splitter": "^1.0.2",
@@ -22946,10 +23022,10 @@
         "lodash.zip": "^4.2.0",
         "minimatch": "^3.0.4",
         "puppeteer-core": "^5.1.0",
-        "resq": "^1.6.0",
+        "resq": "^1.9.1",
         "rgb2hex": "^0.2.0",
         "serialize-error": "^7.0.0",
-        "webdriver": "6.6.2"
+        "webdriver": "6.10.0"
       }
     },
     "webidl-conversions": {
@@ -23706,13 +23782,13 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
-      "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.0.0",
+        "compress-commons": "^4.0.2",
         "readable-stream": "^3.6.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-requirejs": "^1.1.0",
-    "karma-sauce-launcher": "^4.1.5",
+    "karma-sauce-launcher": "^4.3.3",
     "lint-staged": "^10.2.11",
     "markdown-it": "^11.0.0",
     "markdown-it-anchor": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ansi-colors": "4.1.1",
     "browser-stdout": "1.3.1",
     "chokidar": "3.4.3",
-    "debug": "4.2.0",
+    "debug": "4.3.1",
     "diff": "4.0.2",
     "escape-string-regexp": "4.0.0",
     "find-up": "5.0.0",


### PR DESCRIPTION
### Description of the Change

Upgrade to `debug@4.3.1`.
EDIT: now also `karma-sauce-launcher@4.3.3`, to see if it fixes "Browser Tests" step.

### Benefits

fixes a deprecation warning when installing mocha:
`npm WARN deprecated debug@4.2.0: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)`

### Possible Drawbacks

None that I'm aware of.