### PR TITLE
Improve CI tests workflow

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -6,10 +6,13 @@ name: Tests
       - opened
       - synchronize
       - reopened
+    branches:
+      # Branches from forks have the form 'user:branch-name'
+      - '**:**'
 
 jobs:
   prepare-commit-msg:
-    name: Retrive head commit message
+    name: Retrieve head commit message
     runs-on: ubuntu-latest
     outputs:
       HEAD_COMMIT_MSG: '${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}'
@@ -110,60 +113,60 @@ jobs:
             env:
               COVERAGE: 1
     steps:
-      - name: Cache Growl Installer (Windows)
-        if: "${{ matrix.os == 'windows-2019' }}"
-        id: cache-growl
-        uses: actions/cache@v2
-        with:
-          path: GrowlInstaller
-          key: '${{ runner.os }}-growl-installer'
-          restore-keys: |
-            ${{ runner.os }}-growl-installer
-      - name: Download Growl Installer (Windows)
-        if: "${{ matrix.os == 'windows-2019' && steps.cache-growl.outputs.cache-hit != 'true'}}"
-        run: >
-          echo "Downloading Growl installer..."
+      # - name: Cache Growl Installer (Windows)
+      #   if: "${{ matrix.os == 'windows-2019' }}"
+      #   id: cache-growl
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: GrowlInstaller
+      #     key: '${{ runner.os }}-growl-installer'
+      #     restore-keys: |
+      #       ${{ runner.os }}-growl-installer
+      # - name: Download Growl Installer (Windows)
+      #   if: "${{ matrix.os == 'windows-2019' && steps.cache-growl.outputs.cache-hit != 'true'}}"
+      #   run: >
+      #     echo "Downloading Growl installer..."
 
-          mkdir GrowlInstaller | out-null
+      #     mkdir GrowlInstaller | out-null
 
-          $seaURL =
-          "https://github.com/briandunnington/growl-for-windows/releases/download/final/GrowlInstaller.exe"
+      #     $seaURL =
+      #     "https://github.com/briandunnington/growl-for-windows/releases/download/final/GrowlInstaller.exe"
 
-          $seaPath = "GrowlInstaller\GrowlInstaller.exe"
+      #     $seaPath = "GrowlInstaller\GrowlInstaller.exe"
 
-          $webclient = New-Object Net.WebClient
+      #     $webclient = New-Object Net.WebClient
 
-          $webclient.DownloadFile($seaURL, $seaPath)
+      #     $webclient.DownloadFile($seaURL, $seaPath)
 
-          7z x $seaPath -oGrowlInstaller | out-null
+      #     7z x $seaPath -oGrowlInstaller | out-null
 
-          echo "Done."
-      - name: Retrieve Growl Installer (Windows)
-        if: "${{ matrix.os == 'windows-2019' }}"
-        uses: actions/cache@v2
-        with:
-          path: GrowlInstaller
-          key: '${{ runner.os }}-growl-installer'
-          restore-keys: |
-            ${{ runner.os }}-growl-installer
-      - name: Add Growl Installer to Path (Windows)
-        if: "${{ matrix.os == 'windows-2019' }}"
-        run: 'echo "C:\Program Files (x86)\Growl for Windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8'
-      - name: Install Growl
-        if: "${{ matrix.os == 'windows-2019' }}"
-        run: |
-          echo "Installing Growl..."
-          cmd /c start /wait msiexec /i GrowlInstaller\Growl_v2.0.msi /quiet
-          echo "Done."
-      - name: Start Growl Service (Windows)
-        if: "${{ matrix.os == 'windows-2019' }}"
-        run: |
-          echo "Starting Growl service..."
-          Start-Process -NoNewWindow Growl
-          ## Growl requires some time before it's ready to handle notifications
-          echo "Verifying Growl responding"
-          Start-Sleep -s 10
-          growlnotify test
+      #     echo "Done."
+      # - name: Retrieve Growl Installer (Windows)
+      #   if: "${{ matrix.os == 'windows-2019' }}"
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: GrowlInstaller
+      #     key: '${{ runner.os }}-growl-installer'
+      #     restore-keys: |
+      #       ${{ runner.os }}-growl-installer
+      # - name: Add Growl Installer to Path (Windows)
+      #   if: "${{ matrix.os == 'windows-2019' }}"
+      #   run: 'echo "C:\Program Files (x86)\Growl for Windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8'
+      # - name: Install Growl
+      #   if: "${{ matrix.os == 'windows-2019' }}"
+      #   run: |
+      #     echo "Installing Growl..."
+      #     cmd /c start /wait msiexec /i GrowlInstaller\Growl_v2.0.msi /quiet
+      #     echo "Done."
+      # - name: Start Growl Service (Windows)
+      #   if: "${{ matrix.os == 'windows-2019' }}"
+      #   run: |
+      #     echo "Starting Growl service..."
+      #     Start-Process -NoNewWindow Growl
+      #     ## Growl requires some time before it's ready to handle notifications
+      #     echo "Verifying Growl responding"
+      #     Start-Sleep -s 10
+      #     growlnotify test
       - name: Install libnotify-bin (Linux)
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         run: sudo apt-get install libnotify-bin
@@ -202,6 +205,7 @@ jobs:
     # TODO: configure to retain build artifacts in `.karma/` dir
     name: 'Browser Tests'
     needs: smoke
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,21 +1962,6 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.161",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
-      "dev": true
-    },
-    "@types/lodash.merge": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2002,12 +1987,21 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.2.tgz",
-      "integrity": "sha512-JRuHPSbHZBadOxxFwpyZPeRlpPTTeMbQneMdpFd8LXdyNfFSiX950CGewdm69g/ipzEAXAmMyFF1WOWJOL/nKw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.2.tgz",
+      "integrity": "sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/puppeteer-core": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz",
+      "integrity": "sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==",
+      "dev": true,
+      "requires": {
+        "@types/puppeteer": "*"
       }
     },
     "@types/q": {
@@ -2056,20 +2050,20 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
     },
     "@wdio/config": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.6.0.tgz",
-      "integrity": "sha512-7yQds6v1q9oGD+xwDcAmc6klSj1EpjhrgwRXXyVaDxnjyD18Ln03/FOgrpxK5Kr5ra94nvQhA+JkfwlT0k+RdQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.11.0.tgz",
+      "integrity": "sha512-aNkH5sPEybOf7ND1JrAlCsKZow6KMAaY3Wyf9yHralQ3xmclmswFKU/DseP7go17Ivc2KHLl7MMkNaqVY90siw==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.6.0",
+        "@wdio/logger": "6.10.10",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       }
     },
     "@wdio/logger": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.6.0.tgz",
-      "integrity": "sha512-BAvXcnlWdQC93MLWObetpcjHUEGR8niW2mH2KAwLPQhXwJkKxXjhlMKH/DmUn5uQ4/S7iySLlMq9EEEg9KuCwA==",
+      "version": "6.10.10",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.10.tgz",
+      "integrity": "sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -2079,27 +2073,27 @@
       }
     },
     "@wdio/protocols": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.6.0.tgz",
-      "integrity": "sha512-0wWSZTB4sBzr9HG3hT9a0jaO+xPhz+eFdE/qMLvM8b1yPOOgHieGPSoTXPjkBaks0CZpqeimbT4myYoim2JK1w==",
+      "version": "6.10.6",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.6.tgz",
+      "integrity": "sha512-CLLVdc82S+Zij7f9djL90JC1bE5gtaOn+EF2pY4n8XdypqPUa1orQip8stQtX/wXEX0Ak45MEcSU9nCY+CzNnQ==",
       "dev": true
     },
     "@wdio/repl": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.6.0.tgz",
-      "integrity": "sha512-i6Ss+0S4G6Q/3xsvF8uV1WR4mvrVnO0hKmXSfH5ewPHd67MroqemyURmNNoX0R/euHwG3U7tBZQyaK2JGPI0GA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.11.0.tgz",
+      "integrity": "sha512-FxrFKiTkFyELNGGVEH1uijyvNY7lUpmff6x+FGskFGZB4uSRs0rxkOMaEjxnxw7QP1zgQKr2xC7GyO03gIGRGg==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "6.6.0"
+        "@wdio/utils": "6.11.0"
       }
     },
     "@wdio/utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.6.0.tgz",
-      "integrity": "sha512-2BcpNRlsaNEx+UvWay04i3+MS92dL+dMn0K/mi9/5XIgZDIHP+K0FISaZFaERzL/j7inyqjkyZu6xAeYup2O2g==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.11.0.tgz",
+      "integrity": "sha512-vf0sOQzd28WbI26d6/ORrQ4XKWTzSlWLm9W/K/eJO0NASKPEzR+E+Q2kaa+MJ4FKXUpjbt+Lxfo+C26TzBk7tg==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.6.0"
+        "@wdio/logger": "6.10.10"
       }
     },
     "@webassemblyjs/ast": {
@@ -2582,9 +2576,9 @@
       }
     },
     "archiver": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz",
-      "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
+      "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -2593,7 +2587,7 @@
         "readable-stream": "^3.6.0",
         "readdir-glob": "^1.0.0",
         "tar-stream": "^2.1.4",
-        "zip-stream": "^4.0.0"
+        "zip-stream": "^4.0.4"
       },
       "dependencies": {
         "async": {
@@ -2625,9 +2619,9 @@
           }
         },
         "tar-stream": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
           "dev": true,
           "requires": {
             "bl": "^4.0.3",
@@ -3793,9 +3787,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
       "dev": true
     },
     "boxen": {
@@ -4549,9 +4543,9 @@
       }
     },
     "cacheable-lookup": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
-      "integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "dev": true
     },
     "cacheable-request": {
@@ -4755,34 +4749,40 @@
       }
     },
     "capital-case": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz",
-      "integrity": "sha512-OlUSJpUr7SY0uZFOxcwnDOU7/MpHlKTZx2mqnDYQFrDudXLFm0JJ9wr/l4csB+rh2Ug0OPuoSO53PqiZBqno9A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0",
-        "upper-case-first": "^2.0.1"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
       },
       "dependencies": {
         "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         },
         "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
           "dev": true,
           "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         }
       }
     },
@@ -4859,63 +4859,69 @@
       }
     },
     "change-case": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.1.tgz",
-      "integrity": "sha512-qRlUWn/hXnX1R1LBDF/RelJLiqNjKjUqlmuBVSEIyye8kq49CXqkZWKmi8XeUAdDXWFOcGLUMZ+aHn3Q5lzUXw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
       "dev": true,
       "requires": {
-        "camel-case": "^4.1.1",
-        "capital-case": "^1.0.3",
-        "constant-case": "^3.0.3",
-        "dot-case": "^3.0.3",
-        "header-case": "^2.0.3",
-        "no-case": "^3.0.3",
-        "param-case": "^3.0.3",
-        "pascal-case": "^3.1.1",
-        "path-case": "^3.0.3",
-        "sentence-case": "^3.0.3",
-        "snake-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       },
       "dependencies": {
         "camel-case": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
           "dev": true,
           "requires": {
-            "pascal-case": "^3.1.1",
-            "tslib": "^1.10.0"
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
           }
         },
         "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         },
         "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
           "dev": true,
           "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
           }
         },
         "param-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+          "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
           "dev": true,
           "requires": {
-            "dot-case": "^3.0.3",
-            "tslib": "^1.10.0"
+            "dot-case": "^3.0.4",
+            "tslib": "^2.0.3"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         }
       }
     },
@@ -5515,13 +5521,13 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
-      "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
       "dev": true,
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.0",
+        "crc32-stream": "^4.0.1",
         "normalize-path": "^3.0.0",
         "readable-stream": "^3.6.0"
       },
@@ -5721,42 +5727,48 @@
       "dev": true
     },
     "constant-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.3.tgz",
-      "integrity": "sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0",
-        "upper-case": "^2.0.1"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       },
       "dependencies": {
         "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         },
         "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
           "dev": true,
           "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
           }
         },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        },
         "upper-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
-          "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+          "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         }
       }
@@ -5926,22 +5938,23 @@
         "request": "^2.88.2"
       }
     },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.1.0"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "crc32-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
-      "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+      "integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
+        "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "dependencies": {
@@ -6118,6 +6131,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+      "dev": true
+    },
+    "css-shorthand-properties": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
       "dev": true
     },
     "css-tree": {
@@ -6724,15 +6743,15 @@
       "dev": true
     },
     "devtools": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.6.2.tgz",
-      "integrity": "sha512-iogAMiD5lHyEm5Fq+rSHBmfYT0rmmeyJmbbuDKb5vguynM5PHuaH/TIxumJMnhyMqpfuLMkJB/HCt340VQA+UQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.11.0.tgz",
+      "integrity": "sha512-fqiRz77IIGkHfHdIkVYIpBNKz7qllJJvHP92NKDo5e41J+sSVKsjzHsPqvYLugRhSGsZKPrJ19Sj8kmPyFi18w==",
       "dev": true,
       "requires": {
-        "@wdio/config": "6.6.0",
-        "@wdio/logger": "6.6.0",
-        "@wdio/protocols": "6.6.0",
-        "@wdio/utils": "6.6.0",
+        "@wdio/config": "6.11.0",
+        "@wdio/logger": "6.10.10",
+        "@wdio/protocols": "6.10.6",
+        "@wdio/utils": "6.11.0",
         "chrome-launcher": "^0.13.1",
         "edge-paths": "^2.1.0",
         "puppeteer-core": "^5.1.0",
@@ -6741,9 +6760,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.799653",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.799653.tgz",
-      "integrity": "sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg==",
+      "version": "0.0.818844",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
       "dev": true
     },
     "di": {
@@ -6892,33 +6911,39 @@
       }
     },
     "dot-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
-      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       },
       "dependencies": {
         "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         },
         "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
           "dev": true,
           "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         }
       }
     },
@@ -8052,6 +8077,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/exif-reader/-/exif-reader-1.0.3.tgz",
       "integrity": "sha512-tWMBj1+9jUSibgR/kv/GQ/fkR0biaN9GEZ5iPdf7jFeH//d2bSzgPoaWf1OfMv4MXFD4upwvpCCyeMvSyLWSfA==",
+      "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
       "dev": true
     },
     "expand-brackets": {
@@ -9844,13 +9875,21 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "header-case": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.3.tgz",
-      "integrity": "sha512-LChe/V32mnUQnTwTxd3aAlNMk8ia9tjCDb/LjYtoMrdAPApxLB+azejUk5ERZIZdIqvinwv6BAUuFXH/tQPdZA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
       "dev": true,
       "requires": {
-        "capital-case": "^1.0.3",
-        "tslib": "^1.10.0"
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "hex-color-regex": {
@@ -12287,14 +12326,15 @@
       "dev": true
     },
     "karma-sauce-launcher": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-4.1.5.tgz",
-      "integrity": "sha512-X6/1IaUTOhbSuw+Y8ea8/1fAHsIbitDosJVnxqC0ZxIlDQMM4/U0WbETtCIbwUDoa89jwM3alfDs5RTRUW5mJw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-4.3.4.tgz",
+      "integrity": "sha512-sXka3l3Z9x+UhGMsg0fU+i+Jq82j7tfApMrAupM8JxO8ZskmSCozUM4cffLTwuzJPYjf0ffFNu3Up5Pzr26N/g==",
       "dev": true,
       "requires": {
-        "global-agent": "^2.1.8",
-        "saucelabs": "^4.3.0",
-        "webdriverio": "^6.1.9"
+        "fs-extra": "^9.0.1",
+        "global-agent": "^2.1.12",
+        "saucelabs": "^4.5.1",
+        "webdriverio": "^6.7.0"
       }
     },
     "keyv": {
@@ -13076,9 +13116,9 @@
       }
     },
     "loglevel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
-      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
     },
     "loglevel-plugin-prefix": {
@@ -14111,6 +14151,12 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -15396,33 +15442,39 @@
       "dev": true
     },
     "pascal-case": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
-      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       },
       "dependencies": {
         "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         },
         "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
           "dev": true,
           "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         }
       }
     },
@@ -15445,13 +15497,21 @@
       "dev": true
     },
     "path-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.3.tgz",
-      "integrity": "sha512-UMFU6UETFpCNWbIWNczshPrnK/7JAXBP2NYw80ojElbQ2+JYxdqWDBkvvqM93u4u6oLmuJ/tPOf2tM8KtXv4eg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
       "dev": true,
       "requires": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "path-dirname": {
@@ -16653,6 +16713,12 @@
         "parse-ms": "^0.1.0"
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "dev": true
+    },
     "prismjs": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
@@ -17000,15 +17066,16 @@
       }
     },
     "puppeteer-core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.3.1.tgz",
-      "integrity": "sha512-YE6c6FvHAFKQUyNTqFs78SgGmpcqOPhhmVfEVNYB4abv7bV2V+B3r72T3e7vlJkEeTloy4x9bQLrGbHHoKSg1w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.799653",
+        "devtools-protocol": "0.0.818844",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
+        "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
@@ -17065,9 +17132,9 @@
           }
         },
         "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
           "dev": true
         }
       }
@@ -17850,9 +17917,9 @@
       }
     },
     "resq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.8.0.tgz",
-      "integrity": "sha512-VObcnfPcE6/EKfHqsi5qoJ0+BF9qfl5181CytP1su3HgzilqF03DrQ+Y7kZQrd+5myfmantl9W3/5uUcpwvKeg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
+      "integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1"
@@ -17917,9 +17984,9 @@
       "dev": true
     },
     "rgb2hex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.0.tgz",
-      "integrity": "sha512-cHdNTwmTMPu/TpP1bJfdApd6MbD+Kzi4GNnM6h35mdFChhQPSi9cAI8J7DMn5kQDKX8NuBaQXAyo360Oa7tOEA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
+      "integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
       "dev": true
     },
     "rgba-regex": {
@@ -18252,24 +18319,24 @@
       "dev": true
     },
     "saucelabs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.5.0.tgz",
-      "integrity": "sha512-xPMYLLOJMnWRunZKiu92h4cKCR/SCTYBIvAHTlHYtDA09oebnwEOf7cjrv/+R0TuXgSYO85pll0mOXDIKUTB3Q==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.6.2.tgz",
+      "integrity": "sha512-TkMDH6ldTSQGPeNlL4D7rIojxuniVXATdoxxmYCrAEBXYKf9ogxi7rmBDiT3jfTnNU1WDUz59mSeAdBGoY6SpQ==",
       "dev": true,
       "requires": {
         "bin-wrapper": "^4.1.0",
         "change-case": "^4.1.1",
         "form-data": "^3.0.0",
-        "got": "^11.1.4",
+        "got": "^11.7.0",
         "hash.js": "^1.1.7",
         "tunnel": "0.0.6",
-        "yargs": "^15.3.1"
+        "yargs": "^16.0.3"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
           "dev": true
         },
         "cacheable-request": {
@@ -18288,14 +18355,14 @@
           }
         },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "wrap-ansi": "^7.0.0"
           }
         },
         "decompress-response": {
@@ -18313,15 +18380,11 @@
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
+        "escalade": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+          "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+          "dev": true
         },
         "form-data": {
           "version": "3.0.0",
@@ -18344,12 +18407,12 @@
           }
         },
         "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
+          "version": "11.8.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
+          "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^3.1.1",
+            "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
             "@types/cacheable-request": "^6.0.1",
             "@types/responselike": "^1.0.0",
@@ -18389,15 +18452,6 @@
             "json-buffer": "3.0.1"
           }
         },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -18422,24 +18476,6 @@
           "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
           "dev": true
         },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
         "responselike": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
@@ -18461,9 +18497,9 @@
           }
         },
         "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -18471,34 +18507,32 @@
             "strip-ansi": "^6.0.0"
           }
         },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "dev": true
+        },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
           "dev": true,
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
         }
       }
     },
@@ -18684,34 +18718,40 @@
       }
     },
     "sentence-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.3.tgz",
-      "integrity": "sha512-ZPr4dgTcNkEfcGOMFQyDdJrTU9uQO1nb1cjf+nuzb6FxgMDgKddZOM29qEsB7jvsZSMruLRcL2KfM4ypKpa0LA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0",
-        "upper-case-first": "^2.0.1"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
       },
       "dependencies": {
         "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
           "dev": true,
           "requires": {
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.3"
           }
         },
         "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
           "dev": true,
           "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         }
       }
     },
@@ -19113,13 +19153,21 @@
       "dev": true
     },
     "snake-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz",
-      "integrity": "sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
       "dev": true,
       "requires": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "snapdragon": {
@@ -22018,12 +22066,20 @@
       "dev": true
     },
     "upper-case-first": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.1.tgz",
-      "integrity": "sha512-105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
       "dev": true,
       "requires": {
-        "tslib": "^1.10.0"
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "uri-js": {
@@ -22794,24 +22850,23 @@
       }
     },
     "webdriver": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.6.2.tgz",
-      "integrity": "sha512-Xv4ber+2aKkgDtDqweNiEp4whiIO14Me67exHdfwvgOJb2sqrlW8SAz+e8oGI2s0pYZ2LBfHsNGLNcos/xEB/w==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.11.0.tgz",
+      "integrity": "sha512-31uD1Vi+9QAzDSpN3+0oFFRnzJP8IVp8wRjLVbIOaQGPXV1sKjAP7v6LJcxl1JjcmW8keAIh2eyAgbjZJbcyZw==",
       "dev": true,
       "requires": {
-        "@types/lodash.merge": "^4.6.6",
-        "@wdio/config": "6.6.0",
-        "@wdio/logger": "6.6.0",
-        "@wdio/protocols": "6.6.0",
-        "@wdio/utils": "6.6.0",
+        "@wdio/config": "6.11.0",
+        "@wdio/logger": "6.10.10",
+        "@wdio/protocols": "6.10.6",
+        "@wdio/utils": "6.11.0",
         "got": "^11.0.2",
         "lodash.merge": "^4.6.1"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
           "dev": true
         },
         "cacheable-request": {
@@ -22848,12 +22903,12 @@
           }
         },
         "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
+          "version": "11.8.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
+          "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^3.1.1",
+            "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
             "@types/cacheable-request": "^6.0.1",
             "@types/responselike": "^1.0.0",
@@ -22923,20 +22978,21 @@
       }
     },
     "webdriverio": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.6.2.tgz",
-      "integrity": "sha512-tBnAIS5B2/G+50h1+jR5uqahb8qfeh6JF0K9s//gpmv8NJ1X5npOUzJN38G3LtobTbpDMLMOD9LQgeqHknDnkA==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.11.3.tgz",
+      "integrity": "sha512-yHS01H0+oz59Y+JLj/u8piLzOhtTiQSeASwb3hHF1EDuIiiK6JgGYFAqCYr26BrlzqzUOQ/9VpJj11LtcKWF/A==",
       "dev": true,
       "requires": {
-        "@types/puppeteer": "^3.0.1",
-        "@wdio/config": "6.6.0",
-        "@wdio/logger": "6.6.0",
-        "@wdio/repl": "6.6.0",
-        "@wdio/utils": "6.6.0",
+        "@types/puppeteer-core": "^5.4.0",
+        "@wdio/config": "6.11.0",
+        "@wdio/logger": "6.10.10",
+        "@wdio/repl": "6.11.0",
+        "@wdio/utils": "6.11.0",
         "archiver": "^5.0.0",
         "atob": "^2.1.2",
+        "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "6.6.2",
+        "devtools": "6.11.0",
         "fs-extra": "^9.0.1",
         "get-port": "^5.1.1",
         "grapheme-splitter": "^1.0.2",
@@ -22946,10 +23002,10 @@
         "lodash.zip": "^4.2.0",
         "minimatch": "^3.0.4",
         "puppeteer-core": "^5.1.0",
-        "resq": "^1.6.0",
-        "rgb2hex": "^0.2.0",
+        "resq": "^1.9.1",
+        "rgb2hex": "0.2.3",
         "serialize-error": "^7.0.0",
-        "webdriver": "6.6.2"
+        "webdriver": "6.11.0"
       }
     },
     "webidl-conversions": {
@@ -23706,13 +23762,13 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
-      "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.0.0",
+        "compress-commons": "^4.0.2",
         "readable-stream": "^3.6.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-requirejs": "^1.1.0",
-    "karma-sauce-launcher": "^4.1.5",
+    "karma-sauce-launcher": "^4.3.4",
     "lint-staged": "^10.2.11",
     "markdown-it": "^11.0.0",
     "markdown-it-anchor": "^5.3.0",


### PR DESCRIPTION
### Description

- prevent tests from being triggered twice (by the `push` and `pull-request` events).
- browser test:
  - is flaky: update dependency `karma-sauce-launcher`. This could help, maybe.
  - job regularly runs 360m until cancelled by github => sets `timeout-minutes` to 20m.
 - Growl test:
   - fails => temporarily removes download/installation/start of Growl on Windows.