### PR TITLE
Ensure require.resolve is only ever called with absolute filepaths

### DIFF
--- a/lib/nodejs/file-unloader.js
+++ b/lib/nodejs/file-unloader.js
@@ -5,11 +5,16 @@
  * @private
  * @module
  */
+const path = require('path');
 
 /**
- * Deletes a file from the `require` cache.
+ * Deletes a file from the `require` cache. Resolve the file first to prevent
+ * MODULE_NOT_FOUND for relative paths.
+ *
+ * @see https://github.com/mochajs/mocha/issues/4548
  * @param {string} file - File
  */
 exports.unloadFile = file => {
-  delete require.cache[require.resolve(file)];
+  const absoluteModulePath = require.resolve(path.resolve(file));
+  delete require.cache[absoluteModulePath];
 };


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change
`unloadFile` is only ever passed filepaths, but adding a file with `mocha.addFile(relativePath)` throws `MODULE_NOT_FOUND` in an ESM context because `require.resolve(relativeFile)` fails.

Ensuring that `unloadFile` only ever calls `require.resolve` with absolute filepaths by wrapping with `path.resolve(relativePath)` prevents this error.
<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->
### Applicable issues
- Closes #4548

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)? no
* Is it an enhancement (minor release)? yes (?)
* Is it a bug fix, or does it not impact production code (patch release)? yes
-->
