### PR TITLE
Fix workflow filter on pull-request events

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -6,14 +6,13 @@ name: Tests
       - opened
       - synchronize
       - reopened
-    branches:
-      # Branches from forks have the form 'user:branch-name'
-      - '**:**'
 
 jobs:
   prepare-commit-msg:
     name: Retrieve head commit message
     runs-on: ubuntu-latest
+    # Run 'pull-request' event only on external PRs from forked repos.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     outputs:
       HEAD_COMMIT_MSG: '${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}'
     steps:


### PR DESCRIPTION
### Description

When a maintainer pushes a commit to this repo, two events (`push` and `pull-request`) are triggered and the same CI tests run twice. But the `pull-request` event should trigger the tests only for PR's from forked repos (no `push` event).

- my previous fix did not work, since `branches` contains the `into` branch name (`master`),
and not the `from` branch name (`user:branch-name`).
- jobs are skipped now with a `if` conditional.
Drawback: the skipped jobs are listed in the workflow job matrix, but at least the don't run anymore.