### PR TITLE
Add file location when SyntaxError happens in ESM (fixes #4551)

### DIFF
--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -3,7 +3,29 @@ const url = require('url');
 
 const formattedImport = async file => {
   if (path.isAbsolute(file)) {
-    return import(url.pathToFileURL(file));
+    try {
+      return await import(url.pathToFileURL(file));
+    } catch (err) {
+      // This is a hack created because ESM in Node.js (at least in Node v15.5.1) does not emit
+      // the location of the syntax error in the error thrown.
+      // This is problematic because the user can't see what file has the problem,
+      // so we add the file location to the error.
+      // This `if` should be removed once Node.js fixes the problem.
+      if (
+        err instanceof SyntaxError &&
+        err.message &&
+        err.stack &&
+        !err.stack.includes(file)
+      ) {
+        const newErrorWithFilename = new SyntaxError(err.message);
+        newErrorWithFilename.stack = err.stack.replace(
+          /^SyntaxError/,
+          `SyntaxError[ @${file} ]`
+        );
+        throw newErrorWithFilename;
+      }
+      throw err;
+    }
   }
   return import(file);
 };

--- a/test/integration/esm.spec.js
+++ b/test/integration/esm.spec.js
@@ -45,7 +45,10 @@ describe('esm', function() {
     const err = await runMochaAsync(fixture, args, {stdio: 'pipe'}).catch(
       err => err
     );
-    expect(err.output, 'to contain', 'SyntaxError').and('to contain', fixture);
+    expect(err.output, 'to contain', 'SyntaxError').and(
+      'to contain',
+      'esm-syntax-error.fixture.mjs'
+    );
   });
 
   it('should recognize esm files ending with .js due to package.json type flag', function(done) {

--- a/test/integration/esm.spec.js
+++ b/test/integration/esm.spec.js
@@ -1,5 +1,7 @@
 'use strict';
-var run = require('./helpers').runMochaJSON;
+var helpers = require('./helpers');
+var run = helpers.runMochaJSON;
+var runMochaAsync = helpers.runMochaAsync;
 var utils = require('../../lib/utils');
 var args =
   +process.versions.node.split('.')[0] >= 13 ? [] : ['--experimental-modules'];
@@ -36,6 +38,14 @@ describe('esm', function() {
       );
       done();
     });
+  });
+
+  it('should show file location when there is a syntax error in the test', async function() {
+    var fixture = 'esm/syntax-error/esm-syntax-error.fixture.mjs';
+    const err = await runMochaAsync(fixture, args, {stdio: 'pipe'}).catch(
+      err => err
+    );
+    expect(err.output, 'to contain', 'SyntaxError').and('to contain', fixture);
   });
 
   it('should recognize esm files ending with .js due to package.json type flag', function(done) {

--- a/test/integration/fixtures/esm/syntax-error/esm-syntax-error.fixture.mjs
+++ b/test/integration/fixtures/esm/syntax-error/esm-syntax-error.fixture.mjs
@@ -1,0 +1,3 @@
+// This is intentionally a syntax error
+it('should never run because of a syntax error here', => {
+});


### PR DESCRIPTION
### Description of the Change

According to issue #4551 (I verified that it is true), when there is a syntax error in an ESM file, the error thrown by Node.js contains only the error, but not the location (file and line number) where this problem happened. 

While the error doesn't include this information, we have the filename and can "inject" it into the error artificially. At least until Node.js fixes the problem. This change is local to ESM as it is only in the ESM importing code.

### Alternate Designs

The only alternative I can see is to get Node.js to fix the problem.

### Why should this be in core?

Because plugins can't fix this.

### Benefits

It is currently difficult to figure out on which test file the syntax error happened. This helps a lot by at least giving the file where the syntax error is. Usually, in the IDE, the developer can figure out what the problem is.

### Possible Drawbacks

The code that "patches" the error is convoluted and can theoretically fail in weird ways. Also, we won't know when Node.js fixes the problem, so we may have both indications on location in the error once Node.js fixes it.

### Applicable issues

This is a bug fix (patch release)