### PR TITLE
Show where syntax error from with ESM

### DIFF
--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -2,10 +2,40 @@ const path = require('path');
 const url = require('url');
 
 const formattedImport = async file => {
-  if (path.isAbsolute(file)) {
-    return import(url.pathToFileURL(file));
+  try {
+    if (path.isAbsolute(file)) {
+      return await import(url.pathToFileURL(file));
+    }
+    return import(file);
+  } catch (err) {
+    if (err.name === 'SyntaxError') {
+      // This is a hack to print where syntax error is from.
+      // In dynamic import, it doesn't contain filename linenumber in errer.stack
+      // See https://github.com/nodejs/modules/issues/471
+      // FIXME: remove this hack after nodejs suppurt
+      return await new Promise((resolve, reject) => {
+        const {spawn} = require('child_process');
+
+        const proc = spawn(process.execPath, [
+          '--unhandled-rejections=throw',
+          '-e',
+          `import('${file}')`
+        ]);
+
+        let errMsg = '';
+
+        proc.stderr.on('data', data => {
+          errMsg += data;
+        });
+
+        proc.on('exit', () => {
+          const err = new Error(errMsg);
+          err.stack = errMsg;
+          reject(err);
+        });
+      });
+    }
   }
-  return import(file);
 };
 
 exports.requireOrImport = async file => {


### PR DESCRIPTION
### Description of the Change
This is a kind of hack because node.js currently not support syntax errors in detail. See <https://github.com/nodejs/modules/issues/471>
And This is another approach to #4557 .

I found `node --unhandled-rejections=throw -e "import('syntax-error-file.mjs')"`  show syntax erroed file, linenumber, and code.

So, I try to run it with a file to import only when `SyntaxError` raised.

So, it will show like this:

```sh
$ mocha -ui qunit test*.mjs

file:///Users/outsider/Dropbox/projects/github/mocha/test2.mjs:5
test('test2a', => { // syntax error!
               ^^

SyntaxError: Unexpected token '=>'
    at Loader.moduleStrategy (internal/modules/esm/translators.js:145:18)
    at async link (internal/modules/esm/module_job.js:47:21)
```

And `--unhandled-rejections=throw` is default since [Node.js 15.0.0](https://nodejs.org/en/blog/release/v15.0.0/#throw-on-unhandled-rejections-33021)

### Alternate Designs
See #4557

### Why should this be in core?
Before node.js itself support it, Users can find easily where a syntax error from.

### Possible Drawbacks
It can be broken when Node.js itself supports it.

### Applicable issues
close #4551



If we agreed with this approach, I will add tests for It. 
I want to hear your opinion about this workaround.
