### PR TITLE
Introduce the afterThis hook

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -49,6 +49,7 @@ overrides:
     env:
       mocha: true
     globals:
+      afterThis: readonly
       expect: readonly
   - files:
       - bin/*

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -31,6 +31,7 @@ module.exports = function bddInterface(suite) {
     context.after = common.after;
     context.beforeEach = common.beforeEach;
     context.afterEach = common.afterEach;
+    context.afterThis = common.afterThis;
     context.run = mocha.options.delay && common.runWithSuite(suite);
     /**
      * Describe a "suite" with the given `title`

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -70,6 +70,10 @@ module.exports = function(suites, context, mocha) {
       suites[0].afterAll(name, fn);
     },
 
+    afterThis: function(name, fn) {
+      mocha.runner.suite.afterThis(name, fn);
+    },
+
     /**
      * Execute before each test case.
      *

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -39,6 +39,7 @@ module.exports = function qUnitInterface(suite) {
     context.after = common.after;
     context.beforeEach = common.beforeEach;
     context.afterEach = common.afterEach;
+    context.afterThis = common.afterThis;
     context.run = mocha.options.delay && common.runWithSuite(suite);
     /**
      * Describe a "suite" with the given `title`.

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -37,6 +37,7 @@ module.exports = function(suite) {
 
     context.setup = common.beforeEach;
     context.teardown = common.afterEach;
+    // XXX how should afterThis be named?
     context.suiteSetup = common.before;
     context.suiteTeardown = common.after;
     context.run = mocha.options.delay && common.runWithSuite(suite);

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -972,10 +972,10 @@ Mocha.prototype.run = function(fn) {
   var suite = this.suite;
   var options = this.options;
   options.files = this.files;
-  const runner = new this._runnerClass(suite, {
+  const runner = (this.runner = new this._runnerClass(suite, {
     delay: options.delay,
     cleanReferencesAfterRun: this._cleanReferencesAfterRun
-  });
+  }));
   createStatsCollector(runner);
   var reporter = new this._reporter(runner, options);
   runner.checkLeaks = options.checkLeaks === true;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -61,6 +61,7 @@ Runnable.prototype.reset = function() {
   this.timedOut = false;
   this._currentRetry = 0;
   this.pending = false;
+  this._afterThis = [];
   delete this.state;
   delete this.err;
 };
@@ -453,7 +454,11 @@ var constants = utils.defineConstants(
     /**
      * Value of `state` prop when a `Runnable` has been skipped by user
      */
-    STATE_PENDING: 'pending'
+    STATE_PENDING: 'pending',
+    /**
+     * Namespace for collection of a `Runnable`'s "after this" hooks
+     */
+    HOOK_TYPE_AFTER_THIS: 'afterThis'
   }
 );
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -13,6 +13,7 @@ var Runnable = require('./runnable');
 var Suite = require('./suite');
 var HOOK_TYPE_BEFORE_EACH = Suite.constants.HOOK_TYPE_BEFORE_EACH;
 var HOOK_TYPE_AFTER_EACH = Suite.constants.HOOK_TYPE_AFTER_EACH;
+var HOOK_TYPE_AFTER_THIS = Runnable.constants.HOOK_TYPE_AFTER_THIS;
 var HOOK_TYPE_AFTER_ALL = Suite.constants.HOOK_TYPE_AFTER_ALL;
 var HOOK_TYPE_BEFORE_ALL = Suite.constants.HOOK_TYPE_BEFORE_ALL;
 var EVENT_ROOT_SUITE_RUN = Suite.constants.EVENT_ROOT_SUITE_RUN;
@@ -485,7 +486,8 @@ Runner.prototype.hook = function(name, fn) {
     if (!hook) {
       return fn();
     }
-    self.currentRunnable = hook;
+
+    self.currentRunnable = suite.currentRunnable = hook;
 
     if (name === HOOK_TYPE_BEFORE_ALL) {
       hook.ctx.currentTest = hook.parent.tests[0];
@@ -701,6 +703,7 @@ Runner.prototype.runTests = function(suite, fn) {
     self.suite = after ? errSuite.parent : errSuite;
 
     if (self.suite) {
+      // XXX call hookUp afterThis?
       // call hookUp afterEach
       self.hookUp(HOOK_TYPE_AFTER_EACH, function(err2, errSuite2) {
         self.suite = orig;
@@ -797,7 +800,8 @@ Runner.prototype.runTests = function(suite, fn) {
       if (err) {
         return hookErr(err, errSuite, false);
       }
-      self.currentRunnable = self.test;
+
+      self.currentRunnable = self.suite.currentRunnable = self.test;
       self.runTest(function(err) {
         test = self.test;
         // conditional skip within it
@@ -809,7 +813,13 @@ Runner.prototype.runTests = function(suite, fn) {
             self.emit(constants.EVENT_TEST_PENDING, test);
           }
           self.emit(constants.EVENT_TEST_END, test);
-          return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+          return self.hookUp(HOOK_TYPE_AFTER_THIS, function(err) {
+            if (err) {
+              hookErr(err, errSuite, true);
+            } else {
+              self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+            }
+          });
         } else if (err) {
           var retry = test.currentRetry();
           if (retry < test.retries()) {
@@ -821,18 +831,36 @@ Runner.prototype.runTests = function(suite, fn) {
 
             // Early return + hook trigger so that it doesn't
             // increment the count wrong
-            return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+            return self.hookUp(HOOK_TYPE_AFTER_THIS, function(err) {
+              if (err) {
+                hookErr(err, errSuite, true);
+              } else {
+                self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+              }
+            });
           } else {
             self.fail(test, err);
           }
           self.emit(constants.EVENT_TEST_END, test);
-          return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+          return self.hookUp(HOOK_TYPE_AFTER_THIS, function(err) {
+            if (err) {
+              hookErr(err, errSuite, true);
+            } else {
+              self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+            }
+          });
         }
 
         test.state = STATE_PASSED;
         self.emit(constants.EVENT_TEST_PASS, test);
         self.emit(constants.EVENT_TEST_END, test);
-        self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+        return self.hookUp(HOOK_TYPE_AFTER_THIS, function(err) {
+          if (err) {
+            hookErr(err, errSuite, true);
+          } else {
+            self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+          }
+        });
       });
     });
   }

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -6,6 +6,7 @@
  */
 const {EventEmitter} = require('events');
 const Hook = require('./hook');
+const Runnable = require('./runnable');
 var {
   assignNewMochaID,
   clamp,
@@ -343,6 +344,27 @@ Suite.prototype.afterEach = function(title, fn) {
   return this;
 };
 
+Suite.prototype.afterThis = function(title, fn) {
+  if (this.isPending()) {
+    return this;
+  }
+  if (typeof title === 'function') {
+    fn = title;
+    title = fn.name;
+  }
+  title = '"after this" hook' + (title ? ': ' + title : '');
+
+  if (!this.currentRunnable) {
+    throw new Error('Use afterThis only inside a runnable');
+  }
+
+  var hook = this._createHook(title, fn);
+  this.currentRunnable._afterThis.push(hook);
+
+  // XXX emit afterEach hook?
+  return this;
+};
+
 /**
  * Add a test `suite`.
  *
@@ -533,6 +555,10 @@ Suite.prototype.appendOnlyTest = function(test) {
  * @private
  */
 Suite.prototype.getHooks = function getHooks(name) {
+  if (name === Runnable.constants.HOOK_TYPE_AFTER_THIS) {
+    return this.currentRunnable ? this.currentRunnable._afterThis : [];
+  }
+
   return this['_' + name];
 };
 

--- a/test/unit/after-this.spec.js
+++ b/test/unit/after-this.spec.js
@@ -1,0 +1,44 @@
+'use strict';
+
+describe('afterThis', function() {
+  var calls = [];
+
+  it('calls the hook', () => {
+    afterThis(() => {
+      calls.push('sync');
+    });
+  });
+
+  it('calls the hook in an async test', async () => {
+    afterThis(() => {
+      calls.push('async');
+    });
+  });
+
+  it('calls the async hook', () => {
+    afterThis(() => {
+      calls.push('async hook');
+    });
+  });
+
+  it('calls the hook on a skipped test', function() {
+    afterThis(() => {
+      calls.push('skip');
+    });
+
+    this.skip();
+  });
+
+  // XXX what's the proper way to test this?
+  it.skip('calls the hook even on test fail', () => {
+    afterThis(() => {
+      calls.push('test fail');
+    });
+
+    throw new Error('fail');
+  });
+
+  after(() => {
+    expect(calls, 'to equal', ['sync', 'async', 'async hook', 'skip']);
+  });
+});


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

The afterThis hook allows one to write cleanup logic inside the test definition,
enabling the use of variables declared inside the test itself. For example:

```js
// without afterThis hook
let resource;
beforeEach(() => {
    resource = acquireResource();
});
afterEach(() => {
    resource.dispose();
});
it('does something with a resource', () => {
    // use `resource`
});

// using afterThis hook
it('does something with a resource', () => {
    const resource = acquireResource();
    afterThis(() => resource.dispose());

    // use `resource`
});
```

The code using the resource is much closer to the initialisation/cleanup logic,
and there are less lifecycle hooks to be aware of.

This is inspired by bash's `trap` and go's `defer`.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

This design was chosen out of frustration with resource cleanup in
tests. Imagine a test in a larger suite which needs to establish a sinon stub,
like so:

```js
it('does something', () => {
    const stub = sinon.stub(fs, 'readFile').withArgs(...).returns(...);

    // something which calls fs
    sinon.assert.called(stub);

    stub.restore();
});
```

The call to `stub.restore` may never be reached, since the test may fail
beforehand. There are a few alternatives:

1) Use specific `beforeEach` and `afterEach` hooks. In case this stub is shared
between multiple tests, defining the stub in a pair of `before/afterEach` hooks
will be the way to go. However, with a test-specific stub which should /not/ be
shared between tests, you may need to set up a suite just for this test, as
such:

```js
describe('a thing', () => {
    it('does something unrelated to the stub', () => {
        // ...
    });

    describe('uses the stub', () => {
        let stub;
        beforeEach(() => {
            stub = sinon.stub(fs, 'readFile')...;
        });
        afterEach(() => {
            stub.restore();
        });

        it('does something with the stub', () => {
            // something which calls fs
            sinon.assert.called(stub);
        });
    });
});
```

This is possible, and may be the standard in some cases. However, there is a lot
of boilerplate around a single variable. When the friction of doing something is
high, it may end up not being done.

2) Use more global `beforeEach` and `afterEach` hooks. For sinon, this is
possible with `sinon.restore()`, like so:

```js
let stub;
beforeEach(() => {
    stub = sinon.stub(fs, 'readFile')...;
});
afterEach(() => {
    sinon.restore();
});
it('does something with the stub', () => {
    // something which calls fs
    sinon.assert.called(stub);
});
```


This may not be as easy for other kinds of resources, like setting up in-memory
DBs, other mocking libraries, or other mutative or otherwise stateful calls. For
more specific examples, see the "Benefits" section below.

3) A `try { ... } finally { ... }` statement, as such:

```js
it('does something with a stub', () => {
    let stub = sinon.stub(fs, 'readFile')...;

    try {
        // something which uses fs
        sinon.assert.called(stub);
    } finally {
        stub.restore();
    }
});
```

This is the closest in spirit to this commit's implementation, more akin to C#'s
`using` or Python's `with`.

This does incur confusion between test flow and program flow. On reading the
code above, the purpose of the `try...finally` may not be so clear on first
read; is this meant to be part of the test's flow, catching some kinds of
exceptions and trying out different situations, or is it test bookkeeping?

By calling a test bookkeeping function, you advertise your intention more
clearly, allowing the actual test code to dominate the bulk of the test
function.

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

This commit touches some of mocha's inner knobs, in a way that I don't believe
is (yet?) possible with 3rd-party packages.

An avenue I am very willing to explore is how to open up mocha so this will not
have to be in core.

### Benefits

<!-- What benefits will be realized by the code change? -->

A few more examples of resource cleanup:

```js
it('does something with a db connection', async () => {
    const db = await createMockDB();
    afterThis(db.close);

    // ...
});

it('does something with multiple resources', () => {
    const wsServer = new WebSocket.Server({
        host: 'localhost',
        port: 8888,
    });
    afterThis((done) => wsServer.close(done));

    const conn = new WebSocket('http://localhost:8888');
    afterThis((done) => {
        conn.on('close', done);
        conn.close();
    });
});

it('uses nock to persist a specific path', () => {
    const ignoreThisPath = nock('http://localhost:8888')
        .persist()
        .get('/something')
        .reply(200, 'You got something');
    afterThis(() => ignoreThisPath.persist(false));
});
```

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This introduces another hook, which is I believe something that hasn't been done
in a long while. This may be an undesirable precedent, or something which will
require further thought and/or collaboration with other test libraries.

The commit initially presented here may not be suitable for consumption, as I do
believe there are some flows that I've missed. It would be desirable to see if
there's interest in the feature and/or the current design before I continue work
on it.

The lack of prior art on this matter does make me wonder if I'm missing a
fundamental issue at play here.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

This is at least a minor release, and may be a major release since it introduces
a new global variable to existing code bases.
