### PR TITLE
GH actions: purge expired artifacts

### DIFF
--- a/.github/workflows/purge-expired-artifacts.yml
+++ b/.github/workflows/purge-expired-artifacts.yml
@@ -1,0 +1,20 @@
+# Deletes expired artifacts, which are not removed automatically by github.
+
+name: 'Purge expired artifacts'
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  purge-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LKP-RnD/purge-expired-artifacts-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo_to_purge: "mochajs/mocha"
+          dry_run: "false"


### PR DESCRIPTION
### Description

Since recently the ESLint Check in GH actions is failing:
`Error: HttpError: Failed to generate URL to download artifact`
`Error: Failed to generate URL to download artifact`

GH does not delete expired artifacts.
`https://api.github.com/repos/mochajs/mocha/actions/artifacts` shows aprox. 20 artifacts, all of them expired.
When _eslint-plus-action@v3.4.2_ is trying to download an expired artifact, it fails.
It's unclear to me why we have artifact at all on that job.

```
{
  "total_count": 20,
  "artifacts": [
    {
      "id": 24440022,
      "node_id": "MDg6QXJ0aWZhY3QyNDQ0MDAyMg==",
      "name": "eslint-cache-key-lint-results-Tests-4498",
      "size_in_bytes": 5477,
      "url": "https://api.github.com/repos/mochajs/mocha/actions/artifacts/24440022",
      "archive_download_url": "https://api.github.com/repos/mochajs/mocha/actions/artifacts/24440022/zip",
      "expired": true,
      "created_at": "2020-11-03T05:04:09Z",
      "updated_at": "2020-11-03T05:04:17Z",
      "expires_at": "2021-02-01T04:53:25Z"
    },
....
```

### Description

Add a scheduled action which deletes all expired artifacts.
