### PR TITLE
Deps: update workerpool to fix failing CI tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23018,9 +23018,9 @@
       }
     },
     "workerpool": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.4.tgz",
-      "integrity": "sha512-sAc9w9oAJQ2680gDArGinjw0Ygj2K3KF1ZCRfslBKUCzc9Gycwlj9ZIAbizPRBftcXxhXgoGMVPxJE0VMNnWbw=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "supports-color": "8.1.1",
     "which": "2.0.2",
     "wide-align": "1.1.3",
-    "workerpool": "6.0.4",
+    "workerpool": "6.1.0",
     "yargs": "16.2.0",
     "yargs-parser": "20.2.4",
     "yargs-unparser": "2.0.0"


### PR DESCRIPTION
### Description

Our CI tests are failing with Node v15.8

```
node:internal/validators:158
      throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received an instance of Array
    at ChildProcess.target.send (node:internal/child_process:716:7)
    at Array.forEach (<anonymous>)
    at dispatchQueuedRequests (/home/runner/work/mocha/mocha/node_modules/workerpool/src/WorkerHandler.js:262:21)
    at ChildProcess.<anonymous> (/home/runner/work/mocha/mocha/node_modules/workerpool/src/WorkerHandler.js:221:7)
    at ChildProcess.emit (node:events:378:20)
    at emit (node:internal/child_process:920:12)
    at processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

### Description of the Change

Upgrade workerpool to v6.1.0
