### PR TITLE
match supporter's properties with supporter.js

### DIFF
--- a/docs/_includes/supporters.md
+++ b/docs/_includes/supporters.md
@@ -3,7 +3,7 @@
 Use Mocha at Work? Ask your manager or marketing team if they'd help [support](https://opencollective.com/mochajs#support) our project. Your company's logo will also be displayed on [npmjs.com](http://npmjs.com/package/mocha) and our [GitHub repository](https://github.com/mochajs/mocha#sponsors).
 
 <ul class="image-list" id="sponsors">
-{%- for supporter in supporters.sponsors -%}
+{%- for supporter in supporters.sponsor -%}
   <li>
     {%- if supporter.website -%}
     <a href="{{ supporter.website }}" target="_blank" rel="noopener">
@@ -21,7 +21,7 @@ Use Mocha at Work? Ask your manager or marketing team if they'd help [support](h
 Find Mocha helpful? Become a [backer](https://opencollective.com/mochajs#support) and support Mocha with a monthly donation.
 
 <ul class="image-list faded-images" id="backers">
-{%- for supporter in supporters.backers -%}
+{%- for supporter in supporters.backer -%}
   <li>
     {%- if supporter.website -%}
     <a href="{{ supporter.website }}" target="_blank" rel="noopener">


### PR DESCRIPTION
Currently, [mochajs.org](https://mochajs.org/#sponsors) doesn't show any sponsors or backers. 

I'm not sure when this problem occurred. 
[This commit](https://github.com/mochajs/mocha/commit/cf736fedfb15203824c0d21af7900112354f5804#diff-e4c53b7172f4257db299fa9e7502d3ced0348c61013f8816258218a223649186R39-R40) introduced `SPONSOR_TIER` and `BACKER_TIER` constants and then [this commit](https://github.com/mochajs/mocha/commit/df8e9e6f0108cd06925ea745bb26771ed458c7cb#diff-e4c53b7172f4257db299fa9e7502d3ced0348c61013f8816258218a223649186R229-R230) use these constants for `supporters`'s child properties name.

So, we used `supporters.sponsors` and `supporters.backers` previously but, now it changed to `supporters.sponsor` and `supporters.backer`. However we didn't change `supporters.md`. 