### PR TITLE
Exclude wrong sponsor image temporary

### DIFF
--- a/docs/_data/supporters.js
+++ b/docs/_data/supporters.js
@@ -114,6 +114,13 @@ const fetchImage = process.env.MOCHA_DOCS_SKIP_IMAGE_DOWNLOAD
             'received html and expected a png; outage likely'
           );
         }
+        // FIXME: this image causes Unsupported image type
+        if (
+          url ===
+          'https://images.opencollective.com/codepilotai/732befb/logo/64.png'
+        ) {
+          throw new TypeError('temporary fix for build failure');
+        }
         debug('fetched %s', url);
         const canvasImage = await loadImage(imageBuf);
         debug('ok %s', url);


### PR DESCRIPTION
We fixed a bug for the supporter section on mochajs.org in #4569 .
Production build is still failed, but it is not related to #4569. 

No sponsors nor backers image on mochajs.org is critical. So, I made a temporary fix by excluding that sponsor.

## my tracking
As my tracking, downloaded sponsor image is fine, but Buffer data for the sponsor image is broken during making sprite-image.

This is the data we received from open collective and this avatar image(`https://images.opencollective.com/codepilotai/732befb/logo/64.png`) occurred the error.

```
{
  id: 'eeng0kzd-yvor4pz5-grpbma83-7xlw95jl',
  name: 'CodePilot.ai',
  slug: 'codepilotai',
  website: 'https://codepilot.ai',
  imgUrlMed: 'https://images.opencollective.com/codepilotai/732befb/logo/64.png',
  imgUrlSmall: 'https://images.opencollective.com/codepilotai/732befb/logo/32.png',
  firstDonation: '2018-02-09T23:39:30.388Z',
  totalDonations: 25000,
  type: 'ORGANIZATION',
  categories: [],
  avatar: 'https://images.opencollective.com/codepilotai/732befb/logo/64.png',
  tier: 'sponsor',
  dimensions: { width: 241, height: 64 }
}
```

This image saved to `docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png`.  And this image is fine.

[The stacktrace](https://app.netlify.com/sites/mocha/deploys/6020096c2e628958899b43d4) is like:

```
12:41:03 AM: (node:1403) UnhandledPromiseRejectionWarning: Error: Error loading docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png: Unsupported image type
12:41:03 AM:     at canvasImage.onerror (/opt/build/repo/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:16:9)
12:41:03 AM:     at setSource (/opt/build/repo/node_modules/canvas/lib/image.js:91:13)
12:41:03 AM:     at Image.set (/opt/build/repo/node_modules/canvas/lib/image.js:65:7)
12:41:03 AM:     at /opt/build/repo/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:21:21
12:41:03 AM:     at Promise._execute (/opt/build/repo/node_modules/bluebird/js/release/debuggability.js:384:9)
12:41:03 AM:     at Promise._resolveFromExecutor (/opt/build/repo/node_modules/bluebird/js/release/promise.js:518:18)
12:41:03 AM:     at new Promise (/opt/build/repo/node_modules/bluebird/js/release/promise.js:103:10)
12:41:03 AM:     at getCanvasImageFromImageAsset (/opt/build/repo/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:13:9)
12:41:03 AM:     at /opt/build/repo/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:257:11
12:41:03 AM:     at Array.map (<anonymous>)
12:41:03 AM:     at spriteBackgroundImages (/opt/build/repo/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:256:20)
12:41:03 AM:     at Immediate._onImmediate (/opt/build/repo/node_modules/assetgraph/lib/AssetGraph.js:648:25)
12:41:03 AM:     at processImmediate (internal/timers.js:461:21)
```

This is happened during our `nps docs.postbuild`.

On asseetgraph-sprite(see [here](https://github.com/assetgraph/assetgraph-sprite/blob/master/lib/spriteBackgroundImages.js#L11-L24)), `imageAsset.rawSrc` is `Buffer` and Buffer data is broken. 

```html
<div class="sponsor" title="CodePilot.ai"
   style="width: 241px; background-image: url(/docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png?sprite=sponsors)">
</div>
```

This is from our index.html. So, I guess `buildProduction` load the `Buffer` data from `/docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png`.  But I don't how assetgraph in details, 
I believe @Munter can find a hint.

### MCVE
This is MVCE to reproduce the issue.

```html
<!DOCTYPE html>
<html lang="en">
  <body>
    <ul class="image-list" id="sponsors">
      <li><a href="https://codepilot.ai" target="_blank" rel="noopener">
        <div class="sponsor" title="CodePilot.ai"
             style="width: 241px; background-image: url(/docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png?sprite=sponsors)"></div>
      </a></li>
    </ul>
  </body>
</html>
```

The below image is `/docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png`. 

![eeng0kzd-yvor4pz5-grpbma83-7xlw95jl](https://user-images.githubusercontent.com/390146/107156731-6d67f200-69c3-11eb-95a5-bbbd107abc5d.png)

If you run `./node_modules/.bin/buildProduction index.html --outroot _dist`, you can see same error.

```bash
$ ./node_modules/.bin/buildProduction index.html --outroot _dist
Guessing --root from input files: file:///Users/outsider/Dropbox/projects/github/mocha/
 ✔ 0.005 secs: logEvents
 ✔ 0.048 secs: loadAssets
 ℹ INFO: Webpack is installed, but could not load the webpack config (tried webpack.config.js): Cannot find module 'webpack.config.js'
         Require stack:
         - node_modules/assetgraph-builder/bin/buildProduction
 ✔ 0.177 secs: bundleWebpack
 ✔ 0.001 secs: populate
 ✔ 0.001 secs: bundleSystemJs
 ✔ 0.000 secs: bundleRequireJs
 ✔ 0.003 secs: populate
 ✔ 0.000 secs: populate
 ✔ 0.000 secs: checkIncompatibleTypes
 ✔ 0.000 secs: removeRelations
 ✔ 0.000 secs: populate
 ✔ 0.000 secs: populate
 ✔ 0.000 secs: removeRelations
 ✔ 0.049 secs: addDataVersionAttributeToHtmlElement
 ✔ 0.000 secs: stripDebug
 ✔ 0.000 secs: externalizeRelations
 ✔ 0.000 secs: mergeIdenticalAssets
objc[66010]: Class GNotificationCenterDelegate is implemented in both /Users/outsider/Dropbox/projects/github/mocha/node_modules/canvas/build/Release/libgio-2.0.0.dylib (0x11679a2e0) and /Users/outsider/Dropbox/projects/github/mocha/node_modules/sharp/vendor/lib/libgio-2.0.0.dylib (0x13e014578). One of the two will be used. Which one is undefined.
 ✔ 0.123 secs: processImages
/Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph-sprite/lib
(node:66010) UnhandledPromiseRejectionWarning: Error: Error loading 7 eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png - docs/_site/images/supporters/eeng0kzd-yvor4pz5-grpbma83-7xlw95jl.png: Unsupported image type
    at canvasImage.onerror (/Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:21:9)
    at setSource (/Users/outsider/Dropbox/projects/github/mocha/node_modules/canvas/lib/image.js:91:13)
    at Image.set (/Users/outsider/Dropbox/projects/github/mocha/node_modules/canvas/lib/image.js:65:7)
    at /Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:27:21
    at Promise._execute (/Users/outsider/Dropbox/projects/github/mocha/node_modules/bluebird/js/release/debuggability.js:384:9)
    at Promise._resolveFromExecutor (/Users/outsider/Dropbox/projects/github/mocha/node_modules/bluebird/js/release/promise.js:518:18)
    at new Promise (/Users/outsider/Dropbox/projects/github/mocha/node_modules/bluebird/js/release/promise.js:103:10)
    at getCanvasImageFromImageAsset (/Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:17:9)
    at /Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:273:18
    at Array.map (<anonymous>)
    at spriteBackgroundImages (/Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph-sprite/lib/spriteBackgroundImages.js:262:20)
    at Immediate._onImmediate (/Users/outsider/Dropbox/projects/github/mocha/node_modules/assetgraph/lib/AssetGraph.js:648:25)
    at processImmediate (internal/timers.js:461:21)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:66010) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:66010) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

# Additional issue.
This sponsor is CodePilot.ai, but the avatar image(<https://images.opencollective.com/codepilotai/732befb/logo/64.png>) is Netlify. 
I believe this is open collective issue. I made [an issue on Open Collective](https://github.com/opencollective/opencollective/issues/3948).