### PR TITLE
fix(esm): allow `import` from mocha in parallel

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -112,8 +112,18 @@ exports.before = function(...args) {
 exports.describe = function(...args) {
   (currentContext.describe || currentContext.suite).apply(this, args);
 };
+exports.describe.only = function(...args) {
+  (currentContext.describe || currentContext.suite).only.apply(this, args);
+};
+exports.describe.skip = function(...args) {
+  (currentContext.describe || currentContext.suite).skip.apply(this, args);
+};
+
 exports.it = function(...args) {
   (currentContext.it || currentContext.test).apply(this, args);
+};
+exports.it.only = function(...args) {
+  (currentContext.it || currentContext.test).only.apply(this, args);
 };
 exports.xit = function(...args) {
   (
@@ -121,24 +131,13 @@ exports.xit = function(...args) {
     (currentContext.test && currentContext.test.skip)
   ).apply(this, args);
 };
-exports.setup = function(...args) {
-  (currentContext.setup || currentContext.beforeEach).apply(this, args);
-};
-exports.suiteSetup = function(...args) {
-  (currentContext.suiteSetup || currentContext.before).apply(this, args);
-};
-exports.suiteTeardown = function(...args) {
-  (currentContext.suiteTeardown || currentContext.after).apply(this, args);
-};
-exports.suite = function(...args) {
-  (currentContext.suite || currentContext.describe).apply(this, args);
-};
-exports.teardown = function(...args) {
-  (currentContext.teardown || currentContext.afterEach).apply(this, args);
-};
-exports.test = function(...args) {
-  (currentContext.test || currentContext.it).apply(this, args);
-};
+exports.it.skip = exports.xit;
+exports.setup = exports.beforeEach;
+exports.suiteSetup = exports.before;
+exports.suiteTeardown = exports.after;
+exports.suite = exports.describe;
+exports.teardown = exports.afterEach;
+exports.test = exports.it;
 exports.run = function(...args) {
   currentContext.run.apply(this, args);
 };

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -96,6 +96,53 @@ exports.Suite = Suite;
 exports.Hook = require('./hook');
 exports.Test = require('./test');
 
+let currentContext;
+exports.afterEach = function(...args) {
+  (currentContext.afterEach || currentContext.teardown).apply(this, args);
+};
+exports.after = function(...args) {
+  (currentContext.after || currentContext.suiteTeardown).apply(this, args);
+};
+exports.beforeEach = function(...args) {
+  (currentContext.beforeEach || currentContext.setup).apply(this, args);
+};
+exports.before = function(...args) {
+  (currentContext.before || currentContext.suiteSetup).apply(this, args);
+};
+exports.describe = function(...args) {
+  (currentContext.describe || currentContext.suite).apply(this, args);
+};
+exports.it = function(...args) {
+  (currentContext.it || currentContext.test).apply(this, args);
+};
+exports.xit = function(...args) {
+  (
+    currentContext.xit ||
+    (currentContext.test && currentContext.test.skip)
+  ).apply(this, args);
+};
+exports.setup = function(...args) {
+  (currentContext.setup || currentContext.beforeEach).apply(this, args);
+};
+exports.suiteSetup = function(...args) {
+  (currentContext.suiteSetup || currentContext.before).apply(this, args);
+};
+exports.suiteTeardown = function(...args) {
+  (currentContext.suiteTeardown || currentContext.after).apply(this, args);
+};
+exports.suite = function(...args) {
+  (currentContext.suite || currentContext.describe).apply(this, args);
+};
+exports.teardown = function(...args) {
+  (currentContext.teardown || currentContext.afterEach).apply(this, args);
+};
+exports.test = function(...args) {
+  (currentContext.test || currentContext.it).apply(this, args);
+};
+exports.run = function(...args) {
+  currentContext.run.apply(this, args);
+};
+
 /**
  * Constructs a new Mocha instance with `options`.
  *
@@ -351,20 +398,7 @@ Mocha.prototype.ui = function(ui) {
   bindInterface(this.suite);
 
   this.suite.on(EVENT_FILE_PRE_REQUIRE, function(context) {
-    exports.afterEach = context.afterEach || context.teardown;
-    exports.after = context.after || context.suiteTeardown;
-    exports.beforeEach = context.beforeEach || context.setup;
-    exports.before = context.before || context.suiteSetup;
-    exports.describe = context.describe || context.suite;
-    exports.it = context.it || context.test;
-    exports.xit = context.xit || (context.test && context.test.skip);
-    exports.setup = context.setup || context.beforeEach;
-    exports.suiteSetup = context.suiteSetup || context.before;
-    exports.suiteTeardown = context.suiteTeardown || context.after;
-    exports.suite = context.suite || context.describe;
-    exports.teardown = context.teardown || context.afterEach;
-    exports.test = context.test || context.it;
-    exports.run = context.run;
+    currentContext = context;
   });
 
   return this;
@@ -1299,7 +1333,7 @@ Mocha.prototype.hasGlobalTeardownFixtures = function hasGlobalTeardownFixtures()
  * A (sync) function to assert a user-supplied plugin implementation is valid.
  *
  * Defined in a {@link PluginDefinition}.
- 
+
  * @callback PluginValidator
  * @param {*} value - Value to check
  * @this {PluginDefinition}

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -118,20 +118,20 @@ exports.describe.only = function(...args) {
 exports.describe.skip = function(...args) {
   (currentContext.describe || currentContext.suite).skip.apply(this, args);
 };
-
 exports.it = function(...args) {
   (currentContext.it || currentContext.test).apply(this, args);
 };
 exports.it.only = function(...args) {
   (currentContext.it || currentContext.test).only.apply(this, args);
 };
-exports.xit = function(...args) {
+exports.it.skip = function(...args) {
   (
     currentContext.xit ||
     (currentContext.test && currentContext.test.skip)
   ).apply(this, args);
 };
-exports.it.skip = exports.xit;
+exports.xdescribe = exports.describe.skip;
+exports.xit = exports.it.skip;
 exports.setup = exports.beforeEach;
 exports.suiteSetup = exports.before;
 exports.suiteTeardown = exports.after;

--- a/test/integration/common-js-require.spec.js
+++ b/test/integration/common-js-require.spec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const {runMochaAsync} = require('./helpers');
+
+describe('common js require', () => {
+  it('should be able to run a test where all mocha exports are used', async () => {
+    const result = await runMochaAsync('common-js-require.fixture.js', [
+      '--delay'
+    ]);
+    expect(result.output, 'to contain', 'running before');
+    expect(result.output, 'to contain', 'running suiteSetup');
+    expect(result.output, 'to contain', 'running setup');
+    expect(result.output, 'to contain', 'running beforeEach');
+    expect(result.output, 'to contain', 'running it');
+    expect(result.output, 'to contain', 'running afterEach');
+    expect(result.output, 'to contain', 'running teardown');
+    expect(result.output, 'to contain', 'running suiteTeardown');
+    expect(result.output, 'to contain', 'running after');
+  });
+});

--- a/test/integration/fixtures/common-js-require.fixture.js
+++ b/test/integration/fixtures/common-js-require.fixture.js
@@ -3,6 +3,7 @@ const { afterEach,
   beforeEach,
   before,
   describe,
+  xdescribe,
   it,
   xit,
   setup,
@@ -60,10 +61,16 @@ suite('root suite', () => {
 
   describe('describe', () => {});
 
+  xdescribe('xdescribe', () => {});
+
   describe.skip('describe.skip', () => {});
 
   suite.only('suite only', () => {});
 
   suite.skip('suite.skip', () => {});
+
 });
+
+// using `run` here makes it so this suite needs to be run with `--delay` mode.
+// adding it here to test that `run` is correctly exported from mocha.
 setTimeout(run, 0);

--- a/test/integration/fixtures/common-js-require.fixture.js
+++ b/test/integration/fixtures/common-js-require.fixture.js
@@ -1,0 +1,69 @@
+const { afterEach,
+  after,
+  beforeEach,
+  before,
+  describe,
+  it,
+  xit,
+  setup,
+  suiteSetup,
+  suiteTeardown,
+  suite,
+  teardown,
+  test,
+  run } = require('../../..');
+
+
+suite('root suite', () => {
+  setup(() => {
+    console.log('running setup');
+  })
+  before(() => {
+    console.log('running before');
+  });
+  beforeEach(() => {
+    console.log('running beforeEach');
+  });
+  afterEach(() => {
+    console.log('running afterEach');
+  });
+  after(() => {
+    console.log('running after');
+  });
+  teardown(() => {
+    console.log('running teardown');
+  });
+  suiteSetup(() => {
+    console.log('running suiteSetup');
+  });
+  suiteTeardown(() => {
+    console.log('running suiteTeardown');
+  });
+
+  describe.only('describe only', () => {
+    it('it', () => {
+      console.log('running it');
+    });
+    xit('it', () => {
+      console.log('running xit');
+    });
+    it.only('it.only', () => {
+      console.log('running it.only');
+    });
+    it.skip('it.skip', () => {
+      console.log('running it.skip');
+    });
+    test('test', () => {
+      console.log('running test');
+    });
+  });
+
+  describe('describe', () => {});
+
+  describe.skip('describe.skip', () => {});
+
+  suite.only('suite only', () => {});
+
+  suite.skip('suite.skip', () => {});
+});
+setTimeout(run, 0);

--- a/test/integration/fixtures/parallel/test1.mjs
+++ b/test/integration/fixtures/parallel/test1.mjs
@@ -1,0 +1,5 @@
+import {describe,it} from "../../../../index.js";
+
+describe('test1', () => {
+  it('should pass', () => {});
+});

--- a/test/integration/fixtures/parallel/test2.mjs
+++ b/test/integration/fixtures/parallel/test2.mjs
@@ -1,0 +1,5 @@
+import {describe,it} from "../../../../index.js";
+
+describe('test2', () => {
+  it('should pass', () => {});
+});

--- a/test/integration/fixtures/parallel/test3.mjs
+++ b/test/integration/fixtures/parallel/test3.mjs
@@ -1,0 +1,7 @@
+import {describe,it} from "../../../../index.js";
+
+describe('test3', () => {
+  it('should fail', () => {
+    throw new Error('expecting this error to fail');
+  });
+});

--- a/test/integration/parallel.spec.js
+++ b/test/integration/parallel.spec.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assert');
+const {runMochaJSONAsync} = require('./helpers');
+
+describe('parallel run', () => {
+  it('it should allow "const {it} = require("mocha") syntax', async () => {
+    const result = await runMochaJSONAsync('parallel/test3.mjs', [
+      '--parallel',
+      '--jobs',
+      '2',
+      require.resolve('./fixtures/parallel/test1.mjs'),
+      require.resolve('./fixtures/parallel/test2.mjs')
+    ]);
+    assert.strictEqual(result.stats.failures, 1);
+    assert.strictEqual(result.stats.passes, 2);
+  });
+});

--- a/test/integration/parallel.spec.js
+++ b/test/integration/parallel.spec.js
@@ -2,17 +2,27 @@
 
 const assert = require('assert');
 const {runMochaJSONAsync} = require('./helpers');
+const semver = require('semver');
 
 describe('parallel run', () => {
-  it('it should allow "const {it} = require("mocha") syntax', async () => {
-    const result = await runMochaJSONAsync('parallel/test3.mjs', [
-      '--parallel',
-      '--jobs',
-      '2',
-      require.resolve('./fixtures/parallel/test1.mjs'),
-      require.resolve('./fixtures/parallel/test2.mjs')
-    ]);
-    assert.strictEqual(result.stats.failures, 1);
-    assert.strictEqual(result.stats.passes, 2);
+  /**
+   * @see https://github.com/mochajs/mocha/issues/4559
+   */
+  it('should allow `import {it} from "mocha"` module syntax', async () => {
+    if (semver.major(process.version) <= 10) {
+      console.log(
+        `[SKIPPED] for node ${process.version} (es module syntax isn't supported on node <= 10)`
+      );
+    } else {
+      const result = await runMochaJSONAsync('parallel/test3.mjs', [
+        '--parallel',
+        '--jobs',
+        '2',
+        require.resolve('./fixtures/parallel/test1.mjs'),
+        require.resolve('./fixtures/parallel/test2.mjs')
+      ]);
+      assert.strictEqual(result.stats.failures, 1);
+      assert.strictEqual(result.stats.passes, 2);
+    }
   });
 });


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Fixes the issue where `import { describe, it } from 'mocha'` doesn't work with `--parallel` when using es modules by proxying `describe`, `it` and friends to their actual contextual counterpart.

### Alternate Designs

There is not much else we can do I think, other than going full blown esm (for example, using [package exports](https://nodejs.org/api/packages.html#packages_exports)).

### Why should this be in core?

Its imported from core (bare `'mocha'`).

### Benefits

Allows `import {...} from 'mocha'` in an es module setting with `parallel`

### Possible Drawbacks

More code to maintain

### Applicable issues

Closes #4559, should be a patch release.
