### PR TITLE
Remove [skip ci] workaround for GitHub Actions

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -8,37 +8,16 @@ name: Tests
       - reopened
 
 jobs:
-  prepare-commit-msg:
-    name: Retrieve head commit message
+  prevent-run-twice:
+    name: Prevent to run twice
     runs-on: ubuntu-latest
     # Run 'pull-request' event only on external PRs from forked repos.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    outputs:
-      HEAD_COMMIT_MSG: '${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}'
     steps:
-      - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
-      - name: find commit msg for PR
-        id: commitMsg
-        if: github.event_name == 'pull_request'
-        run: >-
-          echo "::set-output name=HEAD_COMMIT_MSG::$(git log --no-merges -1
-          --oneline)"
-
-  check-skip:
-    name: Check to skip CI
-    needs: prepare-commit-msg
-    runs-on: ubuntu-latest
-    if: >-
-      ${{ !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(needs.prepare-commit-msg.outputs.HEAD_COMMIT_MSG, '[ci skip]')
-      }}
-    steps:
-      - run: 'echo "${{ github.event.head_commit.message }}"'
-
+      - run: 'echo run Tests'
   smoke:
     name: 'Smoke [Node.js v${{ matrix.node }} / ${{ matrix.os }}]'
-    needs: check-skip
+    needs: prevent-run-twice
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:


### PR DESCRIPTION
Now [GH actions officially support [skip ci]](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/). So, we don't need this workaround anymore. 

If commit message contains `[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`, or `[actions skip]`, GitHub actions workflow never run. It means there are no logs it was skipped. Just skipped.
