### PR TITLE
fix(watch-run.js): pause stdin on SIGINT

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -211,6 +211,9 @@ const createWatcher = (
 
   let exiting = false;
   process.on('SIGINT', async () => {
+    // stop listening on stdin; otherwise there can be weird behavior if a
+    // parent process like yarn doesn't wait for mocha to exit
+    process.stdin.pause();
     showCursor();
     console.error(`${logSymbols.warning} [mocha] cleaning up, please wait...`);
     if (!exiting) {


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

I can describe this in more detail in an issue if you'd like, but I determined through experimentation that this solved funky behavior after interrupting watch mode run by yarn v1, which forwards SIGINT but doesn't wait for the child process to exit.

Even though `yarn run` exits out to the shell immediately on Ctrl-C, if you then press the **up** key while mocha teardown hooks are still running, for some reason it gets routed to mocha and causes this error:

```
node_modules/mocha/lib/runner.js:962
    throw err;
    ^

Error: read EIO
    at TTY.onStreamRead (internal/stream_base_commons.js:209:20)
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (internal/streams/destroy.js:106:8)
    at emitErrorCloseNT (internal/streams/destroy.js:74:3)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  errno: -5,
  code: 'EIO',
  syscall: 'read'
}
```

I wonder if this is a peculiarity of macOS terminal (it seems really strange that anything would reach mocha's stdin after the parent process has been terminated?) but adding `process.stdin.pause()` prevents this issue as well as other strange behavior (`^[[A` getting printed instead of the previous command when **up** key is pressed).  There's no need to listen on stdin after mocha has received SIGINT anyway.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Yarn and other programs should of course wait for spawned child processes to exit, but as far as what mocha has control over, this is still an improvement

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

This amends the core feature of allowing the user to type `rs` in watch mode.

### Benefits

<!-- What benefits will be realized by the code change? -->

Better behavior when mocha is spawned by programs that don't wait for it to exit when interrupted

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

minor bug fix
