### PR TITLE
Filter active sponsors/backers and categorize correctly

### DIFF
--- a/docs/_data/blocklist.json
+++ b/docs/_data/blocklist.json
@@ -10,7 +10,6 @@
   "mochajs",
   "my-true-media",
   "open-apk-file",
-  "pfannen-test",
   "thetoy",
   "trust-my-paper",
   "writemypaper4me",

--- a/docs/_includes/supporters.md
+++ b/docs/_includes/supporters.md
@@ -3,7 +3,7 @@
 Use Mocha at Work? Ask your manager or marketing team if they'd help [support](https://opencollective.com/mochajs#support) our project. Your company's logo will also be displayed on [npmjs.com](http://npmjs.com/package/mocha) and our [GitHub repository](https://github.com/mochajs/mocha#sponsors).
 
 <ul class="image-list" id="sponsors">
-{%- for supporter in supporters.sponsor -%}
+{%- for supporter in supporters.sponsors -%}
   <li>
     {%- if supporter.website -%}
     <a href="{{ supporter.website }}" target="_blank" rel="noopener">
@@ -21,7 +21,7 @@ Use Mocha at Work? Ask your manager or marketing team if they'd help [support](h
 Find Mocha helpful? Become a [backer](https://opencollective.com/mochajs#support) and support Mocha with a monthly donation.
 
 <ul class="image-list faded-images" id="backers">
-{%- for supporter in supporters.backer -%}
+{%- for supporter in supporters.backers -%}
   <li>
     {%- if supporter.website -%}
     <a href="{{ supporter.website }}" target="_blank" rel="noopener">

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in 
 
 <nav class="badges">
   <a href="https://gitter.im/mochajs/mocha"><img src="/images/join-chat.svg" height="18" alt="Gitter"></a>
-  <a href="#sponsors"><img src="https://opencollective.com/mochajs/sponsors/badge.svg" height="18" alt="OpenCollective sponsors"></a>
-  <a href="#backers"><img src="https://opencollective.com/mochajs/backers/badge.svg" height="18" alt="OpenCollective backers"></a>
+  <a href="#sponsors"><img src="https://opencollective.com/mochajs/tiers/sponsors/badge.svg" height="18" alt="OpenCollective sponsors"></a>
+  <a href="#backers"><img src="https://opencollective.com/mochajs/tiers/backers/badge.svg" height="18" alt="OpenCollective backers"></a>
 </nav>
 
 {% include supporters.md %}


### PR DESCRIPTION
### Description

Our site [mochajs.org](https://mochajs.org/) is listing the avatars/links of our financial contributors at _OpenCollective_:
- all (active and cancelled) contributors are shown
- the distinction between sponsor and backer is incorrect. At the moment we only have one active sponsor.


### Description of the Change

- The majority of monthly contributions (ORDER) has been cancelled by the contributors (ACCOUNT).
We only select orders with `ORDER.status===ACTIVE` and ignore the cancelled ones.
- We use `ORDER.tier` set by _OpenCollective_ for correct distinction (`sponsors`, `backers`).

### Applicable issues

closes #4595