### PR TITLE
Add build to GH actions run

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -88,11 +88,11 @@ module.exports = config => {
     console.error('CI mode enabled');
     if (env.GITHUB_RUN_ID) {
       console.error('Github Actions detected');
-      bundleDirPath = path.join(
-        BASE_BUNDLE_DIR_PATH,
-        `github-${env.GITHUB_RUN_ID}_${env.GITHUB_RUN_NUMBER}`
-      );
-      sauceConfig = {};
+      const buildId = `github-${env.GITHUB_RUN_ID}_${env.GITHUB_RUN_NUMBER}`;
+      bundleDirPath = path.join(BASE_BUNDLE_DIR_PATH, buildId);
+      sauceConfig = {
+        build: buildId
+      };
     } else {
       console.error(`Local environment (${hostname}) detected`);
       // don't need to run sauce from Windows CI b/c travis does it.
@@ -170,15 +170,16 @@ const addSauceTests = (cfg, sauceLabs) => {
 
     // creates Karma `customLauncher` configs from `SAUCE_BROWSER_PLATFORM_MAP`
     const customLaunchers = sauceBrowsers.reduce((acc, sauceBrowser) => {
-      const platform = SAUCE_BROWSER_PLATFORM_MAP[sauceBrowser];
-      const [browserName, version] = sauceBrowser.split('@');
+      const platformName = SAUCE_BROWSER_PLATFORM_MAP[sauceBrowser];
+      const [browserName, browserVersion] = sauceBrowser.split('@');
       return {
         ...acc,
         [sauceBrowser]: {
           base: 'SauceLabs',
           browserName,
-          version,
-          platform
+          browserVersion,
+          platformName,
+          'sauce:options': sauceLabs
         }
       };
     }, {});


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

This patch contains modifications to the `karma.conf.js` to include build ids to the tests. This will fix the invalid badge on the Readme which now shows `unknown` because no new builds have been created for a while.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None, build id is required to display correct badge information

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

Because the readme lives in this repo.

### Benefits

<!-- What benefits will be realized by the code change? -->

Showing up to date build status promotes MochaJS being a stable testing framework.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

It is a documentation update.
