### PR TITLE
Add output option to JSON reporter (#4131)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1933,6 +1933,8 @@ Alias: `JSON`, `json`
 
 The JSON reporter outputs a single large JSON object when the tests have completed (failures or not).
 
+By default, it will output to the console. To write directly to a file, use `--reporter-option output=filename.json`.
+
 ![json reporter](images/reporter-json.png?withoutEnlargement&resize=920,9999){:class="screenshot" loading="lazy"}
 
 ### JSON Stream

--- a/example/config/.mocharc.js
+++ b/example/config/.mocharc.js
@@ -33,7 +33,7 @@ module.exports = {
   parallel: false,
   recursive: false,
   reporter: 'spec',
-  'reporter-option': ['foo=bar', 'baz=quux'],
+  'reporter-option': ['foo=bar', 'baz=quux'], // array, not object
   require: '@babel/register',
   retries: 1,
   slow: '75',

--- a/example/config/.mocharc.yml
+++ b/example/config/.mocharc.yml
@@ -35,7 +35,7 @@ package: './package.json'
 parallel: false
 recursive: false
 reporter: 'spec'
-reporter-option:
+reporter-option: # array, not object
   - 'foo=bar'
   - 'baz=quux'
 require: '@babel/register'

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -90,7 +90,7 @@ exports.colors = {
 
 exports.symbols = {
   ok: symbols.success,
-  err: symbols.err,
+  err: symbols.error,
   dot: '.',
   comma: ',',
   bang: '!'

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -7,6 +7,10 @@
  */
 
 var Base = require('./base');
+var fs = require('fs');
+var path = require('path');
+var errors = require('../errors');
+var createUnsupportedError = errors.createUnsupportedError;
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
@@ -38,6 +42,14 @@ function JSONReporter(runner, options) {
   var pending = [];
   var failures = [];
   var passes = [];
+  var output;
+
+  if (options && options.reporterOptions && options.reporterOptions.output) {
+    if (!fs || !fs.writeFileSync) {
+      throw createUnsupportedError('file output not supported in browser');
+    }
+    output = options.reporterOptions.output;
+  }
 
   runner.on(EVENT_TEST_END, function(test) {
     tests.push(test);
@@ -66,7 +78,13 @@ function JSONReporter(runner, options) {
 
     runner.testResults = obj;
 
-    process.stdout.write(JSON.stringify(obj, null, 2));
+    var json = JSON.stringify(obj, null, 2);
+    if (output) {
+      fs.mkdirSync(path.dirname(output), {recursive: true});
+      fs.writeFileSync(output, json);
+    } else {
+      process.stdout.write(json);
+    }
   });
 }
 

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -9,14 +9,14 @@
 var Base = require('./base');
 var fs = require('fs');
 var path = require('path');
-var errors = require('../errors');
-var createUnsupportedError = errors.createUnsupportedError;
+const createUnsupportedError = require('../errors').createUnsupportedError;
+const utils = require('../utils');
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
+var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_TEST_END = constants.EVENT_TEST_END;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
-var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 
 /**
  * Expose `JSON`.
@@ -34,7 +34,7 @@ exports = module.exports = JSONReporter;
  * @param {Runner} runner - Instance triggers reporter actions.
  * @param {Object} [options] - runner options
  */
-function JSONReporter(runner, options) {
+function JSONReporter(runner, options = {}) {
   Base.call(this, runner, options);
 
   var self = this;
@@ -44,11 +44,11 @@ function JSONReporter(runner, options) {
   var passes = [];
   var output;
 
-  if (options && options.reporterOptions && options.reporterOptions.output) {
-    if (!fs || !fs.writeFileSync) {
+  if (options.reporterOption && options.reporterOption.output) {
+    if (utils.isBrowser()) {
       throw createUnsupportedError('file output not supported in browser');
     }
-    output = options.reporterOptions.output;
+    output = options.reporterOption.output;
   }
 
   runner.on(EVENT_TEST_END, function(test) {
@@ -80,8 +80,15 @@ function JSONReporter(runner, options) {
 
     var json = JSON.stringify(obj, null, 2);
     if (output) {
-      fs.mkdirSync(path.dirname(output), {recursive: true});
-      fs.writeFileSync(output, json);
+      try {
+        fs.mkdirSync(path.dirname(output), {recursive: true});
+        fs.writeFileSync(output, json);
+      } catch (err) {
+        console.error(
+          `${Base.symbols.err} [mocha] writing output to "${output}" failed: ${err.message}\n`
+        );
+        process.stdout.write(json);
+      }
     } else {
       process.stdout.write(json);
     }

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -1,12 +1,15 @@
 'use strict';
 
+var fs = require('fs');
 var sinon = require('sinon');
+var JSONReporter = require('../../lib/reporters/json');
 var Mocha = require('../../');
 var Suite = Mocha.Suite;
 var Runner = Mocha.Runner;
 var Test = Mocha.Test;
 
 describe('JSON reporter', function() {
+  var mocha;
   var suite;
   var runner;
   var testTitle = 'json test 1';
@@ -14,131 +17,188 @@ describe('JSON reporter', function() {
   var noop = function() {};
 
   beforeEach(function() {
-    var mocha = new Mocha({
+    mocha = new Mocha({
       reporter: 'json'
     });
     suite = new Suite('JSON suite', 'root');
     runner = new Runner(suite);
-    var options = {};
-    /* eslint no-unused-vars: off */
-    var mochaReporter = new mocha._reporter(runner, options);
-  });
-
-  beforeEach(function() {
-    sinon.stub(process.stdout, 'write').callsFake(noop);
   });
 
   afterEach(function() {
     sinon.restore();
   });
 
-  it('should have 1 test failure', function(done) {
-    var error = {message: 'oh shit'};
-
-    var test = new Test(testTitle, function(done) {
-      done(new Error(error.message));
+  describe('test results', function() {
+    beforeEach(function() {
+      var options = {};
+      /* eslint no-unused-vars: off */
+      var mochaReporter = new mocha._reporter(runner, options);
     });
 
-    test.file = testFile;
-    suite.addTest(test);
+    beforeEach(function() {
+      sinon.stub(process.stdout, 'write').callsFake(noop);
+    });
 
-    runner.run(function(failureCount) {
-      sinon.restore();
-      expect(runner, 'to satisfy', {
-        testResults: {
-          failures: [
-            {
-              title: testTitle,
-              file: testFile,
-              err: {
-                message: error.message
+    it('should have 1 test failure', function(done) {
+      var error = {message: 'oh shit'};
+
+      var test = new Test(testTitle, function(done) {
+        done(new Error(error.message));
+      });
+
+      test.file = testFile;
+      suite.addTest(test);
+
+      runner.run(function(failureCount) {
+        sinon.restore();
+        expect(runner, 'to satisfy', {
+          testResults: {
+            failures: [
+              {
+                title: testTitle,
+                file: testFile,
+                err: {
+                  message: error.message
+                }
               }
-            }
-          ]
-        }
+            ]
+          }
+        });
+        expect(failureCount, 'to be', 1);
+        done();
       });
-      expect(failureCount, 'to be', 1);
-      done();
-    });
-  });
-
-  it('should have 1 test pending', function(done) {
-    var test = new Test(testTitle);
-    test.file = testFile;
-    suite.addTest(test);
-
-    runner.run(function(failureCount) {
-      sinon.restore();
-      expect(runner, 'to satisfy', {
-        testResults: {
-          pending: [
-            {
-              title: testTitle,
-              file: testFile
-            }
-          ]
-        }
-      });
-      expect(failureCount, 'to be', 0);
-      done();
-    });
-  });
-
-  it('should have 1 test pass', function(done) {
-    const test = new Test(testTitle, () => {});
-
-    test.file = testFile;
-    suite.addTest(test);
-
-    runner.run(function(failureCount) {
-      expect(runner, 'to satisfy', {
-        testResults: {
-          passes: [
-            {
-              title: testTitle,
-              file: testFile,
-              speed: /(slow|medium|fast)/
-            }
-          ]
-        }
-      });
-      expect(failureCount, 'to be', 0);
-      done();
-    });
-  });
-
-  it('should handle circular objects in errors', function(done) {
-    var testTitle = 'json test 1';
-    function CircleError() {
-      this.message = 'oh shit';
-      this.circular = this;
-    }
-    var error = new CircleError();
-
-    var test = new Test(testTitle, function(done) {
-      throw error;
     });
 
-    test.file = testFile;
-    suite.addTest(test);
+    it('should have 1 test pending', function(done) {
+      var test = new Test(testTitle);
+      test.file = testFile;
+      suite.addTest(test);
 
-    runner.run(function(failureCount) {
-      sinon.restore();
-      expect(runner, 'to satisfy', {
-        testResults: {
-          failures: [
-            {
-              title: testTitle,
-              file: testFile,
-              err: {
-                message: error.message
+      runner.run(function(failureCount) {
+        sinon.restore();
+        expect(runner, 'to satisfy', {
+          testResults: {
+            pending: [
+              {
+                title: testTitle,
+                file: testFile
               }
-            }
-          ]
-        }
+            ]
+          }
+        });
+        expect(failureCount, 'to be', 0);
+        done();
       });
-      expect(failureCount, 'to be', 1);
-      done();
+    });
+
+    it('should have 1 test pass', function(done) {
+      const test = new Test(testTitle, () => {});
+
+      test.file = testFile;
+      suite.addTest(test);
+
+      runner.run(function(failureCount) {
+        expect(runner, 'to satisfy', {
+          testResults: {
+            passes: [
+              {
+                title: testTitle,
+                file: testFile,
+                speed: /(slow|medium|fast)/
+              }
+            ]
+          }
+        });
+        expect(failureCount, 'to be', 0);
+        done();
+      });
+    });
+
+    it('should handle circular objects in errors', function(done) {
+      var testTitle = 'json test 1';
+      function CircleError() {
+        this.message = 'oh shit';
+        this.circular = this;
+      }
+      var error = new CircleError();
+
+      var test = new Test(testTitle, function(done) {
+        throw error;
+      });
+
+      test.file = testFile;
+      suite.addTest(test);
+
+      runner.run(function(failureCount) {
+        sinon.restore();
+        expect(runner, 'to satisfy', {
+          testResults: {
+            failures: [
+              {
+                title: testTitle,
+                file: testFile,
+                err: {
+                  message: error.message
+                }
+              }
+            ]
+          }
+        });
+        expect(failureCount, 'to be', 1);
+        done();
+      });
+    });
+  });
+
+  describe("when 'reporterOptions.output' is provided", function() {
+    var expectedDirName = 'reports';
+    var expectedFileName = 'reports/test-results.json';
+    var options = {
+      reporterOptions: {
+        output: expectedFileName
+      }
+    };
+
+    beforeEach(function() {
+      /* eslint no-unused-vars: off */
+      var mochaReporter = new mocha._reporter(runner, options);
+    });
+
+    beforeEach(function() {
+      // Add one test to suite to avoid assertions against empty test results
+      var test = new Test(testTitle, () => {});
+      test.file = testFile;
+      suite.addTest(test);
+    });
+
+    describe('when file can be created', function() {
+      it('should write test results to file', function(done) {
+        var fsMkdirSync = sinon.stub(fs, 'mkdirSync');
+        var fsWriteFileSync = sinon.stub(fs, 'writeFileSync');
+
+        fsWriteFileSync.callsFake(function(filename, content) {
+          var expectedJson = JSON.stringify(runner.testResults, null, 2);
+          expect(expectedFileName, 'to be', filename);
+          expect(content, 'to be', expectedJson);
+        });
+
+        runner.run(function() {
+          fsMkdirSync.calledWith(expectedDirName, {recursive: true});
+          expect(fsWriteFileSync.calledOnce, 'to be true');
+          done();
+        });
+      });
+    });
+
+    describe('when run in browser', function() {
+      it('should throw unsupported error', function() {
+        sinon.stub(fs, 'writeFileSync').value(false);
+        expect(
+          () => new JSONReporter(runner, options),
+          'to throw',
+          'file output not supported in browser'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Extends `JSON` reporter with option to write output directly to file instead of a console.

closes #4131

### Description of the Change

- If output option was provided to JSON reporter:
  - On `EVENT_RUN_END` it will write JSON output to given file - single call to `fs.writeFileSync()`
  - Directory structure will be recursively created if needed - `fs.mkdirSync()`
  - If test runs in browser it will throw unsupported error
- Unit tests has been updated
  - Verifies if reporter writes to given file same JSON content as it sets on the `runner` instance
  - Verifies if reporter throws error if output option is provided and test runs in browser
  - Diff is bigger unless you hide whitespace only changes because existing tests were put into `describe()` group
- Documentation has been updated

### Alternate Designs

`xunit` reporter uses write stream and produces output continuously during test execution.
Similar behavior is provided by `json-stream` reporter.
`json` reporter outputs a single json when the tests have completed so I've used single call to `fs.writeFileSync()` instead of creating write stream.

I've also considered refactoring of `json.spec.js`.
Ideally unit test should execute `JSONReporter` directly instead of using real `Runner` instance.
Also tests should capture standard output and run assertion on it instead of using `testResults` property on runner which doesn't look to be used anywhere else.

I've tried to rewrite tests using `createMockRunner()` from test helpers but it didn't work.
Mock runner doesn't  supports simulation of multiple events and reporter state is not preserved between multiple runs.
Therefore it was not possible to use it for `json` reporter without bigger changes.
I still think refactoring the tests would improve code quality but it is out of scope of this PR.

### Why should this be in core?
- It's a common feature, widely supported in other test frameworks (JavaScript or other languages)
- Same option is already supported in `xunit` reporter
- JSON output is usually processed by another tool and any noise on standard output would break it

### Benefits

Compared to redirecting report output to file using shell pipe:
- valid JSON will be written to file even if some test produces noise on standard output
- together with [mocha-multi-reporters](https://www.npmjs.com/package/mocha-multi-reporters) enables having both console output and file output
