### PR TITLE
docs: update missed default extensions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2237,7 +2237,7 @@ Configurations can inherit from other modules using the `extends` keyword. See [
 
 ## The `test/` Directory
 
-By default, `mocha` looks for the glob `"./test/*.js"`, so you may want to put
+By default, `mocha` looks for the glob `"./test/*.{js,cjs,mjs}"`, so you may want to put
 your tests in `test/` folder. If you want to include subdirectories, pass the
 `--recursive` option.
 


### PR DESCRIPTION
### Description of the Change
Now we suuport `.js`, `.cjs` and `.mjs`.
We missed these extensions for the glob pattern under the `test` directory.

### Applicable issues
fix #4593
