### PR TITLE
Remove unused and incorrect `test.retries(n)`

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -105,13 +105,6 @@ module.exports = function bddInterface(suite) {
     context.xit = context.xspecify = context.it.skip = function(title) {
       return context.it(title);
     };
-
-    /**
-     * Number of attempts to retry.
-     */
-    context.it.retries = function(n) {
-      context.retries(n);
-    };
   });
 };
 

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -187,15 +187,6 @@ module.exports = function(suites, context, mocha) {
        */
       skip: function(title) {
         context.test(title);
-      },
-
-      /**
-       * Number of retry attempts
-       *
-       * @param {number} n
-       */
-      retries: function(n) {
-        context.retries(n);
       }
     }
   };

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -92,7 +92,6 @@ module.exports = function qUnitInterface(suite) {
     };
 
     context.test.skip = common.test.skip;
-    context.test.retries = common.test.retries;
   });
 };
 

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -99,7 +99,6 @@ module.exports = function(suite) {
     };
 
     context.test.skip = common.test.skip;
-    context.test.retries = common.test.retries;
   });
 };
 


### PR DESCRIPTION
### Description of the Change

We remove `test.retries(n)` from our interfaces `common`, `bdd`, `tdd`, `qunit`.
This function has never been used/implemented correctly as shown by coverall's excited reaction. Furthermore the signature is weird and somewhat incomplete.

This PR _does not affect_:
- `this.retries(n)` within `suite`s and `test`s
- `it(title, fn).retries(n)`
