### PR TITLE
Watch for test files are crashed

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -261,17 +261,21 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
   let rerunScheduled = false;
 
   const run = () => {
-    mocha = beforeRun ? beforeRun({mocha, watcher}) || mocha : mocha;
-    runner = mocha.run(() => {
-      debug('finished watch run');
-      runner = null;
-      blastCache(watcher);
-      if (rerunScheduled) {
-        rerun();
-      } else {
-        console.error(`${logSymbols.info} [mocha] waiting for changes...`);
-      }
-    });
+    try {
+      mocha = beforeRun ? beforeRun({mocha, watcher}) || mocha : mocha;
+      runner = mocha.run(() => {
+        debug('finished watch run');
+        runner = null;
+        blastCache(watcher);
+        if (rerunScheduled) {
+          rerun();
+        } else {
+          console.error(`${logSymbols.info} [mocha] waiting for changes...`);
+        }
+      });
+    } catch (e) {
+      console.error(e.stack);
+    }
   };
 
   const scheduleRun = () => {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -470,6 +470,7 @@ async function runMochaWatchJSONAsync(args, opts, change) {
       // eslint-disable-next-line no-control-regex
       .replace(/\u001b\[\?25./g, '')
       .split('\u001b[2K')
+      .filter(x => x)
       .map(x => JSON.parse(x))
   );
 }

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -47,6 +47,23 @@ describe('--watch', function() {
       });
     });
 
+    it('reruns test when watched test file is crashed', function() {
+      const testFile = path.join(tempDir, 'test.js');
+      copyFixture(DEFAULT_FIXTURE, testFile);
+
+      return runMochaWatchJSONAsync([testFile], tempDir, () => {
+        replaceFileContents(testFile, 'done();', 'done((;');
+      })
+        .then(() => {
+          return runMochaWatchJSONAsync([testFile], tempDir, () => {
+            replaceFileContents(testFile, 'done((;', 'done();');
+          });
+        })
+        .then(results => {
+          expect(results, 'to have length', 1);
+        });
+    });
+
     describe('when in parallel mode', function() {
       it('reruns test when watched test file is touched', function() {
         const testFile = path.join(tempDir, 'test.js');
@@ -57,6 +74,23 @@ describe('--watch', function() {
         }).then(results => {
           expect(results, 'to have length', 2);
         });
+      });
+
+      it('reruns test when watched test file is crashed', function() {
+        const testFile = path.join(tempDir, 'test.js');
+        copyFixture(DEFAULT_FIXTURE, testFile);
+
+        return runMochaWatchJSONAsync(['--parallel', testFile], tempDir, () => {
+          replaceFileContents(testFile, 'done();', 'done((;');
+        })
+          .then(() => {
+            return runMochaWatchJSONAsync([testFile], tempDir, () => {
+              replaceFileContents(testFile, 'done((;', 'done();');
+            });
+          })
+          .then(results => {
+            expect(results, 'to have length', 1);
+          });
       });
     });
 

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -47,21 +47,17 @@ describe('--watch', function() {
       });
     });
 
-    it('reruns test when watched test file is crashed', function() {
+    it('reruns test when watched test file crashes', function() {
       const testFile = path.join(tempDir, 'test.js');
       copyFixture(DEFAULT_FIXTURE, testFile);
 
+      replaceFileContents(testFile, 'done();', 'done((;');
+
       return runMochaWatchJSONAsync([testFile], tempDir, () => {
-        replaceFileContents(testFile, 'done();', 'done((;');
-      })
-        .then(() => {
-          return runMochaWatchJSONAsync([testFile], tempDir, () => {
-            replaceFileContents(testFile, 'done((;', 'done();');
-          });
-        })
-        .then(results => {
-          expect(results, 'to have length', 1);
-        });
+        replaceFileContents(testFile, 'done((;', 'done();');
+      }).then(results => {
+        expect(results, 'to have length', 1);
+      });
     });
 
     describe('when in parallel mode', function() {
@@ -80,17 +76,13 @@ describe('--watch', function() {
         const testFile = path.join(tempDir, 'test.js');
         copyFixture(DEFAULT_FIXTURE, testFile);
 
-        return runMochaWatchJSONAsync(['--parallel', testFile], tempDir, () => {
-          replaceFileContents(testFile, 'done();', 'done((;');
-        })
-          .then(() => {
-            return runMochaWatchJSONAsync([testFile], tempDir, () => {
-              replaceFileContents(testFile, 'done((;', 'done();');
-            });
-          })
-          .then(results => {
-            expect(results, 'to have length', 1);
-          });
+        replaceFileContents(testFile, 'done();', 'done((;');
+
+        return runMochaWatchJSONAsync([testFile], tempDir, () => {
+          replaceFileContents(testFile, 'done((;', 'done();');
+        }).then(results => {
+          expect(results, 'to have length', 1);
+        });
       });
     });
 


### PR DESCRIPTION
### Description of the Change
In watch mode, the watcher crashed when there are syntax errors in test files during `require('test file')`.
It only happens in serial mode and Node v15+.

This `try - catch` statement removed [when we introduce parallel mode](https://github.com/mochajs/mocha/commit/2078c3203f55ee0e1783dc2fc9e20ac51dcb6896#diff-14a1e3aa193d6f208b9ffdfeec1876f2cbc0e51007d061a87644e9ea9df59676L94).
I think we need `try - catch` here.

And I added test cases for the crash case to prevent regression.

### Why should this be in core?
Watching should be worked.

### Benefits
Users can use watch mode when the test code is broken.


### Applicable issues
Fix #4580