### PR TITLE
Run browser tests on forked PRs by a dedicated label

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -1,4 +1,4 @@
-name: Browser Tests
+name: Browser Tests for foked PRs
 'on':
   pull_request_target:
     types:
@@ -34,3 +34,10 @@ jobs:
         env:
           SAUCE_USERNAME: '${{secrets.SAUCE_USERNAME}}'
           SAUCE_ACCESS_KEY: '${{secrets.SAUCE_ACCESS_KEY}}'
+      - name: remove 'run-browser-test' label
+        uses: buildsville/add-remove-label@v1
+        if: ${{ always() }}
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          label: run-browser-test
+          type: remove

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -1,4 +1,4 @@
-name: Browser Tests for foked PRs
+name: Browser Tests for forked PRs
 'on':
   pull_request_target:
     types:
@@ -22,8 +22,6 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '~/.npm'
-          # this key is different than above, since we are running scripts
-          # (builds, postinstall lifecycle hooks, etc.)
           key: "ubuntu-latest-node-full-v14-${{ hashFiles('**/package-lock.json') }}"
           restore-keys: |
             ubuntu-latest-node-full-v14-

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -1,0 +1,36 @@
+name: Browser Tests
+'on':
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  test-browser:
+    # TODO: configure to retain build artifacts in `.karma/` dir
+    name: 'Browser Tests'
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run-browser-test')
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: 'Cache node_modules'
+        uses: actions/cache@v2
+        with:
+          path: '~/.npm'
+          # this key is different than above, since we are running scripts
+          # (builds, postinstall lifecycle hooks, etc.)
+          key: "ubuntu-latest-node-full-v14-${{ hashFiles('**/package-lock.json') }}"
+          restore-keys: |
+            ubuntu-latest-node-full-v14-
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Browser Tests
+        run: npm start test.browser
+        env:
+          SAUCE_USERNAME: '${{secrets.SAUCE_USERNAME}}'
+          SAUCE_ACCESS_KEY: '${{secrets.SAUCE_ACCESS_KEY}}'

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -174,6 +174,8 @@ jobs:
     needs: smoke
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    # Run 'push' event only because of sauce labs token
+    if: github.event_name == 'push'
     steps:
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
### Description of the Change
It is the only way I found to run browser tests on forked PR. 

After reviewing code of a forked PR, maintainers can attach [a `run-browser-test` label](https://github.com/mochajs/mocha/labels/run-browser-test).
Maintainers should check there is no malicious code to steal our secrets or do something bad on our repository.

This `Browser Tests` workflow will run based on forked PRs with writing repo and access secrets permissions. So, it can be  dangerous if the forked PR has malicious code.

I've tested `pull_request_target` event.

<img width="918" alt="스크린샷 2021-03-31 오후 5 48 07" src="https://user-images.githubusercontent.com/390146/113136202-085fa880-925e-11eb-9f44-4acfd8c2c356.png">

When users open a pull request, `push`, `pull_reqeust` and `pull_request_target`  will be run automatically. But `pull_request_target: types: [labeled]`(in this case `Browser Tests`) will not be run because `labeled` type.

<img width="914" alt="스크린샷 2021-03-31 오후 5 48 54" src="https://user-images.githubusercontent.com/390146/113136452-5b396000-925e-11eb-9837-1f903fe70a54.png">

If maintainers attach a label except `run-browser-test` label, `Browser Tests` workflow will be triggered, but it skipped because the label is not `run-browser-test`. In the above screenshot, `pull request safe run` workflow is `pull_request_target` workflow with `labeled` type. 

<img width="928" alt="스크린샷 2021-03-31 오후 5 49 32" src="https://user-images.githubusercontent.com/390146/113136854-cedb6d00-925e-11eb-8ff6-e8b0725e4719.png">

When maintainers attach the `run-browser-test` label, `Browser Tests` workflow will be triggered. In above screenshot, I tested it with `safe-to-run` label.

<img width="916" alt="스크린샷 2021-03-31 오후 5 50 51" src="https://user-images.githubusercontent.com/390146/113137050-021dfc00-925f-11eb-977e-0cf2f65cbddc.png">

After that, when author of the forked PR pushed new commits, only default workflows will. be run. 

That means maintainers should remove and re-attache `run-browser-test` label to run `Browser Tests` again. 

And when the forked PR already has `run-browser-test` label, `Browser Tests` workflow will be triggered if maintainers attach a new label except `run-browser-test` label. **We have to be careful with this.**

### Alternate Designs
We can use [`workflow_dispatch` event](https://github.com/mochajs/mocha/issues/4553#issuecomment-806439992). `workflow_dispatch` is a workflow that we should trigger it manually with PR number.

I think there are some cons.

* Process is not convenient. maintainers enter PR number and trigger the workflow manually. 
* It couldn't be integrated with PR. So, we cannot the result of the workflow in GitHub's checks tab. It is hard to know whether browser tests are successful or fail. 

Therefore, I think `pull_request_target` event with `labeled` type is better than `workflow_dispatch` event.

### Why should this be in core?
All forked PRs failed because of browser tests.

### Applicable issues
close #4553