### PR TITLE
docs: dynamically generating tests with `top-level await` and ESM test files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -684,7 +684,7 @@ Given Mocha's use of function expressions to define suites and test cases, it's 
 Take the following example:
 
 ```js
-const assert = require('chai').assert;
+const assert = require('assert');
 
 function add(args) {
   return args.reduce((prev, curr) => prev + curr, 0);
@@ -700,7 +700,7 @@ describe('add()', function() {
   tests.forEach(({args, expected}) => {
     it(`correctly adds ${args.length} args`, function() {
       const res = add(args);
-      assert.equal(res, expected);
+      assert.strictEqual(res, expected);
     });
   });
 });
@@ -725,12 +725,40 @@ describe('add()', function() {
   const testAdd = ({args, expected}) =>
     function() {
       const res = add(args);
-      assert.equal(res, expected);
+      assert.strictEqual(res, expected);
     };
 
   it('correctly adds 2 args', testAdd({args: [1, 2], expected: 3}));
   it('correctly adds 3 args', testAdd({args: [1, 2, 3], expected: 6}));
   it('correctly adds 4 args', testAdd({args: [1, 2, 3, 4], expected: 10}));
+});
+```
+
+With `top-level await` you can collect your test data in a dynamic and asynchronous way while the test file is being loaded:
+
+```js
+// testfile.mjs
+import assert from 'assert';
+
+// top-level await: Node >= v14.8.0 with ESM test file
+const tests = await new Promise(resolve => {
+  setTimeout(() => {
+    resolve([
+      {args: [1, 2], expected: 3},
+      {args: [1, 2, 3], expected: 6},
+      {args: [1, 2, 3, 4], expected: 10}
+    ]);
+  }, 5000);
+});
+
+// in suites ASYNCHRONOUS callbacks are NOT supported
+describe('add()', function() {
+  tests.forEach(({args, expected}) => {
+    it(`correctly adds ${args.length} args`, function() {
+      const res = args.reduce((sum, curr) => sum + curr, 0);
+      assert.strictEqual(res, expected);
+    });
+  });
 });
 ```
 


### PR DESCRIPTION
### Description of the Change

With `top-level await` test data can be collected in a dynamic and asynchronous way, while the test file is loaded and before the test `runner` is created. Since ESM files are already loaded in an asynchronous way, no changes to our code base are needed.

Requisite:
- `top-level await`: since Node >= v14.8.0
- `ESM` (ECMAScript module) test file