### PR TITLE
GH actions: add Node v16

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -28,7 +28,7 @@ jobs:
           - 10
           - 12
           - 14
-          - 15
+          - 16
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -73,7 +73,7 @@ jobs:
           - 10
           - 12
           - 14
-          - 15
+          - 16
         include:
           - os: ubuntu-latest
             node: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,6 @@ jobs:
           stale-pr-message: >
             This PR hasn't had any recent activity, and I'm labeling it `stale`.
             Remove the label or comment or this PR will be closed in 14 days.
-            Thanks for contributing to Mocha!'
+            Thanks for contributing to Mocha!
           exempt-issue-labels: browser,chore,confirmed-bug,developer-experience,documentation,faq,feature,future,good-first-issue,help wanted,nice-to-have,qa,reporter,unconfirmed-bug,usability
           exempt-pr-labels: browser,chore,confirmed-bug,developer-experience,documentation,faq,feature,future,needs-review,nice-to-have,qa,reporter,semver-major,semver-minor,semver-patch,usability


### PR DESCRIPTION
### Description of the Change

Replaces Node v15 by v16.
End-of-life of v15 is 2021-06-01.