### PR TITLE
Docs: add "options.require" to Mocha constructor for root hooks on parallel runs.

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -180,10 +180,10 @@ exports.run = function(...args) {
  * @param {number} [options.slow] - Slow threshold value.
  * @param {number|string} [options.timeout] - Timeout threshold value.
  * @param {string} [options.ui] - Interface name.
- * @param {boolean} [options.parallel] - Run jobs in parallel
- * @param {number} [options.jobs] - Max number of worker processes for parallel runs
- * @param {MochaRootHookObject} [options.rootHooks] - Hooks to bootstrap the root
- * suite with
+ * @param {boolean} [options.parallel] - Run jobs in parallel.
+ * @param {number} [options.jobs] - Max number of worker processes for parallel runs.
+ * @param {MochaRootHookObject} [options.rootHooks] - Hooks to bootstrap the root suite with.
+ * @param {string[]} [options.require] - Pathname of `rootHooks` plugin for parallel runs.
  * @param {boolean} [options.isWorker] - Should be `true` if `Mocha` process is running in a worker process.
  */
 function Mocha(options = {}) {


### PR DESCRIPTION
### Description of the Change

#closes #4575

The root hooks aren't executed when Mocha is run programmatically and in parallel.
In parallel mode it's necessary to pass the path of the `rootHooks` plugin to the `mocha` instance as this information is not available via IPC to the worker processes.

We add `options.require` to the API docs for the Mocha constructor. No code change is required.