### PR TITLE
Remove deprecated "utils.lookupFiles()"

### DIFF
--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -8,11 +8,9 @@
 var fs = require('fs');
 var path = require('path');
 var glob = require('glob');
-var {format} = require('util');
 var errors = require('../errors');
 var createNoFilesMatchPatternError = errors.createNoFilesMatchPatternError;
 var createMissingArgumentError = errors.createMissingArgumentError;
-var {sQuote, dQuote} = require('../utils');
 const debug = require('debug')('mocha:cli:lookup-files');
 
 /**
@@ -91,7 +89,7 @@ module.exports = function lookupFiles(
     files.push(...glob.sync(pattern, {nodir: true}));
     if (!files.length) {
       throw createNoFilesMatchPatternError(
-        'Cannot find any files matching pattern ' + dQuote(filepath),
+        `Cannot find any files matching pattern "${filepath}"`,
         filepath
       );
     }
@@ -127,11 +125,7 @@ module.exports = function lookupFiles(
     }
     if (!extensions.length) {
       throw createMissingArgumentError(
-        format(
-          'Argument %s required when argument %s is a directory',
-          sQuote('extensions'),
-          sQuote('filepath')
-        ),
+        `Argument '${extensions}' required when argument '${filepath}' is a directory`,
         'extensions',
         'array'
       );

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,6 @@ const {nanoid} = require('nanoid/non-secure');
 var path = require('path');
 var util = require('util');
 var he = require('he');
-const errors = require('./errors');
 
 const MOCHA_ID_PROP_NAME = '__mocha_id__';
 
@@ -648,35 +647,6 @@ exports.cwd = function cwd() {
  */
 exports.isBrowser = function isBrowser() {
   return Boolean(process.browser);
-};
-
-/**
- * Lookup file names at the given `path`.
- *
- * @description
- * Filenames are returned in _traversal_ order by the OS/filesystem.
- * **Make no assumption that the names will be sorted in any fashion.**
- *
- * @public
- * @alias module:lib/cli.lookupFiles
- * @param {string} filepath - Base path to start searching from.
- * @param {string[]} [extensions=[]] - File extensions to look for.
- * @param {boolean} [recursive=false] - Whether to recurse into subdirectories.
- * @return {string[]} An array of paths.
- * @throws {Error} if no files match pattern.
- * @throws {TypeError} if `filepath` is directory and `extensions` not provided.
- * @deprecated Moved to {@link module:lib/cli.lookupFiles}
- */
-exports.lookupFiles = (...args) => {
-  if (exports.isBrowser()) {
-    throw errors.createUnsupportedError(
-      'lookupFiles() is only supported in Node.js!'
-    );
-  }
-  errors.deprecate(
-    '`lookupFiles()` in module `mocha/lib/utils` has moved to module `mocha/lib/cli` and will be removed in the next major revision of Mocha'
-  );
-  return require('./cli').lookupFiles(...args);
 };
 
 /*

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var utils = require('../../lib/utils');
-const errors = require('../../lib/errors');
 var sinon = require('sinon');
 
 describe('lib/utils', function() {
@@ -775,51 +774,6 @@ describe('lib/utils', function() {
     describe('when provided null', function() {
       it('should return an array containing a null value only', function() {
         expect(utils.castArray(null), 'to equal', [null]);
-      });
-    });
-  });
-
-  describe('lookupFiles()', function() {
-    beforeEach(function() {
-      sinon.stub(errors, 'deprecate');
-    });
-
-    describe('when run in Node.js', function() {
-      before(function() {
-        if (process.browser) {
-          return this.skip();
-        }
-      });
-
-      beforeEach(function() {
-        sinon.stub(utils, 'isBrowser').returns(false);
-        sinon.stub(require('../../lib/cli'), 'lookupFiles').returns([]);
-      });
-
-      it('should print a deprecation message', function() {
-        utils.lookupFiles();
-        expect(errors.deprecate, 'was called once');
-      });
-
-      it('should delegate to new location of lookupFiles()', function() {
-        utils.lookupFiles(['foo']);
-        expect(
-          require('../../lib/cli').lookupFiles,
-          'to have a call satisfying',
-          [['foo']]
-        ).and('was called once');
-      });
-    });
-
-    describe('when run in browser', function() {
-      beforeEach(function() {
-        sinon.stub(utils, 'isBrowser').returns(true);
-      });
-
-      it('should throw', function() {
-        expect(() => utils.lookupFiles(['foo']), 'to throw', {
-          code: 'ERR_MOCHA_UNSUPPORTED'
-        });
       });
     });
   });


### PR DESCRIPTION
### Description

- `lookupFiles()` in module _mocha/lib/utils.js_ has moved to its own module in _mocha/lib/cli/lookup-files.js_
- `utils.lookupFiles()` has been deprecated in Mocha v8.2.0


### Description of the Change

- remove `utils.lookupFiles()`
- _cli/lookup-files.js_: use template strings to format error messages