### PR TITLE
GH actions: delete old workflow runs

### DIFF
--- a/.github/workflows/delete-runs.yml
+++ b/.github/workflows/delete-runs.yml
@@ -1,0 +1,20 @@
+name: Delete workflow runs
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days'
+        required: true
+        default: 120
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@main
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days }}
+          keep_minimum_runs: 10


### PR DESCRIPTION
### Description of the Change

We add a GH action to delete old workflow runs. There is no sense in keeping thousands of run logs.
- GH action: [delete-workflow-runs](https://github.com/marketplace/actions/delete-workflow-runs)
- manually triggered
- retain days: 120 days
