### PR TITLE
Limit the size of 'actual'/'expected' strings before generating a diff

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -190,6 +190,13 @@ function stringifyDiffObjs(err) {
  */
 var generateDiff = (exports.generateDiff = function(actual, expected) {
   try {
+    const diffSize = 2048;
+    if (actual.length > diffSize) {
+      actual = actual.substring(0, diffSize) + ' ... Lines skipped';
+    }
+    if (expected.length > diffSize) {
+      expected = expected.substring(0, diffSize) + ' ... Lines skipped';
+    }
     return exports.inlineDiffs
       ? inlineDiff(actual, expected)
       : unifiedDiff(actual, expected);

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -164,6 +164,34 @@ describe('Base reporter', function() {
         '      \n      actual expected\n      \n      a foobar inline diff\n      '
       );
     });
+
+    it("should truncate overly long 'actual' ", function() {
+      var actual = '';
+      var i = 0;
+      while (i++ < 120) {
+        actual += 'a foo unified diff ';
+      }
+      var expected = 'a bar unified diff';
+
+      inlineDiffsStub.value(false);
+      var output = generateDiff(actual, expected);
+
+      expect(output, 'to match', / \.\.\. Lines skipped/);
+    });
+
+    it("should truncate overly long 'expected' ", function() {
+      var actual = 'a foo unified diff';
+      var expected = '';
+      var i = 0;
+      while (i++ < 120) {
+        expected += 'a bar unified diff ';
+      }
+
+      inlineDiffsStub.value(false);
+      var output = generateDiff(actual, expected);
+
+      expect(output, 'to match', / \.\.\. Lines skipped/);
+    });
   });
 
   describe('inline strings diff', function() {


### PR DESCRIPTION
### Description

Mocha prints its own diff on assertion errors by stringifying `err.actual` and `err.expected`, then passing both strings to [jsdiff](https://github.com/kpdecker/jsdiff) for generating a diff-patch. For big strings this synchronous process can take several minutes.

_jsdiff_ has some known performance issues, so in mid-term we evtl. should evaluate a _jsdiff_ alternative.
On the other hand it's not a good idea to calculate a diff for two huge strings, even with a faster algorithm. We should limit the size of the input strings, as eg. done by Node's `assert` as well.

### Description of the Change

- no change: stringify `err.actual` and `err.expected`
- new: when too big, truncate the resulting strings and add a message `... Lines skipped`


### Applicable issues

closes #3675