### PR TITLE
Deprecate "new Runner(suite: Suite, delay: boolean)"

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -148,7 +148,10 @@ class Runner extends EventEmitter {
       opts = {};
     }
     if (typeof opts === 'boolean') {
-      // TODO: deprecate this
+      // TODO: remove this
+      require('./errors').deprecate(
+        '"Runner(suite: Suite, delay: boolean)" is deprecated. Use "Runner(suite: Suite, {delay: boolean})" instead.'
+      );
       this._delay = opts;
       opts = {};
     } else {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -138,7 +138,7 @@ class Runner extends EventEmitter {
    * @public
    * @class
    * @param {Suite} suite - Root suite
-   * @param {Object|boolean} [opts] - Options. If `boolean`, whether or not to delay execution of root suite until ready (for backwards compatibility).
+   * @param {Object|boolean} [opts] - Options. If `boolean` (deprecated), whether or not to delay execution of root suite until ready.
    * @param {boolean} [opts.delay] - Whether to delay execution of root suite until ready.
    * @param {boolean} [opts.cleanReferencesAfterRun] - Whether to clean references to test fns and hooks when a suite is done.
    */

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -11,6 +11,7 @@ const {
   MULTIPLE_DONE,
   UNSUPPORTED
 } = require('../../lib/errors').constants;
+const errors = require('../../lib/errors');
 
 const {
   EVENT_HOOK_BEGIN,
@@ -30,6 +31,15 @@ const {STATE_FAILED} = Mocha.Runnable.constants;
 describe('Runner', function() {
   afterEach(function() {
     sinon.restore();
+  });
+
+  describe('constructor deprecation', function() {
+    it('should print a deprecation warning', function() {
+      sinon.stub(errors, 'deprecate');
+      const suite = new Suite('Suite', 'root');
+      new Runner(suite, false); /* eslint no-new: "off" */
+      expect(errors.deprecate, 'was called once');
+    });
   });
 
   describe('instance method', function() {


### PR DESCRIPTION
### Description

We deprecate following signature of the `Runner` constructor: `Runner(suite: Suite, delay: boolean)`

Instead use an option object: `Runner(suite: Suite, {delay: boolean})`
=> [API docs](https://mochajs.org/api/runner)