### PR TITLE
fix: proper version check in hasStableEsmImplementation

### DIFF
--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -34,7 +34,9 @@ const hasStableEsmImplementation = (() => {
   const [major, minor] = process.version.split('.');
   // ESM is stable from v12.22.0 onward
   // https://nodejs.org/api/esm.html#esm_modules_ecmascript_modules
-  return parseInt(major.slice(1), 10) > 12 || parseInt(minor, 10) >= 22;
+  const majorNumber = parseInt(major.slice(1), 10);
+  const minorNumber = parseInt(minor, 10);
+  return majorNumber > 12 || (majorNumber === 12 && minorNumber >= 22);
 })();
 
 exports.requireOrImport = hasStableEsmImplementation


### PR DESCRIPTION
Fixes #4652.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

The version check in `hasStableEsmImplementation` returns `true` for any version that has minor component >= 22 (e.g. for version 10.24.x which is currently the latest one in the 10.x branch).  Even though Node.js v10 is officially not supported, I still see a lot of sense to fix this and make `hasStableEsmImplementation` work properly.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

A lot of CI tasks are still using 10.x for compatibility reasons.

### Benefits

<!-- What benefits will be realized by the code change? -->

No unintended breaking change to Node.js v10.24.x users.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None known.

### Applicable issues

#4652

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
