### PR TITLE
Add support for `reporterOptions` as an object in config files

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -82,6 +82,25 @@ const coerceOpts = Object.assign(
 );
 
 /**
+ * To support configuring reporter options as an object we need to convert the
+ * object to a string of comma-separated key=value pairs so that yargs will
+ * properly parse the options. Without this coercion, using an object for
+ * reporter options results in the options being passed in an unexpected format:
+ * (e.g., `{ reporterOption: { foo: 'bar' } } -> { 'reporterOption.foo': 'bar' }`)
+ * @private
+ * @ignore
+ */
+const parseReporterOptions = v =>
+  v != null && typeof v === 'object' && !Array.isArray(v)
+    ? Object.entries(v)
+        .map(([key, val]) => `${key}=${val}`)
+        .join(',')
+    : coerceOpts['reporter-option'](v);
+coerceOpts.reporterOption = parseReporterOptions;
+// Ensure backwards compatibility
+coerceOpts.reporterOptions = parseReporterOptions;
+
+/**
  * We do not have a case when multiple arguments are ever allowed after a flag
  * (e.g., `--foo bar baz quux`), so we fix the number of arguments to 1 across
  * the board of non-boolean options.


### PR DESCRIPTION
### Description of the Change

When using a configuration file, users can pass options to a reporter via the `reporterOption` property. The value of this property is expected to be a string or comma-separated list of `key=value` pairs. This format matches the CLI but is a bit awkward in a config file where using an object would be more natural.  The problem with using an object currently is that it ends up being parsed by `yargs`, then unparsed by `yargs-unparser`, and re-parsed a second time by `yargs` and the end result is not the same as the original input.

For example, given the following config file:
```json
// .mocharc.json
{
  "reporter": "mochawesome",
  "reporterOption": {
    "reportFilename": "customReportFilename",
    "quiet": true,
  }
}
```
the options object will look like this when passed to the reporter:
```js
{
  reporter: 'mochawesome',
  'reporterOption.reportFilename': 'customReportFilename',
  'reporterOption.quiet': true
}
```

This change ensures that when using an object for the `reporterOption` option, it will be passed as expected to the reporter. This is achieved by defining a coerce function that transforms the object to a comma-separated "key=value" string as expected by `yargs`.

### Alternate Designs

I considered a PR to `yargs-unparser` to preserve the object format but that route would require considerably more effort and would add behavior that may not be desired for all users of that library.

### Why should this be in core?

While it is possible for reporters to parse the options object as it currently is, doing so seems unnecessary since I believe the underlying issue here is that mocha is not parsing the configuration as expected. The input is not the same as the output for this use-case.

### Benefits

With this change, users can pass options to reporters in a much more familiar and expected way when using a config file. 

### Possible Drawbacks

As written, this change does not support using nested objects as it seemed unnecessary. Should that change, the code would need to be modified.

### Reviewer note

I wasn't quite sure where to add a test for this change as it didn't seem to fit in with the format of the existing tests for either config or reporters. With some guidance I'd be happy to update the PR with necessary tests.