### PR TITLE
Fix: 'karma-mocha' should run both browser bundles

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,6 +29,11 @@ const BASE_BUNDLE_DIR_PATH = path.join(__dirname, '.karma');
 const env = process.env;
 const hostname = os.hostname();
 
+if (fs.existsSync('./mocha.js') && fs.existsSync('./mocha-es5.js')) {
+  fs.renameSync('./mocha.js', './mocha-es2018.js');
+  fs.renameSync('./mocha-es5.js', './mocha.js');
+}
+
 const SAUCE_BROWSER_PLATFORM_MAP = {
   'chrome@latest': 'Windows 10',
   'MicrosoftEdge@latest': 'Windows 10',

--- a/karma_no-ie11.conf.js
+++ b/karma_no-ie11.conf.js
@@ -18,6 +18,11 @@ const BASE_BUNDLE_DIR_PATH = path.join(__dirname, '.karma');
 const env = process.env;
 const hostname = os.hostname();
 
+if (fs.existsSync('./mocha.js') && fs.existsSync('./mocha-es2018.js')) {
+  fs.renameSync('./mocha.js', './mocha-es5.js');
+  fs.renameSync('./mocha-es2018.js', './mocha.js');
+}
+
 const SAUCE_BROWSER_PLATFORM_MAP = {
   'chrome@latest': 'Windows 10',
   'MicrosoftEdge@latest': 'Windows 10',

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -211,7 +211,7 @@ module.exports = {
         },
         unit: {
           script:
-            'cross-env NODE_PATH=. karma start karma.conf.js --single-run --colors && cross-env NODE_PATH=. karma start karma_no-ie11.conf.js --single-run --colors',
+            'cross-env NODE_PATH=. karma start karma_no-ie11.conf.js --single-run --colors && cross-env NODE_PATH=. karma start karma.conf.js --single-run --colors',
           description: 'Run browser unit tests'
         },
         bdd: {


### PR DESCRIPTION
### Description

Some days ago I added a second browser bundle to our package:
- `mocha.js` transpiled to ES5
- new: `mocha-es2018.js` without transpilation

When customizing our browser tests I ended up with executing the _karma_ tests twice, using the same bundle `mocha.js`. So the new `mocha-es2018` currently remains untested.

### Description of the Change

I could not find a way to convince _karma-mocha_ to run a browser bundle other than named `mocha.js`.
Therefore I rename the two bundles accordingly before launching _karma_.
