### PR TITLE
GH actions: don't run CI tests for 'push' events on tags

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
-node >= 10
+node >= 12
 last 2 Chrome versions
 last 2 Edge versions
 last 2 Firefox versions

--- a/.github/workflows/delete-runs.yml
+++ b/.github/workflows/delete-runs.yml
@@ -5,7 +5,7 @@ on:
       days:
         description: 'Number of days'
         required: true
-        default: 120
+        default: 180
 
 jobs:
   del_runs:

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -1,6 +1,10 @@
 name: Tests
-'on':
+on:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
### Description

When pushing a new Mocha version/release to our `master` branch, the identical CI tests run twice. Once for the new commit and a second time for the new version tag. With this PR `push` events on new tags get ignored and no CI tests are triggered.