### PR TITLE
ESM: Fix importing `index.js` files by folder name

### DIFF
--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -49,7 +49,8 @@ exports.requireOrImport = hasStableEsmImplementation
       } catch (err) {
         if (
           err.code === 'ERR_MODULE_NOT_FOUND' ||
-          err.code === 'ERR_UNKNOWN_FILE_EXTENSION'
+          err.code === 'ERR_UNKNOWN_FILE_EXTENSION' ||
+          err.code === 'ERR_UNSUPPORTED_DIR_IMPORT'
         ) {
           return require(file);
         } else {


### PR DESCRIPTION
### Description of the Change

This is a fix for #4665, where running with `-r ts-node/register` or similar flags doesn't work.

The reason this fails is because Node cannot resolve `node_modules/ts-node/register/index.js` as an ESM module. The returned error has a `code` of `'ERR_UNSUPPORTED_DIR_IMPORT'`, which should trigger the `require` fall-back logic, but it doesn't because that error code is not on the list.

### Alternate Designs

Mocha v8 used a much simpler `try` / `catch` approach that worked reliably. Mocha v9 tries to be more picky, which is good, but we need to include all the edge cases for this to work smoothly.

### Why should this be in core?

It's a bug-fix for a pretty serious v9 regression.

### Benefits

`mocha -r ts-node/register` works again! Or `mocha -r sucrase/register`, if you prefer that one.

### Possible Drawbacks

I can't think of any - it's a pretty obvious fix.

### Applicable issues

#4665

This is a minor patch fix for a pretty common issue, so it would be good to release as v9.0.1 -> v9.0.2.
