### PR TITLE
Fixes #4665. make "-r <dir>" work with new import-first loading

### DIFF
--- a/lib/esm-utils.js
+++ b/lib/esm-utils.js
@@ -49,7 +49,8 @@ exports.requireOrImport = hasStableEsmImplementation
       } catch (err) {
         if (
           err.code === 'ERR_MODULE_NOT_FOUND' ||
-          err.code === 'ERR_UNKNOWN_FILE_EXTENSION'
+          err.code === 'ERR_UNKNOWN_FILE_EXTENSION' ||
+          err.code === 'ERR_UNSUPPORTED_DIR_IMPORT'
         ) {
           return require(file);
         } else {

--- a/test/integration/esm.spec.js
+++ b/test/integration/esm.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+var path = require('path');
 var helpers = require('./helpers');
 var run = helpers.runMochaJSON;
 var runMochaAsync = helpers.runMochaAsync;
@@ -64,5 +65,20 @@ describe('esm', function() {
       expect(result, 'to have passed test count', 1);
       done();
     });
+  });
+
+  it('should enable requiring/loading a cjs module with "dir" as filename', async function() {
+    var fixture = 'esm/test-that-uses-dir-cjs-require.fixture.js';
+    const result = await runMochaAsync(
+      fixture,
+      [
+        ...args,
+        '--require',
+        path.resolve(__dirname, './fixtures/esm/dir-cjs-require')
+      ],
+      {stdio: 'pipe'}
+    );
+
+    expect(result, 'to have passed test count', 1);
   });
 });

--- a/test/integration/fixtures/esm/dir-cjs-require/index.js
+++ b/test/integration/fixtures/esm/dir-cjs-require/index.js
@@ -1,0 +1,1 @@
+global.testPassesIfThisVariableIsDefined = true

--- a/test/integration/fixtures/esm/test-that-uses-dir-cjs-require.fixture.js/index.js
+++ b/test/integration/fixtures/esm/test-that-uses-dir-cjs-require.fixture.js/index.js
@@ -1,0 +1,4 @@
+// See https://github.com/mochajs/mocha/issues/4665 for an explanation of this test
+it('should require a dir import', () => {
+  expect(global.testPassesIfThisVariableIsDefined, 'to be', true)
+})


### PR DESCRIPTION
### Description of the Change

When falling back on CJS when loading test files, ensure that `ERR_UNSUPPORTED_DIR_IMPORT` is supported so that `-r <cjs-package>/dir` will work. See #4665 for a more detailed description.

### Benefits

This is a bug fix to return support to what was before enabled.

### Possible Drawbacks

None

### Applicable issues

#4665 
* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)? No
* Is it an enhancement (minor release)? No
* Is it a bug fix, or does it not impact production code (patch release)? Yes

