### PR TITLE
Fix: using custom interface in parallel mode

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -195,10 +195,10 @@ exports.runMocha = async (mocha, options) => {
  * it actually exists. This must be run _after_ requires are processed (see
  * {@link handleRequires}), as it'll prevent interfaces from loading otherwise.
  * @param {Object} opts - Options object
- * @param {"reporter"|"interface"} pluginType - Type of plugin.
- * @param {Object} [map] - An object perhaps having key `key`. Used as a cache
- * of sorts; `Mocha.reporters` is one, where each key corresponds to a reporter
- * name
+ * @param {"reporter"|"ui"} pluginType - Type of plugin.
+ * @param {Object} [map] - Used as a cache of sorts;
+ * `Mocha.reporters` where each key corresponds to a reporter name,
+ * `Mocha.interfaces` where each key corresponds to an interface name.
  * @private
  */
 exports.validateLegacyPlugin = (opts, pluginType, map = {}) => {
@@ -226,12 +226,12 @@ exports.validateLegacyPlugin = (opts, pluginType, map = {}) => {
   // if this exists, then it's already loaded, so nothing more to do.
   if (!map[pluginId]) {
     try {
-      opts[pluginType] = require(pluginId);
+      map[pluginId] = require(pluginId);
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         // Try to load reporters from a path (absolute or relative)
         try {
-          opts[pluginType] = require(path.resolve(pluginId));
+          map[pluginId] = require(path.resolve(pluginId));
         } catch (err) {
           throw createUnknownError(err);
         }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -328,7 +328,7 @@ function createFatalError(message, value) {
 /**
  * Dynamically creates a plugin-type-specific error based on plugin type
  * @param {string} message - Error message
- * @param {"reporter"|"interface"} pluginType - Plugin type. Future: expand as needed
+ * @param {"reporter"|"ui"} pluginType - Plugin type. Future: expand as needed
  * @param {string} [pluginId] - Name/path of plugin, if any
  * @throws When `pluginType` is not known
  * @public
@@ -339,7 +339,7 @@ function createInvalidLegacyPluginError(message, pluginType, pluginId) {
   switch (pluginType) {
     case 'reporter':
       return createInvalidReporterError(message, pluginId);
-    case 'interface':
+    case 'ui':
       return createInvalidInterfaceError(message, pluginId);
     default:
       throw new Error('unknown pluginType "' + pluginType + '"');

--- a/test/node-unit/cli/run-helpers.spec.js
+++ b/test/node-unit/cli/run-helpers.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {validateLegacyPlugin, list} = require('../../../lib/cli/run-helpers');
+const Mocha = require('../../../lib/mocha');
 
 describe('helpers', function() {
   describe('validateLegacyPlugin()', function() {
@@ -25,24 +26,19 @@ describe('helpers', function() {
       });
     });
 
-    describe('when used with an "interfaces" key', function() {
+    describe('when used with an "ui" key', function() {
       it('should disallow an array of names', function() {
-        expect(
-          () => validateLegacyPlugin({interface: ['bar']}, 'interface'),
-          'to throw',
-          {
-            code: 'ERR_MOCHA_INVALID_INTERFACE',
-            message: /can only be specified once/i
-          }
-        );
+        expect(() => validateLegacyPlugin({ui: ['bar']}, 'ui'), 'to throw', {
+          code: 'ERR_MOCHA_INVALID_INTERFACE',
+          message: /can only be specified once/i
+        });
       });
 
       it('should fail to recognize an unknown interface', function() {
-        expect(
-          () => validateLegacyPlugin({interface: 'bar'}, 'interface'),
-          'to throw',
-          {code: 'ERR_MOCHA_INVALID_INTERFACE', message: /cannot find module/i}
-        );
+        expect(() => validateLegacyPlugin({ui: 'bar'}, 'ui'), 'to throw', {
+          code: 'ERR_MOCHA_INVALID_INTERFACE',
+          message: /cannot find module/i
+        });
       });
     });
 
@@ -53,6 +49,17 @@ describe('helpers', function() {
           'to throw',
           /unknown plugin/i
         );
+      });
+    });
+
+    describe('when used with a third-party interface', function() {
+      it('should add the interface to "Mocha.interfaces"', function() {
+        // let's suppose that `glob` is an interface
+        const opts = {ui: 'glob'};
+        validateLegacyPlugin(opts, 'ui', Mocha.interfaces);
+        expect(opts.ui, 'to equal', 'glob');
+        expect(Mocha.interfaces, 'to satisfy', {glob: require('glob')});
+        delete Mocha.interfaces.glob;
       });
     });
 


### PR DESCRIPTION
### Description

see discussion in #4659, thanks to @love-expressen for his analysis.

> When using the `--ui` option together with `--parallel` the `ui` option is not passed to the workers. This causes errors when running test files that depend on the UI being set up in the worker executing the test.

> The root cause of the issue is that mocha refers to external UI:s in the options object as function references and not the UI identifier string. When the options object is being serialized all functions are (thankfully) ignored. This causes the mocha instance in the workers to default to the bdd UI.

### Description of the Change

Mocha's native interfaces are cached in `Mocha.interfaces` as function references where each key corresponds to an interface name. The interface name can easily be serialized and passed to the parallel workers.
Now we use an identical approach for third party interfaces and add them to `Mocha.interfaces`. 


### Applicable issues

closes #4659
