### PR TITLE
Fix error rethrow from cwd-relative path js config file

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -31,7 +31,7 @@ exports.CONFIG_FILES = [
 ];
 
 const isModuleNotFoundError = err =>
-  err.code !== 'MODULE_NOT_FOUND' ||
+  err.code === 'MODULE_NOT_FOUND' ||
   err.message.indexOf('Cannot find module') !== -1;
 
 /**

--- a/test/integration/config.spec.js
+++ b/test/integration/config.spec.js
@@ -47,6 +47,28 @@ describe('config', function() {
       expect(js, 'to equal', json);
     });
 
+    it('should rethrow error from absolute path configuration', function() {
+      function _loadConfig() {
+        loadConfig(path.join(configDir, 'mocharcWithThrowError.js'));
+      }
+
+      expect(_loadConfig, 'to throw', {
+        message: /Error from mocharcWithThrowError/
+      });
+    });
+
+    it('should rethrow error from cwd-relative path configuration', function() {
+      var relConfigDir = configDir.substring(projRootDir.length + 1);
+
+      function _loadConfig() {
+        loadConfig(path.join('.', relConfigDir, 'mocharcWithThrowError.js'));
+      }
+
+      expect(_loadConfig, 'to throw', {
+        message: /Error from mocharcWithThrowError/
+      });
+    });
+
     // In other words, path does not begin with '/', './', or '../'
     describe('when path is neither absolute or relative', function() {
       var nodeModulesDir = path.join(projRootDir, 'node_modules');

--- a/test/integration/fixtures/config/mocharcWithThrowError.js
+++ b/test/integration/fixtures/config/mocharcWithThrowError.js
@@ -1,0 +1,11 @@
+'use strict';
+
+throw new Error("Error from mocharcWithThrowError");
+
+// a comment
+module.exports = {
+  require: ['foo', 'bar'],
+  bail: true,
+  reporter: 'dot',
+  slow: 60
+};


### PR DESCRIPTION
### Description of the Change
Fixed incorrect comparison operator in `isModuleNotFoundError` function in `lib/cli/config.js` so Mocha rethrows error from cwd-relative path js config file

### Why should this be in core?

It is already in core but doesn't work as expected

### Benefits

Mocha rethrows error from cwd-relative path js config file

### Possible Drawbacks

None that I can think of

### Applicable issues
Closes https://github.com/mochajs/mocha/issues/4701
Is this a breaking change (major release)? No
Is it an enhancement (minor release)? No
Is it a bug fix, or does it not impact production code (patch release)? Yes

