### PR TITLE
Set CSP on karma to prevent evalError regression

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -72,6 +72,13 @@ const baseConfig = {
   mochaReporter: {
     showDiff: true
   },
+  customHeaders: [
+    {
+      match: '.*.html',
+      name: 'Content-Security-Policy',
+      value: "script-src https: 'self' 'unsafe-inline'"
+    }
+  ],
   customLaunchers: {
     ChromeDebug: {
       base: 'Chrome',


### PR DESCRIPTION
This karma config set CSP header for browser test to prevent evalError regression in future.

When I test it with mocha@8.3.0, `EvalError` occurred as I expected.

```bash
$ npm start test.browser

> mocha@8.3.0 start
> nps "test.browser"

nps is executing `test.browser` : nps clean build test.browser.unit test.browser.bdd test.browser.tdd test.browser.qunit test.browser.esm test.browser.requirejs test.browser.webpack
nps is executing `clean` : rimraf mocha.js
nps is executing `build` : rollup -c

./browser-entry.js → ./mocha.js...
created ./mocha.js in 7.7s
nps is executing `test.browser.unit` : cross-env NODE_PATH=. karma start --single-run --colors

START:
wrote bundle to /Users/outsider/Dropbox/projects/github/mocha/.karma/Edward.kornet/26f394cf-2f4b-442f-b68d-8aafd4fe616e.rollup.js
29 07 2021 21:51:30.548:INFO [karma-server]: Karma v5.2.3 server started at http://localhost:9876/
29 07 2021 21:51:30.551:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
29 07 2021 21:51:30.557:INFO [launcher]: Starting browser ChromeHeadless
29 07 2021 21:51:32.127:INFO [Chrome Headless 92.0.4515.107 (Mac OS 10.15.7)]: Connected on socket WA07RiE5vXntQyXyAAAA with id 92272476
Chrome Headless 92.0.4515.107 (Mac OS 10.15.7) ERROR
  Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src https: 'self' 'unsafe-inline'".

  at mocha.js:13554:11

  EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src https: 'self' 'unsafe-inline'".

      at Function (<anonymous>)
      at mocha.js:13554:11
      at createCommonjsModule (mocha.js:16:6)
      at mocha.js:12845:2
      at mocha.js:4:92
      at mocha.js:5:2

Finished in 0.891 secs / 0 secs @ 21:51:33 GMT+0900 (대한민국 표준시)

SUMMARY:
✔ 0 tests completed
Chrome Headless 92.0.4515.107 (Mac OS 10.15.7) ERROR
  Uncaught TypeError: Cannot read property 'setup' of undefined
  at node_modules/karma-mocha/lib/adapter.js:255:16

  TypeError: Cannot read property 'setup' of undefined
      at node_modules/karma-mocha/lib/adapter.js:255:16
      at node_modules/karma-mocha/lib/adapter.js:256:3

✖ Error while running the tests! Exit code: 1

Chrome Headless 92.0.4515.107 (Mac OS 10.15.7) ERROR
  Uncaught ReferenceError: describe is not defined
  at .karma/Edward.kornet/26f394cf-2f4b-442f-b68d-8aafd4fe616e.rollup.js:13645:2

  ReferenceError: describe is not defined
      at .karma/Edward.kornet/26f394cf-2f4b-442f-b68d-8aafd4fe616e.rollup.js:13645:2
      at .karma/Edward.kornet/26f394cf-2f4b-442f-b68d-8aafd4fe616e.rollup.js:4:77
      at .karma/Edward.kornet/26f394cf-2f4b-442f-b68d-8aafd4fe616e.rollup.js:5:2

✖ Error while running the tests! Exit code: 1

The script called "test.browser.unit" which runs "cross-env NODE_PATH=. karma start --single-run --colors" failed with exit code 1 https://github.com/sezna/nps/blob/master/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
The script called "test.browser" which runs "nps clean build test.browser.unit test.browser.bdd test.browser.tdd test.browser.qunit test.browser.esm test.browser.requirejs test.browser.webpack" failed with exit code 1 https://github.com/sezna/nps/blob/master/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
```

And it is fine with the current master which is version-pinned devDependencies. 

However, when I removed version-pinned devDependencies, it is passed as well. So, I'm not sure this config is correct to prevent evalError regression. 