### PR TITLE
Docs: `grep()` using RegExp with global flag `/g`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1138,9 +1138,12 @@ Cause Mocha to only run tests matching the given `regexp`, which is internally c
 
 Suppose, for example, you have "api" related tests, as well as "app" related tests, as shown in the following snippet; One could use `--grep api` or `--grep app` to run one or the other. The same goes for any other part of a suite or test-case title, `--grep users` would be valid as well, or even `--grep GET`.
 
+And another option with double quotes: `--grep "groupA|groupB"`.<br>
+And for more complex criterias: `--grep "/get/i"`. Some shells as e.g. Git-Bash-for-Windows may require: `--grep "'/get/i'"`. Using flags other than the `ignoreCase /i` (especially `/g` and `/y`) may lead to unpredictable results.
+
 ```js
 describe('api', function() {
-  describe('GET /api/users', function() {
+  describe('GET /api/users groupA', function() {
     it('respond with an array of users', function() {
       // ...
     });
@@ -1148,7 +1151,7 @@ describe('api', function() {
 });
 
 describe('app', function() {
-  describe('GET /users', function() {
+  describe('GET /users groupB', function() {
     it('respond with an array of users', function() {
       // ...
     });

--- a/example/config/.mocharc.js
+++ b/example/config/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 // This is a JavaScript-based config file containing every Mocha option plus others.
-// If you need conditional logic, you might want to use this type of config.
+// If you need conditional logic, you might want to use this type of config,
+// e.g. set options via environment variables 'process.env'.
 // Otherwise, JSON or YAML is recommended.
 
 module.exports = {

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -581,7 +581,7 @@ Mocha.prototype.fgrep = function(str) {
 Mocha.prototype.grep = function(re) {
   if (utils.isString(re)) {
     // extract args if it's regex-like, i.e: [string, pattern, flag]
-    var arg = re.match(/^\/(.*)\/(g|i|)$|.*/);
+    var arg = re.match(/^\/(.*)\/([gimy]{0,4})$|.*/);
     this.options.grep = new RegExp(arg[1] || arg[0], arg[2]);
   } else {
     this.options.grep = re;


### PR DESCRIPTION
### Description

The global flag `/g` in a RegExp expression is behaving weirdly with Mocha's `--grep` option. The selection of tests based on the fullTitle seems wrong as tests get lost, but at the end it's just javascript.
```js
let reIgnore = /a/g;

console.log(reIgnore.test("a")); // true
console.log(reIgnore.test("a")); // false
console.log(reIgnore.test("a")); // true
console.log(reIgnore.test("a")); // false
```

### Description of the Change

Using a flag as `/g` or `/y` doesn't make any sense in this context. 
- improve `Mocha.prototype.grep` for better conversion of `string` into `RegExp`
- clarify documentation

### Alternate Designs

Instead of re-using the same RegExp instance for checking each test, we could construct new instances:
```js
let reIgnore = /a/g;

console.log(new RegExp(reIgnore).test("a")); // true
console.log(new RegExp(reIgnore).test("a")); // true
console.log(new RegExp(reIgnore).test("a")); // true
console.log(new RegExp(reIgnore).test("a")); // true
```
Mocha's `grep` selection is running in any case, with the `--grep` value or with our defaultGrep `/.*/`. Therefore I decided to not apply any fix for this edge case.

### Applicable issues

closes #4704