### PR TITLE
Docs: remove unsupported 'no-timeout' option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -937,13 +937,13 @@ Note: A test that executes for _half_ of the "slow" time will be highlighted _in
 
 ### `--timeout <ms>, -t <ms>`
 
-> _Update in v6.0.0: `--no-timeout` is implied when invoking Mocha using inspect flags. It is equivalent to `--timeout 0`. `--timeout 99999999` is no longer needed._
+> _Update in v6.0.0: `--timeout 0` is implied when invoking Mocha using inspect flags. `--timeout 99999999` is no longer needed._
 
 Specifies the test case timeout, defaulting to two (2) seconds (2000 milliseconds). Tests taking longer than this amount of time will be marked as failed.
 
 To override you may pass the timeout in milliseconds, or a value with the `s` suffix, e.g., `--timeout 2s` and `--timeout 2000` are equivalent.
 
-To disable timeouts, use `--no-timeout`.
+To disable timeouts, use `--timeout 0`.
 
 Note: synchronous (blocking) tests are also bound by the timeout, but they will not complete until the code stops blocking. Infinite loops will still be infinite loops!
 
@@ -1174,7 +1174,7 @@ Use `inspect` to launch Node.js' internal debugger.
 
 All of these options are mutually exclusive.
 
-Implies `--no-timeout`.
+Implies `--timeout 0`.
 
 ### `--parallel, -p`
 

--- a/example/config/.mocharc.js
+++ b/example/config/.mocharc.js
@@ -13,14 +13,14 @@ module.exports = {
   delay: false,
   diff: true,
   exit: false, // could be expressed as "'no-exit': true"
-  extension: ['js'],
-  // fgrep: something, // fgrep and grep are mutually exclusive
+  extension: ['js', 'cjs', 'mjs'],
+  fgrep: 'something', // fgrep and grep are mutually exclusive
   file: ['/path/to/some/file', '/path/to/some/other/file'],
   'forbid-only': false,
   'forbid-pending': false,
   'full-trace': false,
   global: ['jQuery', '$'],
-  // grep: something, // fgrep and grep are mutually exclusive
+  grep: /something/i, // also 'something', fgrep and grep are mutually exclusive
   growl: false,
   ignore: ['/path/to/some/ignored/file'],
   'inline-diffs': false,
@@ -38,7 +38,7 @@ module.exports = {
   sort: false,
   spec: ['test/**/*.spec.js'], // the positional arguments!
   timeout: '2000', // same as "timeout: '2s'"
-  // timeout: false, // same as "'no-timeout': true" or "timeout: 0"
+  // timeout: false, // same as "timeout: 0"
   'trace-warnings': true, // node flags ok
   ui: 'bdd',
   'v8-stack-trace-limit': 100, // V8 flags are prepended with "v8-"

--- a/example/config/.mocharc.yml
+++ b/example/config/.mocharc.yml
@@ -7,10 +7,9 @@ color: true
 delay: false
 diff: true
 exit: false # could be expressed as "no-exit: true"
-extension:
-  - 'js'
+extension: ['js', 'cjs', 'mjs']
 # fgrep and grep are mutually exclusive
-# fgrep: something
+fgrep: 'something'
 file:
   - '/path/to/some/file'
   - '/path/to/some/other/file'
@@ -21,7 +20,7 @@ global:
   - 'jQuery'
   - '$'
 # fgrep and grep are mutually exclusive
-# grep: something
+grep: '/something/i' # also 'something'
 growl: false
 ignore:
   - '/path/to/some/ignored/file'
@@ -45,7 +44,7 @@ sort: false
 spec:
   - 'test/**/*.spec.js' # the positional arguments!
 timeout: '2000' # same as "timeout: '2s'"
-# timeout: false # same as "no-timeout: true" or "timeout: 0"
+# timeout: false # same as "timeout: 0"
 trace-warnings: true # node flags ok
 ui: 'bdd'
 v8-stack-trace-limit: 100 # V8 flags are prepended with "v8-"


### PR DESCRIPTION
### Description

The `timeout` option is `typeof string` and the boolean negation does not work.
We remove any reference to `no-timeout` from our sample config files and documentation.

### Applicable issues

closes #4717