### PR TITLE
add retrytimedout arg

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -809,6 +809,24 @@ Mocha.prototype.timeout = function(msecs) {
 };
 
 /**
+ * @summary
+ * Enable retrying only timed out tests
+ *
+ * @description
+ * A boolean to determine whether
+ *
+ * @public
+ * @see [CLI option](../#-retry-timeouts)
+ * @see [Timeouts](../#timeouts)
+ * @return {Mocha} this
+ * @chainable
+ */
+Mocha.prototype.retryTimedOut = function(retryTimedOut) {
+  this.options.retryTimedOut = retryTimedOut !== false;
+  return this;
+};
+
+/**
  * Sets the number of times to retry failed tests.
  *
  * @public
@@ -1042,6 +1060,7 @@ Mocha.prototype.run = function(fn) {
     cleanReferencesAfterRun: this._cleanReferencesAfterRun,
     delay: options.delay,
     dryRun: options.dryRun,
+    retryTimedOut: options.retryTimedOut,
     failZero: options.failZero
   });
   createStatsCollector(runner);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -140,6 +140,8 @@ class Runner extends EventEmitter {
    * @param {boolean} [opts.delay] - Whether to delay execution of root suite until ready.
    * @param {boolean} [opts.dryRun] - Whether to report tests without running them.
    * @param {boolean} [options.failZero] - Whether to fail test run if zero tests encountered.
+   * @param {boolean} [opts.retryTimedOut] - Whether to retry only timed out tests.
+
    */
   constructor(suite, opts) {
     super();
@@ -815,7 +817,12 @@ Runner.prototype.runTests = function(suite, fn) {
           return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
         } else if (err) {
           var retry = test.currentRetry();
-          if (retry < test.retries()) {
+          // if not timed out tests only then check if retries passed
+          // else check if the duration of test was longer than _timeout
+          var timedOut = !self._opts.retryTimedOut
+            ? true
+            : Boolean(test.duration > test._timeout);
+          if (timedOut && retry < test.retries()) {
             var clonedTest = test.clone();
             clonedTest.currentRetry(retry + 1);
             tests.unshift(clonedTest);

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -581,6 +581,18 @@ describe('Mocha', function() {
       });
     });
 
+    describe('retryTimedOut()', function() {
+      it('should set the retryTimedOut option to true', function() {
+        mocha.retryTimedOut();
+        expect(mocha.options, 'to have property', 'retryTimedOut', true);
+      });
+
+      it('should set the retryTimedOut option to false', function() {
+        mocha.retryTimedOut(false);
+        expect(mocha.options, 'to have property', 'retryTimedOut', false);
+      });
+    });
+
     describe('run()', function() {
       let globalFixtureContext;
 


### PR DESCRIPTION
### Requirements



### Description of the Change

Added a CLI parameter ( `--retry-timed-out` ) that when used with `--retries` would only retry tests if they had timed out
https://github.com/mochajs/mocha/issues/4722

### Alternate Designs

I was thinking of adding `this.retryTimedOut` as a suite and test level parameter as well.


### Why should this be in core?

This is a simple change that would help retry for flakey tests only. 

### Benefits

Help keep retries to a minimum 

### Possible Drawbacks

Not useful for everyone ¯\_(ツ)_/¯

### Applicable issues

Minor Release