### PR TITLE
docs: fix broken table width under 450 screen width

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -352,6 +352,16 @@ figure#wallaby-logo figcaption {
   -webkit-font-smoothing: antialiased;
 }
 
+table {
+  width: 100%;
+}
+
+table td {
+  border-top: 1px solid #eee;
+  vertical-align: top;
+  word-break: break-all;
+}
+
 @media all and (max-width: 960px) {
   #copyright-notice {
     max-width: initial;

--- a/docs/index.md
+++ b/docs/index.md
@@ -2316,15 +2316,15 @@ _Note_: Double quotes around the glob are recommended for portability.
 
 When Mocha itself throws exception, the associated `Error` will have a `code` property. Where applicable, consumers should check the `code` property instead of string-matching against the `message` property. The following table describes these error codes:
 
-| Code                             | Description                                                  |
-| -------------------------------- | ------------------------------------------------------------ |
-| ERR_MOCHA_INVALID_ARG_TYPE       | wrong type was passed for a given argument                   |
-| ERR_MOCHA_INVALID_ARG_VALUE      | invalid or unsupported value was passed for a given argument |
-| ERR_MOCHA_INVALID_EXCEPTION      | a falsy or otherwise underspecified exception was thrown     |
-| ERR_MOCHA_INVALID_INTERFACE      | interface specified in options not found                     |
-| ERR_MOCHA_INVALID_REPORTER       | reporter specified in options not found                      |
-| ERR_MOCHA_NO_FILES_MATCH_PATTERN | test file(s) could not be found                              |
-| ERR_MOCHA_UNSUPPORTED            | requested behavior, option, or parameter is unsupported      |
+| Code                               | Description                                                  |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `ERR_MOCHA_INVALID_ARG_TYPE`       | wrong type was passed for a given argument                   |
+| `ERR_MOCHA_INVALID_ARG_VALUE`      | invalid or unsupported value was passed for a given argument |
+| `ERR_MOCHA_INVALID_EXCEPTION`      | a falsy or otherwise underspecified exception was thrown     |
+| `ERR_MOCHA_INVALID_INTERFACE`      | interface specified in options not found                     |
+| `ERR_MOCHA_INVALID_REPORTER`       | reporter specified in options not found                      |
+| `ERR_MOCHA_NO_FILES_MATCH_PATTERN` | test file(s) could not be found                              |
+| `ERR_MOCHA_UNSUPPORTED`            | requested behavior, option, or parameter is unsupported      |
 
 ## Editor Plugins
 


### PR DESCRIPTION
### Description of the Change

I found our homepage width was unnecessarily stretched because of error codes table.

<img width="421" alt="스크린샷 2021-08-29 오후 6 40 37" src="https://user-images.githubusercontent.com/390146/131245999-ee61f345-067e-437b-8696-d9f2fa39217e.png">

So, I prevent overflow table width and improve readability. Now it works like below.

<img width="369" alt="스크린샷 2021-08-29 오후 6 43 58" src="https://user-images.githubusercontent.com/390146/131246070-e2bae887-be5a-4d74-b217-496d45d432b5.png">
