### PR TITLE
fix `utils.stringify` failed on html elements

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,7 @@ function emptyRepresentation(value, typeHint) {
     case 'function':
       return '[Function]';
     case 'object':
-    case 'htmlelement':
+    case 'htmldocument':
       return '{}';
     case 'array':
       return '[]';
@@ -290,11 +290,13 @@ function jsonStringify(object, spaces, depth) {
       case 'undefined':
         val = '[' + val + ']';
         break;
+      case 'htmldocument':
       case 'array':
       case 'object':
-      case 'htmldocument':
-      case 'htmlelement':
         val = jsonStringify(val, spaces, depth + 1);
+        break;
+      case 'htmlelement':
+        val = val.outerHTML;
         break;
       case 'boolean':
       case 'regexp':
@@ -410,7 +412,6 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
       }
     /* falls through */
     case 'object':
-    case 'htmlelement':
     case 'htmldocument':
       canonicalizedObj = canonicalizedObj || {};
       withStack(value, function() {
@@ -420,6 +421,9 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
             canonicalizedObj[key] = exports.canonicalize(value[key], stack);
           });
       });
+      break;
+    case 'htmlelement':
+      canonicalizedObj = value.outerHTML;
       break;
     case 'date':
     case 'number':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,6 +111,7 @@ function emptyRepresentation(value, typeHint) {
     case 'function':
       return '[Function]';
     case 'object':
+    case 'htmlelement':
       return '{}';
     case 'array':
       return '[]';
@@ -150,8 +151,10 @@ var canonicalType = (exports.canonicalType = function canonicalType(value) {
   } else if (Buffer.isBuffer(value)) {
     return 'buffer';
   }
+
   return Object.prototype.toString
     .call(value)
+    .replace(/^\[.+\s(HTML)(?:\w*)(Element)]$/, '$1$2')
     .replace(/^\[.+\s(.+?)]$/, '$1')
     .toLowerCase();
 });
@@ -214,8 +217,11 @@ exports.type = function type(value) {
  */
 exports.stringify = function(value) {
   var typeHint = canonicalType(value);
-
-  if (!~['object', 'array', 'function'].indexOf(typeHint)) {
+  if (
+    !~['object', 'array', 'function', 'htmlelement', 'htmldocument'].indexOf(
+      typeHint
+    )
+  ) {
     if (typeHint === 'buffer') {
       var json = Buffer.prototype.toJSON.call(value);
       // Based on the toJSON result
@@ -286,6 +292,8 @@ function jsonStringify(object, spaces, depth) {
         break;
       case 'array':
       case 'object':
+      case 'htmldocument':
+      case 'htmlelement':
         val = jsonStringify(val, spaces, depth + 1);
         break;
       case 'boolean':
@@ -402,6 +410,8 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
       }
     /* falls through */
     case 'object':
+    case 'htmlelement':
+    case 'htmldocument':
       canonicalizedObj = canonicalizedObj || {};
       withStack(value, function() {
         Object.keys(value)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -393,6 +393,7 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
       canonicalizedObj = value;
       break;
     case 'array':
+    case 'htmlcollection':
       withStack(value, function() {
         canonicalizedObj = value.map(function(item) {
           return exports.canonicalize(item, stack);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -217,11 +217,7 @@ exports.type = function type(value) {
  */
 exports.stringify = function(value) {
   var typeHint = canonicalType(value);
-  if (
-    !~['object', 'array', 'function', 'htmlelement', 'htmldocument'].indexOf(
-      typeHint
-    )
-  ) {
+  if (!~['object', 'array', 'function', 'htmldocument'].indexOf(typeHint)) {
     if (typeHint === 'buffer') {
       var json = Buffer.prototype.toJSON.call(value);
       // Based on the toJSON result
@@ -241,6 +237,10 @@ exports.stringify = function(value) {
       typeHint = 'object';
     } else {
       return jsonStringify(value);
+    }
+
+    if (typeHint === 'htmlelement') {
+      return jsonStringify(value.outerHTML);
     }
   }
 
@@ -296,7 +296,7 @@ function jsonStringify(object, spaces, depth) {
         val = jsonStringify(val, spaces, depth + 1);
         break;
       case 'htmlelement':
-        val = val.outerHTML;
+        val = JSON.stringify(val.outerHTML);
         break;
       case 'boolean':
       case 'regexp':
@@ -423,7 +423,7 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
       });
       break;
     case 'htmlelement':
-      canonicalizedObj = value.outerHTML;
+      canonicalizedObj = value;
       break;
     case 'date':
     case 'number':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -217,7 +217,7 @@ exports.type = function type(value) {
  */
 exports.stringify = function(value) {
   var typeHint = canonicalType(value);
-  if (!~['object', 'array', 'function', 'htmldocument'].indexOf(typeHint)) {
+  if (!~['object', 'array', 'function'].indexOf(typeHint)) {
     if (typeHint === 'buffer') {
       var json = Buffer.prototype.toJSON.call(value);
       // Based on the toJSON result
@@ -290,9 +290,9 @@ function jsonStringify(object, spaces, depth) {
       case 'undefined':
         val = '[' + val + ']';
         break;
-      case 'htmldocument':
       case 'array':
       case 'object':
+      case 'htmldocument':
         val = jsonStringify(val, spaces, depth + 1);
         break;
       case 'htmlelement':

--- a/package.json
+++ b/package.json
@@ -197,5 +197,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "resolutions": {
+    "minipass": "2.7.0"
   }
 }

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -583,8 +583,6 @@ describe('lib/utils', function() {
       expect(type('type'), 'to be', 'string');
       expect(type(new Error()), 'to be', 'error');
       expect(type(global), 'to be', 'object');
-      expect(type(global.document), 'to be', 'object');
-      expect(type(global.document.body), 'to be', 'object');
       expect(type(true), 'to be', 'boolean');
       expect(type(Buffer.from('ff', 'hex')), 'to be', 'object');
       expect(type(Symbol.iterator), 'to be', 'symbol');
@@ -638,8 +636,6 @@ describe('lib/utils', function() {
       expect(type(/foo/), 'to be', 'regexp');
       expect(type('type'), 'to be', 'string');
       expect(type(global), 'to be', 'domwindow');
-      expect(type(global.document), 'to be', 'htmldocument');
-      expect(type(global.document.body), 'to be', 'htmlelement');
       expect(type(true), 'to be', 'boolean');
     });
 

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -295,22 +295,25 @@ describe('lib/utils', function() {
           return;
         }
 
-        var document = global.document;
+        var win = global.open('');
+        var document = win.document;
+        document.body.innerHTML = '<div>foo</div>';
         var expected = {
-          document: document,
           body: document.body,
-          div: document.createElement('div')
+          div: document.createElement('div'),
+          document: document
         };
         var actual = [
           '{',
-          '  "body": {}',
-          '  "div": {}',
+          '  "body": "<body><div>foo</div></body>"',
+          '  "div": "<div></div>"',
           '  "document": {',
-          '    "location": "http://localhost:9876/context.html"',
+          '    "location": "about:blank"',
           '  }',
           '}'
         ].join('\n');
         expect(stringify(expected), 'to be', actual);
+        win.close();
       });
     });
 

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -583,6 +583,8 @@ describe('lib/utils', function() {
       expect(type('type'), 'to be', 'string');
       expect(type(new Error()), 'to be', 'error');
       expect(type(global), 'to be', 'object');
+      expect(type(global.document), 'to be', 'object');
+      expect(type(global.document.body), 'to be', 'object');
       expect(type(true), 'to be', 'boolean');
       expect(type(Buffer.from('ff', 'hex')), 'to be', 'object');
       expect(type(Symbol.iterator), 'to be', 'symbol');
@@ -636,6 +638,8 @@ describe('lib/utils', function() {
       expect(type(/foo/), 'to be', 'regexp');
       expect(type('type'), 'to be', 'string');
       expect(type(global), 'to be', 'domwindow');
+      expect(type(global.document), 'to be', 'htmldocument');
+      expect(type(global.document.body), 'to be', 'htmlelement');
       expect(type(true), 'to be', 'boolean');
     });
 

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -297,7 +297,8 @@ describe('lib/utils', function() {
 
         var win = global.open('');
         var document = win.document;
-        document.body.innerHTML = '<div>foo</div>';
+        document.body.innerHTML = '<div class="foo">bar</div>';
+
         var expected = {
           body: document.body,
           div: document.createElement('div'),
@@ -305,7 +306,7 @@ describe('lib/utils', function() {
         };
         var actual = [
           '{',
-          '  "body": "<body><div>foo</div></body>"',
+          '  "body": "<body><div class=\\"foo\\">bar</div></body>"',
           '  "div": "<div></div>"',
           '  "document": {',
           '    "location": "about:blank"',

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -288,6 +288,30 @@ describe('lib/utils', function() {
         ].join('\n');
         expect(stringify(expected), 'to be', actual);
       });
+
+      it('should represent the actual full result for document and elements', function() {
+        if (!process.browser) {
+          this.skip();
+          return;
+        }
+
+        var document = global.document;
+        var expected = {
+          document: document,
+          body: document.body,
+          div: document.createElement('div')
+        };
+        var actual = [
+          '{',
+          '  "body": {}',
+          '  "div": {}',
+          '  "document": {',
+          '    "location": "http://localhost:9876/context.html"',
+          '  }',
+          '}'
+        ].join('\n');
+        expect(stringify(expected), 'to be', actual);
+      });
     });
 
     it('should canonicalize the object', function() {


### PR DESCRIPTION
### Description of the Change
[`stringify`](https://github.com/mochajs/mocha/blob/master/lib/utils.js#L215) should represent the actual full result for html elements and html document object.

```js
var win = global.open('');
var document = win.document;
document.body.innerHTML = '<div class="foo">bar</div>';

var expected = {
  body: document.body,
  div: document.createElement('div'),
  document: document
};
var actual = [
  '{',
  '  "body": "<body><div class=\\"foo\\">bar</div></body>"',
  '  "div": "<div></div>"',
  '  "document": {',
  '    "location": "about:blank"',
  '  }',
  '}'
].join('\n');

expect(stringify(expected), 'to be', actual);
win.close();
```


### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
This change fix the issue of that test suit on failed case:
```
expect(document.querySelector('#my-btn')).be.eq(document.activeElement)
```

Because [_stringify](https://github.com/mochajs/mocha/blob/master/lib/utils.js#L281) has no case for the `HTMLEelement` and `HTMLDocument` object, so that it throw an error, but not report a failed message, and test runner is sticking.

This PR should fix the issue, test runner should report the failed message, now.
