### PR TITLE
Website: improve backers' sprite image

### DIFF
--- a/docs/css/supporters.css
+++ b/docs/css/supporters.css
@@ -8,6 +8,7 @@
   -sprite-selector-for-group: backers;
   -sprite-location: url(/images/sprite-backers.png?pngquant);
   -sprite-image-format: png;
+  -sprite-padding: 0 10;
   width: 32px;
   height: 32px;
 }


### PR DESCRIPTION
### Description

We have backer images with `width<32px`. The current spritesheet looks like this:

![image](https://user-images.githubusercontent.com/44573692/134859627-4ab08322-8d03-44fb-ac27-6c6a73829aca.png)

After this PR:

![image](https://user-images.githubusercontent.com/44573692/134859787-6bdbde6a-1980-4779-b60b-5df908da9fe3.png)

### Description of the Change

We add `-sprite-padding: 0 10;` to the CSS class `backer`. I got this solution from assetgraph-builder maintainers in gitter chanel.
This change has no effect on netlify deploy-previews, since the sprite image is generated for production deploys only.

### Applicable issues

closes #4752