### PR TITLE
Remove listing of EVENT_SUITE_ADD* events as deprecated (#4760)

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -603,7 +603,7 @@ var constants = defineConstants(
    */
   {
     /**
-     * Event emitted after a test file has been loaded Not emitted in browser.
+     * Event emitted after a test file has been loaded. Not emitted in browser.
      */
     EVENT_FILE_POST_REQUIRE: 'post-require',
     /**
@@ -615,24 +615,24 @@ var constants = defineConstants(
      */
     EVENT_FILE_REQUIRE: 'require',
     /**
-     * Event emitted when `global.run()` is called (use with `delay` option)
+     * Event emitted when `global.run()` is called (use with `delay` option).
      */
     EVENT_ROOT_SUITE_RUN: 'run',
 
     /**
-     * Namespace for collection of a `Suite`'s "after all" hooks
+     * Namespace for collection of a `Suite`'s "after all" hooks.
      */
     HOOK_TYPE_AFTER_ALL: 'afterAll',
     /**
-     * Namespace for collection of a `Suite`'s "after each" hooks
+     * Namespace for collection of a `Suite`'s "after each" hooks.
      */
     HOOK_TYPE_AFTER_EACH: 'afterEach',
     /**
-     * Namespace for collection of a `Suite`'s "before all" hooks
+     * Namespace for collection of a `Suite`'s "before all" hooks.
      */
     HOOK_TYPE_BEFORE_ALL: 'beforeAll',
     /**
-     * Namespace for collection of a `Suite`'s "before all" hooks
+     * Namespace for collection of a `Suite`'s "before each" hooks.
      */
     HOOK_TYPE_BEFORE_EACH: 'beforeEach',
 
@@ -640,21 +640,20 @@ var constants = defineConstants(
      * Emitted after a child `Suite` has been added to a `Suite`.
      */
     EVENT_SUITE_ADD_SUITE: 'suite',
-
     /**
-     * Emitted after an "after all" `Hook` has been added to a `Suite`
+     * Emitted after an "after all" `Hook` has been added to a `Suite`.
      */
     EVENT_SUITE_ADD_HOOK_AFTER_ALL: 'afterAll',
     /**
-     * Emitted after an "after each" `Hook` has been added to a `Suite`
+     * Emitted after an "after each" `Hook` has been added to a `Suite`.
      */
     EVENT_SUITE_ADD_HOOK_AFTER_EACH: 'afterEach',
     /**
-     * Emitted after an "before all" `Hook` has been added to a `Suite`
+     * Emitted after an "before all" `Hook` has been added to a `Suite`.
      */
     EVENT_SUITE_ADD_HOOK_BEFORE_ALL: 'beforeAll',
     /**
-     * Emitted after an "before each" `Hook` has been added to a `Suite`
+     * Emitted after an "before each" `Hook` has been added to a `Suite`.
      */
     EVENT_SUITE_ADD_HOOK_BEFORE_EACH: 'beforeEach',
     /**

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -10,7 +10,6 @@ var {
   assignNewMochaID,
   clamp,
   constants: utilsConstants,
-  createMap,
   defineConstants,
   getMochaID,
   inherits,
@@ -92,16 +91,6 @@ function Suite(title, parentContext, isRoot) {
   });
 
   this.reset();
-
-  this.on('newListener', function(event) {
-    if (deprecatedEvents[event]) {
-      errors.deprecate(
-        'Event "' +
-          event +
-          '" is deprecated.  Please let the Mocha team know about your use case: https://git.io/v6Lwm'
-      );
-    }
-  });
 }
 
 /**
@@ -647,49 +636,32 @@ var constants = defineConstants(
      */
     HOOK_TYPE_BEFORE_EACH: 'beforeEach',
 
-    // the following events are all deprecated
+    /**
+     * Emitted after a child `Suite` has been added to a `Suite`.
+     */
+    EVENT_SUITE_ADD_SUITE: 'suite',
 
     /**
-     * Emitted after an "after all" `Hook` has been added to a `Suite`. Deprecated
+     * Emitted after an "after all" `Hook` has been added to a `Suite`
      */
     EVENT_SUITE_ADD_HOOK_AFTER_ALL: 'afterAll',
     /**
-     * Emitted after an "after each" `Hook` has been added to a `Suite` Deprecated
+     * Emitted after an "after each" `Hook` has been added to a `Suite`
      */
     EVENT_SUITE_ADD_HOOK_AFTER_EACH: 'afterEach',
     /**
-     * Emitted after an "before all" `Hook` has been added to a `Suite` Deprecated
+     * Emitted after an "before all" `Hook` has been added to a `Suite`
      */
     EVENT_SUITE_ADD_HOOK_BEFORE_ALL: 'beforeAll',
     /**
-     * Emitted after an "before each" `Hook` has been added to a `Suite` Deprecated
+     * Emitted after an "before each" `Hook` has been added to a `Suite`
      */
     EVENT_SUITE_ADD_HOOK_BEFORE_EACH: 'beforeEach',
     /**
-     * Emitted after a child `Suite` has been added to a `Suite`. Deprecated
-     */
-    EVENT_SUITE_ADD_SUITE: 'suite',
-    /**
-     * Emitted after a `Test` has been added to a `Suite`. Deprecated
+     * Emitted after a `Test` has been added to a `Suite`.
      */
     EVENT_SUITE_ADD_TEST: 'test'
   }
 );
-
-/**
- * @summary There are no known use cases for these events.
- * @desc This is a `Set`-like object having all keys being the constant's string value and the value being `true`.
- * @todo Remove eventually
- * @type {Object<string,boolean>}
- * @ignore
- */
-var deprecatedEvents = Object.keys(constants)
-  .filter(function(constant) {
-    return constant.substring(0, 15) === 'EVENT_SUITE_ADD';
-  })
-  .reduce(function(acc, constant) {
-    acc[constants[constant]] = true;
-    return acc;
-  }, createMap());
 
 Suite.constants = constants;

--- a/test/unit/suite.spec.js
+++ b/test/unit/suite.spec.js
@@ -548,16 +548,6 @@ describe('Suite', function() {
           new Suite('Bdd suite', 'root');
         }, 'not to throw');
       });
-
-      it('should report listened-for deprecated events as deprecated', function() {
-        new Suite('foo').on(
-          Suite.constants.EVENT_SUITE_ADD_TEST,
-          function() {}
-        );
-        expect(errors.deprecate, 'to have a call satisfying', [
-          /Event "[^"]+" is deprecated/i
-        ]);
-      });
     });
 
     describe('timeout()', function() {


### PR DESCRIPTION
### Description of the Change
Other projects (such as [Nigthwatch.js](https://github.com/nightwatchjs/nightwatch)) may be relying on these events in order to be able to extend the test suite object during the parsing cycle. 

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

### Alternate Designs

None.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues
These is a minimal risk change and it has been reviewed in https://github.com/mochajs/mocha/issues/4760.

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
