### PR TITLE
Browser: improve 'bdd' import for bundlers

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -209,8 +209,18 @@ Mocha.process = process;
 /**
  * Expose mocha.
  */
-
 global.Mocha = Mocha;
 global.mocha = mocha;
+
+// for bundlers: enable `import {describe, it} from 'mocha'`
+// `bdd` interface only
+// prettier-ignore
+[ 
+  'describe', 'context', 'it', 'specify',
+  'xdescribe', 'xcontext', 'xit', 'xspecify',
+  'before', 'beforeEach', 'afterEach', 'after'
+].forEach(function(key) {
+  mocha[key] = global[key];
+});
 
 module.exports = mocha;

--- a/test/browser-specific/setup.js
+++ b/test/browser-specific/setup.js
@@ -8,5 +8,3 @@ global.expect = require('unexpected')
   .use(require('unexpected-map'))
   .use(require('unexpected-sinon'))
   .use(require('unexpected-eventemitter'));
-
-require('../../browser-entry');

--- a/test/unit/required-tokens.spec.js
+++ b/test/unit/required-tokens.spec.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const assert = require('assert');
+const {describe, it} = require('../..');
+
+describe('using imported "describe"', function() {
+  it('using imported "it"', function(done) {
+    assert.ok(true);
+    done();
+  });
+});


### PR DESCRIPTION
### Description

History: #4746

Above PR proved to be too restrictive as it's no longer possible to do ES6 style `import { describe, it } from 'mocha'` while using bundlers.

### Description of the Change

_browser-entry.js_: push all `bdd` functions from `global` to `mocha`.

We have conflicts between `global.setup` (`tdd` version of `beforeEach` hook) and `mocha.setup`(browser setup), and therefore we don't copy the `tdd` functions to `mocha`. The `tdd` interface has never/won't be available for ES6 style import. 

At the time of copying the `bdd` functions are undefined, nevertheless bundlers seem to rely on those lines. The exact logic remained unclear to me.

### Applicable issues

closes #4763