### PR TITLE
fix the regular expression for function `clean` in `utils.js`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ exports.clean = function(str) {
     .replace(/^\uFEFF/, '')
     // (traditional)->  space/name     parameters    body     (lambda)-> parameters       body   multi-statement/single          keep body content
     .replace(
-      /^function(?:\s*|\s[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\}|((?:.|\n)*))$/
+      /^function(?:\s*|\s[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\}|((?:.|\n)*))$/,
       '$1$2$3'
     );
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ exports.clean = function(str) {
     .replace(/^\uFEFF/, '')
     // (traditional)->  space/name     parameters    body     (lambda)-> parameters       body   multi-statement/single          keep body content
     .replace(
-      /^function(?:\s*|\s+[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\s*\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\s*\}|((?:.|\n)*))$/,
+      /^function(?:\s*|\s[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\}|((?:.|\n)*))$/
       '$1$2$3'
     );
 


### PR DESCRIPTION

### Description of the Change

Fix the regular expression for function `clean` in `utils.js` to avoid potential Regular Expression Denial of Service (ReDoS) vulnerabilities.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The ReDoS vulnerabilities of the regex  `/^function(?:\s*|\s+[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\s*\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\s*\}|((?:.|\n)*))$/` are mainly due to the overlapped sub-patterns `\s+[^(]*`  and `((?:.|\n)*?)\s*`.
We can ignore `\s` first, because in the end, we can also deal with `\s` using the `trim` function (see the code below）https://github.com/mochajs/mocha/blob/8421974e8d252e2ef11602d15bed178e4f5f4534/lib/utils.js#L92

So I am willing to suggest that you replace the ReDoS-vulnerable regex  `/^function(?:\s*|\s+[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\s*\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\s*\}|((?:.|\n)*))$/` with the safe regex `/^function(?:\s*|\s[^(]*)\([^)]*\)\s*\{((?:.|\n)*?)\}$|^\([^)]*\)\s*=>\s*(?:\{((?:.|\n)*?)\}|((?:.|\n)*))$/`



### Benefits

It achieves functional equivalence and is not subject to ReDoS attacks.


### Applicable issues

See the link https://www.huntr.dev/bounties/1d8a3d95-d199-4129-a6ad-8eafe5e77b9e/
