### PR TITLE
Add Node v17 into ci matrix

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -48,15 +48,15 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/checkout@v2
       - name: 'Cache node_modules'
         uses: actions/cache@v2
         with:
           path: '~/.npm'
-          key: "ubuntu-latest-node-v14-${{ hashFiles('**/package-lock.json') }}"
+          key: "ubuntu-latest-node-v16-${{ hashFiles('**/package-lock.json') }}"
           restore-keys: |
-            ubuntu-latest-node-v14-
+            ubuntu-latest-node-v16-
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: 'Check lint'
@@ -80,7 +80,7 @@ jobs:
           - 17
         include:
           - os: ubuntu-latest
-            node: 14
+            node: 16
             env:
               COVERAGE: 1
     steps:
@@ -183,7 +183,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/checkout@v2
       - name: 'Cache node_modules'
         uses: actions/cache@v2
@@ -191,9 +191,9 @@ jobs:
           path: '~/.npm'
           # this key is different than above, since we are running scripts
           # (builds, postinstall lifecycle hooks, etc.)
-          key: "ubuntu-latest-node-full-v14-${{ hashFiles('**/package-lock.json') }}"
+          key: "ubuntu-latest-node-full-v16-${{ hashFiles('**/package-lock.json') }}"
           restore-keys: |
-            ubuntu-latest-node-full-v14-
+            ubuntu-latest-node-full-v16-
       - name: Install Dependencies
         run: npm ci
       - name: Run Browser Tests


### PR DESCRIPTION
Node 17 is a new Current version. So, mocha will run tests on Node v17.

~And Netlify runs on node 12, but 12 is a pretty old version. 
I updated it to Node 16. v16 will be the new LTS version soon.~