### PR TITLE
Run netlify with Node 16

### DIFF
--- a/docs/_data/supporters.js
+++ b/docs/_data/supporters.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const {loadImage} = require('canvas');
-const {writeFile, mkdir, rmdir} = require('fs').promises;
+const {writeFile, mkdir, rm} = require('fs').promises;
 const {resolve} = require('path');
 const debug = require('debug')('mocha:docs:data:supporters');
 const needle = require('needle');
@@ -225,7 +225,7 @@ const getSupporters = async () => {
       }
     );
 
-  await rmdir(SUPPORTER_IMAGE_PATH, {recursive: true});
+  await rm(SUPPORTER_IMAGE_PATH, {recursive: true, force: true});
   debug('blasted %s', SUPPORTER_IMAGE_PATH);
   await mkdir(SUPPORTER_IMAGE_PATH, {recursive: true});
   debug('created %s', SUPPORTER_IMAGE_PATH);

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,7 +15,7 @@
 [build.environment]
   DEBUG = "mocha:docs*"
   NODE_VERSION = "16"
-  RUBY_VERSION = "2.7.1"
+  RUBY_VERSION = "2.7.2"
 
 [context.deploy-preview]
   command = "npm start docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,7 +14,7 @@
 
 [build.environment]
   DEBUG = "mocha:docs*"
-  NODE_VERSION = "12"
+  NODE_VERSION = "16"
   RUBY_VERSION = "2.7.1"
 
 [context.deploy-preview]


### PR DESCRIPTION
Netlify runs on node 12, but 12 is a pretty old version.
- I updated it to Node 16
- _supporter.js_: replace `rmdir` by `rm`
- netlify settings: load netlify build image `focal` instead of `xenial`