### PR TITLE
devDeps: remove 'cross-spawn'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "core-js": "^3.16.3",
         "coveralls": "^3.1.1",
         "cross-env": "^7.0.2",
-        "cross-spawn": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-semistandard": "^16.0.0",
@@ -2579,9 +2578,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
-      "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==",
+      "version": "16.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -4797,13 +4796,13 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
     },
     "node_modules/browser-sync": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.5.tgz",
-      "integrity": "sha512-0GMEPDqccbTxwYOUGCk5AZloDj9I/1eDZCLXUKXu7iBJPznGGOnMHs88mrhaFL0fTA0R23EmsXX9nLZP+k5YzA==",
+      "version": "2.27.6",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.6.tgz",
+      "integrity": "sha512-lknOs7RmALVC8iLvQuNv0vhe6lChaT+GTP8qVw7s4+fZAhNvFn6jWedX94HMRs4iJOrwrm7kdg52G9mf1oHmAA==",
       "dev": true,
       "dependencies": {
-        "browser-sync-client": "^2.27.5",
-        "browser-sync-ui": "^2.27.5",
+        "browser-sync-client": "^2.27.6",
+        "browser-sync-ui": "^2.27.6",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
         "chokidar": "^3.5.1",
@@ -4830,7 +4829,7 @@
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
         "socket.io": "2.4.0",
-        "ua-parser-js": "^0.7.28",
+        "ua-parser-js": "1.0.1",
         "yargs": "^15.4.1"
       },
       "bin": {
@@ -4841,9 +4840,9 @@
       }
     },
     "node_modules/browser-sync-client": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.5.tgz",
-      "integrity": "sha512-l2jtf60/exv0fQiZkhi3z8RgexYYLGS7DVDnyepkrp+oFAPlKW69daL6NrVSgrwu6lzSTCCTAiPXnUSrQ57e/Q==",
+      "version": "2.27.6",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.6.tgz",
+      "integrity": "sha512-hqTThp4/nE0Rxu6kn2UXVH9f8WhoHDls+bfhkZjhzCJfDdnGN9VyuwcgfD6gofaxvbzaDK00FiSCACFdmILDdg==",
       "dev": true,
       "dependencies": {
         "etag": "1.8.1",
@@ -4856,9 +4855,9 @@
       }
     },
     "node_modules/browser-sync-ui": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.5.tgz",
-      "integrity": "sha512-KxBJhQ6XNbQ8w8UlkPa9/J5R0nBHgHuJUtDpEXQx1jBapDy32WGzD0NENDozP4zGNvJUgZk3N80hqB7YCieC3g==",
+      "version": "2.27.6",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.6.tgz",
+      "integrity": "sha512-0nKvGG39z5cGIyPWhNgJBF4p6n6X6JjQj99EpilHEkUOnagbVRtJaWOXlOrkPNxsz5IZ3zx4pk0wYEO4IX7J8w==",
       "dev": true,
       "dependencies": {
         "async-each-series": "0.1.1",
@@ -7746,6 +7745,25 @@
       "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
       "dev": true
     },
+    "node_modules/devtools/node_modules/ua-parser-js": {
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -8124,9 +8142,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.878",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.878.tgz",
-      "integrity": "sha512-O6yxWCN9ph2AdspAIszBnd9v8s11hQx8ub9w4UGApzmNRnoKhbulOWqbO8THEQec/aEHtvy+donHZMlh6l1rbA==",
+      "version": "1.3.879",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.879.tgz",
+      "integrity": "sha512-zJo+D9GwbJvM31IdFmwcGvychhk4KKbKYo2GWlsn+C/dxz2NwmbhGJjWwTfFSF2+eFH7VvfA8MCZ8SOqTrlnpw==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -13360,6 +13378,25 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/karma/node_modules/ua-parser-js": {
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/karma/node_modules/ws": {
@@ -19965,9 +20002,9 @@
       }
     },
     "node_modules/remark-github": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/remark-github/-/remark-github-11.1.1.tgz",
-      "integrity": "sha512-k0BmmGxBMK3f18nkZAdqWjt4vzjrsnbv9W1Uf+DtlFmqWJQr+7lMQLpVpiybR8Ov0WZ0WE8HOMsCl4hCCR95ew==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/remark-github/-/remark-github-11.2.0.tgz",
+      "integrity": "sha512-3c/pSLPktel3ZskD8QYRBz9oqOeqSoUPAcafXGs6Sz9mIUdtAe6hGYfwUzjFF7Zmwv5QfXfa2TXbMUqmgxwK2w==",
       "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -23486,9 +23523,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.30",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
-      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.1.tgz",
+      "integrity": "sha512-ZMu7XRN3M3R+g/YaFQKiVW0J42bzciF0+xAxP5uuO6VibE30MQvRRBctHuh22uS3yAe5jkru/i8QVOwRDJazIw==",
       "dev": true,
       "funding": [
         {
@@ -27234,9 +27271,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
-      "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==",
+      "version": "16.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -29060,13 +29097,13 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
     },
     "browser-sync": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.5.tgz",
-      "integrity": "sha512-0GMEPDqccbTxwYOUGCk5AZloDj9I/1eDZCLXUKXu7iBJPznGGOnMHs88mrhaFL0fTA0R23EmsXX9nLZP+k5YzA==",
+      "version": "2.27.6",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.6.tgz",
+      "integrity": "sha512-lknOs7RmALVC8iLvQuNv0vhe6lChaT+GTP8qVw7s4+fZAhNvFn6jWedX94HMRs4iJOrwrm7kdg52G9mf1oHmAA==",
       "dev": true,
       "requires": {
-        "browser-sync-client": "^2.27.5",
-        "browser-sync-ui": "^2.27.5",
+        "browser-sync-client": "^2.27.6",
+        "browser-sync-ui": "^2.27.6",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
         "chokidar": "^3.5.1",
@@ -29093,7 +29130,7 @@
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
         "socket.io": "2.4.0",
-        "ua-parser-js": "^0.7.28",
+        "ua-parser-js": "1.0.1",
         "yargs": "^15.4.1"
       },
       "dependencies": {
@@ -29226,9 +29263,9 @@
       }
     },
     "browser-sync-client": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.5.tgz",
-      "integrity": "sha512-l2jtf60/exv0fQiZkhi3z8RgexYYLGS7DVDnyepkrp+oFAPlKW69daL6NrVSgrwu6lzSTCCTAiPXnUSrQ57e/Q==",
+      "version": "2.27.6",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.6.tgz",
+      "integrity": "sha512-hqTThp4/nE0Rxu6kn2UXVH9f8WhoHDls+bfhkZjhzCJfDdnGN9VyuwcgfD6gofaxvbzaDK00FiSCACFdmILDdg==",
       "dev": true,
       "requires": {
         "etag": "1.8.1",
@@ -29238,9 +29275,9 @@
       }
     },
     "browser-sync-ui": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.5.tgz",
-      "integrity": "sha512-KxBJhQ6XNbQ8w8UlkPa9/J5R0nBHgHuJUtDpEXQx1jBapDy32WGzD0NENDozP4zGNvJUgZk3N80hqB7YCieC3g==",
+      "version": "2.27.6",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.6.tgz",
+      "integrity": "sha512-0nKvGG39z5cGIyPWhNgJBF4p6n6X6JjQj99EpilHEkUOnagbVRtJaWOXlOrkPNxsz5IZ3zx4pk0wYEO4IX7J8w==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -31523,6 +31560,14 @@
         "puppeteer-core": "^5.1.0",
         "ua-parser-js": "^0.7.21",
         "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "ua-parser-js": {
+          "version": "0.7.30",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+          "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
+          "dev": true
+        }
       }
     },
     "devtools-protocol": {
@@ -31865,9 +31910,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.878",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.878.tgz",
-      "integrity": "sha512-O6yxWCN9ph2AdspAIszBnd9v8s11hQx8ub9w4UGApzmNRnoKhbulOWqbO8THEQec/aEHtvy+donHZMlh6l1rbA==",
+      "version": "1.3.879",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.879.tgz",
+      "integrity": "sha512-zJo+D9GwbJvM31IdFmwcGvychhk4KKbKYo2GWlsn+C/dxz2NwmbhGJjWwTfFSF2+eFH7VvfA8MCZ8SOqTrlnpw==",
       "dev": true
     },
     "elliptic": {
@@ -35766,6 +35811,12 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.30",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+          "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
           "dev": true
         },
         "ws": {
@@ -41149,9 +41200,9 @@
       }
     },
     "remark-github": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/remark-github/-/remark-github-11.1.1.tgz",
-      "integrity": "sha512-k0BmmGxBMK3f18nkZAdqWjt4vzjrsnbv9W1Uf+DtlFmqWJQr+7lMQLpVpiybR8Ov0WZ0WE8HOMsCl4hCCR95ew==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/remark-github/-/remark-github-11.2.0.tgz",
+      "integrity": "sha512-3c/pSLPktel3ZskD8QYRBz9oqOeqSoUPAcafXGs6Sz9mIUdtAe6hGYfwUzjFF7Zmwv5QfXfa2TXbMUqmgxwK2w==",
       "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
@@ -43992,9 +44043,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.30",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
-      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.1.tgz",
+      "integrity": "sha512-ZMu7XRN3M3R+g/YaFQKiVW0J42bzciF0+xAxP5uuO6VibE30MQvRRBctHuh22uS3yAe5jkru/i8QVOwRDJazIw==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "core-js": "^3.16.3",
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.2",
-    "cross-spawn": "^7.0.3",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-semistandard": "^16.0.0",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -297,7 +297,7 @@ function invokeNode(args, done, opts = {}) {
  *
  * @param {string[]} args - Path to executable and arguments
  * @param {RawResultCallback} done - Callback
- * @param {Object|string} [opts] - Options to `cross-spawn` or `child_process.fork` or 'pipe' for shortcut to `{stdio: pipe}`
+ * @param {Object|string} [opts] - Options to `child_process` or 'pipe' for shortcut to `{stdio: pipe}`
  * @param {boolean} [opts.fork] - If `true`, use `child_process.fork` instead
  * @returns {import('child_process').ChildProcess}
  */
@@ -334,7 +334,7 @@ function createSubprocess(args, done, opts = {}) {
     debug('forking: %s', args.join(' '));
     mocha = fork(args[0], args.slice(1), opts);
   } else {
-    const {spawn} = require('cross-spawn');
+    const {spawn} = require('child_process');
     debug('spawning: %s', [process.execPath].concat(args).join(' '));
     mocha = spawn(process.execPath, args, opts);
   }
@@ -400,11 +400,11 @@ function getSummary(res) {
  * and waits until the second test run has been completed. Mocha is
  * killed and the result is returned.
  *
- * On Windows, this will call `child_process.fork()` instead of `cross-spawn.spawn()`.
+ * On Windows, this will call `child_process.fork()` instead of `spawn()`.
  *
  * **Exit code will always be 0**
  * @param {string[]} args - Array of argument strings
- * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `cross-spawn.spawn` or `child_process.fork`
+ * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process`
  * @param {Function} change - A potentially `Promise`-returning callback to execute which will change a watched file
  * @returns {Promise<RawResult>}
  */
@@ -451,11 +451,11 @@ async function runMochaWatchAsync(args, opts, change) {
  * and waits until the second test run has been completed. Mocha is
  * killed and the result is returned.
  *
- * On Windows, this will call `child_process.fork()` instead of `cross-spawn.spawn()`.
+ * On Windows, this will call `child_process.fork()` instead of `spawn()`.
  *
  * **Exit code will always be 0**
  * @param {string[]} args - Array of argument strings
- * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `cross-spawn.spawn` or `child_process.fork`
+ * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process`
  * @param {Function} change - A potentially `Promise`-returning callback to execute which will change a watched file
  * @returns {Promise<JSONResult>}
  */


### PR DESCRIPTION
### Description

We use _cross-spawn_ in our integration tests only.
We remove it from our devDependencies and use Node's native `child-process` module instead, which has been stable for many years now.