### PR TITLE
fixed: mocha definition is hardly readable #4787

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -59,7 +59,7 @@ header {
   animation: fadein 1s forwards, slideright 1s forwards;
   color: #c29d7f;
   font-size: 30px;
-  font-weight: 100;
+  font-weight: 200;
   letter-spacing: 2px;
   margin-top: -158px;
   margin-left: 185px;
@@ -150,7 +150,7 @@ h3 > code {
 
 #content > p:first-child {
   font-size: 20px;
-  font-weight: 200;
+  font-weight: 400;
   letter-spacing: 1px;
 }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

To resolve the issue "docs: mocha definition is hardly readable #4787",
changed the font-weight from 200 to 400 for #content > p:first-child, and
changed the font-weight from 100 to 200 for #tag

### Alternate Designs

Considered a heavier font-weight, but 400 and 200 seemed appropriate.

### Why should this be in core?

That is where the issue was posted.

### Benefits

Better readability.

### Possible Drawbacks

None come to mind for this minor fix.

### Applicable issues

This is a change to the docs, and shouldn't affect any changes to the application.
