### PR TITLE
docs: fix DEP0147 DeprecationWarning

### DIFF
--- a/docs/_data/supporters.js
+++ b/docs/_data/supporters.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const {loadImage} = require('canvas');
-const {writeFile, mkdir, rmdir} = require('fs').promises;
+const {writeFile, mkdir, rm} = require('fs').promises;
 const {resolve} = require('path');
 const debug = require('debug')('mocha:docs:data:supporters');
 const needle = require('needle');
@@ -225,7 +225,7 @@ const getSupporters = async () => {
       }
     );
 
-  await rmdir(SUPPORTER_IMAGE_PATH, {recursive: true});
+  await rm(SUPPORTER_IMAGE_PATH, {recursive: true, force: true});
   debug('blasted %s', SUPPORTER_IMAGE_PATH);
   await mkdir(SUPPORTER_IMAGE_PATH, {recursive: true});
   debug('created %s', SUPPORTER_IMAGE_PATH);


### PR DESCRIPTION

### Description of the Change
Because `fs.rmdir` usage, Node 16 show [DEP0147 DeprecationWarning](https://nodejs.org/api/deprecations.html#DEP0147).

```
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

* Node 16.0.0: Runtime deprecation.
* Node 14.154.0: Documentation-only deprecation.