### PR TITLE
Fixes #4803: wrong error thrown if loader is used

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -53,15 +53,30 @@ exports.requireOrImport = hasStableEsmImplementation
           err.code === 'ERR_UNSUPPORTED_DIR_IMPORT'
         ) {
           try {
+            // Importing a file usually works, but the resolution of `import` is the ESM
+            // resolution algorithm, and not the CJS resolution algorithm. So in this case
+            // if we fail, we may have failed because we tried the ESM resolution and failed
+            // So we try to `require` it
             return require(file);
           } catch (requireErr) {
-            if (requireErr.code === 'ERR_REQUIRE_ESM') {
-              // This happens when the test file is a JS file, but via type:module is actually ESM,
+            if (
+              requireErr.code === 'ERR_REQUIRE_ESM' ||
+              (requireErr instanceof SyntaxError &&
+                requireErr
+                  .toString()
+                  .includes('Cannot use import statement outside a module'))
+            ) {
+              // ERR_REQUIRE_ESM happens when the test file is a JS file, but via type:module is actually ESM,
               // AND has an import to a file that doesn't exist.
-              // This throws an `ERR_MODULE_NOT_FOUND` // error above,
+              // This throws an `ERR_MODULE_NOT_FOUND` error above,
               // and when we try to `require` it here, it throws an `ERR_REQUIRE_ESM`.
               // What we want to do is throw the original error (the `ERR_MODULE_NOT_FOUND`),
               // and not the `ERR_REQUIRE_ESM` error, which is a red herring.
+              //
+              // SyntaxError happens when in an edge case: when we're using an ESM loader that loads
+              // a `test.ts` file (i.e. unrecognized extension), and that file includes an unknown
+              // import (which thows an ERR_MODULE_NOT_FOUND). require-ing it will throw the
+              // syntax error, because we cannot require a file that has import-s.
               throw err;
             } else {
               throw requireErr;

--- a/test/integration/esm.spec.js
+++ b/test/integration/esm.spec.js
@@ -81,4 +81,25 @@ describe('esm', function () {
       'test-that-imports-non-existing-module'
     );
   });
+
+  it('should throw an ERR_MODULE_NOT_FOUND and not ERR_REQUIRE_ESM if file imports a non-existing module with a loader', async function () {
+    const fixture =
+      'esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.ts';
+
+    const err = await runMochaAsync(
+      fixture,
+      [
+        '--unhandled-rejections=warn',
+        '--loader=./test/integration/fixtures/esm/loader-with-module-not-found/loader-that-recognizes-ts.mjs'
+      ],
+      {
+        stdio: 'pipe'
+      }
+    ).catch(err => err);
+
+    expect(err.output, 'to contain', 'ERR_MODULE_NOT_FOUND').and(
+      'to contain',
+      'non-existent-package'
+    );
+  });
 });

--- a/test/integration/fixtures/esm/loader-with-module-not-found/loader-that-recognizes-ts.mjs
+++ b/test/integration/fixtures/esm/loader-with-module-not-found/loader-that-recognizes-ts.mjs
@@ -1,0 +1,18 @@
+import path from 'path'
+import {fileURLToPath} from 'url'
+
+/**
+ * @param {string} specifier
+ * @param {{
+ *   conditions: !Array<string>,
+ *   parentURL: !(string | undefined),
+ * }} context
+ * @param {Function} defaultResolve
+ * @returns {Promise<{ url: string }>}
+ */
+export async function resolve(specifier, context, defaultResolve) {
+  const extension = path.extname(
+    fileURLToPath(/**@type {import('url').URL}*/ (new URL(specifier, context.parentURL))),
+  )
+  return await defaultResolve(specifier.replace('.ts', '.mjs'), context, defaultResolve)
+}

--- a/test/integration/fixtures/esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.mjs
+++ b/test/integration/fixtures/esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.mjs
@@ -1,0 +1,1 @@
+import 'non-existent-package';

--- a/test/integration/fixtures/esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.ts
+++ b/test/integration/fixtures/esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.ts
@@ -1,2 +1,2 @@
-// This file will be resolved to test.js by the loader
+// This file will be resolved to `test-that-imports-non-existing-module.fixture.mjs` by the loader
 import 'non-existent-package';

--- a/test/integration/fixtures/esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.ts
+++ b/test/integration/fixtures/esm/loader-with-module-not-found/test-that-imports-non-existing-module.fixture.ts
@@ -1,0 +1,2 @@
+// This file will be resolved to test.js by the loader
+import 'non-existent-package';

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -368,7 +368,11 @@ function createSubprocess(args, done, opts = {}) {
  * @returns {string} Resolved filepath
  */
 function resolveFixturePath(fixture) {
-  if (path.extname(fixture) !== '.js' && path.extname(fixture) !== '.mjs') {
+  if (
+    path.extname(fixture) !== '.js' &&
+    path.extname(fixture) !== '.mjs' &&
+    path.extname(fixture) !== '.ts'
+  ) {
     fixture += '.fixture.js';
   }
   return path.isAbsolute(fixture)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

When loading test files, there is a heuristic that tries to determine whether to `import` or `require` them. This heuristic failed in the presence of a loader that recognizes filenames that are not `.js/.mjs`. In this case, when `require`-ing the file, Node.js does not throw `ERR_REQUIRE_ESM` (because of the different extension) but rather a `SyntaxError` saying that a CJSJ cannot use `import`.

I added some more code to this heuristic to deal with the problem by checking if the error is the aforementioned syntax error, and if so, throw the original error.


### Alternate Designs

Couldn't think of any.

### Why should this be in core?

Well... this is the code of the loading mechanism in Mocha. 

### Benefits

Devs that use ESM with loaders will get the correct error and not a weird error that they can't use to understand what the problem is.

### Possible Drawbacks

Heuristics, as they go, should be tampered with lightly, given that they may succeed in all _our_ tests, but fail in the wild world out there.

I have been careful to add tests to all weird cases I've seen, so I'm pretty confident of the change, but as I said, this may be problematic.

### Applicable issues

Not a breaking change.