### PR TITLE
Assign each worker a worker id in parallel mode.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1379,6 +1379,12 @@ Free-tier cloud CI services may not provide a suitable multi-core container or V
 
 It's unlikely (but not impossible) to see a performance gain from a [job count](#-jobs-count-j-count) _greater than_ the number of available CPU cores. That said, _play around with the job count_--there's no one-size-fits all, and the unique characteristics of your tests will determine the optimal number of jobs; it may even be that fewer is faster!
 
+### Parallel Mode Worker IDs
+
+> _New in v9.2.0_
+
+Each process launched by parallel mode is assigned a unique id, from 0 for the first process to be launched, to N-1 for the Nth process. This worker id may be accessed in tests via the environment variable `MOCHA_WORKER_ID`. It can be used for example to assign a different database, service port, etc for each test process.
+
 ## Root Hook Plugins
 
 > _New in v8.0.0_

--- a/lib/nodejs/buffered-worker-pool.js
+++ b/lib/nodejs/buffered-worker-pool.js
@@ -75,7 +75,23 @@ class BufferedWorkerPool {
       process.execArgv.join(' ')
     );
 
-    this.options = {...WORKER_POOL_DEFAULT_OPTS, opts, maxWorkers};
+    let counter = 0;
+    const onCreateWorker = ({forkOpts}) => {
+      return {
+        forkOpts: {
+          ...forkOpts,
+          // adds an incremental id to all workers, which can be useful to allocate resources for each process
+          env: {...process.env, MOCHA_WORKER_ID: counter++}
+        }
+      };
+    };
+
+    this.options = {
+      ...WORKER_POOL_DEFAULT_OPTS,
+      ...opts,
+      maxWorkers,
+      onCreateWorker
+    };
     this._pool = workerpool.pool(WORKER_PATH, this.options);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -25120,9 +25120,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -45239,9 +45239,9 @@
       }
     },
     "workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "strip-json-comments": "3.1.1",
     "supports-color": "8.1.1",
     "which": "2.0.2",
-    "workerpool": "6.1.5",
+    "workerpool": "6.2.0",
     "yargs": "16.2.0",
     "yargs-parser": "20.2.4",
     "yargs-unparser": "2.0.0"

--- a/test/integration/fixtures/parallel/testworkerid1.mjs
+++ b/test/integration/fixtures/parallel/testworkerid1.mjs
@@ -1,0 +1,7 @@
+import assert from 'assert';
+
+describe('test1', () => {
+  it('should always run on worker with id 0', () => {
+    assert.ok(process.env.MOCHA_WORKER_ID === '0');
+  });
+});

--- a/test/integration/fixtures/parallel/testworkerid2.mjs
+++ b/test/integration/fixtures/parallel/testworkerid2.mjs
@@ -1,0 +1,7 @@
+import assert from 'assert';
+
+describe('test2', () => {
+  it('should always run on worker with id 1', () => {
+    assert.ok(process.env.MOCHA_WORKER_ID === '1');
+  });
+});

--- a/test/integration/fixtures/parallel/testworkerid3.mjs
+++ b/test/integration/fixtures/parallel/testworkerid3.mjs
@@ -1,0 +1,9 @@
+import assert from 'assert';
+
+describe('test3', () => {
+  it('should run on worker with either id 0 or 1', () => {
+    assert.ok(
+      process.env.MOCHA_WORKER_ID === '0' || process.env.MOCHA_WORKER_ID === '1'
+    );
+  });
+});

--- a/test/integration/parallel.spec.js
+++ b/test/integration/parallel.spec.js
@@ -18,4 +18,16 @@ describe('parallel run', () => {
     assert.strictEqual(result.stats.failures, 1);
     assert.strictEqual(result.stats.passes, 2);
   });
+
+  it('should correctly set worker ids for each process', async () => {
+    const result = await runMochaJSONAsync('parallel/testworkerid3.mjs', [
+      '--parallel',
+      '--jobs',
+      '2',
+      require.resolve('./fixtures/parallel/testworkerid1.mjs'),
+      require.resolve('./fixtures/parallel/testworkerid2.mjs')
+    ]);
+    assert.strictEqual(result.stats.failures, 0);
+    assert.strictEqual(result.stats.passes, 3);
+  });
 });


### PR DESCRIPTION
This change is similar to https://github.com/mochajs/mocha/pull/4463 but is cleaner as is uses a new feature from workerpool (`onCreateWorker`) to override each process environment when each process is launched. I'm copying most of the description.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

This change addresses #4456. It adds a MOCHA_WORKER_ID environment variable that is unique for each worker, so that it may be used for by any test resources that need to use global resources (network ports, filesystem paths, etc.) but ensure that these are unique in order to avoid conflicts during parallel tests.

### Alternate Designs

https://github.com/mochajs/mocha/pull/4463 is an alternate way of doing the same thing, but this one is cleaner (less hacky).

https://github.com/mochajs/mocha/pull/4463 suggest forkArgs might have been used, but this seem really unsafe and hacky.

### Why should this be in core?

It is common for tests to use global resources like network ports, which can conflict during parallel testing. Without a feature like this in core, users would be left on their own to create a home-brewed solution (using filesystem files as signals, sockets that elect a leader in the cluster so that one process hands out all global data, a standalone cluster orchestration system), all of which add a lot of complication to writing tests. This would also be a difference when writing tests that run in series vs. parallel, as this concern would not exist (and potentially needs to be turned off) for test in series, and would add pain points when taking existing serial tests and having them run in parallel. This makes using mocha significantly less fun.

This feature takes that pain point away. For example, allocating ports would once again be trivial, using const port = 1234 + Number(process.env.MOCHA_WORKER_ID || 0).

Other parallel testing frameworks, like jest, already use this approach: facebook/jest#2284

### Benefits

This solves common pain points for developers writing tests.

### Possible Drawbacks

Other than more complexity, I can't think of a drawback for the feature itself. The drawback noted by https://github.com/mochajs/mocha/pull/4463 is mostly addressed by this PR, by using a cleaner way to override each process environment. Another pool implementation could easily implement a similar feature.

### Applicable issues

Enter any applicable Issues here.

closes #4456

Mocha follows semantic versioning: http://semver.org

Is this a breaking change (major release)? No

Is it an enhancement (minor release)? Yes

Is it a bug fix, or does it not impact production code (patch release)? No