### PR TITLE
fix: :arrow_up: CVE-2021-23566

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.1.31",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -15767,9 +15767,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.1.31",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
+      "integrity": "sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -37689,9 +37689,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+      "version": "3.1.31",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
+      "integrity": "sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "log-symbols": "4.1.0",
     "minimatch": "3.0.4",
     "ms": "2.1.3",
-    "nanoid": "3.1.25",
+    "nanoid": "3.1.31",
     "serialize-javascript": "6.0.0",
     "strip-json-comments": "3.1.1",
     "supports-color": "8.1.1",


### PR DESCRIPTION
update nanoid version 3.1.31 to

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

update nanoid version to 3.1.31 to fix [CVE-2021-23566](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2)

### Alternate Designs

[CVE-2021-23566](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2)

### Why should this be in core?

This is not a new function.

### Benefits

Solve dependabot alert.

### Possible Drawbacks

None.

### Applicable issues

This is a bug fix.
