### PR TITLE
Add JSON Reporter output to object similar to #2651

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -32,7 +32,8 @@ exports = module.exports = JSONReporter;
  * @memberof Mocha.reporters
  * @extends Mocha.reporters.Base
  * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
+ * @param {Object} [options] - runner options - the property 'output' defines a target file to write to
+ *   the property 'targetObject' an object into which the results of the tests will be written
  */
 function JSONReporter(runner, options = {}) {
   Base.call(this, runner, options);
@@ -43,12 +44,17 @@ function JSONReporter(runner, options = {}) {
   var failures = [];
   var passes = [];
   var output;
+  var targetObject;
 
   if (options.reporterOption && options.reporterOption.output) {
     if (utils.isBrowser()) {
       throw createUnsupportedError('file output not supported in browser');
     }
     output = options.reporterOption.output;
+  }
+
+  if (options.reporterOption && 'targetObject' in options.reporterOption) {
+    targetObject = options.reporterOption.targetObject;
   }
 
   runner.on(EVENT_TEST_END, function (test) {
@@ -89,6 +95,8 @@ function JSONReporter(runner, options = {}) {
         );
         process.stdout.write(json);
       }
+    } else if (targetObject !== undefined) {
+      Object.assign(targetObject, obj);
     } else {
       process.stdout.write(json);
     }

--- a/test/reporters/json.spec.js
+++ b/test/reporters/json.spec.js
@@ -230,4 +230,33 @@ describe('JSON reporter', function () {
       );
     });
   });
+
+  describe('when "reporterOption.targetObject" is provided', function () {
+    var theObject = {};
+
+    var options = {
+      reporterOption: {
+        targetObject: theObject
+      }
+    };
+
+    beforeEach(function () {
+      /* eslint no-unused-vars: off */
+      var mochaReporter = new mocha._reporter(runner, options);
+    });
+
+    beforeEach(function () {
+      // Add one test to suite to avoid assertions against empty test results
+      var test = new Test(testTitle, () => {});
+      test.file = testFile;
+      suite.addTest(test);
+    });
+
+    it('should write test results to the object', function (done) {
+      runner.run(function () {
+        expect(theObject, 'not to be empty');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Change

Add to the existing configuration options for the JSON reporter by allowing a target object to be provided to be populated with test results.

This follows on from the existing ability to specify an output file, but suits situations where files cannot be used to communicate results to the outside world.

### Alternate Designs

We could make a duplicate of the JSON reporter, purely for writing to objects. A workaround is to hack in an alternative of the JSON reporter into the reporters in the runner. However, this is such a small addition to the core, and entirely in keeping with the behaviour of producing a JavaScript model of the test results, that it seems to belong in core.

### Why should this be in core?

This is a minor, useful change to an existing reporter.

### Benefits

When executing mocha within a browser test, or explicitly, there's a way to capture the outcome of the test for reporting.

The use case that drove this is where I'm using mocha as the test framework, running it in a virtual browser, driving the tests from a Java application and need to gather the test results from Mocha. I don't have the ability to send them to a file from this environment, but being able to put them into a variable means I can pull the results out at the end.

### Possible Drawbacks

This is a minor alternative to the existing options of the reporter. It should be dormant unless used.

### Applicable issues

- PR #2651
