### PR TITLE
Create Module not found error

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -11,7 +11,10 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('mocha:cli:config');
 const findUp = require('find-up');
-const {createUnparsableFileError} = require('../errors');
+const {
+  createUnparsableFileError,
+  createModuleNotFoundError
+} = require('../errors');
 const utils = require('../utils');
 
 /**
@@ -82,6 +85,12 @@ exports.loadConfig = filepath => {
       config = parsers.json(filepath);
     }
   } catch (err) {
+    if (isModuleNotFoundError(err)) {
+      throw createModuleNotFoundError(
+        `${filepath} is attempting to import a module that does not exist: ${err}`,
+        filepath
+      );
+    }
     throw createUnparsableFileError(
       `Unable to read/parse ${filepath}: ${err}`,
       filepath

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -170,7 +170,14 @@ var constants = {
    * @constant
    * @default
    */
-  UNPARSABLE_FILE: 'ERR_MOCHA_UNPARSABLE_FILE'
+  UNPARSABLE_FILE: 'ERR_MOCHA_UNPARSABLE_FILE',
+
+  /**
+   * File attempts to import non-existent module
+   * @constant
+   * @default
+   */
+  MODULE_NOT_FOUND: 'ERR_MOCHA_MODULE_NOT_FOUND'
 };
 
 /**
@@ -517,6 +524,25 @@ function createUnparsableFileError(message, filename) {
 }
 
 /**
+ * Creates an error object to be thrown when file attempts to import module that does not exist.
+ * @public
+ * @static
+ * @param {string} message - Error message to be displayed.
+ * @param {string} importerFilename - File name of importing module
+ * @param {string} importedFilename - File name of imported module
+ * @returns {Error} Error with code {@link constants.MODULE_NOT_FOUND}
+ */
+function createModuleNotFoundError(
+  message,
+  importerFilename,
+  importedFilename
+) {
+  var err = new Error(message);
+  err.code = constants.MODULE_NOT_FOUND;
+  return err;
+}
+
+/**
  * Returns `true` if an error came out of Mocha.
  * _Can suffer from false negatives, but not false positives._
  * @static
@@ -547,6 +573,7 @@ module.exports = {
   createNoFilesMatchPatternError,
   createTimeoutError,
   createUnparsableFileError,
+  createModuleNotFoundError,
   createUnsupportedError,
   deprecate,
   isMochaError,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mocha",
       "version": "9.2.0",
       "license": "MIT",
       "dependencies": {

--- a/test/integration/config.spec.js
+++ b/test/integration/config.spec.js
@@ -5,6 +5,7 @@
 
 var fs = require('fs');
 var path = require('path');
+const {constants} = require('../../lib/errors');
 var loadConfig = require('../../lib/cli/config').loadConfig;
 
 describe('config', function () {
@@ -45,6 +46,28 @@ describe('config', function () {
 
       expect(_loadConfig, 'not to throw');
       expect(js, 'to equal', json);
+    });
+
+    it('should throw module not found error from absolute path configuration', function () {
+      function _loadConfig() {
+        loadConfig(path.join(configDir, 'mocharcWithInvalidImport.js'));
+      }
+
+      expect(_loadConfig, 'to throw', {
+        code: constants.MODULE_NOT_FOUND
+      });
+    });
+
+    it('should throw module not found error from relative path configuration', function () {
+      var relConfigDir = configDir.substring(projRootDir.length + 1);
+
+      function _loadConfig() {
+        loadConfig(path.join('.', relConfigDir, 'mocharcWithInvalidImport.js'));
+      }
+
+      expect(_loadConfig, 'to throw', {
+        code: constants.MODULE_NOT_FOUND
+      });
     });
 
     it('should rethrow error from absolute path configuration', function () {

--- a/test/integration/fixtures/config/mocharcWithInvalidImport.js
+++ b/test/integration/fixtures/config/mocharcWithInvalidImport.js
@@ -1,7 +1,6 @@
 'use strict';
 
-throw new Error('Error from mocharcWithThrowError');
-
+require('invalidImport.js');
 // a comment
 module.exports = {
   require: ['foo', 'bar'],


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

In this PR, we throw the "Module Not Found" error when a non-existent module is being imported in the config file. Before this was introduced, an unhelpful message of "Unparsable File Error" is being thrown, which may confuse the users. This aims to resolve issue #4781 

### Alternate Designs

The alternative would be to ignore the "Module Not Found" error, and just display these errors as "Unparsable File". But "Module Not Found" should not be under "Unparsable File" since "Unparsable File" implies that there might be a syntax error somewhere in the program.

### Why should this be in core?

This should be in the core because one of the main functionalities of Mocha is to show the users the correct error messages.

### Benefits

A more helpful error message will be shown to users of Mocha, which leads to less confusion when using this package.

### Possible Drawbacks

There are no drawbacks to this change, unless maybe if some old users are not used to seeing this new error message.

### Applicable issues

Not a breaking change
This is an enhancement.
It should not impact production code.

Other notes: Hi, I am a new contributor :) Thank you very much for reviewing!