### PR TITLE
feat: include `.cause` stacks in the error stack traces

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -230,7 +230,7 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
  * @return {{ message: string, msg: string, stack: string }}
  */
 var getFullErrorStack = function (err, seen) {
-  if (seen && seen.has(err)) {
+  if (seen?.has(err)) {
     return { message: '', msg: '<circular>', stack: '' };
   }
 

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -226,24 +226,49 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
  *
  * @private
  * @param {Error} err
- * @param {string} message
  * @param {Set<Error>} [seen]
- * @return {string}
+ * @return {{ message: string, msg: string, stack: string }}
  */
-var getFullErrorStack = function (err, message, seen) {
+var getFullErrorStack = function (err, seen) {
   if (seen && seen.has(err)) {
-    return '<circular>';
+    return { message: '', msg: '<circular>', stack: '' };
   }
 
-  var ret = err.stack || message || '';
+  var message;
 
-  if (err.cause) {
-    seen = seen || new Set();
-    seen.add(err);
-    ret += '\n   Caused by: ' + getFullErrorStack(err.cause, err.message, seen);
+  if (typeof err.inspect === 'function') {
+    message = err.inspect() + '';
+  } else if (err.message && typeof err.message.toString === 'function') {
+    message = err.message + '';
+  } else {
+    message = '';
   }
 
-  return ret;
+  var msg;
+  var stack = err.stack || message;
+  var index = message ? stack.indexOf(message) : -1;
+
+  if (index === -1) {
+    msg = message;
+  } else {
+    index += message.length;
+    msg = stack.slice(0, index);
+    // remove msg from stack
+    stack = stack.slice(index + 1);
+
+    if (err.cause) {
+      seen = seen || new Set();
+      seen.add(err);
+      const causeStack = getFullErrorStack(err.cause, seen)
+      stack += '\n   Caused by: ' + causeStack.msg + (causeStack.stack ? '\n' + causeStack.stack : '');
+    }
+  }
+
+  return {
+    message,
+    msg,
+    stack
+  };
 };
 
 /**
@@ -266,7 +291,6 @@ exports.list = function (failures) {
       color('error stack', '\n%s\n');
 
     // msg
-    var msg;
     var err;
     if (test.err && test.err.multiple) {
       if (multipleTest !== test) {
@@ -277,25 +301,8 @@ exports.list = function (failures) {
     } else {
       err = test.err;
     }
-    var message;
-    if (typeof err.inspect === 'function') {
-      message = err.inspect() + '';
-    } else if (err.message && typeof err.message.toString === 'function') {
-      message = err.message + '';
-    } else {
-      message = '';
-    }
-    var stack = getFullErrorStack(err);
-    var index = message ? stack.indexOf(message) : -1;
 
-    if (index === -1) {
-      msg = message;
-    } else {
-      index += message.length;
-      msg = stack.slice(0, index);
-      // remove msg from stack
-      stack = stack.slice(index + 1);
-    }
+    var { message, msg, stack } = getFullErrorStack(err);
 
     // uncaught
     if (err.uncaught) {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -222,18 +222,17 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
 });
 
 /**
- * This function dumps long stack traces for exceptions having
- *  an Error cause() method
+ * Traverses err.cause and returns all stack traces
  *
- * @public
- * @memberof Mocha.reporters.Base
- * @param {Error} ex
+ * @private
+ * @param {Error} err
+ * @param {string} [message]
  * @return {string}
  */
-exports.getFullErrorStack = function (err, message) {
+var getFullErrorStack = function (err, message) {
   var ret = err.stack || message || '';
   if (err.cause) {
-    ret += '\n   Caused by: ' + exports.getFullErrorStack(err.cause);
+    ret += '\n   Caused by: ' + getFullErrorStack(err.cause);
   }
   return ret;
 };
@@ -277,7 +276,7 @@ exports.list = function (failures) {
     } else {
       message = '';
     }
-    var stack = exports.getFullErrorStack(err, message);
+    var stack = getFullErrorStack(err, message);
     var index = message ? stack.indexOf(message) : -1;
 
     if (index === -1) {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -230,7 +230,7 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
  * @return {{ message: string, msg: string, stack: string }}
  */
 var getFullErrorStack = function (err, seen) {
-  if (seen?.has(err)) {
+  if (seen && seen.has(err)) {
     return { message: '', msg: '<circular>', stack: '' };
   }
 

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -222,6 +222,23 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
 });
 
 /**
+ * This function dumps long stack traces for exceptions having
+ *  an Error cause() method
+ *
+ * @public
+ * @memberof Mocha.reporters.Base
+ * @param {Error} ex
+ * @return {string}
+ */
+exports.getFullErrorStack = function (err, message) {
+  var ret = err.stack || message || '';
+  if (err.cause) {
+    ret += '\n' + '   ' + 'Caused by: ' + exports.getFullErrorStack(err.cause);
+  }
+  return ret;
+};
+
+/**
  * Outputs the given `failures` as a list.
  *
  * @public
@@ -260,7 +277,7 @@ exports.list = function (failures) {
     } else {
       message = '';
     }
-    var stack = err.stack || message;
+    var stack = exports.getFullErrorStack(err, message);
     var index = message ? stack.indexOf(message) : -1;
 
     if (index === -1) {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -233,7 +233,7 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
 exports.getFullErrorStack = function (err, message) {
   var ret = err.stack || message || '';
   if (err.cause) {
-    ret += '\n' + '   ' + 'Caused by: ' + exports.getFullErrorStack(err.cause);
+    ret += '\n   Caused by: ' + exports.getFullErrorStack(err.cause);
   }
   return ret;
 };

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -226,14 +226,23 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
  *
  * @private
  * @param {Error} err
- * @param {string} [message]
+ * @param {string} message
+ * @param {Set<Error>} [seen]
  * @return {string}
  */
-var getFullErrorStack = function (err, message) {
-  var ret = err.stack || message || '';
-  if (err.cause) {
-    ret += '\n   Caused by: ' + getFullErrorStack(err.cause);
+var getFullErrorStack = function (err, message, seen) {
+  if (seen && seen.has(err)) {
+    return '<circular>';
   }
+
+  var ret = err.stack || message || '';
+
+  if (err.cause) {
+    seen = seen || new Set();
+    seen.add(err);
+    ret += '\n   Caused by: ' + getFullErrorStack(err.cause, err.message, seen);
+  }
+
   return ret;
 };
 
@@ -276,7 +285,7 @@ exports.list = function (failures) {
     } else {
       message = '';
     }
-    var stack = getFullErrorStack(err, message);
+    var stack = getFullErrorStack(err);
     var index = message ? stack.indexOf(message) : -1;
 
     if (index === -1) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -450,6 +450,22 @@ Runner.prototype.fail = function (test, err, force) {
     // some environments do not take kindly to monkeying with the stack
   }
 
+  // Support for error causes
+  try {
+    let nextErr = err;
+
+    while (nextErr.cause && nextErr.cause.stack) {
+      nextErr = nextErr.cause;
+
+      err.stack +=
+        '\n' + (this.fullStackTrace || !nextErr.stack)
+          ? nextErr.stack
+          : stackFilter(nextErr.stack);
+    }
+  } catch (ignore) {
+    // some environments do not take kindly to monkeying with the stack
+  }
+
   this.emit(constants.EVENT_TEST_FAIL, test, err);
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -443,27 +443,22 @@ Runner.prototype.fail = function (test, err, force) {
     err = thrown2Error(err);
   }
 
-  try {
-    err.stack =
-      this.fullStackTrace || !err.stack ? err.stack : stackFilter(err.stack);
-  } catch (ignore) {
-    // some environments do not take kindly to monkeying with the stack
-  }
+  // Filter the stack traces
+  if (!this.fullStackTrace) {
+    const alreadyFiltered = new Set();
+    let currentErr = err;
 
-  // Support for error causes
-  try {
-    let nextErr = err;
+    while (currentErr && currentErr.stack && !alreadyFiltered.has(currentErr)) {
+      alreadyFiltered.add(currentErr);
 
-    while (nextErr.cause && nextErr.cause.stack) {
-      nextErr = nextErr.cause;
+      try {
+        currentErr.stack = stackFilter(currentErr.stack);
+      } catch (ignore) {
+        // some environments do not take kindly to monkeying with the stack
+      }
 
-      err.stack +=
-        '\n' + (this.fullStackTrace || !nextErr.stack)
-          ? nextErr.stack
-          : stackFilter(nextErr.stack);
+      currentErr = currentErr.cause;
     }
-  } catch (ignore) {
-    // some environments do not take kindly to monkeying with the stack
   }
 
   this.emit(constants.EVENT_TEST_FAIL, test, err);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -448,7 +448,7 @@ Runner.prototype.fail = function (test, err, force) {
     const alreadyFiltered = new Set();
     let currentErr = err;
 
-    while (currentErr?.stack && !alreadyFiltered.has(currentErr)) {
+    while (currentErr && currentErr.stack && !alreadyFiltered.has(currentErr)) {
       alreadyFiltered.add(currentErr);
 
       try {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -448,7 +448,7 @@ Runner.prototype.fail = function (test, err, force) {
     const alreadyFiltered = new Set();
     let currentErr = err;
 
-    while (currentErr && currentErr.stack && !alreadyFiltered.has(currentErr)) {
+    while (currentErr?.stack && !alreadyFiltered.has(currentErr)) {
       alreadyFiltered.add(currentErr);
 
       try {

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -477,60 +477,6 @@ describe('Base reporter', function () {
     expect(errOut, 'to be', '1) test title:');
   });
 
-  it('should append any error cause trail to stack traces', function () {
-    var err = {
-      message: 'Error',
-      stack: 'Error\nfoo\nbar',
-      showDiff: false,
-      cause: {
-        message: 'Cause1',
-        stack: 'Cause1\nbar\nfoo',
-        showDiff: false,
-        cause: {
-          message: 'Cause2',
-          stack: 'Cause2\nabc\nxyz',
-          showDiff: false
-        }
-      }
-    };
-    var test = makeTest(err);
-
-    list([test]);
-
-    var errOut = stdout.join('\n').trim();
-    expect(
-      errOut,
-      'to be',
-      '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause1\n  bar\n  foo\n     Caused by: Cause2\n  abc\n  xyz'
-    );
-  });
-
-  it('should not get stuck in a hypothetical circular error cause trail', function () {
-    var err1 = {
-      message: 'Error',
-      stack: 'Error\nfoo\nbar',
-      showDiff: false,
-    };
-    var err2 = {
-      message: 'Cause1',
-      stack: 'Cause1\nbar\nfoo',
-      showDiff: false,
-      cause: err1
-    }
-    err1.cause = err2;
-
-    var test = makeTest(err1);
-
-    list([test]);
-
-    var errOut = stdout.join('\n').trim();
-    expect(
-      errOut,
-      'to be',
-      '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause1\n  bar\n  foo\n     Caused by: <circular>'
-    );
-  });
-
   it('should not modify stack if it does not contain message', function () {
     var err = {
       message: 'Error',
@@ -543,6 +489,108 @@ describe('Base reporter', function () {
 
     var errOut = stdout.join('\n').trim();
     expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
+  });
+
+  describe('error causes', function () {
+    it('should append any error cause trail to stack traces', function () {
+      var err = {
+        message: 'Error',
+        stack: 'Error\nfoo\nbar',
+        showDiff: false,
+        cause: {
+          message: 'Cause1',
+          stack: 'Cause1\nbar\nfoo',
+          showDiff: false,
+          cause: {
+            message: 'Cause2',
+            stack: 'Cause2\nabc\nxyz',
+            showDiff: false
+          }
+        }
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join('\n').trim();
+      expect(
+        errOut,
+        'to be',
+        '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause1\n  bar\n  foo\n     Caused by: Cause2\n  abc\n  xyz'
+      );
+    });
+
+    it('should not get stuck in a hypothetical circular error cause trail', function () {
+      var err1 = {
+        message: 'Error',
+        stack: 'Error\nfoo\nbar',
+        showDiff: false,
+      };
+      var err2 = {
+        message: 'Cause1',
+        stack: 'Cause1\nbar\nfoo',
+        showDiff: false,
+        cause: err1
+      }
+      err1.cause = err2;
+
+      var test = makeTest(err1);
+
+      list([test]);
+
+      var errOut = stdout.join('\n').trim();
+      expect(
+        errOut,
+        'to be',
+        '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause1\n  bar\n  foo\n     Caused by: <circular>'
+      );
+    });
+
+    it("should set an empty cause if neither 'inspect' nor 'message' is set", function () {
+      var err = {
+        message: 'Error',
+        stack: 'Error\nfoo\nbar',
+        showDiff: false,
+        cause: {
+          showDiff: false,
+        }
+      };
+
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join('\n').trim();
+      expect(
+        errOut,
+        'to be',
+        '1) test title:\n     Error\n  foo\n  bar\n     Caused by:'
+      );
+    });
+
+    it('should not add cause trail if error does not contain message', function () {
+      var err = {
+        message: 'Error',
+        stack: 'foo\nbar',
+        showDiff: false,
+        cause: {
+          message: 'Cause1',
+          stack: 'Cause1\nbar\nfoo',
+          showDiff: false,
+          cause: {
+            message: 'Cause2',
+            stack: 'Cause2\nabc\nxyz',
+            showDiff: false
+          }
+        }
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join('\n').trim();
+      expect(errOut, 'to be', '1) test title:\n     Error\n  foo\n  bar');
+    });
   });
 
   it('should list multiple Errors per test', function () {

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -477,6 +477,32 @@ describe('Base reporter', function () {
     expect(errOut, 'to be', '1) test title:');
   });
 
+  it('should append any error cause trail to stack traces', function () {
+    var err = {
+      message: 'Error',
+      stack: 'Error\nfoo\nbar',
+      showDiff: false,
+      cause: {
+        message: 'Cause1',
+        stack: 'Cause1\nbar\nfoo',
+        showDiff: false,
+        cause: {
+          message: 'Cause2',
+          stack: 'Cause2\nabc\nxyz',
+          showDiff: false
+        }
+      }
+    };
+    var test = makeTest(err);
+
+    Base.list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    errOut.should.equal(
+      '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause Stack'
+    );
+  });
+
   it('should not modify stack if it does not contain message', function () {
     var err = {
       message: 'Error',

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -495,11 +495,13 @@ describe('Base reporter', function () {
     };
     var test = makeTest(err);
 
-    Base.list([test]);
+    list([test]);
 
     var errOut = stdout.join('\n').trim();
-    errOut.should.equal(
-      '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause Stack'
+    expect(
+      errOut,
+      'to be',
+      '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause1\n  bar\n  foo\n     Caused by: Cause2\n  abc\n  xyz'
     );
   });
 

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -505,6 +505,32 @@ describe('Base reporter', function () {
     );
   });
 
+  it('should not get stuck in a hypothetical circular error cause trail', function () {
+    var err1 = {
+      message: 'Error',
+      stack: 'Error\nfoo\nbar',
+      showDiff: false,
+    };
+    var err2 = {
+      message: 'Cause1',
+      stack: 'Cause1\nbar\nfoo',
+      showDiff: false,
+      cause: err1
+    }
+    err1.cause = err2;
+
+    var test = makeTest(err1);
+
+    list([test]);
+
+    var errOut = stdout.join('\n').trim();
+    expect(
+      errOut,
+      'to be',
+      '1) test title:\n     Error\n  foo\n  bar\n     Caused by: Cause1\n  bar\n  foo\n     Caused by: <circular>'
+    );
+  });
+
   it('should not modify stack if it does not contain message', function () {
     var err = {
       message: 'Error',

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -629,6 +629,22 @@ describe('Runner', function () {
             });
             runner.fail(hook, err);
           });
+
+          it('should prettify stack-traces in error cause trail', function (done) {
+            var hook = new Hook();
+            hook.parent = suite;
+            var causeErr = new Error();
+            // Fake stack-trace
+            causeErr.stack = stack.join('\n');
+            var err = new Error();
+            err.cause = causeErr;
+
+            runner.on(EVENT_TEST_FAIL, function (_hook, _err) {
+              expect(_err.cause.stack, 'to be', stack.slice(0, 3).join('\n'));
+              done();
+            });
+            runner.fail(hook, err);
+          });
         });
 
         describe('long', function () {
@@ -643,6 +659,24 @@ describe('Runner', function () {
 
             runner.on(EVENT_TEST_FAIL, function (_hook, _err) {
               expect(_err.stack, 'to be', stack.join('\n'));
+              done();
+            });
+            runner.fail(hook, err);
+          });
+
+          it('should display full stack-traces in error cause trail', function (done) {
+            var hook = new Hook();
+            hook.parent = suite;
+            var causeErr = new Error();
+            // Fake stack-trace
+            causeErr.stack = stack.join('\n');
+            var err = new Error();
+            err.cause = causeErr;
+            // Add --stack-trace option
+            runner.fullStackTrace = true;
+
+            runner.on(EVENT_TEST_FAIL, function (_hook, _err) {
+              expect(_err.cause.stack, 'to be', stack.join('\n'));
               done();
             });
             runner.fail(hook, err);


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Appends the full error stack chain for errors with causes.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Prior to the Error cause standardization, there was `VError` which I did a PR for supporting some years ago #2381. That one as primarily closed because an aversion to supporting random module hooks, which this now being a standard changes.

So I think this is now more a matter of:

* Should this be on by default?
* How should this be formatted?

### Why should this be in core?

All current browsers supports this property and Node.js as well since `16.x`.

See also eg:

* [V8 blog post](https://v8.dev/features/error-cause)
* [My blog post describing my ponyfill + helpers for it](https://dev.to/voxpelli/pony-cause-1-0-error-causes-2l2o)
* `pino` merging support for it: https://github.com/pinojs/pino-std-serializers/pull/78

### Benefits

Error causes are a great way to enrich errors and to ensure that one can catch all relevant places across an async workflow. See also eg. this old Joyent article explaining [how they uses VError](https://www.joyent.com/node-js/production/design/errors#5-if-you-pass-a-lower-level-error-to-your-caller-consider-wrapping-it-instead).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

* It can become a bit too verbose if a lot of unnecessary causes gets printed, but is that an issue to take into consideration here?

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

* This would be a breaking change for everyone that relies on specific stack output for current error object's containing a stack possessing `cause` property, else it would be a minor. So depends on whether the specific stack output is seen as an API that should be stable or whether it's simply a presentation detail.

Fixes #2735.