### PR TITLE
Fix loading of config files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ Place an `x` between the square brackets on the lines below for every satisfied 
 - [ ] Checked that your issue hasn't already been filed by cross-referencing [issues with the `faq` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Afaq%20)
 - [ ] Checked next-gen ES issues and syntax problems by using the same environment and/or transpiler configuration without Mocha to ensure it isn't just a feature that actually isn't supported in the environment in question or a bug in your code.
 - [ ] 'Smoke tested' the code to be tested by running it outside the real test suite to get a better sense of whether the problem is in the code under test, your usage of Mocha, or Mocha itself
-- [ ] Ensured that there is no discrepancy between the locally and globally installed versions of Mocha. You can find them with: `node node_modules/.bin/mocha --version`(Local) and `mocha --version`(Global). We recommend that you _not_ install Mocha globally.
+- [ ] Ensured that there is no discrepancy between the locally and globally installed versions of Mocha. You can find them with: `node_modules/.bin/mocha --version`(Local) and `mocha --version`(Global). We recommend that you _not_ install Mocha globally.
 
 ### Description
 
@@ -51,7 +51,7 @@ Scrub if needed so as not to reveal passwords, etc.
 
 <!-- If applicable, please specify: -->
 
-- The output of `mocha --version` and `node node_modules/.bin/mocha --version`:
+- The output of `mocha --version` and `node_modules/.bin/mocha --version`:
 - The output of `node --version`:
 - Your operating system
   - name and version:

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -30,10 +30,6 @@ exports.CONFIG_FILES = [
   '.mocharc.json'
 ];
 
-const isModuleNotFoundError = err =>
-  err.code === 'MODULE_NOT_FOUND' ||
-  err.message.indexOf('Cannot find module') !== -1;
-
 /**
  * Parsers for various config filetypes. Each accepts a filepath and
  * returns an object (but could throw)
@@ -41,17 +37,16 @@ const isModuleNotFoundError = err =>
 const parsers = (exports.parsers = {
   yaml: filepath => require('js-yaml').load(fs.readFileSync(filepath, 'utf8')),
   js: filepath => {
-    const cwdFilepath = path.resolve(filepath);
+    let cwdFilepath;
     try {
-      debug('parsers: load using cwd-relative path: "%s"', cwdFilepath);
+      debug('parsers: load cwd-relative path: "%s"', path.resolve(filepath));
+      cwdFilepath = require.resolve(path.resolve(filepath)); // evtl. throws
       return require(cwdFilepath);
     } catch (err) {
-      if (isModuleNotFoundError(err)) {
-        debug('parsers: retry load as module-relative path: "%s"', filepath);
-        return require(filepath);
-      } else {
-        throw err; // rethrow
-      }
+      if (cwdFilepath) throw err;
+
+      debug('parsers: retry load as module-relative path: "%s"', filepath);
+      return require(filepath);
     }
   },
   json: filepath =>

--- a/test/node-unit/cli/config.spec.js
+++ b/test/node-unit/cli/config.spec.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon');
 const rewiremock = require('rewiremock/node');
+const {parsers} = require('../../../lib/cli/config');
 
 describe('cli/config', function () {
   const phonyConfigObject = {ok: true};
@@ -152,6 +153,25 @@ describe('cli/config', function () {
       expect(findup, 'to have a call satisfying', {
         args: [CONFIG_FILES, {cwd: '/some/path/'}],
         returned: '/some/path/.mocharc.js'
+      });
+    });
+  });
+
+  describe('parsers()', function () {
+    it('should print error message for faulty require', function () {
+      // Fixture exists, but fails loading.
+      // Prints correct error message without using fallback path.
+      expect(
+        () => parsers.js(require.resolve('./fixtures/bad-require.fixture.js')),
+        'to throw',
+        {message: /Cannot find module 'fake'/, code: 'MODULE_NOT_FOUND'}
+      );
+    });
+
+    it('should print error message for non-existing file', function () {
+      expect(() => parsers.js('not-existing.js'), 'to throw', {
+        message: /Cannot find module 'not-existing.js'/,
+        code: 'MODULE_NOT_FOUND'
       });
     });
   });

--- a/test/node-unit/cli/fixtures/bad-require.fixture.js
+++ b/test/node-unit/cli/fixtures/bad-require.fixture.js
@@ -1,0 +1,1 @@
+require('fake');


### PR DESCRIPTION
### Description

While loading a js/cjs config file, Mocha uses the cwd-realtive path and as a fallback the module-relative path.
Edge case: a config file is successfully found, but its loading fails due to a bad require. There is no sense in using the fallback for a second file search which results in an incorrect error message.

### Description of the Change

We add a `require.resolve()` check which throws in case no config file can be found on the cwd-relative path. If it fails, retry again using the fallback path.

### Applicable issues

closes #4781
