### PR TITLE
docs: add `expect` as assertion library

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -211,6 +211,7 @@ Mocha allows you to use any assertion library you wish. In the above example, we
 - [chai][] - `expect()`, `assert()` and `should`-style assertions
 - [better-assert][] - C-style self-documenting `assert()`
 - [unexpected][] - "the extensible BDD assertion toolkit"
+- [expect][] - The `expect` function that ships with Jest (except snapshots)
 
 ## Asynchronous Code
 
@@ -2444,6 +2445,7 @@ or the [source](https://github.com/mochajs/mocha/blob/master/lib/mocha.js).
 [example-third-party-reporter]: https://github.com/mochajs/mocha-examples/tree/master/packages/third-party-reporter
 [example-typescript]: https://github.com/mochajs/mocha-examples/tree/master/packages/typescript
 [example-websocket.io-test]: https://github.com/LearnBoost/websocket.io/tree/master/test
+[expect]: https://jestjs.io/docs/expect
 [expect.js]: https://github.com/LearnBoost/expect.js
 [expresso]: https://github.com/tj/expresso
 [fish-globbing]: https://fishshell.com/docs/current/#expand-wildcard


### PR DESCRIPTION
### Description of the Change

(Jest maintainer here, for transparency 👋)

`expect` is purposefully kept usable outside the context of Jest, so linking to it makes sense so people are aware they can use it 🙂 

Example

```js
const expect = require('expect');

it('works with expect', () => {
  expect(4).toBe(5);
});
```

<img width="539" alt="image" src="https://user-images.githubusercontent.com/1404810/154436256-6a836827-0d46-402e-8fe6-a0e70214c562.png">

### Alternate Designs

N/A, website change

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

N/A, website change

### Benefits

<!-- What benefits will be realized by the code change? -->

Might be interesting to people if they want to use matchers created for Jest (such as something from `jest-extended`).

Or since mocha can run in browsers, but people might like `expect` from Jest, it's the best of both worlds. 😀 

Semi-related: we're currently working on improving our types (jest is written in typescript), so hopefully soon people will add custom matchers to `expect` directly rather than relying on `@types/jest`. At which point the TypeScript story is hopefully good for `expect` outside of Jest as well. The builtin matchers are typed, of course.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

One thing I'm not sure about is how to make it clear snapshot matchers doesn't work (as they require support in the test runner). They are not included when you do `require('expect')`, but the docs talk about them without making a distinction. Probably, we can improve our docs in Jest.

### Applicable issues

N/A