### PR TITLE
Fix: potential call-stack crash when using 'dry-run' option

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -655,7 +655,7 @@ Runner.prototype.parents = function () {
  * @private
  */
 Runner.prototype.runTest = function (fn) {
-  if (this._opts.dryRun) return fn();
+  if (this._opts.dryRun) return Runner.immediately(fn);
 
   var self = this;
   var test = this.test;

--- a/test/integration/fixtures/options/dry-run/stack-size.fixture.js
+++ b/test/integration/fixtures/options/dry-run/stack-size.fixture.js
@@ -1,0 +1,11 @@
+var assert = require('assert');
+
+describe('Wrapper suite', function () {
+  for(let i=0; i < 400; i++) {
+    describe(`suite ${i}`, function () {
+      it(`test ${i}`, function () {
+        assert.equal(1, 1);
+      });
+    });
+  }
+});

--- a/test/integration/options/dryRun.spec.js
+++ b/test/integration/options/dryRun.spec.js
@@ -27,4 +27,16 @@ describe('--dry-run', function () {
       done();
     });
   });
+
+  it('should pass without "RangeError: maximum call stack size exceeded"', function (done) {
+    var fixture = path.join('options/dry-run', 'stack-size');
+    runMochaJSON(fixture, args, function (err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res, 'to have passed test count', 400);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Description

`dry-run` mode: since the tests are not executed, but triggered only into an empty synchronous run, there is a potential risk of `RangeError: Maximum call stack size exceeded`.

### Description of the Change

For each test we add an asynchronous function call with `Runner.immediately()`. We pay a slight performance costs for this which is insignificant in `dry-run` mode. 

### Applicable issues

closes #4838