### PR TITLE
Drop support of Node v12

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
-node >= 12
+node >= 14
 last 2 Chrome versions
 last 2 Edge versions
 last 2 Firefox versions

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -22,9 +22,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '~/.npm'
-          key: "ubuntu-latest-node-full-v14-${{ hashFiles('**/package-lock.json') }}"
+          key: "ubuntu-latest-node-full-v16-${{ hashFiles('**/package-lock.json') }}"
           restore-keys: |
-            ubuntu-latest-node-full-v14-
+            ubuntu-latest-node-full-v16-
       - name: Install Dependencies
         run: npm ci
       - name: Run Browser Tests

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -29,7 +29,6 @@ jobs:
           - ubuntu-latest
           - windows-2019
         node:
-          - 12
           - 14
           - 16
           - 17
@@ -74,7 +73,6 @@ jobs:
           - ubuntu-latest
           - windows-2019
         node:
-          - 12
           - 14
           - 16
           - 17

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ or as a development dependency for your project:
 $ npm install --save-dev mocha
 ```
 
-> As of v9.0.0, Mocha requires Node.js v12.0.0 or newer.
+> As of v10.0.0, Mocha requires Node.js v14.0.0 or newer.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 14.0.0"
   },
   "scripts": {
     "prepublishOnly": "nps test clean build",


### PR DESCRIPTION
### Description of the Change

We drop support of Node v12 which will be end-of-life: 2022-04-30