### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -181,7 +181,7 @@ function HTML(runner, options) {
       if (indexOfMessage === -1) {
         stackString = test.err.stack;
       } else {
-        stackString = test.err.stack.substr(
+        stackString = test.err.stack.slice(
           test.err.message.length + indexOfMessage
         );
       }


### PR DESCRIPTION
### Description of the Change

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Alternate Designs

It would also be possible to use `substring()` instead of `slice()`

### Why should this be in core?

Best to not use deprecated functions

### Benefits

No more deprecated functions

### Possible Drawbacks

None

### Applicable issues

None so far
