### PR TITLE
Implement ESM cache blasting in watch mode

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -88,7 +88,7 @@ overrides:
         - selector: '*[object.object.name=global][object.property.name=/(Date|(set|clear)(Timeout|Immediate|Interval))/]:expression'
           message: *GH-237
   - files:
-      - test/**/*.mjs
+      - ./**/*.mjs
     parserOptions:
       ecmaVersion: 2018
       sourceType: module

--- a/bin/mocha
+++ b/bin/mocha
@@ -10,6 +10,8 @@
  * @private
  */
 
+const path = require('path');
+const getPackageType = require('get-package-type');
 const {loadOptions} = require('../lib/cli/options');
 const {
   unparseNodeFlags,
@@ -26,6 +28,23 @@ let hasInspect = false;
 
 const opts = loadOptions(process.argv.slice(2));
 debug('loaded opts', opts);
+
+if (
+  opts.watch &&
+  ((opts.require && opts.require.find(str => str.endsWith('.mjs'))) ||
+    // `getPackageType()` only supports files, not folders. A trick to pass in a
+    // folder is to append '/.' to cwd, but `path.join()` would resolve it, so:
+    getPackageType.sync(`${process.cwd()}${path.sep}.`) === 'module')
+) {
+  nodeArgs['no-warnings'] = true;
+  nodeArgs['experimental-loader'] = path.resolve(
+    __dirname,
+    '..',
+    'lib',
+    'nodejs',
+    'esm-loader.mjs'
+  );
+}
 
 /**
  * Given option/command `value`, disable timeouts if applicable

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -257,9 +257,10 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
-  const run = () => {
+  const run = async () => {
     try {
       mocha = beforeRun ? beforeRun({mocha, watcher}) || mocha : mocha;
+      await mocha.loadFilesAsync();
       runner = mocha.run(() => {
         debug('finished watch run');
         runner = null;
@@ -356,6 +357,9 @@ const blastCache = watcher => {
   files.forEach(file => {
     delete require.cache[file];
   });
+  if (global.blastLoaderCache) {
+    global.blastLoaderCache(files);
+  }
   debug('deleted %d file(s) from the require cache', files.length);
 };
 

--- a/lib/nodejs/esm-loader.mjs
+++ b/lib/nodejs/esm-loader.mjs
@@ -1,0 +1,48 @@
+import {URL, pathToFileURL} from 'url';
+
+const versions = {};
+
+export function resolve(specifier, context, defaultResolve) {
+  const result = defaultResolve(specifier, context, defaultResolve);
+  if (specifier.endsWith('/bin/mocha')) {
+    result.format = 'commonjs';
+  }
+
+  const child = new URL(result.url);
+
+  if (
+    child.protocol === 'nodejs:' ||
+    child.protocol === 'node:' ||
+    child.pathname.includes('/node_modules/')
+  ) {
+    return result;
+  } else {
+    const {url} = result;
+    versions[url] = versions[url] || 1;
+    const version = versions[url];
+    // console.log(`${url}?v=${version}`);
+    return {
+      url: `${result.url}?v=${version}`,
+      format: result.format
+    };
+  }
+}
+
+function blastCache(files) {
+  files.forEach(file => {
+    const url = pathToFileURL(file).href;
+    // console.log('blast', url);
+    versions[url] = (versions[url] || 1) + 1;
+  });
+}
+
+export function globalPreload({port}) {
+  port.onmessage = ({data: files}) => {
+    blastCache(files);
+  };
+  return `\
+    global.blastLoaderCache = files => {
+      port.postMessage(files);
+    }
+  `;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
+        "get-package-type": "^0.1.0",
         "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "diff": "5.0.0",
     "escape-string-regexp": "4.0.0",
     "find-up": "5.0.0",
+    "get-package-type": "^0.1.0",
     "glob": "7.2.0",
     "growl": "1.10.5",
     "he": "1.2.0",
@@ -163,7 +164,7 @@
   "files": [
     "bin/*mocha",
     "assets/growl/*.png",
-    "lib/**/*.{js,html,json}",
+    "lib/**/*.{js,mjs,html,json}",
     "index.js",
     "mocha.css",
     "mocha.js",


### PR DESCRIPTION
### Description of the Change

Mocha [watch mode](https://mochajs.org/#-watch-w) does currently not support ES Module test files because cache blasting was not possible to implement.

This PR implements ESM cache blasting through a custom experimental loader that appends version query to each script URL and increases the version number each time the cache for a given script is blasted. The work is based on the comment of @cspotcode in https://github.com/mochajs/mocha/issues/4374#issuecomment-792326668 and the experiment by @vsnthdev in https://github.com/nodejs/modules/issues/307#issuecomment-764560656.

### Why should this be in core?

ESM projects are increasingly common and not being able to run mocha in watch mode in such projects is a downside.

### Benefits

Faster development when working on tests in ESM projects

### Possible Drawbacks

The Node.js loaders are still experimental and subject to future changes. We could follow `node-dev` and mirror their semver based approach to handling loaders for different node versions:

https://github.com/fgnass/node-dev/blob/4cac78e6e3faa40ed26446ed1f097613f58ecc4d/lib/index.js#L97-L108

There is a suspicion that this approach may cause memory leaks, but according to @vsnthdev in https://github.com/nodejs/modules/issues/307#issuecomment-764560656, that is not the case:

> To see if this leaks memory, I made a chain of JS files that import, and then continuously changed their contents 1000+ times, and monitored the RAM usage of `node` and it seems all normal to me. 🤷‍♂️ ESM cache seems to be cleared automatically as soon as no other file imports that particular file.

### Applicable issues

- #4374
- #4854 