### PR TITLE
Remove deprecated Runner signature

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -135,27 +135,15 @@ class Runner extends EventEmitter {
    * @public
    * @class
    * @param {Suite} suite - Root suite
-   * @param {Object|boolean} [opts] - Options. If `boolean` (deprecated), whether to delay execution of root suite until ready.
+   * @param {Object} [opts] - Settings object
    * @param {boolean} [opts.cleanReferencesAfterRun] - Whether to clean references to test fns and hooks when a suite is done.
    * @param {boolean} [opts.delay] - Whether to delay execution of root suite until ready.
    * @param {boolean} [opts.dryRun] - Whether to report tests without running them.
    * @param {boolean} [opts.failZero] - Whether to fail test run if zero tests encountered.
    */
-  constructor(suite, opts) {
+  constructor(suite, opts = {}) {
     super();
-    if (opts === undefined) {
-      opts = {};
-    }
-    if (typeof opts === 'boolean') {
-      // TODO: remove this
-      require('./errors').deprecate(
-        '"Runner(suite: Suite, delay: boolean)" is deprecated. Use "Runner(suite: Suite, {delay: boolean})" instead.'
-      );
-      this._delay = opts;
-      opts = {};
-    } else {
-      this._delay = opts.delay;
-    }
+
     var self = this;
     this._globals = [];
     this._abort = false;
@@ -1066,7 +1054,7 @@ Runner.prototype.run = function (fn, opts = {}) {
       debug('run(): filtered exclusive Runnables');
     }
     this.state = constants.STATE_RUNNING;
-    if (this._delay) {
+    if (this._opts.delay) {
       this.emit(constants.EVENT_DELAY_END);
       debug('run(): "delay" ended');
     }
@@ -1093,7 +1081,7 @@ Runner.prototype.run = function (fn, opts = {}) {
   this._addEventListener(process, 'uncaughtException', this.uncaught);
   this._addEventListener(process, 'unhandledRejection', this.unhandled);
 
-  if (this._delay) {
+  if (this._opts.delay) {
     // for reporters, I guess.
     // might be nice to debounce some dots while we wait.
     this.emit(constants.EVENT_DELAY_BEGIN, rootSuite);

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -8,7 +8,6 @@ const {Suite, Runner, Test, Hook, Runnable} = Mocha;
 const {noop} = Mocha.utils;
 const {FATAL, MULTIPLE_DONE, UNSUPPORTED} =
   require('../../lib/errors').constants;
-const errors = require('../../lib/errors');
 
 const {
   EVENT_HOOK_BEGIN,
@@ -28,15 +27,6 @@ const {STATE_FAILED} = Mocha.Runnable.constants;
 describe('Runner', function () {
   afterEach(function () {
     sinon.restore();
-  });
-
-  describe('constructor deprecation', function () {
-    it('should print a deprecation warning', function () {
-      sinon.stub(errors, 'deprecate');
-      const suite = new Suite('Suite', 'root');
-      new Runner(suite, false); /* eslint no-new: "off" */
-      expect(errors.deprecate, 'was called once');
-    });
   });
 
   describe('instance method', function () {


### PR DESCRIPTION
### Description

In Mocha v9.0.0 the Runner constructor signature `Runner(suite: Suite, delay: boolean)` has been deprecated, see #4646.

### Description of the Change

We remove mentioned `Runner(suite: Suite, delay: boolean)`.

Instead use an option object: `Runner(suite: Suite, {delay: boolean})`.
