### PR TITLE
Deps: upgrade 'minimatch'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1084,11 +1084,12 @@ Files specified in this way should contain one or more suites, tests or hooks. I
 
 ### `--ignore <file|directory|glob>, --exclude <file|directory|glob>,`
 
-Explicitly ignore (exclude) one or more test files, directories or globs (e.g., `some/**/files*`) that would otherwise be loaded.
+Explicitly ignore one or more test files, directories or globs (e.g., `some/**/files*`) that would otherwise be loaded.<br>
+Can be specified multiple times.
+
+> _New in v10.0.0:_ In Windows always use forward-slashes `/` as path separator.
 
 Files specified using `--file` _are not affected_ by this option.
-
-Can be specified multiple times.
 
 ### `--recursive`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
         "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
@@ -36,7 +36,7 @@
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",
@@ -14698,14 +14698,22 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/minimist": {
@@ -35837,11 +35845,21 @@
       "dev": true
     },
     "minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
       }
     },
     "minimist": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "he": "1.2.0",
     "js-yaml": "4.1.0",
     "log-symbols": "4.1.0",
-    "minimatch": "4.2.1",
+    "minimatch": "5.0.1",
     "ms": "2.1.3",
     "nanoid": "3.3.1",
     "serialize-javascript": "6.0.0",

--- a/scripts/karma-rollup-plugin.js
+++ b/scripts/karma-rollup-plugin.js
@@ -53,7 +53,7 @@ function framework(fileConfigs, pluginConfig, basePath, preprocessors) {
     .map(fileConfig => fileConfig.pattern)
     .filter(filePath =>
       includePatterns.some(includePattern =>
-        minimatch(filePath, includePattern)
+        minimatch(filePath, includePattern.replace(/\\/g, '/'))
       )
     );
 

--- a/test/integration/options/ignore.spec.js
+++ b/test/integration/options/ignore.spec.js
@@ -30,7 +30,10 @@ describe('--ignore', function () {
     var fixtures = path.join('options', 'ignore', '*');
     runMochaTest(
       fixtures,
-      ['--ignore', resolvePath(path.join('options', 'ignore', 'fail'))],
+      [
+        '--ignore',
+        resolvePath(path.join('options', 'ignore', 'fail')).replace(/\\/g, '/')
+      ],
       function (res) {
         expect(res, 'to have passed')
           .and('to have run test', 'should find this test')
@@ -60,9 +63,12 @@ describe('--ignore', function () {
       fixtures,
       [
         '--ignore',
-        resolvePath(path.join('options', 'ignore', 'fail')),
+        resolvePath(path.join('options', 'ignore', 'fail')).replace(/\\/g, '/'),
         '--ignore',
-        resolvePath(path.join('options', 'ignore', 'nested', 'fail'))
+        resolvePath(path.join('options', 'ignore', 'nested', 'fail')).replace(
+          /\\/g,
+          '/'
+        )
       ],
       function (res) {
         expect(res, 'to have passed')


### PR DESCRIPTION
### Description

This is a **breaking change** and applies to the usage of `--ignore` (alias: `--exclude`) option in **Windows**.

see [Minimatch docs](https://github.com/isaacs/minimatch#windows)

> **Please only use forward-slashes in glob expressions.**
Though windows uses either `/` or `\` as its path separator, only `/` characters are used by this glob implementation. You must use forward-slashes **only** in glob expressions. Back-slashes in patterns will always be interpreted as escape characters, not path separators.
Note that `\` or `/` will be interpreted as path separators in paths on Windows, and will match against `/` in glob expressions.
So just always use `/` in patterns.

### Description of the Change

| dependencies | from | to |  |
|------------|----------|----------|----------|
| minimatch | 4.2.1 | 5.0.1 | breaking change |
