### PR TITLE
fix: docs parallel fgrep url fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1287,7 +1287,7 @@ In serial mode, tests results will "stream" as they occur. In parallel mode, rep
 
 Suggested workarounds:
 
-1. Use [`--grep`](#-grep-regexp-g-regexp) or [`--fgrep`](http://localhost:8080/#-fgrep-string-f-string) instead; it's not particularly efficient, but it will work.
+1. Use [`--grep`](#-grep-regexp-g-regexp) or [`--fgrep`](#-fgrep-string-f-string) instead; it's not particularly efficient, but it will work.
 1. Don't use parallel mode. Likely, you won't be running very many exclusive tests, so you won't see a great benefit from parallel mode anyhow.
 
 > _TIP: If parallel mode is defined in your config file, you can temporarily disable it on the command-line by using either the `--no-parallel` flag or reducing the job count, e.g., `--jobs=0`._


### PR DESCRIPTION
Hi, I was reading through the documentation and I noticed that `--fgrep` link was redirecting to the localhost. The link is located in the `Parallel` section, right under [Exclusive tests are disallowed](https://mochajs.org/#exclusive-tests-are-disallowed)

<img width="653" alt="Screen Shot 2022-04-17 at 9 29 57 p m" src="https://user-images.githubusercontent.com/12686935/163746549-718c66a4-68f1-46df-b873-862c980d1db2.png">

### Description of the Change

- Updates the link with to link the just header without the host.
- Remove the localhost reference
