### PR TITLE
ci: add Node 18

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -19,17 +19,17 @@ jobs:
     outputs:
       pr-id: ${{ steps.findPr.outputs.number }}
     steps:
-    - name: Check event pull_request
-      if: github.event_name == 'pull_request'
-      run: 'echo pull_request: run workflow'
-    - uses: actions/checkout@v2
-      if: github.event_name == 'push'
-    - name: Check event push
-      id: findPr
-      if: github.event_name == 'push'      
-      uses: jwalton/gh-find-current-pr@v1
-      with:
-        state: open
+      - name: Check event pull_request
+        if: github.event_name == 'pull_request'
+        run: 'echo pull_request: run workflow'
+      - uses: actions/checkout@v2
+        if: github.event_name == 'push'
+      - name: Check event push
+        id: findPr
+        if: github.event_name == 'push'
+        uses: jwalton/gh-find-current-pr@v1
+        with:
+          state: open
 
   smoke:
     name: 'Smoke [Node.js v${{ matrix.node }} / ${{ matrix.os }}]'
@@ -44,7 +44,7 @@ jobs:
         node:
           - 14
           - 16
-          - 17
+          - 18
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -88,7 +88,7 @@ jobs:
         node:
           - 14
           - 16
-          - 17
+          - 18
         include:
           - os: ubuntu-latest
             node: 16


### PR DESCRIPTION
### Description of the Change
Replaces Node v17 by v18.
End-of-life of v17 is 2022-06-01, see [the release schedule.](https://nodejs.org/en/about/releases/)
