### PR TITLE
refactor: replace git.io short link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2376,7 +2376,7 @@ or the [source](https://github.com/mochajs/mocha/blob/master/lib/mocha.js).
 [expresso]: https://github.com/tj/expresso
 [fish-globbing]: https://fishshell.com/docs/current/#expand-wildcard
 [github-mocha]: https://github.com/mochajs/mocha
-[gist-async-hooks]: https://git.io/vdlNM
+[gist-async-hooks]: https://gist.github.com/boneskull/7fe75b63d613fa940db7ec990a5f5843
 [gist-globbing-tutorial]: https://gist.github.com/reggi/475793ea1846affbcfe8
 [gitter-mocha]: https://gitter.im/mochajs/mocha
 [jetbrains]: https://www.jetbrains.com/

--- a/lib/cli/commands.js
+++ b/lib/cli/commands.js
@@ -2,7 +2,7 @@
 
 /**
  * Exports Yargs commands
- * @see https://git.io/fpJ0G
+ * @see https://github.com/yargs/yargs/blob/main/docs/advanced.md
  * @private
  * @module
  */

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -329,7 +329,7 @@ exports.builder = yargs =>
       if (argv.compilers) {
         throw createUnsupportedError(
           `--compilers is DEPRECATED and no longer supported.
-          See https://git.io/vdcSr for migration information.`
+          See https://github.com/mochajs/mocha/wiki/compilers-deprecation for migration information.`
         );
       }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Github has deprecated git.io and will be [disabling all links on April 29th](https://github.blog/changelog/2022-04-25-git-io-deprecation/).

This PR replaces all git.io shortened links with the URL they redirect to.
