### PR TITLE
fix: support canonical module

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,7 +215,7 @@ exports.type = function type(value) {
 exports.stringify = function (value) {
   var typeHint = canonicalType(value);
 
-  if (!~['object', 'array', 'function'].indexOf(typeHint)) {
+  if (!~['object', 'array', 'function', 'module'].indexOf(typeHint)) {
     if (typeHint === 'buffer') {
       var json = Buffer.prototype.toJSON.call(value);
       // Based on the toJSON result
@@ -399,6 +399,12 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
       if (!canonicalizedObj) {
         canonicalizedObj = emptyRepresentation(value, typeHint);
         break;
+      }
+    /* falls through */
+    case 'module':
+      if (value[Symbol.toStringTag] === 'Module') {
+        canonicalizedObj = canonicalizedObj || {};
+        canonicalizedObj['[Symbol.toStringTag]'] = 'Module';
       }
     /* falls through */
     case 'object':

--- a/test/unit/fixtures/module.mjs
+++ b/test/unit/fixtures/module.mjs
@@ -1,0 +1,4 @@
+export default 123;
+
+export const foo = 'abc';
+export const bar = true;

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -2,6 +2,8 @@
 'use strict';
 
 var utils = require('../../lib/utils');
+const esmUtils = require('../../lib/nodejs/esm-utils');
+const Path = require('node:path');
 var sinon = require('sinon');
 
 describe('lib/utils', function () {
@@ -286,6 +288,22 @@ describe('lib/utils', function () {
           '  "zero": -0',
           '}'
         ].join('\n');
+        expect(stringify(expected), 'to be', actual);
+      });
+
+      it('should represent modules', async function () {
+        const expected = await esmUtils.requireOrImport(
+          Path.join(__dirname, './fixtures/module.mjs')
+        );
+        const actual = [
+          '{',
+          '  "[Symbol.toStringTag]": "Module"',
+          '  "bar": true',
+          '  "default": 123',
+          '  "foo": "abc"',
+          '}'
+        ].join('\n');
+
         expect(stringify(expected), 'to be', actual);
       });
     });


### PR DESCRIPTION
### Description of the Change

Handle canonicalizing `Module`, prevent implicit stringification failures

### Alternate Designs

* Have `canonicalType` return `'object'` for modules (not chosen as that _could_ be breaking, not sure...)
* Have `'module'` fallthrough to `'object'` with no custom logic (not chosen so we can indicate different between "object" and "module")

### Why should this be in core?

Current module canonicalization is broken, see https://github.com/mochajs/mocha/issues/4887

### Benefits

Tests can properly handle errors with a Module inside

### Possible Drawbacks

Small chance there is some internal/custom handling expecting canonicalization of modules to fail... Seems unlikely?

### Applicable issues

Fixes https://github.com/mochajs/mocha/issues/4887

Bug fix, patch release
