### PR TITLE
Upgrade official GitHub actions to latest versions

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'run-browser-test')
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: 'Cache node_modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '~/.npm'
           key: "ubuntu-latest-node-full-v16-${{ hashFiles('**/package-lock.json') }}"

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -46,8 +46,8 @@ jobs:
           - 16
           - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '${{ matrix.node }}'
       - run: npm install --production
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: smoke
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Cache node_modules'
         uses: actions/cache@v2
         with:
@@ -95,17 +95,17 @@ jobs:
             env:
               COVERAGE: 1
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '${{ matrix.node }}'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get npm cache directory in Windows
         id: npm-cache
         if: ${{ matrix.os == 'windows-2019' }}
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
       - name: 'Cache node_modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ matrix.os == 'ubuntu-latest' && '~/.npm' || steps.npm-cache.outputs.dir }}
           key: "${{ matrix.os }}-node-v${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}"
@@ -139,12 +139,12 @@ jobs:
     # Don't run forked 'pull_request' without saucelabs token
     if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Cache node_modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '~/.npm'
           # this key is different than above, since we are running scripts


### PR DESCRIPTION
### Description of the Change

Quick PR to upgrade all the official GitHub actions to their latest versions in order to stay up-to-date.

### Alternate Designs

Dependabot could be used to automate this.

### Why should this be in core?

N/A

### Benefits

This will reinforce CI stability.

### Possible Drawbacks

No breaking changes that I'm aware of.

### Applicable issues

N/A
