### PR TITLE
Only transform file import path if not already transformed

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -88,7 +88,10 @@ function dealWithExports(module) {
 exports.loadFilesAsync = async (files, preLoadFunc, postLoadFunc) => {
   for (const file of files) {
     preLoadFunc(file);
-    const result = await exports.requireOrImport(path.resolve(file));
+    const filePath = file.startsWith('file://')
+        ? file
+        : path.resolve(file)
+    const result = await exports.requireOrImport(filePath);
     postLoadFunc(file, result);
   }
 };

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -90,7 +90,7 @@ exports.loadFilesAsync = async (files, preLoadFunc, postLoadFunc) => {
     preLoadFunc(file);
     const filePath = file.startsWith('file://')
         ? file
-        : path.resolve(file)
+        : path.resolve(file);
     const result = await exports.requireOrImport(filePath);
     postLoadFunc(file, result);
   }

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -88,9 +88,7 @@ function dealWithExports(module) {
 exports.loadFilesAsync = async (files, preLoadFunc, postLoadFunc) => {
   for (const file of files) {
     preLoadFunc(file);
-    const filePath = file.startsWith('file://')
-        ? file
-        : path.resolve(file);
+    const filePath = file.startsWith('file://') ? file : path.resolve(file);
     const result = await exports.requireOrImport(filePath);
     postLoadFunc(file, result);
   }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

Passing in a file path, e.g. `file:///foo/bar` in Node causes problems as Mocha tries to resolve the path, e.g.:

```js
path.resolve('file:///foo/bar.spec.js') // returns "/path/to/cwd/file:/foo/bar.spec.js"
```

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

n/a

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

This seems to be a bug in core.

### Benefits

<!-- What benefits will be realized by the code change? -->

It allows Mocha to use file urls. This is important for Windows where `import('d:\foo\bar.spec.js')` is not possible.

### Possible Drawbacks

n/a

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
n/a