### PR TITLE
Use standard Promise.allSettled instead polyfill

### DIFF
--- a/lib/nodejs/parallel-buffered-runner.js
+++ b/lib/nodejs/parallel-buffered-runner.js
@@ -6,7 +6,6 @@
 
 'use strict';
 
-const allSettled = require('@ungap/promise-all-settled').bind(Promise);
 const Runner = require('../runner');
 const {EVENT_RUN_BEGIN, EVENT_RUN_END} = Runner.constants;
 const debug = require('debug')('mocha:parallel:parallel-buffered-runner');
@@ -322,7 +321,7 @@ class ParallelBufferedRunner extends Runner {
           delete options[opt];
         });
 
-        const results = await allSettled(
+        const results = await Promise.allSettled(
           files.map(this._createFileRunner(pool, options))
         );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -1576,11 +1575,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
     },
     "node_modules/@wdio/config": {
       "version": "6.12.1",
@@ -25664,11 +25658,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
     },
     "@wdio/config": {
       "version": "6.12.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "test:smoke": "node ./bin/mocha --no-config test/smoke/smoke.spec.js"
   },
   "dependencies": {
-    "@ungap/promise-all-settled": "1.1.2",
     "ansi-colors": "4.1.1",
     "browser-stdout": "1.3.1",
     "chokidar": "3.5.3",


### PR DESCRIPTION
### Description of the Change
We've introduced [@ungap/promise-all-settled](https://www.npmjs.com/package/@ungap/promise-all-settled) in #4476. 
And Node.js support [Promise.allSettled](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) in Node 12.9.0.

So, we don't need polyfill anymore because we support Node 14+.

### Why should this be in core?
We don't need polyfill anymore.

### Benefits
dependency is reduced.

### Possible Drawbacks
N/A