### PR TITLE
fix: increase contrast for replay buttons

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -297,7 +297,7 @@ body {
 }
 
 #mocha .test:hover a.replay {
-  box-shadow: 0 0 1px inset var(--mocha-test-replay-bg-color);
+  box-shadow: 0 0 1px inset var(--mocha-test-replay-color);
   opacity: 1;
 }
 

--- a/mocha.css
+++ b/mocha.css
@@ -17,7 +17,7 @@
   --mocha-test-html-error-color: #000;
   --mocha-box-shadow-color: #eee;
   --mocha-box-bottom-color: #ddd;
-  --mocha-test-replay-color: #888;
+  --mocha-test-replay-color: #000;
   --mocha-test-replay-bg-color: #eee;
   --mocha-stats-color: #888;
   --mocha-stats-em-color: #000;
@@ -49,7 +49,7 @@
      --mocha-test-html-error-color: #fff;
      --mocha-box-shadow-color: #444;
      --mocha-box-bottom-color: #555;
-     --mocha-test-replay-color: #888;
+     --mocha-test-replay-color: #fff;
      --mocha-test-replay-bg-color: #444;
      --mocha-stats-color: #aaa;
      --mocha-stats-em-color: #fff;
@@ -292,11 +292,12 @@ body {
   -moz-transition:opacity 200ms;
   -o-transition:opacity 200ms;
   transition: opacity 200ms;
-  opacity: 0.3;
+  opacity: 0.7;
   color: var(--mocha-test-replay-color);
 }
 
 #mocha .test:hover a.replay {
+  box-shadow: 0 0 1px inset var(--mocha-test-replay-bg-color);
   opacity: 1;
 }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Adds the increased visual emphasis as mentioned in #4911.

<table>
<thead>
<tr>
<th>Light mode</th>
<th>Dark mode</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="443" alt="Light mode screenshot with more visible replay buttons" src="https://user-images.githubusercontent.com/3335181/188291262-9e4ec1a8-3c5a-490a-88b2-f8cda034365f.png">
</td>
<td>
<img width="444" alt="Dark mode screenshot with more visible replay buttons" src="https://user-images.githubusercontent.com/3335181/188291267-70a1fe39-6ae1-4d14-aba9-f4e94105ec6f.png">
</td>
</tr>
</tbody>
</table>



### Alternate Designs

n/a

### Why should this be in core?

n/a

### Benefits

Users can more easily see the replay buttons.

### Possible Drawbacks

n/a

### Applicable issues

* Fixes #4911
* Patch, bugfix