### PR TITLE
Add test to prevent ReDoS for clean()

### DIFF
--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -142,6 +142,12 @@ describe('lib/utils', function () {
       var fn = '() => foo()';
       expect(utils.clean(fn), 'to be', 'foo()');
     });
+
+    it('should prevent ReDoS attack', function () {
+      this.timeout(100);
+      var attackFn = 'function' + ' '.repeat(20000);
+      expect(utils.clean(attackFn), 'to be', 'function');
+    });
   });
 
   describe('stringify()', function () {


### PR DESCRIPTION
### Description of the Change
In #4770 , ReDoS vulnerabilities of the regex fixed. So, this test to prevent regression ReDoS.
