### PR TITLE
feat: deprecation message when an async callback is used in a Suite

### DIFF
--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -148,7 +148,7 @@ module.exports = function (suites, context, mocha) {
           const suiteResult = opts.fn.call(suite);
           if (suiteResult instanceof Promise) {
             errors.deprecate(
-              'Suite "' +
+              '[mocha] Suite "' +
                 suite.fullTitle() +
                 '" returned a Promise. ' +
                 'Asynchronous suites are not supported, use a ' +

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -145,7 +145,16 @@ module.exports = function (suites, context, mocha) {
           throw createUnsupportedError('Pending test forbidden');
         }
         if (typeof opts.fn === 'function') {
-          opts.fn.call(suite);
+          const suiteResult = opts.fn.call(suite);
+          if (suiteResult instanceof Promise) {
+            errors.deprecate(
+              'Suite "' +
+                suite.fullTitle() +
+                '" returned a Promise. ' +
+                'Asynchronous suites are not supported, use a ' +
+                'synchronous callback instead.'
+            );
+          }
           suites.shift();
         } else if (typeof opts.fn === 'undefined' && !suite.pending) {
           throw createMissingArgumentError(

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -146,7 +146,7 @@ module.exports = function (suites, context, mocha) {
         }
         if (typeof opts.fn === 'function') {
           const suiteResult = opts.fn.call(suite);
-          if (suiteResult instanceof Promise) {
+          if (suiteResult !== undefined) {
             errors.deprecate(
               '[mocha] Suite "' +
                 suite.fullTitle() +

--- a/test/integration/fixtures/suite/suite-async-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-async-callback.fixture.js
@@ -1,3 +1,3 @@
 'use strict';
 
-describe('a suite without an async callback', async function () {});
+describe('a suite with an async callback', async function () {});

--- a/test/integration/fixtures/suite/suite-async-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-async-callback.fixture.js
@@ -1,0 +1,3 @@
+'use strict';
+
+describe('a suite without an async callback', async function () {});

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -72,3 +72,24 @@ describe('suite returning a value', function () {
     );
   });
 });
+
+describe('suite w/async callback', function () {
+  it('should print a helpful deprecation message when a callback for suite is async', function (done) {
+    run(
+      'suite/suite-async-callback.fixture.js',
+      args,
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(
+          res.output,
+          'to match',
+          /Asynchronous suites are not supported, use a synchronous callback instead./
+        );
+        done();
+      },
+      {stdio: 'pipe'}
+    );
+  });
+});


### PR DESCRIPTION
_I'm sending this PR after having proposed this feature in #4920, getting some positive reactions, and researching the history of a similar feature that was removed_

### Description of the Change

This PR introduces a change that prints a depreciation message if an `async` callback is used in a `Suite`.

### Alternate Designs

`v6.0.0` introduced a similar feature, but it printed a deprecation warning if a `Suite` returned any value other than `undefined`, which was not practical in some cases (see #3744), so it was removed.

This PR is a specialization of that feature that prints a warning when `Promise`s are returned instead.

Also, I originally proposed throwing a fatal error, but that would be a breaking change, so I changed it to a deprecation message. This same criteria was applied to the previous version of this feature.

### Why should this be in core?

I don't think this can be implemented outside of core. 

As this PR benefits users who don't have a clear understanding of how a `Suite` works, taking this functionality out of core will have much lower, as there wouldn't be a clear path for those users to discover how to enable it. 

### Benefits

Many users don't realize that Suite's callbacks can't be `async`. In some cases, they get away with `async` callbacks, which further increases the confusion.

This PR is intended to clarify that confusion.

### Possible Drawbacks

I don't think this version of the feature has any serious drawback. 

It may print deprecation warnings for people who were using async callbacks in `Suite`s with some success (and a ton of luck), but those users were already at high risk of their code breaking. This change is intended to help them.

### Applicable issues

Fixes #4920
semver-patch 
(copying the semver criteria of #3550)
