### PR TITLE
feat: introduce `__mocha_worker_id__` property

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -2,7 +2,7 @@
 
 var Runnable = require('./runnable');
 const {inherits, constants} = require('./utils');
-const {MOCHA_ID_PROP_NAME} = constants;
+const {MOCHA_ID_PROP_NAME, MOCHA_WORKER_ID_PROP_NAME} = constants;
 
 /**
  * Expose `Hook`.
@@ -84,6 +84,7 @@ Hook.prototype.serialize = function serialize() {
     state: this.state,
     title: this.title,
     type: this.type,
-    [MOCHA_ID_PROP_NAME]: this.id
+    [MOCHA_ID_PROP_NAME]: this.id,
+    [MOCHA_WORKER_ID_PROP_NAME]: process.env.MOCHA_WORKER_ID
   };
 };

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -19,7 +19,7 @@ const debug = require('debug')('mocha:suite');
 const milliseconds = require('ms');
 const errors = require('./errors');
 
-const {MOCHA_ID_PROP_NAME} = utilsConstants;
+const {MOCHA_ID_PROP_NAME, MOCHA_WORKER_ID_PROP_NAME} = utilsConstants;
 
 /**
  * Expose `Suite`.
@@ -586,8 +586,9 @@ Suite.prototype.serialize = function serialize() {
     $$isPending: Boolean(this.isPending()),
     root: this.root,
     title: this.title,
+    parent: this.parent ? {[MOCHA_ID_PROP_NAME]: this.parent.id} : null,
     [MOCHA_ID_PROP_NAME]: this.id,
-    parent: this.parent ? {[MOCHA_ID_PROP_NAME]: this.parent.id} : null
+    [MOCHA_WORKER_ID_PROP_NAME]: process.env.MOCHA_WORKER_ID
   };
 };
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -5,7 +5,7 @@ var errors = require('./errors');
 var createInvalidArgumentTypeError = errors.createInvalidArgumentTypeError;
 var isString = utils.isString;
 
-const {MOCHA_ID_PROP_NAME} = utils.constants;
+const {MOCHA_ID_PROP_NAME, MOCHA_WORKER_ID_PROP_NAME} = utils.constants;
 
 module.exports = Test;
 
@@ -108,6 +108,7 @@ Test.prototype.serialize = function serialize() {
     title: this.title,
     type: this.type,
     file: this.file,
-    [MOCHA_ID_PROP_NAME]: this.id
+    [MOCHA_ID_PROP_NAME]: this.id,
+    [MOCHA_WORKER_ID_PROP_NAME]: process.env.MOCHA_WORKER_ID
   };
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,8 @@ var he = require('he');
 
 const MOCHA_ID_PROP_NAME = '__mocha_id__';
 
+const MOCHA_WORKER_ID_PROP_NAME = '__mocha_worker_id__';
+
 /**
  * Inherit the prototype methods from one constructor into another.
  *
@@ -612,7 +614,8 @@ exports.castArray = function castArray(value) {
 };
 
 exports.constants = exports.defineConstants({
-  MOCHA_ID_PROP_NAME
+  MOCHA_ID_PROP_NAME,
+  MOCHA_WORKER_ID_PROP_NAME
 });
 
 /**


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

The PR brings `__mocha_worker_id__` property to tests, suites and hooks, just to understand on reporter level, which worker has been used and categorize multiple parallel tests on reporter level.

At this moment, many solutions are compatible only with the serial mode and when we try to run parallel one current test/suite/hook will be overwritten.

This solution doesn't bring something, which can break the runner or any solution based on it because it adds `__mocha_worker_id__` field what has `MOCHA_WORKER_ID` value (or it equals to `undefined`, e.g. in serial mode).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I've tried to get `MOCHA_WORKER_ID` during `allure-mocha` reporter development, but it's not possible to get it due the reporter receives only IPC message.

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

Many people run `mocha` in parallel mode and they want to use their own or third-party reporters which are compatible only with serial mode, so we can't store any concurrent data inside. If we have worker ID, we would store running tests by it without any collision.

### Benefits

<!-- What benefits will be realized by the code change? -->

We can adapt any reporter to work in parallel mode. The main motivation – make `allure-mocha` work.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

`__mocha_worker_id__` can be `undefined` in the serial mode. Maybe it worth to omit the field, but from my vision, better to keep it all the time.

### Applicable issues

#4768
<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->
