### PR TITLE
docs: use mocha.js instead of mocha in the example run

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ describe('Array', function () {
 Back in the terminal:
 
 ```bash
-$ ./node_modules/mocha/bin/mocha
+$ ./node_modules/mocha/bin/mocha.js
 
   Array
     #indexOf()


### PR DESCRIPTION
It looks like `mocha/bin/mocha` isn't there anymore.

