### PR TITLE
ci: update stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           days-before-stale: 120
           days-before-close: 14


### PR DESCRIPTION
[GitHub Actions deprecated Node.js 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and [actions/stale support Node.js 16](https://github.com/actions/stale/releases/tag/v5.0.0).

Updating `actions/stale` to v6 will [the deprecation warning](https://github.com/mochajs/mocha/actions/runs/3246673616).

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/stale