### PR TITLE
CI: workaround for firefox error

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -90,7 +90,8 @@ module.exports = config => {
       const buildId = `github-${env.GITHUB_RUN_ID}_${env.GITHUB_RUN_NUMBER}`;
       bundleDirPath = path.join(BASE_BUNDLE_DIR_PATH, buildId);
       sauceConfig = {
-        build: buildId
+        build: buildId,
+        geckodriverVersion: '0.30.0' // temporary workaround for firefox
       };
     } else {
       console.error(`Local environment (${hostname}) detected`);


### PR DESCRIPTION
### Description

I contacted Saucelabs for support and was adviced to temporarily pin the version of the Firefox GeckoDiver to 0.30.0 while waiting for Karma's issue to be resolved.

fixes #4930