### PR TITLE
docs: remove duplicated header "command-line usage"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -990,8 +990,6 @@ It can however make the output harder to interpret when comparing large strings.
 
 A value of 0 indicates no limit, default is 8192 characters.
 
-## Command-Line Usage
-
 ### `--full-trace`
 
 Enable "full" stack traces. By default, Mocha attempts to distill stack traces into less noisy (though still useful) output.


### PR DESCRIPTION
### Description of the Change

The "Command-Line Usage" section is split in 2 without any gain, as can be seen in the screenshot below.

I'm removing the "Command-Line Usage" which is written in the middle of the "Command-Line Usage" section.

![image](https://user-images.githubusercontent.com/29241659/200873196-05325fae-4908-4f48-b687-085632b17ffb.png)

---

![image](https://user-images.githubusercontent.com/29241659/200873282-d03a11f1-3a7e-46df-be0b-97fa0a789b1e.png)

Original header: https://mochajs.org/#command-line-usage

Duplicated header: https://mochajs.org/#command-line-usage-1


### Alternate Designs

N/A

### Why should this be in core?

N/A

### Benefits

Make documentation on using the command line easier to read.

### Possible Drawbacks

N/A

### Applicable issues

It does not impact production code, only documentation.
