### PR TITLE
feat: ability to decorate esm module name before importing it

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -429,6 +429,8 @@ Mocha.prototype.loadFiles = function (fn) {
  * @see {@link Mocha#addFile}
  * @see {@link Mocha#run}
  * @see {@link Mocha#unloadFiles}
+ * @param {Object} [options] - Settings object.
+ * @param {Function} [options.esmDecorator] - Function invoked on esm module name right before importing it. By default will passthrough as is.
  * @returns {Promise}
  * @example
  *

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -437,7 +437,7 @@ Mocha.prototype.loadFiles = function (fn) {
  *   .then(() => mocha.run(failures => process.exitCode = failures ? 1 : 0))
  *   .catch(() => process.exitCode = 1);
  */
-Mocha.prototype.loadFilesAsync = function () {
+Mocha.prototype.loadFilesAsync = function ({esmDecorator} = {}) {
   var self = this;
   var suite = this.suite;
   this.lazyLoadFiles(true);
@@ -450,7 +450,8 @@ Mocha.prototype.loadFilesAsync = function () {
     function (file, resultModule) {
       suite.emit(EVENT_FILE_REQUIRE, resultModule, file, self);
       suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
-    }
+    },
+    esmDecorator
   );
 };
 

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -6,7 +6,7 @@ const forward = x => x;
 const formattedImport = async (file, esmDecorator = forward) => {
   if (path.isAbsolute(file)) {
     try {
-      return await import(esmDecorator(url.pathToFileURL(file)));
+      return await exports.doImport(esmDecorator(url.pathToFileURL(file)));
     } catch (err) {
       // This is a hack created because ESM in Node.js (at least in Node v15.5.1) does not emit
       // the location of the syntax error in the error thrown.
@@ -29,8 +29,10 @@ const formattedImport = async (file, esmDecorator = forward) => {
       throw err;
     }
   }
-  return import(esmDecorator(file));
+  return exports.doImport(esmDecorator(file));
 };
+
+exports.doImport = async file => import(file);
 
 exports.requireOrImport = async (file, esmDecorator) => {
   if (path.extname(file) === '.mjs') {

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const url = require('url');
 
-const formattedImport = async file => {
+const forward = x => x;
+
+const formattedImport = async (file, esmDecorator = forward) => {
   if (path.isAbsolute(file)) {
     try {
-      return await import(url.pathToFileURL(file));
+      return await import(esmDecorator(url.pathToFileURL(file)));
     } catch (err) {
       // This is a hack created because ESM in Node.js (at least in Node v15.5.1) does not emit
       // the location of the syntax error in the error thrown.
@@ -27,15 +29,15 @@ const formattedImport = async file => {
       throw err;
     }
   }
-  return import(file);
+  return import(esmDecorator(file));
 };
 
-exports.requireOrImport = async file => {
+exports.requireOrImport = async (file, esmDecorator) => {
   if (path.extname(file) === '.mjs') {
-    return formattedImport(file);
+    return formattedImport(file, esmDecorator);
   }
   try {
-    return dealWithExports(await formattedImport(file));
+    return dealWithExports(await formattedImport(file, esmDecorator));
   } catch (err) {
     if (
       err.code === 'ERR_MODULE_NOT_FOUND' ||
@@ -85,10 +87,18 @@ function dealWithExports(module) {
   }
 }
 
-exports.loadFilesAsync = async (files, preLoadFunc, postLoadFunc) => {
+exports.loadFilesAsync = async (
+  files,
+  preLoadFunc,
+  postLoadFunc,
+  esmDecorator
+) => {
   for (const file of files) {
     preLoadFunc(file);
-    const result = await exports.requireOrImport(path.resolve(file));
+    const result = await exports.requireOrImport(
+      path.resolve(file),
+      esmDecorator
+    );
     postLoadFunc(file, result);
   }
 };

--- a/test/node-unit/esm-utils.spec.js
+++ b/test/node-unit/esm-utils.spec.js
@@ -2,6 +2,7 @@
 
 const esmUtils = require('../../lib/nodejs/esm-utils');
 const sinon = require('sinon');
+const url = require('url');
 
 describe('esm-utils', function () {
   beforeEach(function () {
@@ -23,7 +24,7 @@ describe('esm-utils', function () {
       expect(
         esmUtils.doImport.firstCall.args[0].toString(),
         'to be',
-        'file:///foo/bar.mjs'
+        url.pathToFileURL('/foo/bar.mjs').toString()
       );
     });
 
@@ -38,7 +39,7 @@ describe('esm-utils', function () {
       expect(
         esmUtils.doImport.firstCall.args[0].toString(),
         'to be',
-        'file:///foo/bar.mjs?foo=bar'
+        `${url.pathToFileURL('/foo/bar.mjs').toString()}?foo=bar`
       );
     });
   });

--- a/test/node-unit/esm-utils.spec.js
+++ b/test/node-unit/esm-utils.spec.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const esmUtils = require('../../lib/nodejs/esm-utils');
+const sinon = require('sinon');
+
+describe('esm-utils', function () {
+  beforeEach(function () {
+    sinon.stub(esmUtils, 'doImport').resolves({});
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('loadFilesAsync()', function () {
+    it('should not decorate imported module if no decorator passed', async function () {
+      await esmUtils.loadFilesAsync(
+        ['/foo/bar.mjs'],
+        () => {},
+        () => {}
+      );
+
+      expect(
+        esmUtils.doImport.firstCall.args[0].toString(),
+        'to be',
+        'file:///foo/bar.mjs'
+      );
+    });
+
+    it('should decorate imported module with passed decorator', async function () {
+      await esmUtils.loadFilesAsync(
+        ['/foo/bar.mjs'],
+        () => {},
+        () => {},
+        x => `${x}?foo=bar`
+      );
+
+      expect(
+        esmUtils.doImport.firstCall.args[0].toString(),
+        'to be',
+        'file:///foo/bar.mjs?foo=bar'
+      );
+    });
+  });
+});

--- a/test/node-unit/mocha.spec.js
+++ b/test/node-unit/mocha.spec.js
@@ -48,6 +48,9 @@ describe('Mocha', function () {
     stubs.Suite = sinon.stub().returns(stubs.suite);
     stubs.Suite.constants = {};
     stubs.ParallelBufferedRunner = sinon.stub().returns({});
+    stubs.esmUtils = {
+      loadFilesAsync: sinon.stub()
+    };
     const runner = Object.assign(sinon.createStubInstance(EventEmitter), {
       runAsync: sinon.stub().resolves(0),
       globals: sinon.stub(),
@@ -66,6 +69,7 @@ describe('Mocha', function () {
         '../../lib/suite.js': stubs.Suite,
         '../../lib/nodejs/parallel-buffered-runner.js':
           stubs.ParallelBufferedRunner,
+        '../../lib/nodejs/esm-utils': stubs.esmUtils,
         '../../lib/runner.js': stubs.Runner,
         '../../lib/errors.js': stubs.errors
       })
@@ -216,6 +220,21 @@ describe('Mocha', function () {
         expect(cb => {
           mocha.loadFiles(cb);
         }, 'to call the callback');
+      });
+    });
+
+    describe('loadFilesAsync()', function () {
+      it('shoud pass esmDecorator to actual load function', async function () {
+        const esmDecorator = x => `${x}?foo=bar`;
+
+        await mocha.loadFilesAsync({esmDecorator});
+
+        expect(stubs.esmUtils.loadFilesAsync, 'was called once');
+        expect(
+          stubs.esmUtils.loadFilesAsync.firstCall.args[3],
+          'to be',
+          esmDecorator
+        );
       });
     });
 


### PR DESCRIPTION
### Description of the Change
This PR adds ability to decorate ESM-module name right before it will be imported by passing `esmDecorator` function to `loadFilesAsync` method.

### Why should this be in core?

It helps to deal with ESM cashing issues just by adding some query parameters to modue name:
```js
mocha.loadFilesAsync({
    esmDecorator: file => `${file}?foo=bar`
})
```
And it backwards compatible.
Note though that the sub-dependencies of the test files will not be reloaded.

### Applicable issues
- https://github.com/mochajs/mocha/issues/4655

It is an enhancement (minor release).
