### PR TITLE
fix(browser): failed test icon color

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -193,7 +193,7 @@ body {
   display: block;
   float: left;
   margin-right: 5px;
-  color: var(--mocha-pass-icon-color);
+  color: var(--mocha-test-fail-icon-color);
 }
 
 #mocha .test pre.error {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Due to the wrong variable being referenced in `#mocha .test.fail::before`, the failed test icon (`✖`) is currently incorrectly colored as `#00d6b2` instead of `#cc0000` (light schema) or `#ff4444` (dark schema). See for example the screenshot posted in comment https://github.com/mochajs/mocha/pull/4896#issuecomment-1229477806.

### Alternate Designs

n/a - this is clearly a bug fix.

### Why should this be in core?

n/a - this is clearly a bug fix.

### Benefits

Users may now notice test errors more easily, which makes developers, especially the UX/UI ones, happier.

### Possible Drawbacks

n/a - this is clearly a bug fix.

### Applicable issues

Regressed since https://github.com/mochajs/mocha/pull/4896, mentioned 15 days ago (as a review comment) in https://github.com/mochajs/mocha/pull/4896#discussion_r1008725810, but since there was no response to that, I decided to open this PR.