### PR TITLE
fix: delay parallel pool termination to prevent false negatives

### DIFF
--- a/lib/nodejs/parallel-buffered-runner.js
+++ b/lib/nodejs/parallel-buffered-runner.js
@@ -325,9 +325,6 @@ class ParallelBufferedRunner extends Runner {
           files.map(this._createFileRunner(pool, options))
         );
 
-        // note that pool may already be terminated due to --bail
-        await pool.terminate();
-
         results
           .filter(({status}) => status === 'rejected')
           .forEach(({reason}) => {
@@ -356,6 +353,10 @@ class ParallelBufferedRunner extends Runner {
           throw err;
         });
       } finally {
+        // note that pool may already be terminated due to --bail
+        if (pool && pool.terminate) {
+          await pool.terminate();
+        }
         clearInterval(debugInterval);
         process.removeListener('SIGINT', sigIntListener);
       }


### PR DESCRIPTION
I found that moving `await pool.terminate()` into the finally block here could prevent some false negatives, where tests could fail but node would mysteriously exit 0 anyway. (That is, by "false negative", I mean that the mocha test suite gave a passing exit code when it should have failed.)

### Description of the Change

We saw some sporadic cases where a mixture of tests run with `--parallel` would exit clean with code 0 despite there being some test failures. It's difficult to reproduce. (One specific case can be found in the PrairieLearn project issue linked on this PR.) After some experimentation, I found that the call to `await pool.terminate()` here is sometimes causing the entire node process to immediately exit with 0. I'm not entirely sure of the cause, but it may be due to the unusual implementation of cancellable promises in the `workerpool` library (named `Promise` like the official JS version, but different). When the false negative issue arises in `pool.terminate()`, the calls seem to descend into the version of `Promise.all` in `workerpool` and then suddenly exit. It may be that some signal handlers for uncaught exceptions are misconfigured somewhere.

At any rate, when I move this call to `await pool.terminate();` later in the code (into the `finally` block), the test results appear to accurately show when at least one test has failed or not. Maybe someone else can test this if they've seen anything similar.

### Alternate Designs

I tried to figure out a way to fix the issue in the `workerpool` library's handling of Promise.all (which uses its own Promise type, not the standard JS one), since the call to `terminate` here ultimately ends up there. But I couldn't conclusively determine if the issue was arising there.

Even without this change, it _does_ work to use `--bail` with `--parallel` and still catch the first failure that way. But then, the downside would be that the CI test run won't include test results beyond the first failure.

### Why should this be in core?

The `--parallel` feature sometimes has false negatives (failed tests that show as passing with exit 0 in CI).

### Benefits

This change successfully catches some unusual failing cases in the particular situation we saw on the PrairieLearn project. I'm not entirely certain, but I think it doesn't hurt anything to terminate the pool later, in the finally block.

### Possible Drawbacks

I don't know if this will cause new false negatives or false positives for other users in strange cases. The underlying issue(s) may be in the `workerpool` library, in which case it could theoretically be fixed without changing the mocha code at all.

### Applicable issues

Maybe related somehow to https://github.com/mochajs/mocha/issues/4559

Hopefully fixes https://github.com/PrairieLearn/PrairieLearn/issues/6940

### Possibility of breaking change

This may be a harmless bug fix _or_ a breaking change. I won't know unless more people test it.