### PR TITLE
Fix deprecated warn gh actions

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -33,7 +33,7 @@ jobs:
           SAUCE_USERNAME: '${{secrets.SAUCE_USERNAME}}'
           SAUCE_ACCESS_KEY: '${{secrets.SAUCE_ACCESS_KEY}}'
       - name: remove 'run-browser-test' label
-        uses: buildsville/add-remove-label@v1
+        uses: buildsville/add-remove-label@v2.0.0
         if: ${{ always() }}
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -103,7 +103,7 @@ jobs:
         id: npm-cache
         if: ${{ matrix.os == 'windows-2019' }}
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $env:GITHUB_OUTPUT
       - name: 'Cache node_modules'
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Fix deprecation warnning on GitHub Actions

* Node.js 12 actions are deprecated on [browser test](https://github.com/mochajs/mocha/actions/runs/3613741323).
* `set-output` command is deprecated on [tests](https://github.com/mochajs/mocha/actions/runs/3669300442).

`set-output` will be removed on June 1st and Node.js 12 will be unsupported in this summer.

There are still warns for `coverallsapp/github-action@master`. But coveralls don't update their actions yet. We should wait it or consider another option.