### PR TITLE
Add Node v19 to test matrix

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -45,6 +45,7 @@ jobs:
           - 14
           - 16
           - 18
+          - 19
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -89,6 +90,7 @@ jobs:
           - 14
           - 16
           - 18
+          - 19
         include:
           - os: ubuntu-latest
             node: 16

--- a/package.json
+++ b/package.json
@@ -27,10 +27,6 @@
   "bugs": {
     "url": "https://github.com/mochajs/mocha/issues/"
   },
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/mochajs"
-  },
   "gitter": "https://gitter.im/mochajs/mocha",
   "homepage": "https://mochajs.org/",
   "logo": "https://cldup.com/S9uQ-cOLYz.svg",


### PR DESCRIPTION
### Description of the Change

Add Node v19 to test CI matrix.
Initial release: 2022-10-18