### PR TITLE
fix!: correct precedence of configuration extends and defaults 

### DIFF
--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('mocha:cli:config');
 const findUp = require('find-up');
+const yargs = require('yargs/yargs');
 const {createUnparsableFileError} = require('../errors');
 const utils = require('../utils');
 
@@ -76,6 +77,10 @@ exports.loadConfig = filepath => {
     } else {
       config = parsers.json(filepath);
     }
+
+    config = yargs(undefined, path.dirname(filepath))
+      .parserConfiguration(require('./options').YARGS_PARSER_CONFIG)
+      .config(config);
   } catch (err) {
     throw createUnparsableFileError(
       `Unable to read/parse ${filepath}: ${err}`,

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -78,7 +78,7 @@ exports.loadConfig = filepath => {
       config = parsers.json(filepath);
     }
 
-    const {$0, ...options} = yargs(undefined, path.dirname(filepath))
+    const {$0, ...options} = yargs(config._, path.dirname(filepath))
       .parserConfiguration(require('./options').YARGS_PARSER_CONFIG)
       .config(config).argv;
 

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -78,9 +78,11 @@ exports.loadConfig = filepath => {
       config = parsers.json(filepath);
     }
 
-    config = yargs(undefined, path.dirname(filepath))
+    const {$0, ...options} = yargs(undefined, path.dirname(filepath))
       .parserConfiguration(require('./options').YARGS_PARSER_CONFIG)
-      .config(config);
+      .config(config).argv;
+
+    config = options;
   } catch (err) {
     throw createUnparsableFileError(
       `Unable to read/parse ${filepath}: ${err}`,

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -11,7 +11,6 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('mocha:cli:config');
 const findUp = require('find-up');
-const yargs = require('yargs/yargs');
 const {createUnparsableFileError} = require('../errors');
 const utils = require('../utils');
 
@@ -77,12 +76,6 @@ exports.loadConfig = filepath => {
     } else {
       config = parsers.json(filepath);
     }
-
-    const {$0, ...options} = yargs(config._, path.dirname(filepath))
-      .parserConfiguration(require('./options').YARGS_PARSER_CONFIG)
-      .config(config).argv;
-
-    config = options;
   } catch (err) {
     throw createUnparsableFileError(
       `Unable to read/parse ${filepath}: ${err}`,

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -8,7 +8,9 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const ansi = require('ansi-colors');
+const yargs = require('yargs/yargs');
 const yargsParser = require('yargs-parser');
 const {
   types,
@@ -212,7 +214,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
 const loadRc = (args = {}) => {
   if (args.config !== false) {
     const config = args.config || findConfig();
-    return config ? loadConfig(config) : {};
+    return config ? loadRcFile(loadConfig(config), config) : {};
   }
 };
 
@@ -254,7 +256,7 @@ const loadPkgRc = (args = {}) => {
       const pkg = JSON.parse(configData);
       if (pkg.mocha) {
         debug('`mocha` prop of package.json parsed: %O', pkg.mocha);
-        result = pkg.mocha;
+        result = loadRcFile(pkg.mocha, filepath);
       } else {
         debug('no config found in %s', filepath);
       }
@@ -270,6 +272,20 @@ const loadPkgRc = (args = {}) => {
 };
 
 module.exports.loadPkgRc = loadPkgRc;
+
+/**
+ * Loads the inherited configuration of the rc file located at the specified {@linkcode filePath}.
+ *
+ * @param {Object} config - The parsed configuration of the rc file.
+ * @param {string} filePath - The name of the file containing the parsed configuration.
+ */
+const loadRcFile = (config, filePath) => {
+  const {$0, ...options} = yargs(config._, path.dirname(filePath))
+    .parserConfiguration(configuration)
+    .config(config).argv;
+
+  return options;
+};
 
 /**
  * Priority list:

--- a/test/integration/fixtures/config/mocharc-extended/.mocharc.json
+++ b/test/integration/fixtures/config/mocharc-extended/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./extends.json"
+}

--- a/test/integration/fixtures/config/mocharc-extended/base.json
+++ b/test/integration/fixtures/config/mocharc-extended/base.json
@@ -1,0 +1,6 @@
+{
+  "require": ["foo", "bar"],
+  "bail": true,
+  "reporter": "dot",
+  "slow": 60
+}

--- a/test/integration/fixtures/config/mocharc-extended/extends.json
+++ b/test/integration/fixtures/config/mocharc-extended/extends.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./modifiers.json"
+}

--- a/test/integration/fixtures/config/mocharc-extended/extends.json
+++ b/test/integration/fixtures/config/mocharc-extended/extends.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./modifiers.json"
+  "extends": "./modifiers.json",
+  "_": ["**/*.spec.js"]
 }

--- a/test/integration/fixtures/config/mocharc-extended/modifiers.json
+++ b/test/integration/fixtures/config/mocharc-extended/modifiers.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./base.json",
+  "reporter": "html",
+  "slow": 30
+}

--- a/test/integration/fixtures/config/mocharc-extended/package-lock.json
+++ b/test/integration/fixtures/config/mocharc-extended/package-lock.json
@@ -1,0 +1,6 @@
+{
+    "mocha": {
+        "extends": "./extends.json",
+        "grep": "package"
+    }
+}

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -42,4 +42,16 @@ describe('options', function () {
     expect(extended.reporter, 'to equal', 'html');
     expect(extended.slow, 'to equal', 30);
   });
+
+  it('Should support extended options using package.json', function () {
+    var extended = loadOptions([
+      '--package',
+      path.join(workspaceDir, 'package-lock.json')
+    ]);
+    expect(extended.require, 'to equal', ['foo', 'bar']);
+    expect(extended.bail, 'to equal', true);
+    expect(extended.reporter, 'to equal', 'html');
+    expect(extended.slow, 'to equal', 30);
+    expect(extended.grep, 'to equal', 'package');
+  });
 });

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -11,6 +11,7 @@ describe('options', function () {
     'config',
     'mocharc-extended'
   );
+  const configFile = path.join(workspaceDir, 'extends.json');
 
   beforeEach(function () {
     workingDirectory = process.cwd();
@@ -21,11 +22,13 @@ describe('options', function () {
     process.chdir(workingDirectory);
   });
 
+  it('Should load `_`-option properly', function () {
+    var extended = loadOptions(['--config', configFile]);
+    expect(extended._, 'to equal', ['**/*.spec.js']);
+  });
+
   it('Should support extended options using --config parameter', function () {
-    var extended = loadOptions([
-      '--config',
-      path.join(workspaceDir, 'extends.json')
-    ]);
+    var extended = loadOptions(['--config', configFile]);
     expect(extended.require, 'to equal', ['foo', 'bar']);
     expect(extended.bail, 'to equal', true);
     expect(extended.reporter, 'to equal', 'html');

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -45,6 +45,7 @@ describe('options', function () {
 
   it('Should support extended options using package.json', function () {
     var extended = loadOptions([
+      '--no-config',
       '--package',
       path.join(workspaceDir, 'package-lock.json')
     ]);

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var path = require('path');
+var loadOptions = require('../../lib/cli/options').loadOptions;
+
+describe('options', function () {
+  it('Should support extended options', function () {
+    var configDir = path.join(
+      __dirname,
+      'fixtures',
+      'config',
+      'mocharc-extended'
+    );
+    var extended = loadOptions([
+      '--config',
+      path.join(configDir, 'extends.json')
+    ]);
+    expect(extended.require, 'to equal', ['foo', 'bar']);
+    expect(extended.bail, 'to equal', true);
+    expect(extended.reporter, 'to equal', 'html');
+    expect(extended.slow, 'to equal', 30);
+  });
+});

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -43,6 +43,13 @@ describe('options', function () {
     expect(extended.slow, 'to equal', 30);
   });
 
+  it('Should support standalone options using standalone rc file', function () {
+    var extended = loadOptions(['--config', configFileStandalone]);
+    expect(extended.require, 'to equal', ['foo', 'bar']);
+    expect(extended.bail, 'to equal', true);
+    expect(extended.reporter, 'to equal', 'dot');
+    expect(extended.slow, 'to equal', 60);
+  });
   it('Should support extended options using package.json', function () {
     var extended = loadOptions([
       '--no-config',

--- a/test/integration/options.spec.js
+++ b/test/integration/options.spec.js
@@ -4,17 +4,36 @@ var path = require('path');
 var loadOptions = require('../../lib/cli/options').loadOptions;
 
 describe('options', function () {
-  it('Should support extended options', function () {
-    var configDir = path.join(
-      __dirname,
-      'fixtures',
-      'config',
-      'mocharc-extended'
-    );
+  var workingDirectory;
+  const workspaceDir = path.join(
+    __dirname,
+    'fixtures',
+    'config',
+    'mocharc-extended'
+  );
+
+  beforeEach(function () {
+    workingDirectory = process.cwd();
+    process.chdir(workspaceDir);
+  });
+
+  afterEach(function () {
+    process.chdir(workingDirectory);
+  });
+
+  it('Should support extended options using --config parameter', function () {
     var extended = loadOptions([
       '--config',
-      path.join(configDir, 'extends.json')
+      path.join(workspaceDir, 'extends.json')
     ]);
+    expect(extended.require, 'to equal', ['foo', 'bar']);
+    expect(extended.bail, 'to equal', true);
+    expect(extended.reporter, 'to equal', 'html');
+    expect(extended.slow, 'to equal', 30);
+  });
+
+  it('Should support extended options using rc file', function () {
+    var extended = loadOptions([]);
     expect(extended.require, 'to equal', ['foo', 'bar']);
     expect(extended.bail, 'to equal', true);
     expect(extended.reporter, 'to equal', 'html');


### PR DESCRIPTION
### Description of the Change

- [x] Addresses an existing open issue: fixes #3916
- [x] That issue was marked as [status: accepting prs](https://github.com/mochajs/mocha/issues?q=sort%3Aupdated-desc+is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md?rgh-link-date=2026-04-18T14%3A45%3A43Z) were taken

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

As described in issue #4979, due to `mocha` first loading its default settings and after doing so processing the arguments using `args`, there are some settings which cannot be inherited by specifying an `extends` file:

  - First, default values get loaded:
    https://github.com/mochajs/mocha/blob/37deed262d4bc0788d32c66636495d10038ad398/lib/cli/options.js#L246
  - Sometime later, the configuration gets processed:
    https://github.com/mochajs/mocha/blob/37deed262d4bc0788d32c66636495d10038ad398/lib/cli/cli.js#L77

Changes made in this PR processes configuration files using `yargs` right after they have been parsed. Thus, the order of events is now the following:
  - RC files are parsed
    - RC files are processed using `yargs`
  - `package.json` settings are loaded
  - Collected configs and `argv` get merged
  - `mocha`s default values (from `lib/mocharc.json`) get applied

### Alternate Designs

Configuration files could be processed right before `mocha`s defaults get applied. However, the context of the file path would get lost thus causing relative `extends` paths to possibly fail.

Applying `mocha`s default values could be removed from here:
https://github.com/mochajs/mocha/blob/37deed262d4bc0788d32c66636495d10038ad398/lib/cli
And instead be done somewhere around here (after `yargs` has been executed):
https://github.com/mochajs/mocha/blob/37deed262d4bc0788d32c66636495d10038ad398/lib/cli/cli.js#L47

### Why should this be in core?

Currently, the inheritance will not work for a number of settings while other settings do. This might cause confusion and unexpected results. Thus, I'd recommend to have this change in core. 

### Benefits

<!-- What benefits will be realized by the code change? -->
All settings will be able to be inherited while `mocha`s defaults still get applied if necessary.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None that I have heard of.
If people already used `extends` for their own project, there is a chance that they relied on the inheritance of `ui` to not work, so there is a small possibility they will have to perform a one-time change to their config file.

### Applicable issues
* Enter any applicable Issues here.
  - #4979
  - #3916
  - Original PR: #4407

* Mocha follows semantic versioning: http://semver.org
* [ ] ~~Is this a breaking change (major release)?~~
* [ ] Is it an enhancement (minor release)? (Maybe?)
* [x] Is it a bug fix, or does it not impact production code (patch release)?

Or probably a minor as there is a small possibility people have to adjust their configuration if they used `extends` before

Fixes #4979
Fixes #3916

Co-authored-by: Pat Herlihy @mf-pherlihy