### PR TITLE
fix: ensure that the xunit reporter emits well-formed XML

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,7 @@ var util = require('util');
 var he = require('he');
 
 const MOCHA_ID_PROP_NAME = '__mocha_id__';
+const RESTRICTED_CHAR = /[\x01-\x08\x0B-\x0C\x0E-\x1F\x7F-\x84\x86-\x9F]/g;
 
 /**
  * Inherit the prototype methods from one constructor into another.
@@ -35,6 +36,7 @@ exports.inherits = util.inherits;
  * @return {string}
  */
 exports.escape = function (html) {
+  html = html.toString().replaceAll(RESTRICTED_CHAR, "�");
   return he.encode(String(html), {useNamedReferences: false});
 };
 

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -357,6 +357,45 @@ describe('XUnit reporter', function () {
         expect(expectedWrite, 'to be', expectedTag);
       });
 
+      it('should write well-formed XML', function () {
+        var xunit = new XUnit(runner);
+        var inputMessage = '\x1Bsome message';
+        expectedMessage = '&#xFFFD;some message';
+        var expectedTest = {
+          state: STATE_FAILED,
+          title: expectedTitle,
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            }
+          },
+          duration: 1000,
+          err: {
+            actual: 'foo',
+            expected: 'bar',
+            message: inputMessage,
+            stack: expectedStack
+          }
+        };
+
+        xunit.test.call(fakeThis, expectedTest);
+        sinon.restore();
+
+        var expectedTag =
+          '<testcase classname="' +
+          expectedClassName +
+          '" name="' +
+          expectedTitle +
+          '" time="1"><failure>' +
+          expectedMessage +
+          '\n' +
+          expectedDiff +
+          '\n' +
+          expectedStack +
+          '</failure></testcase>';
+        expect(expectedWrite, 'to be', expectedTag);
+      });
+
       it('should handle non-string diff values', function () {
         var runner = new EventEmitter();
         createStatsCollector(runner);


### PR DESCRIPTION

Edit: I have updated this PR to fix the bug in addition to creating a failing test.

### Description of the Change

From the PR:

    XML does not allow certain characters to appear in documents. This
    change ensures that those restricted characters are replaced by legal
    characters.

    This bug means that when a test ends up containing, for example, ANSI
    color codes (i.e. `&#x1B;[36m&#x3C;div&#x1B;[39m`) then the generated
    XML file is invalid and some consumers (such as CircleCI) are unable to
    parse the contents.

    Link: https://www.w3.org/TR/2006/REC-xml11-20060816/#charsets

### Alternate Designs

This is a lossy conversion. An alternative to displaying the replacement character would be to display some message explaining what character has been replaced. This is a lot less verbose and will be easier to read when your tests are outputting ANSI control codes, and if the original text is needed you can rerun the tests locally.

### Why should this be in core?

This is a bug. Mocha is generating malformed XML documents that cannot be parsed.

### Benefits

XML documents generated by the XUnit reporter are now well-formed and thus can be parsed.

### Possible Drawbacks

It's a lossy conversion. Probably 99% of the time it's going to be an ANSI control code being removed.

### Applicable issues

This is a bug fix.