### PR TITLE
docs: Add warning about async callback for describe

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -296,6 +296,10 @@ describe('#find()', function () {
 });
 ```
 
+### Limitations of asynchronous callbacks
+
+You can use all three asynchronous patterns (`done`, `Promise`, and `async`/`await`) in callbacks for `it()` and for all hooks (`before()`, `after()`, `beforeEach()`, `afterEach()`), but `describe()` will not work correctly with an asynchronous callback -- it must be synchronous. This is because, in the "parsing" cycle all `describe` callbacks are excecuted and the test hierarchy (`runner`) is created, before any tests are run.
+
 ## Synchronous Code
 
 When testing synchronous code, omit the callback and Mocha will automatically continue on to the next test.

--- a/docs/index.md
+++ b/docs/index.md
@@ -298,7 +298,7 @@ describe('#find()', function () {
 
 ### Limitations of asynchronous callbacks
 
-You can use all three asynchronous patterns (`done`, `Promise`, and `async`/`await`) in callbacks for `it()` and for all hooks (`before()`, `after()`, `beforeEach()`, `afterEach()`), but `describe()` will not work correctly with an asynchronous callback -- it must be synchronous. This is because, in the "parsing" cycle all `describe` callbacks are excecuted and the test hierarchy (`runner`) is created, before any tests are run.
+You can use all three asynchronous patterns (`done`, `Promise`, and `async`/`await`) in callbacks for `it()` and for all hooks (`before()`, `after()`, `beforeEach()`, `afterEach()`), but `describe()` will not work correctly with an asynchronous callback -- it must be synchronous. This is because in the "parsing" cycle all `describe` callbacks are executed and the test hierarchy (`runner`) is created before any tests are run.
 
 ## Synchronous Code
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -298,7 +298,8 @@ describe('#find()', function () {
 
 ### Limitations of asynchronous callbacks
 
-You can use all three asynchronous patterns (`done`, `Promise`, and `async`/`await`) in callbacks for `it()` and for all hooks (`before()`, `after()`, `beforeEach()`, `afterEach()`), but `describe()` will not work correctly with an asynchronous callback -- it must be synchronous. This is because in the "parsing" cycle all `describe` callbacks are executed and the test hierarchy (`runner`) is created before any tests are run.
+You can use all asynchronous callbacks (`done`, `Promise`, and `async`/`await`) in callbacks for `it()`, `before()`, `after()`, `beforeEach()`, `afterEach()`) but not `describe()` -- it must be synchronous.
+See [#5046](https://github.com/mochajs/mocha/pull/5046) for more information.
 
 ## Synchronous Code
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. Keep in mind that the maintainers and/or community members reviewing this PR may not be familiar with the subsystem. Please be verbose.

-->

This is a documentation only change.

I couldn't find any reference to `describe` not supporting an async callback. It seems like a natural conclusion to draw, given mocha specializes in async tests, and given `it` and hook do.

I spent considerable time trying to figure out why an async test was failing in one of my modules before I discovered the reason deep in an issue discussion (https://github.com/mochajs/mocha/issues/2975#issuecomment-1004176440)!

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why should this be in core?

<!-- Explain why this functionality should be in mocha as opposed to its own package -->

This is a documentation change.

### Benefits

<!-- What benefits will be realized by the code change? -->

I hope that this helps others design their test suites (I saw a number of comments about spending 'lots of time' trying to figure this out).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!--
* Enter any applicable Issues here.

* Mocha follows semantic versioning: http://semver.org

* Is this a breaking change (major release)?
* Is it an enhancement (minor release)?
* Is it a bug fix, or does it not impact production code (patch release)?
-->

* #2975 
* #2116 
* #2085