### PR TITLE
docs: touchups to labels and a template title post-revamp

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,10 +59,10 @@ We ask you please keep these goals in mind when making or proposing changes.
 
 _Excellent._ Here's how:
 
-- **Handy with JavaScript?** Please check out the issues labeled [`help wanted`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [`good-first-issue`](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Agood-first-issue).
+- **Handy with JavaScript?** Please check out the issues labeled [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [`good first issue`](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+).
   Try `npx good-first-issue mocha`!
 - **Can you write ~~good~~ well?** The [documentation](https://mochajs.org) almost always needs some love.
-  See the [doc-related issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3Adocumentation).
+  See the [doc-related issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22area%3A+documentation%22).
 - **Design your thing?** [Our site](https://mochajs.org) needs your magic touch.
 - **Familiar with Mocha's codebase?** We could use your help triaging issues and/or reviewing pull requests.
   Please contact an [org member](https://github.com/orgs/mochajs/people), and we'll chat.

--- a/.github/ISSUE_TEMPLATE/04-repository-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/04-repository-tooling.yml
@@ -27,4 +27,4 @@ description: Report a bug or request an enhancement in the Mocha repository's in
 labels:
   - "area: repository-tooling"
 name: 🛠 Repository Tooling
-title: "🛠 Repository Tooling: <short description of the change>"
+title: "🛠 Repo: <short description of the change>"

--- a/.github/ISSUE_TEMPLATE/04-repository-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/04-repository-tooling.yml
@@ -25,6 +25,6 @@ body:
     type: textarea
 description: Report a bug or request an enhancement in the Mocha repository's internal tooling
 labels:
-  - "area: repository-tooling"
+  - "area: repository tooling"
 name: 🛠 Repository Tooling
 title: "🛠 Repo: <short description of the change>"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ You might want to know that:
 
 You might want to help:
 
-- New to contributing to Mocha? Check out this list of [good first issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
-- Mocha could use a hand with [these issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- New to contributing to Mocha? Check out this list of [good first issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+- Mocha could use a hand with [these issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
 - The [maintainer's handbook](https://github.com/mochajs/mocha/blob/master/MAINTAINERS.md) explains how things get done
 
 Finally, come [chat with the maintainers on Discord](https://discord.gg/KeDn2uXhER) if you want to help with:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing ~open~ ~issue~: continues #5038
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes up issue query links. It was easier to merge to `master` then get make sure each issue query was correct in "production".

Also I noticed we'd been using `🛠️ Tooling: ` as the effective tooling issue title prefix, so updated the template to use that... then updated it to the even shorter `🛠️ Repo:` so folks don't get confused between it and end-user Mocha tools.