### PR TITLE
fix: add alt text to Built with Netlify badge

### DIFF
--- a/docs/_includes/default.liquid
+++ b/docs/_includes/default.liquid
@@ -129,7 +129,7 @@
           </li>
         </ul>
         <div class="netlify-badge">
-          <a href="https://www.netlify.com">
+          <a alt="Built with Netlify (Netlify logo)" href="https://www.netlify.com">
             <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" loading="lazy">
           </a>
         </div>

--- a/docs/_includes/default.liquid
+++ b/docs/_includes/default.liquid
@@ -129,8 +129,8 @@
           </li>
         </ul>
         <div class="netlify-badge">
-          <a alt="Built with Netlify (Netlify logo)" href="https://www.netlify.com">
-            <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" loading="lazy">
+          <a href="https://www.netlify.com">
+            <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Built with Netlify (Netlify logo)" loading="lazy">
           </a>
         </div>
       </div>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5066
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds alt text matching the image's current contents.