### PR TITLE
fix: use original Error object for uncaught errors when provided in browser

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -71,8 +71,11 @@ process.listenerCount = function (name) {
 
 process.on = function (e, fn) {
   if (e === 'uncaughtException') {
-    global.onerror = function (err, url, line) {
-      fn(new Error(err + ' (' + url + ':' + line + ')'));
+    global.onerror = function (err, url, line, colno, error) {
+      if (!error) {
+        error = new Error(err + ' (' + url + ':' + line + ')');
+      }
+      fn(error);
       return !mocha.options.allowUncaught;
     };
     uncaughtExceptionHandlers.push(fn);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes ~958 (which is closed but not really fixed)~ #5106
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In case of uncaught errors, mocha would print only the error message, which is essentially the first line of the stack trace. The actual stack trace was unused. This is essentially https://github.com/mochajs/mocha/pull/2403 which was closed for inactivity.

Here's a fiddle demonstrating the problem: https://jsfiddle.net/Lru1q4n6/ (updated from the PR above). Unfortunately, I don't know how to demonstrate the fix there. Of course it does work locally, I used this fix to debug our tests.

Co-authored-by: @mgiuffrida 