### PR TITLE
chore: bump ESLint ecmaVersion to 2020

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ module.exports = [
   {
     ...js.configs.recommended,
     languageOptions: {
-      ecmaVersion: 2018,
+      ecmaVersion: 2020,
       globals: {
         ...globals.browser,
         ...globals.node


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5103
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md) were taken

## Overview

Bumps the lint preset version so we can use `?.`.