### PR TITLE
fix: eleventy template builds crash with 'unexpected token at ": string, msg..."'

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -227,7 +227,7 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
  * @private
  * @param {Error} err
  * @param {Set<Error>} [seen]
- * @return {{ message: string, msg: string, stack: string }}
+ * @return {FullErrorStack}
  */
 var getFullErrorStack = function (err, seen) {
   if (seen && seen.has(err)) {
@@ -580,3 +580,12 @@ function sameType(a, b) {
 Base.consoleLog = consoleLog;
 
 Base.abstract = true;
+
+/**
+ * An object with all stack traces recursively mounted from each err.cause
+ * @memberof module:lib/reporters/base
+ * @typedef {Object} FullErrorStack
+ * @property {string} message
+ * @property {string} msg
+ * @property {string} stack
+ */


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5115
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md) were taken

## Overview

Eleventy wasn't being able to parse the JSDocs for the returned type on the getFullErrorStack function. Defining it as a new type and then referencing it on the function fixes the issue.
Running `npm run docs` on this branch should work now.
