### PR TITLE
chore: rename 'master' to 'main' in docs and tooling

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -100,4 +100,4 @@ This is a foundation-wide team established to manage escalation when a reporter 
 In order to escalate to the CoCP send an email to `"coc-escalation@lists.openjsf.org`.
 
 For more information, refer to the full
-[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/master/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/main/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -100,4 +100,4 @@ This is a foundation-wide team established to manage escalation when a reporter 
 In order to escalate to the CoCP send an email to `"coc-escalation@lists.openjsf.org`.
 
 For more information, refer to the full
-[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/main/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/tree/main/proposals/approved/CODE_OF_CONDUCT).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,11 +99,11 @@ Then:
    - Add detail in subsequent lines.
    - A pre-commit hook will run which automatically formats your staged changes (and fixes any problems it can) with ESLint and Prettier.
      If ESLint fails to fix an issue, your commit will fail and you will need to manually correct the problem.
-1. <a name="up-to-date"/> (Optional) Ensure you are up-to-date with Mocha's `master` branch:
+1. <a name="up-to-date"/> (Optional) Ensure you are up-to-date with Mocha's `main` branch:
    - You can add an "upstream" remote repo using `git remote add upstream https://github.com/mochajs/mocha.git && git fetch upstream`.
-   - Navigate to your `master` branch using `git checkout master`.
-   - Pull changes from `upstream` using `git pull upstream master`.
-   - If any changes were pulled in, update your branch from `master` by switching back to your branch (`git checkout <your-branch>`) then merging using `git merge master`.
+   - Navigate to your `main` branch using `git checkout main`.
+   - Pull changes from `upstream` using `git pull upstream main`.
+   - If any changes were pulled in, update your branch from `main` by switching back to your branch (`git checkout <your-branch>`) then merging using `git merge main`.
 1. Push your changes to your fork; `git push origin`.
 1. In your browser, navigate to [mochajs/mocha](https://github.com/mochajs/mocha).
    You should see a notification about your recent changes in your fork's branch, with a (green?) button to create a pull request.
@@ -126,7 +126,7 @@ Now that the pull request exists, some tasks will be run on it:
 1. Be patient while your PR is reviewed.
    This can take a while.
    We may request changes, but don't be afraid to question them.
-1. Your PR might become conflicted with the code in `master`.
+1. Your PR might become conflicted with the code in `main`.
    If this is the case, you will need to [update your PR](#up-to-date) and resolve your conflicts.
 1. You don't need to make a new PR to any needed changes.
    Instead, commit on top of your changes, and push these to your fork's branch.

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -3,7 +3,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Bug Report Checklist
       options:
-        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
+        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md)
           required: true
         - label: I have searched for [related issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue) and [issues with the `faq` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Afaq%20), but none matched my issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/02-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/02-documentation.yml
@@ -3,7 +3,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Documentation Request Checklist
       options:
-        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
+        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md)
           required: true
         - label: I have searched for [related issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue) and [issues with the `faq` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Afaq%20), but none matched my issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/03-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request.yml
@@ -3,7 +3,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Feature Request Checklist
       options:
-        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
+        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md)
           required: true
         - label: I have searched for [related issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue) and [issues with the `faq` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Afaq%20), but none matched my issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/04-repository-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/04-repository-tooling.yml
@@ -5,9 +5,9 @@ body:
       options:
         - label: I have tried restarting my IDE and the issue persists.
           required: true
-        - label: I have pulled the latest `master` branch of the repository.
+        - label: I have pulled the latest `main` branch of the repository.
           required: true
-        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
+        - label: I have read and agree to Mocha's [Code of Conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md)
           required: true
         - label: I have searched for [related issues](https://github.com/mochajs/mocha/issues?q=is%3Aissue) and [issues with the `faq` label](https://github.com/mochajs/mocha/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Afaq%20), but none matched my issue.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Otherwise we may not be able to review your PR. -->
 
 - [ ] Addresses an existing open issue: fixes #000
 - [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-- [ ] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md) were taken
+- [ ] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken
 
 ## Overview
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -12,7 +12,7 @@ name: Compliance
 on:
   pull_request:
     branches:
-      - master
+      - main
     types:
       - edited
       - opened

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,7 +25,7 @@ A "user" for the purpose of this document is any _individual developer_ who cons
 A user interacts with contributors.
 A user interacts with the software, web site, documentation, etc., which these contributors provide.
 
-As a user, you're expected to follow the [code of conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) when interacting in Mocha's "official" social spaces.
+As a user, you're expected to follow the [code of conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md) when interacting in Mocha's "official" social spaces.
 This includes:
 
 - Any channel under the `mochajs` Discord
@@ -54,7 +54,7 @@ Contributions include (but are not limited to):
 1. Researching the user base, getting feedback, etc. Don't spam.
 
 A contributor is _usually_ a user as well, but this isn't a hard-and-fast rule.
-A contributor is also expected to adhere to the [code of conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) as a user would.
+A contributor is also expected to adhere to the [code of conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md) as a user would.
 
 As you can see, it's wide open! Think of it another way: if you are _adding value to Mocha_, then you are a contributor.
 
@@ -123,7 +123,7 @@ You may choose to do zero or more of these _at their discretion_:
 - Add new maintainers to the team
 - Tag releases and publish Mocha to npm
 
-> While maintainers have the ability to commit directly to the `master` branch, _this is to be avoided_ if any other maintainer could reasonably take issue with the change, or the change affects Mocha's API or output.
+> While maintainers have the ability to commit directly to the `main` branch, _this is to be avoided_ if any other maintainer could reasonably take issue with the change, or the change affects Mocha's API or output.
 > For example, a spelling correction in `CHANGELOG.md` may not require a pull request.
 > A change to a reporter's output most certainly would! Maintainers are trusted to use their best judgement; if unsure, err on the side of caution.
 
@@ -347,8 +347,8 @@ Here are some suggestions:
 
 ## Branches
 
-`master` is the only maintained branch in `mochajs/mocha` or any of the other repos.
-**`master` is the only branch to which force-pushing is disallowed.**
+`main` is the only maintained branch in `mochajs/mocha` or any of the other repos.
+**`main` is the only branch to which force-pushing is disallowed.**
 
 Maintainers may push new branches to a repo, as long as they remove them when finished (merging a PR will prompt to do so).
 
@@ -371,7 +371,7 @@ Likewise, if the PR is `semver-minor`, create or use a new milestone correlating
 If it's unclear what the next milestone will be, use or create a milestone named `next`.
 This milestone will be renamed to the new version at release time.
 
-By using milestones, we can cherry-pick non-breaking changes into minor or patch releases, and keep `master` as the latest version.
+By using milestones, we can cherry-pick non-breaking changes into minor or patch releases, and keep `main` as the latest version.
 
 **This is subject to change, hopefully.**
 
@@ -380,7 +380,7 @@ By using milestones, we can cherry-pick non-breaking changes into minor or patch
 _It's easier to release often._
 
 1. Decide whether this is a `patch`, `minor`, or `major` release.
-1. Checkout `master` in your working copy & pull.
+1. Checkout `main` in your working copy & pull.
 1. Modify `CHANGELOG.md`; follow the existing conventions in that file.
    Use the "pull request" number, unless there isn't one.
    _You do not need to add Markdown links; this is done automatically._
@@ -391,15 +391,15 @@ _It's easier to release often._
    (Hint--use `-m`: e.g., `npm version patch -m 'Release v%s'`)
    1. This command will update the list of authors (from the Git history) in `AUTHORS`, and add GitHub links to `CHANGELOG.md`.
    1. These changes are then added to the Git "stage" and will be added to the commit.
-1. Push `master` to `origin` with your new tag; e.g. `git push origin master --tags`
+1. Push `main` to `origin` with your new tag; e.g. `git push origin main --tags`
 1. Copy & paste the `CHANGELOG.md` lines to a new GitHub "release".
    Save release as draft.
 1. Meanwhile, you can check [the build](https://travis-ci.org/mochajs/mocha) on Travis-CI and [GitHub Actions](https://github.com/mochajs/mocha/actions?query=workflow%3A%22Windows+CI%22).
    1. Once the build is green, you'll want to trigger an update of `mochajs.org`:
-   1. _If you're doing a prerelease_, fast-forward the `next` branch to `master`, and push it.
+   1. _If you're doing a prerelease_, fast-forward the `next` branch to `main`, and push it.
       This updates [https://next.mochajs.org](https://next.mochajs.org).
       That's all.
-   1. _If this is NOT a prerelease_, fast-forward the `mochajs.org` branch to `master` and push it.
+   1. _If this is NOT a prerelease_, fast-forward the `mochajs.org` branch to `main` and push it.
       This updates [https://mochajs.org](https://mochajs.org).
    1. _If this is a "final" release_ (the first release of a major _after_ one or more prereleases) then remove the `next` tag from npm via `npm dist-tag rm next`.
 1. Finally, you're satisfied with the release notes, open your draft release on GitHub, then click "publish."

--- a/PROJECT_CHARTER.md
+++ b/PROJECT_CHARTER.md
@@ -32,7 +32,7 @@ The **Mocha** project is part of the [OpenJS Foundation], which operates transpa
   - Command-line execution and options
   - Browser-based execution and options
   - [Project administration](https://github.com/mochajs/admin)
-  - [Contribution guide](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
+  - [Contribution guide](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md)
 - General support for multiple levels of tests, including (but not limited to):
   - Unit tests
   - Integration tests
@@ -72,7 +72,7 @@ Changes to the following **cannot** unilaterally be applied by project leadershi
 
 - Mocha's Project Charter (this document)
 - Mocha's [Code of Conduct]
-- Mocha's licenses: [MIT](https://github.com/mochajs/mocha/blob/master/LICENSE) (for code) and [CC-BY-4.0](https://github.com/mochajs/mocha/blob/master/docs/LICENSE-CC-BY-4.0) (for documentation/website)
+- Mocha's licenses: [MIT](https://github.com/mochajs/mocha/blob/main/LICENSE) (for code) and [CC-BY-4.0](https://github.com/mochajs/mocha/blob/main/docs/LICENSE-CC-BY-4.0) (for documentation/website)
 
 ### §3.1: Other Formal Project Relationships
 
@@ -103,5 +103,5 @@ Section Intentionally Left Blank
 Section Intentionally Left Blank
 
 [openjs foundation]: https://openjsf.org
-[maintainers.md]: https://github.com/mochajs/mocha/blob/master/MAINTAINERS.md
-[code of conduct]: https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md
+[maintainers.md]: https://github.com/mochajs/mocha/blob/main/MAINTAINERS.md
+[code of conduct]: https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">☕️ Simple, flexible, fun JavaScript test framework for Node.js & The Browser ☕️</p>
 
 <p align="center">
-<a href="https://github.com/mochajs/mocha/actions?query=workflow%3ATests+branch%3Amaster"><img src="https://github.com/mochajs/mocha/workflows/Tests/badge.svg?branch=master" alt="GitHub Actions Build Status"></a>
+<a href="https://github.com/mochajs/mocha/actions?query=workflow%3ATests+branch%3Amain"><img src="https://github.com/mochajs/mocha/workflows/Tests/badge.svg?branch=main" alt="GitHub Actions Build Status"></a>
 <a href="https://coveralls.io/github/mochajs/mocha"><img src="https://coveralls.io/repos/github/mochajs/mocha/badge.svg" alt="Coverage Status"></a>
 <a href="https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha?ref=badge_shield"><img src="https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha.svg?type=shield" alt="FOSSA Status"></a>
 <a href="https://discord.gg/KeDn2uXhER"><img alt="Chat - Discord" src="https://img.shields.io/badge/chat-Discord-5765F2.svg" /></a>
@@ -23,10 +23,10 @@
 ## Links
 
 - **[Documentation](https://mochajs.org)**
-- **[Release Notes / History / Changes](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md)**
-- [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md)
-- [Contributing](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md)
-- [Development](https://github.com/mochajs/mocha/blob/master/.github/DEVELOPMENT.md)
+- **[Release Notes / History / Changes](https://github.com/mochajs/mocha/blob/main/CHANGELOG.md)**
+- [Code of Conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md)
+- [Contributing](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md)
+- [Development](https://github.com/mochajs/mocha/blob/main/.github/DEVELOPMENT.md)
 - [Discord](https://discord.gg/KeDn2uXhER) (ask questions here!)
 - [Issue Tracker](https://github.com/mochajs/mocha/issues)
 
@@ -59,7 +59,7 @@ You might want to help:
 
 - New to contributing to Mocha? Check out this list of [good first issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 - Mocha could use a hand with [these issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-- The [maintainer's handbook](https://github.com/mochajs/mocha/blob/master/MAINTAINERS.md) explains how things get done
+- The [maintainer's handbook](https://github.com/mochajs/mocha/blob/main/MAINTAINERS.md) explains how things get done
 
 Finally, come [chat with the maintainers on Discord](https://discord.gg/KeDn2uXhER) if you want to help with:
 
@@ -69,6 +69,6 @@ Finally, come [chat with the maintainers on Discord](https://discord.gg/KeDn2uXh
 
 ## License
 
-Copyright 2011-2022 OpenJS Foundation and contributors. Licensed [MIT](https://github.com/mochajs/mocha/blob/master/LICENSE).
+Copyright 2011-2022 OpenJS Foundation and contributors. Licensed [MIT](https://github.com/mochajs/mocha/blob/main/LICENSE).
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha?ref=badge_large)

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,7 +13,7 @@ Otherwise, **you probably want the [main documentation](https://mochajs.org)**.
 ## Other Links
 
 - **[Main Documentation](https://mochajs.org)**
-- **[Release Notes / History / Changes](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md)**
-- [Code of Conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md)
+- **[Release Notes / History / Changes](https://github.com/mochajs/mocha/blob/main/CHANGELOG.md)**
+- [Code of Conduct](https://github.com/mochajs/mocha/blob/main/.github/CODE_OF_CONDUCT.md)
 - [Discord](https://discord.gg/KeDn2uXhER) (ask questions here!)
 - [Issue Tracker](https://github.com/mochajs/mocha/issues)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,6 @@ cp: docs/_dist/_headers: No such file or directory
 
 :copyright: 2016-2018 [JS Foundation](https://js.foundation) and contributors.
 
-Content licensed [CC-BY-4.0](https://raw.githubusercontent.com/mochajs/mocha/master/docs/LICENSE-CC-BY-4.0).
+Content licensed [CC-BY-4.0](https://raw.githubusercontent.com/mochajs/mocha/main/docs/LICENSE-CC-BY-4.0).
 
-Code licensed [MIT](https://raw.githubusercontent.com/mochajs/mocha/master/LICENSE-MIT).
+Code licensed [MIT](https://raw.githubusercontent.com/mochajs/mocha/main/LICENSE-MIT).

--- a/docs/api-tutorials/custom-reporter.md
+++ b/docs/api-tutorials/custom-reporter.md
@@ -13,7 +13,7 @@ If you're looking to get started quickly, here's an example of a custom reporter
 
 To use this reporter, execute `mocha --reporter /path/to/my-reporter.js`.
 
-For further examples, the built-in reporter implementations are the [best place to look](https://github.com/mochajs/mocha/tree/master/lib/reporters). The [integration tests](https://github.com/mochajs/mocha/tree/master/test/reporters) may also be helpful.
+For further examples, the built-in reporter implementations are the [best place to look](https://github.com/mochajs/mocha/tree/main/lib/reporters). The [integration tests](https://github.com/mochajs/mocha/tree/main/test/reporters) may also be helpful.
 
 ## The `Base` Reporter Class
 

--- a/docs/changelogs/README.md
+++ b/docs/changelogs/README.md
@@ -4,4 +4,4 @@ These are changelogs for (very) old versions of Mocha.
 
 These changelogs are _not_ included in the website, and are here only for archival purposes.
 
-_If you're looking for the current changelog, [here is the current changelog](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md)._
+_If you're looking for the current changelog, [here is the current changelog](https://github.com/mochajs/mocha/blob/main/CHANGELOG.md)._

--- a/docs/index.md
+++ b/docs/index.md
@@ -2350,7 +2350,7 @@ $ npm test
 In addition to chatting with us on [our Discord][discord-mocha], for additional information such as using
 spies, mocking, and shared behaviours be sure to check out the [Mocha Wiki][mocha-wiki] on GitHub.
 For a running example of Mocha, view [example/tests.html](example/tests.html). For the JavaScript API, view the [API documentation](api/)
-or the [source](https://github.com/mochajs/mocha/blob/master/lib/mocha.js).
+or the [source](https://github.com/mochajs/mocha/blob/main/lib/mocha.js).
 
 [//]: # 'Cross reference section'
 [bash-globbing]: https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
@@ -2362,14 +2362,14 @@ or the [source](https://github.com/mochajs/mocha/blob/master/lib/mocha.js).
 [discord-mocha]: https://discord.gg/KeDn2uXhER
 [emacs]: https://www.gnu.org/software/emacs/
 [emacs-mocha.el]: https://github.com/scottaj/mocha.el
-[example-babel]: https://github.com/mochajs/mocha-examples/tree/master/packages/babel
+[example-babel]: https://github.com/mochajs/mocha-examples/tree/main/packages/babel
 [example-connect-test]: https://github.com/senchalabs/connect/tree/master/test
 [example-express-test]: https://github.com/visionmedia/express/tree/master/test
-[example-mocha-test]: https://github.com/mochajs/mocha/tree/master/test
-[example-mocha-config]: https://github.com/mochajs/mocha/tree/master/example/config
+[example-mocha-test]: https://github.com/mochajs/mocha/tree/main/test
+[example-mocha-config]: https://github.com/mochajs/mocha/tree/main/example/config
 [example-superagent-test]: https://github.com/visionmedia/superagent/tree/master/test/node
-[example-third-party-reporter]: https://github.com/mochajs/mocha-examples/tree/master/packages/third-party-reporter
-[example-typescript]: https://github.com/mochajs/mocha-examples/tree/master/packages/typescript
+[example-third-party-reporter]: https://github.com/mochajs/mocha-examples/tree/main/packages/third-party-reporter
+[example-typescript]: https://github.com/mochajs/mocha-examples/tree/main/packages/typescript
 [example-websocket.io-test]: https://github.com/LearnBoost/websocket.io/tree/master/test
 [expect.js]: https://github.com/LearnBoost/expect.js
 [expresso]: https://github.com/tj/expresso


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5051
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md) were taken

## Overview

Roughly a straightforward find-and-replace.

Once this is approved, I can rename the branches here and in github.com/mochajs/mocha-examples.