### PR TITLE
feat: allow ^ versions for yargs packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "supports-color": "8.1.1",
         "workerpool": "6.2.1",
         "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.4",
+        "yargs-parser": "^20.2.9",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {
@@ -22257,9 +22257,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
       }
@@ -39717,9 +39717,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.4",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",

--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
     "strip-json-comments": "3.1.1",
     "supports-color": "8.1.1",
     "workerpool": "6.2.1",
-    "yargs": "16.2.0",
-    "yargs-parser": "20.2.4",
-    "yargs-unparser": "2.0.0"
+    "yargs": "^16.2.0",
+    "yargs-parser": "^20.2.4",
+    "yargs-unparser": "^2.0.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "supports-color": "8.1.1",
     "workerpool": "6.2.1",
     "yargs": "^16.2.0",
-    "yargs-parser": "^20.2.4",
+    "yargs-parser": "^20.2.9",
     "yargs-unparser": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5114 _(part of it)_
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `^` range to the following packages related to Yargs:

* `yargs`: no new _minor_ versions available - just new majors
* `yargs-parser`: new minor versions available, up to `20.2.9`
* `yargs-unparser`: latest version; hasn't been updated in 4 years