### PR TITLE
chore: fully clear require/import cache in non-parallel watch mode

### DIFF
--- a/lib/cli/handle-requires.js
+++ b/lib/cli/handle-requires.js
@@ -1,0 +1,38 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const debug = require('debug')('mocha:cli:handle:requires');
+const {requireOrImport} = require('../nodejs/esm-utils');
+const PluginLoader = require('../plugin-loader');
+
+/**
+ * `require()` the modules as required by `--require <require>`.
+ *
+ * Returns array of `mochaHooks` exports, if any.
+ * @param {string[]} requires - Modules to require
+ * @returns {Promise<object>} Plugin implementations
+ * @private
+ */
+exports.handleRequires = async (requires = [], {ignoredPlugins = []} = {}) => {
+  const pluginLoader = PluginLoader.create({ignore: ignoredPlugins});
+  for await (const mod of requires) {
+    let modpath = mod;
+    // this is relative to cwd
+    if (fs.existsSync(mod) || fs.existsSync(`${mod}.js`)) {
+      modpath = path.resolve(mod);
+      debug('resolved required file %s to %s', mod, modpath);
+    }
+    const requiredModule = await requireOrImport(modpath);
+    if (requiredModule && typeof requiredModule === 'object') {
+      if (pluginLoader.load(requiredModule)) {
+        debug('found one or more plugin implementations in %s', modpath);
+      }
+    }
+    debug('loaded required module "%s"', mod);
+  }
+  const plugins = await pluginLoader.finalize();
+  if (Object.keys(plugins).length) {
+    debug('finalized plugin implementations: %O', plugins);
+  }
+  return plugins;
+};

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -7,15 +7,12 @@
  * @private
  */
 
-const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('mocha:cli:run:helpers');
 const {watchRun, watchParallelRun} = require('./watch-run');
 const collectFiles = require('./collect-files');
 const {format} = require('util');
 const {createInvalidLegacyPluginError} = require('../errors');
-const {requireOrImport} = require('../nodejs/esm-utils');
-const PluginLoader = require('../plugin-loader');
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
@@ -73,38 +70,6 @@ const exitMocha = code => {
  */
 exports.list = str =>
   Array.isArray(str) ? exports.list(str.join(',')) : str.split(/ *, */);
-
-/**
- * `require()` the modules as required by `--require <require>`.
- *
- * Returns array of `mochaHooks` exports, if any.
- * @param {string[]} requires - Modules to require
- * @returns {Promise<object>} Plugin implementations
- * @private
- */
-exports.handleRequires = async (requires = [], {ignoredPlugins = []} = {}) => {
-  const pluginLoader = PluginLoader.create({ignore: ignoredPlugins});
-  for await (const mod of requires) {
-    let modpath = mod;
-    // this is relative to cwd
-    if (fs.existsSync(mod) || fs.existsSync(`${mod}.js`)) {
-      modpath = path.resolve(mod);
-      debug('resolved required file %s to %s', mod, modpath);
-    }
-    const requiredModule = await requireOrImport(modpath);
-    if (requiredModule && typeof requiredModule === 'object') {
-      if (pluginLoader.load(requiredModule)) {
-        debug('found one or more plugin implementations in %s', modpath);
-      }
-    }
-    debug('loaded required module "%s"', mod);
-  }
-  const plugins = await pluginLoader.finalize();
-  if (Object.keys(plugins).length) {
-    debug('finalized plugin implementations: %O', plugins);
-  }
-  return plugins;
-};
 
 /**
  * Collect and load test files, then run mocha instance.

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -16,12 +16,8 @@ const {
   createMissingArgumentError
 } = require('../errors');
 
-const {
-  list,
-  handleRequires,
-  validateLegacyPlugin,
-  runMocha
-} = require('./run-helpers');
+const {list, validateLegacyPlugin, runMocha} = require('./run-helpers');
+const {handleRequires} = require('./handle-requires');
 const {ONE_AND_DONES, ONE_AND_DONE_ARGS} = require('./one-and-dones');
 const debug = require('debug')('mocha:cli:run');
 const defaults = require('../mocharc');

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -2,7 +2,6 @@
 
 const logSymbols = require('log-symbols');
 const debug = require('debug')('mocha:cli:watch');
-const path = require('path');
 const chokidar = require('chokidar');
 const Context = require('../context');
 const collectFiles = require('./collect-files');
@@ -261,8 +260,6 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
   // running.
   let runner = null;
 
-  const blastFullCache = !mocha.options.parallel;
-
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
@@ -272,10 +269,8 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
       runner = mocha.run(() => {
         debug('finished watch run');
         runner = null;
-        if (blastFullCache) {
-          setCacheBusterKey(uniqueID());
-        }
-        blastCache(watcher, blastFullCache);
+        setCacheBusterKey(uniqueID());
+        blastCache();
         if (rerunScheduled) {
           rerun();
         } else {
@@ -313,25 +308,6 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
 };
 
 /**
- * Return the list of absolute paths watched by a chokidar watcher.
- *
- * @param watcher - Instance of a chokidar watcher
- * @return {string[]} - List of absolute paths
- * @ignore
- * @private
- */
-const getWatchedFiles = watcher => {
-  const watchedDirs = watcher.getWatched();
-  return Object.keys(watchedDirs).reduce(
-    (acc, dir) => [
-      ...acc,
-      ...watchedDirs[dir].map(file => path.join(dir, file))
-    ],
-    []
-  );
-};
-
-/**
  * Hide the cursor.
  * @ignore
  * @private
@@ -359,31 +335,22 @@ const eraseLine = () => {
 
 /**
  * Blast all of the watched files out of `require.cache`
- * @param {FSWatcher} watcher - chokidar FSWatcher
- * @param {boolean} blastAll
  * @ignore
  * @private
  */
-const blastCache = (watcher, blastAll) => {
-  if (blastAll) {
-    Object.keys(require.cache)
-      // Avoid deleting mocha binary
-      .filter(
-        file =>
-          !file.includes('mocha/bin/mocha.js') &&
-          !file.includes('mocha/lib/mocha.js')
-      )
-      .forEach(file => {
-        delete require.cache[file];
-      });
-    debug('deleted all files from the require cache');
-  } else {
-    const files = getWatchedFiles(watcher);
-    files.forEach(file => {
-      delete require.cache[file];
-    });
-    debug('deleted %d file(s) from the require cache', files.length);
-  }
+const blastCache = () => {
+  const files = Object.keys(require.cache)
+    // Avoid deleting mocha binary
+    .filter(
+      file =>
+        !file.includes('mocha/bin/mocha.js') &&
+        !file.includes('mocha/lib/mocha.js')
+    );
+
+  files.forEach(file => {
+    delete require.cache[file];
+  });
+  debug('deleted %d file(s) from the require cache', files.length);
 };
 
 /**

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -261,13 +261,14 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
   // running.
   let runner = null;
 
+  const blastFullCache = !mocha.options.parallel;
+
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
   const run = async () => {
     try {
       mocha = beforeRun ? (await beforeRun({mocha, watcher})) || mocha : mocha;
-      const blastFullCache = !mocha.options.parallel;
       runner = mocha.run(() => {
         debug('finished watch run');
         runner = null;

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -367,8 +367,12 @@ const eraseLine = () => {
 const blastCache = (watcher, blastAll) => {
   if (blastAll) {
     Object.keys(require.cache)
-      // Avoid deleting mocha binary (at minimum, breaks Mocha's watch tests)
-      .filter(file => !file.includes('/mocha/bin/'))
+      // Avoid deleting mocha binary
+      .filter(
+        file =>
+          !file.includes('mocha/bin/mocha.js') &&
+          !file.includes('mocha/lib/mocha.js')
+      )
       .forEach(file => {
         delete require.cache[file];
       });

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -6,7 +6,9 @@ const path = require('path');
 const chokidar = require('chokidar');
 const Context = require('../context');
 const collectFiles = require('./collect-files');
-
+const {handleRequires} = require('./handle-requires');
+const {setCacheBusterKey} = require('../nodejs/esm-utils');
+const {uniqueID} = require('../utils');
 /**
  * Exports the `watchRun` function that runs mocha in "watch" mode.
  * @see module:lib/cli/run-helpers
@@ -97,8 +99,13 @@ exports.watchRun = (mocha, {watchFiles, watchIgnore}, fileCollectParams) => {
   return createWatcher(mocha, {
     watchFiles,
     watchIgnore,
-    beforeRun({mocha}) {
+    async beforeRun({mocha}) {
       mocha.unloadFiles();
+
+      // Reload hooks. If not done, global hooks keep their state between watch runs, but test files always get a new
+      // instance, making state mutation impossible via global hooks.
+      const plugins = await handleRequires(mocha.options.require);
+      mocha.options.rootHooks = plugins.rootHooks;
 
       // I don't know why we're cloning the root suite.
       const rootSuite = mocha.suite.clone();
@@ -257,13 +264,17 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
-  const run = () => {
+  const run = async () => {
     try {
-      mocha = beforeRun ? beforeRun({mocha, watcher}) || mocha : mocha;
+      mocha = beforeRun ? (await beforeRun({mocha, watcher})) || mocha : mocha;
+      const blastFullCache = !mocha.options.parallel;
       runner = mocha.run(() => {
         debug('finished watch run');
         runner = null;
-        blastCache(watcher);
+        if (blastFullCache) {
+          setCacheBusterKey(uniqueID());
+        }
+        blastCache(watcher, blastFullCache);
         if (rerunScheduled) {
           rerun();
         } else {
@@ -348,15 +359,26 @@ const eraseLine = () => {
 /**
  * Blast all of the watched files out of `require.cache`
  * @param {FSWatcher} watcher - chokidar FSWatcher
+ * @param {boolean} blastAll
  * @ignore
  * @private
  */
-const blastCache = watcher => {
-  const files = getWatchedFiles(watcher);
-  files.forEach(file => {
-    delete require.cache[file];
-  });
-  debug('deleted %d file(s) from the require cache', files.length);
+const blastCache = (watcher, blastAll) => {
+  if (blastAll) {
+    Object.keys(require.cache)
+      // Avoid deleting mocha binary (at minimum, breaks Mocha's watch tests)
+      .filter(file => !file.includes('/mocha/bin/'))
+      .forEach(file => {
+        delete require.cache[file];
+      });
+    debug('deleted all files from the require cache');
+  } else {
+    const files = getWatchedFiles(watcher);
+    files.forEach(file => {
+      delete require.cache[file];
+    });
+    debug('deleted %d file(s) from the require cache', files.length);
+  }
 };
 
 /**

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -3,6 +3,12 @@ const url = require('url');
 
 const forward = x => x;
 
+let cacheBusterKey = '';
+
+exports.setCacheBusterKey = key => {
+  cacheBusterKey = key;
+};
+
 const formattedImport = async (file, esmDecorator = forward) => {
   if (path.isAbsolute(file)) {
     try {
@@ -32,7 +38,9 @@ const formattedImport = async (file, esmDecorator = forward) => {
   return exports.doImport(esmDecorator(file));
 };
 
-exports.doImport = async file => import(file);
+// When changing the key, old items won't be garbage collected, but there is no alternative with import().
+// More info: https://github.com/nodejs/node/issues/49442
+exports.doImport = async file => import(`${file}?cache=${cacheBusterKey}`);
 
 exports.requireOrImport = async (file, esmDecorator) => {
   if (path.extname(file) === '.mjs') {

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -5,6 +5,22 @@ const forward = x => x;
 
 let cacheBusterKey = '';
 
+// When changing the key, old items won't be garbage collected, but there is no alternative with import().
+// More info: https://github.com/nodejs/node/issues/49442
+const withCacheBuster = x => {
+  if (!cacheBusterKey) {
+    return x;
+  }
+  if (typeof x === 'string') {
+    return x.includes('?')
+      ? `${x}&cache=${cacheBusterKey}`
+      : `${x}?cache=${cacheBusterKey}`;
+  } else if (x instanceof url.URL) {
+    x.searchParams.append('cache', cacheBusterKey);
+  }
+  return x;
+};
+
 exports.setCacheBusterKey = key => {
   cacheBusterKey = key;
 };
@@ -12,7 +28,9 @@ exports.setCacheBusterKey = key => {
 const formattedImport = async (file, esmDecorator = forward) => {
   if (path.isAbsolute(file)) {
     try {
-      return await exports.doImport(esmDecorator(url.pathToFileURL(file)));
+      return await exports.doImport(
+        withCacheBuster(esmDecorator(url.pathToFileURL(file)))
+      );
     } catch (err) {
       // This is a hack created because ESM in Node.js (at least in Node v15.5.1) does not emit
       // the location of the syntax error in the error thrown.
@@ -35,12 +53,10 @@ const formattedImport = async (file, esmDecorator = forward) => {
       throw err;
     }
   }
-  return exports.doImport(esmDecorator(file));
+  return exports.doImport(withCacheBuster(esmDecorator(file)));
 };
 
-// When changing the key, old items won't be garbage collected, but there is no alternative with import().
-// More info: https://github.com/nodejs/node/issues/49442
-exports.doImport = async file => import(`${file}?cache=${cacheBusterKey}`);
+exports.doImport = async file => import(file);
 
 exports.requireOrImport = async (file, esmDecorator) => {
   if (path.extname(file) === '.mjs') {

--- a/lib/nodejs/worker.js
+++ b/lib/nodejs/worker.js
@@ -12,7 +12,8 @@ const {
 } = require('../errors');
 const workerpool = require('workerpool');
 const Mocha = require('../mocha');
-const {handleRequires, validateLegacyPlugin} = require('../cli/run-helpers');
+const {validateLegacyPlugin} = require('../cli/run-helpers');
+const {handleRequires} = require('../cli/handle-requires');
 const d = require('debug');
 const debug = d.debug(`mocha:parallel:worker:${process.pid}`);
 const isDebugEnabled = d.enabled(`mocha:parallel:worker:${process.pid}`);

--- a/test/integration/fixtures/options/watch/dependency-with-state.fixture.js
+++ b/test/integration/fixtures/options/watch/dependency-with-state.fixture.js
@@ -1,0 +1,11 @@
+let flag = false;
+
+module.exports.getFlag = () => flag;
+
+module.exports.enableFlag = () => {
+  flag = true;
+};
+
+module.exports.disableFlag = () => {
+  flag = false;
+};

--- a/test/integration/fixtures/options/watch/hook-mutating-dependency.fixture.js
+++ b/test/integration/fixtures/options/watch/hook-mutating-dependency.fixture.js
@@ -1,0 +1,9 @@
+const dependency = require('./lib/dependency-with-state');
+
+module.exports = {
+  mochaHooks: {
+    beforeEach: () => {
+      dependency.enableFlag();
+    }
+  }
+};

--- a/test/integration/fixtures/options/watch/test-mutating-dependency.fixture.js
+++ b/test/integration/fixtures/options/watch/test-mutating-dependency.fixture.js
@@ -1,0 +1,9 @@
+const dependency = require('./lib/dependency-with-state');
+
+it('checks and mutates dependency', () => {
+  if (dependency.getFlag()) {
+    throw new Error('test failed');
+  }
+  // Will pass 1st run, fail on subsequent ones
+  dependency.enableFlag();
+});

--- a/test/integration/fixtures/options/watch/test-with-hook-mutated-dependency.fixture.js
+++ b/test/integration/fixtures/options/watch/test-with-hook-mutated-dependency.fixture.js
@@ -1,0 +1,17 @@
+const dependency = require('./lib/dependency-with-state');
+
+// Will fail 1st run, unless hook runs
+before(() => {
+  dependency.disableFlag();
+});
+
+// Will pass 1st run, fail on subsequent ones, unless hook runs
+afterEach(() => {
+  dependency.disableFlag();
+});
+
+it('hook should have mutated dependency', () => {
+  if (!dependency.getFlag()) {
+    throw new Error('test failed');
+  }
+});

--- a/test/node-unit/esm-utils.spec.js
+++ b/test/node-unit/esm-utils.spec.js
@@ -11,6 +11,7 @@ describe('esm-utils', function () {
 
   afterEach(function () {
     sinon.restore();
+    esmUtils.setCacheBusterKey('');
   });
 
   describe('loadFilesAsync()', function () {
@@ -40,6 +41,23 @@ describe('esm-utils', function () {
         esmUtils.doImport.firstCall.args[0].toString(),
         'to be',
         `${url.pathToFileURL('/foo/bar.mjs').toString()}?foo=bar`
+      );
+    });
+
+    it('should decorate imported module with passed decorator - with cache buster key', async function () {
+      esmUtils.setCacheBusterKey('1234');
+
+      await esmUtils.loadFilesAsync(
+        ['/foo/bar.mjs'],
+        () => {},
+        () => {},
+        x => `${x}?foo=bar`
+      );
+
+      expect(
+        esmUtils.doImport.firstCall.args[0].toString(),
+        'to be',
+        `${url.pathToFileURL('/foo/bar.mjs').toString()}?foo=bar&cache=1234`
       );
     });
   });

--- a/test/node-unit/worker.spec.js
+++ b/test/node-unit/worker.spec.js
@@ -54,8 +54,11 @@ describe('worker', function () {
       };
 
       stubs.runHelpers = {
-        handleRequires: sinon.stub().resolves({}),
         validateLegacyPlugin: sinon.stub()
+      };
+
+      stubs.handleRequires = {
+        handleRequires: sinon.stub().resolves({})
       };
 
       stubs.plugin = {
@@ -67,6 +70,7 @@ describe('worker', function () {
         '../../lib/mocha': stubs.Mocha,
         '../../lib/nodejs/serializer': stubs.serializer,
         '../../lib/cli/run-helpers': stubs.runHelpers,
+        '../../lib/cli/handle-requires': stubs.handleRequires,
         '../../lib/plugin-loader': stubs.plugin
       });
     });
@@ -148,7 +152,7 @@ describe('worker', function () {
               serializeJavascript({require: 'foo'})
             );
             expect(
-              stubs.runHelpers.handleRequires,
+              stubs.handleRequires.handleRequires,
               'to have a call satisfying',
               [
                 'foo',
@@ -217,8 +221,10 @@ describe('worker', function () {
               await worker.run('some-other-file.js');
 
               expect(stubs.runHelpers, 'to satisfy', {
-                handleRequires: expect.it('was called once'),
                 validateLegacyPlugin: expect.it('was called once')
+              });
+              expect(stubs.handleRequires, 'to satisfy', {
+                handleRequires: expect.it('was called once')
               });
             });
           });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5149
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) <- no, but I filled it 😄 
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/master/.github/CONTRIBUTING.md) were taken

## Overview

After filling #5149, I had some time to try to narrow the problem.

When running mocha in non-parallel watch mode, we are not spawning new processes, so the initial require hooks get loaded once, but on reloads/reruns, if they contained some stateful dependency, each subsequent run gets a new set of mocha requires for the test files, but not those global hooks, so they keep their initial state, and effectively the tests now run with a different context and can't affect/read the global hooks.
This issue can only be avoided by watching also the root hooks and their dependencies, which in large projects is not always easy to do (and can lead to big watched path lists in large repositories).


Explained with code:
- `watchRun.createWatcher` -> `beforeRun` does `const newMocha = new Mocha(mocha.options);` which means that the global hooks (stored inside `mocha.options` keep their initial load's closure.
- `watchRun.createRerunner` -> `run` performs a `blastCache()`, but that blasting is only aware of watched files.
- When re-running, `blastCache()` causes the tests to re-import/re-require, creating a new closure for their stateful dependency; If all files are watched, that's fine, but just by not watching the global hooks (I added a test for this scenario), `beforeRun` creates the `newMocha` but `mocha.options` are the same, effectively now having two scopes, one with the original global hooks and another for the test run.

My changes fix this scenarios by:
- Extracting `handleRequires()` to a separate file (else there would be a circular dependency between `run-helpers` and `watch-run`)
- Adding a parameter to `blastCache` to do a full cache blast
  - when not running in parallel, as parallel mode is not affected
  - full blast empties the `require.cache`, but for `import` there's no alternative than to play around with the querystring, so it changes its key (default is `""`, so only changes for non-parallel watch reruns)
- Modifying `watchRun.createWatcher` -> `beforeRun` so that it reloads the global hooks (via `handleRequires()`), which means that that each rerun will have the same **new** `mocha.options` closure as the tests it'll run.

I've added two test scenarios:
- simple one: a test with an unwatched stateful dependency. The test mutates the dep's state in a way that reruns will fail, unless we fully blast & reimport.
- complex one: a test with unwatched dependency & unwatched hook. The hook mutates the dependency state in a `beforeHook`, and the test has `before` and `afterEach` hooks to mutate it again to attempt to make it fail, so will only pass if the global hook is reloaded and the test picks the same closure.

As mentioned, I wanted to avoid full blasts when not needed, so parallel watch mode is not affected. An alternative is to always do a full blast, and then we can remove some conditional logic and simplify a bit.

Let me know if I should further explain something.