### PR TITLE
chore: allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Documentation Website
     about: Please read our documentation website before filing new issues.


### PR DESCRIPTION
I personally think we should allow for blank issues even though we might prioritize them lower. Not all issues fit into pre-defined templates and I know myself that I get very frustrated when I'm being forced to use a template that might not fit the issue that I need to open with the team.

I can take it upon myself to triage all the blank issues if that's the sticking point.