### PR TITLE
fix: crash with --parallel and --retries both enabled

### DIFF
--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -259,7 +259,7 @@ class SerializableEvent {
     });
 
     // mutates the object
-    breakCircularDeps(result);
+    breakCircularDeps(result.error);
 
     const pairs = Object.keys(result).map(key => [result, key]);
 

--- a/test/integration/fixtures/parallel/non-circular-error.mjs
+++ b/test/integration/fixtures/parallel/non-circular-error.mjs
@@ -1,0 +1,5 @@
+import {it} from '../../../../index.js';
+
+it('test', () => {
+  throw new Error('Foo');
+});

--- a/test/integration/parallel.spec.js
+++ b/test/integration/parallel.spec.js
@@ -43,4 +43,19 @@ describe('parallel run', () => {
     assert.strictEqual(result.failures[0].err.message, 'Foo');
     assert.strictEqual(result.failures[0].err.foo.props[0], '[Circular]');
   });
+
+  it('should correctly handle an exception with retries', async () => {
+    const result = await runMochaJSONAsync('parallel/circular-error.mjs', [
+      '--parallel',
+      '--jobs',
+      '2',
+      '--retries',
+      '1',
+      require.resolve('./fixtures/parallel/testworkerid1.mjs')
+    ]);
+    assert.strictEqual(result.stats.failures, 1);
+    assert.strictEqual(result.stats.passes, 1);
+    assert.strictEqual(result.failures[0].err.message, 'Foo');
+    assert.strictEqual(result.failures[0].err.foo.props[0], '[Circular]');
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5170
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Turns out there are no existing tests for the case of having both `--parallel` and `--retries` enabled. The problem is that the new circular-reference-breaking logic from #5032 was also being run on other properties in `result` - not just `result.error`.