### PR TITLE
chore: remove failing hyperlink linkcheck task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "fail-on-errors-webpack-plugin": "^3.0.0",
         "fs-extra": "^10.0.0",
         "globals": "^13.24.0",
-        "hyperlink": "^5.0.4",
         "jsdoc": "^3.6.7",
         "jsdoc-ts-utils": "^2.0.1",
         "karma": "^6.4.2",
@@ -1058,15 +1057,6 @@
       },
       "peerDependencies": {
         "jsdoc": "^3.6.7"
-      }
-    },
-    "node_modules/@munter/tap-render": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@munter/tap-render/-/tap-render-0.2.0.tgz",
-      "integrity": "sha512-m6xHJ6MhWBj2+BmxmRmdLas6P6yvrsThoRsOsrnZkTbJq9yPgxilqCGxKrPO9sFrsj9of5keUlLw5PkEjEj5kQ==",
-      "dev": true,
-      "dependencies": {
-        "pause-stream": "0.0.11"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2873,15 +2863,6 @@
       "dev": true,
       "dependencies": {
         "urltools": "^0.4.1"
-      }
-    },
-    "node_modules/assetgraph-plugin-sitemap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assetgraph-plugin-sitemap/-/assetgraph-plugin-sitemap-1.0.0.tgz",
-      "integrity": "sha512-NaGLdrFemTLss6PxW0f1JVqcV8n1jjERwyBTyz49PZCKkARkZTSOvnoM55wxTXlPkqsLZq7K2/lO56pmYbbCOA==",
-      "dev": true,
-      "peerDependencies": {
-        "assetgraph": "^7.0.0"
       }
     },
     "node_modules/assetgraph-sprite": {
@@ -9089,12 +9070,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/hreftypes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hreftypes/-/hreftypes-1.0.1.tgz",
-      "integrity": "sha512-zBoWrxmo6oyIvWtaHyLkIaZdFg27Zz8NETanUWfgIWWEkaXAutATUx4jP+dkqtV+G0Y7sMiAE7LZ3BVMLzLjNA==",
-      "dev": true
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -9268,26 +9243,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.12.0"
-      }
-    },
-    "node_modules/hyperlink": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hyperlink/-/hyperlink-5.0.4.tgz",
-      "integrity": "sha512-McN25ky/8OszPWctZJbvNYb4odYQSYeqE8hNK1aH/oM9GtmOyBZNE4ObkIEKOxIntG1PVfPp7uP7QoIdFEKkDg==",
-      "dev": true,
-      "dependencies": {
-        "@munter/tap-render": "^0.2.0",
-        "assetgraph": "^7.3.1",
-        "assetgraph-plugin-sitemap": "^1.0.0",
-        "async": "^3.1.0",
-        "hreftypes": "^1.0.1",
-        "pretty-bytes": "^5.2.0",
-        "request": "^2.88.0",
-        "urltools": "^0.4.2",
-        "yargs": "^16.0.3"
-      },
-      "bin": {
-        "hyperlink": "lib/cli.js"
       }
     },
     "node_modules/icc": {
@@ -23023,15 +22978,6 @@
         "taffydb": "^2.7.3"
       }
     },
-    "@munter/tap-render": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@munter/tap-render/-/tap-render-0.2.0.tgz",
-      "integrity": "sha512-m6xHJ6MhWBj2+BmxmRmdLas6P6yvrsThoRsOsrnZkTbJq9yPgxilqCGxKrPO9sFrsj9of5keUlLw5PkEjEj5kQ==",
-      "dev": true,
-      "requires": {
-        "pause-stream": "0.0.11"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -24651,13 +24597,6 @@
       "requires": {
         "urltools": "^0.4.1"
       }
-    },
-    "assetgraph-plugin-sitemap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assetgraph-plugin-sitemap/-/assetgraph-plugin-sitemap-1.0.0.tgz",
-      "integrity": "sha512-NaGLdrFemTLss6PxW0f1JVqcV8n1jjERwyBTyz49PZCKkARkZTSOvnoM55wxTXlPkqsLZq7K2/lO56pmYbbCOA==",
-      "dev": true,
-      "requires": {}
     },
     "assetgraph-sprite": {
       "version": "3.2.1",
@@ -29475,12 +29414,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "hreftypes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hreftypes/-/hreftypes-1.0.1.tgz",
-      "integrity": "sha512-zBoWrxmo6oyIvWtaHyLkIaZdFg27Zz8NETanUWfgIWWEkaXAutATUx4jP+dkqtV+G0Y7sMiAE7LZ3BVMLzLjNA==",
-      "dev": true
-    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -29619,23 +29552,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
-    },
-    "hyperlink": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hyperlink/-/hyperlink-5.0.4.tgz",
-      "integrity": "sha512-McN25ky/8OszPWctZJbvNYb4odYQSYeqE8hNK1aH/oM9GtmOyBZNE4ObkIEKOxIntG1PVfPp7uP7QoIdFEKkDg==",
-      "dev": true,
-      "requires": {
-        "@munter/tap-render": "^0.2.0",
-        "assetgraph": "^7.3.1",
-        "assetgraph-plugin-sitemap": "^1.0.0",
-        "async": "^3.1.0",
-        "hreftypes": "^1.0.1",
-        "pretty-bytes": "^5.2.0",
-        "request": "^2.88.0",
-        "urltools": "^0.4.2",
-        "yargs": "^16.0.3"
-      }
     },
     "icc": {
       "version": "1.0.0",

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -259,7 +259,7 @@ module.exports = {
     docs: {
       default: {
         script:
-          'nps docs.clean && nps docs.api && eleventy && nps docs.linkcheck',
+          'nps docs.clean && nps docs.api && eleventy',
         description: 'Build documentation'
       },
       production: {
@@ -270,10 +270,6 @@ module.exports = {
         script: 'rimraf docs/_dist docs/_site docs/api',
         description: 'Prepare system for doc building',
         hiddenFromHelp: true
-      },
-      linkcheck: {
-        script:
-          'hyperlink -ri --canonicalroot https://mochajs.org --skip ".js.html#line" docs/_site/index.html --todo "HTTP 429 Too Many Requests"'
       },
       postbuild: {
         script:

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "fail-on-errors-webpack-plugin": "^3.0.0",
     "fs-extra": "^10.0.0",
     "globals": "^13.24.0",
-    "hyperlink": "^5.0.4",
     "jsdoc": "^3.6.7",
     "jsdoc-ts-utils": "^2.0.1",
     "karma": "^6.4.2",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5174
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Although I like the idea of making sure links are correct, this is always failing and we don't change the site much anyway. 

[`hyperlink`](https://www.npmjs.com/package/hyperlink) is rarely used and hasn't been updated in a few years. Long-term it'd be great to move to a system with built-in link checking, like [Docusaurus `onBrokenLinks`](https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks) / other bits mentioned in https://github.com/withastro/starlight/discussions/946. 