### PR TITLE
chore: switch Runnable, Hook, and Test from util.inherits to ES2015 classes

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -1,14 +1,8 @@
 'use strict';
 
 var Runnable = require('./runnable');
-const {inherits, constants} = require('./utils');
+const {constants} = require('./utils');
 const {MOCHA_ID_PROP_NAME} = constants;
-
-/**
- * Expose `Hook`.
- */
-
-module.exports = Hook;
 
 /**
  * Initialize a new `Hook` with the given `title` and callback `fn`
@@ -18,72 +12,71 @@ module.exports = Hook;
  * @param {String} title
  * @param {Function} fn
  */
-function Hook(title, fn) {
-  Runnable.call(this, title, fn);
-  this.type = 'hook';
-}
-
-/**
- * Inherit from `Runnable.prototype`.
- */
-inherits(Hook, Runnable);
-
-/**
- * Resets the state for a next run.
- */
-Hook.prototype.reset = function () {
-  Runnable.prototype.reset.call(this);
-  delete this._error;
-};
-
-/**
- * Get or set the test `err`.
- *
- * @memberof Hook
- * @public
- * @param {Error} err
- * @return {Error}
- */
-Hook.prototype.error = function (err) {
-  if (!arguments.length) {
-    err = this._error;
-    this._error = null;
-    return err;
+class Hook extends Runnable {
+  constructor(title, fn) {
+    super(title, fn);
+    this.type = 'hook';
   }
 
-  this._error = err;
-};
+  /**
+   * Resets the state for a next run.
+   */
+  reset() {
+    Runnable.prototype.reset.call(this);
+    delete this._error;
+  }
 
-/**
- * Returns an object suitable for IPC.
- * Functions are represented by keys beginning with `$$`.
- * @private
- * @returns {Object}
- */
-Hook.prototype.serialize = function serialize() {
-  return {
-    $$currentRetry: this.currentRetry(),
-    $$fullTitle: this.fullTitle(),
-    $$isPending: Boolean(this.isPending()),
-    $$titlePath: this.titlePath(),
-    ctx:
-      this.ctx && this.ctx.currentTest
-        ? {
-            currentTest: {
-              title: this.ctx.currentTest.title,
-              [MOCHA_ID_PROP_NAME]: this.ctx.currentTest.id
+  /**
+   * Get or set the test `err`.
+   *
+   * @memberof Hook
+   * @public
+   * @param {Error} err
+   * @return {Error}
+   */
+  error(err) {
+    if (!arguments.length) {
+      err = this._error;
+      this._error = null;
+      return err;
+    }
+
+    this._error = err;
+  }
+
+  /**
+   * Returns an object suitable for IPC.
+   * Functions are represented by keys beginning with `$$`.
+   * @protected
+   * @returns {Object}
+   */
+  serialize() {
+    return {
+      $$currentRetry: this.currentRetry(),
+      $$fullTitle: this.fullTitle(),
+      $$isPending: Boolean(this.isPending()),
+      $$titlePath: this.titlePath(),
+      ctx:
+        this.ctx && this.ctx.currentTest
+          ? {
+              currentTest: {
+                title: this.ctx.currentTest.title,
+                [MOCHA_ID_PROP_NAME]: this.ctx.currentTest.id
+              }
             }
-          }
-        : {},
-    duration: this.duration,
-    file: this.file,
-    parent: {
-      $$fullTitle: this.parent.fullTitle(),
-      [MOCHA_ID_PROP_NAME]: this.parent.id
-    },
-    state: this.state,
-    title: this.title,
-    type: this.type,
-    [MOCHA_ID_PROP_NAME]: this.id
-  };
-};
+          : {},
+      duration: this.duration,
+      file: this.file,
+      parent: {
+        $$fullTitle: this.parent.fullTitle(),
+        [MOCHA_ID_PROP_NAME]: this.parent.id
+      },
+      state: this.state,
+      title: this.title,
+      type: this.type,
+      [MOCHA_ID_PROP_NAME]: this.id
+    };
+  }
+}
+
+module.exports = Hook;

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -22,414 +22,423 @@ var toString = Object.prototype.toString;
 
 var MAX_TIMEOUT = Math.pow(2, 31) - 1;
 
-module.exports = Runnable;
+class Runnable extends EventEmitter {
+  /**
+   * @param {String} title
+   * @param {Function} fn
+   */
+  constructor(title, fn) {
+    super();
+    this.title = title;
+    this.fn = fn;
+    this.body = (fn || '').toString();
+    this.async = fn && fn.length;
+    this.sync = !this.async;
+    this._timeout = 2000;
+    this._slow = 75;
+    this._retries = -1;
+    utils.assignNewMochaID(this);
+    Object.defineProperty(this, 'id', {
+      get() {
+        return utils.getMochaID(this);
+      }
+    });
+    this.reset();
+  }
 
-/**
- * Initialize a new `Runnable` with the given `title` and callback `fn`.
- *
- * @class
- * @extends external:EventEmitter
- * @public
- * @param {String} title
- * @param {Function} fn
- */
-function Runnable(title, fn) {
-  this.title = title;
-  this.fn = fn;
-  this.body = (fn || '').toString();
-  this.async = fn && fn.length;
-  this.sync = !this.async;
-  this._timeout = 2000;
-  this._slow = 75;
-  this._retries = -1;
-  utils.assignNewMochaID(this);
-  Object.defineProperty(this, 'id', {
-    get() {
-      return utils.getMochaID(this);
+  /**
+   * Resets the state initially or for a next run.
+   */
+  reset() {
+    this.timedOut = false;
+    this._currentRetry = 0;
+    this.pending = false;
+    delete this.state;
+    delete this.err;
+  }
+
+  /**
+   * Get current timeout value in msecs.
+   *
+   * @private
+   * @returns {number} current timeout threshold value
+   */
+  /**
+   * @summary
+   * Set timeout threshold value (msecs).
+   *
+   * @description
+   * A string argument can use shorthand (e.g., "2s") and will be converted.
+   * The value will be clamped to range [<code>0</code>, <code>2^<sup>31</sup>-1</code>].
+   * If clamped value matches either range endpoint, timeouts will be disabled.
+   *
+   * @private
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Maximum_delay_value}
+   * @param {number|string} ms - Timeout threshold value.
+   * @returns {Runnable} this
+   * @chainable
+   */
+  timeout(ms) {
+    if (!arguments.length) {
+      return this._timeout;
     }
-  });
-  this.reset();
-}
+    if (typeof ms === 'string') {
+      ms = milliseconds(ms);
+    }
 
-/**
- * Inherit from `EventEmitter.prototype`.
- */
-utils.inherits(Runnable, EventEmitter);
+    // Clamp to range
+    var range = [0, MAX_TIMEOUT];
+    ms = utils.clamp(ms, range);
 
-/**
- * Resets the state initially or for a next run.
- */
-Runnable.prototype.reset = function () {
-  this.timedOut = false;
-  this._currentRetry = 0;
-  this.pending = false;
-  delete this.state;
-  delete this.err;
-};
+    // see #1652 for reasoning
+    if (ms === range[0] || ms === range[1]) {
+      this._timeout = 0;
+    } else {
+      this._timeout = ms;
+    }
+    debug('timeout %d', this._timeout);
 
-/**
- * Get current timeout value in msecs.
- *
- * @private
- * @returns {number} current timeout threshold value
- */
-/**
- * @summary
- * Set timeout threshold value (msecs).
- *
- * @description
- * A string argument can use shorthand (e.g., "2s") and will be converted.
- * The value will be clamped to range [<code>0</code>, <code>2^<sup>31</sup>-1</code>].
- * If clamped value matches either range endpoint, timeouts will be disabled.
- *
- * @private
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Maximum_delay_value}
- * @param {number|string} ms - Timeout threshold value.
- * @returns {Runnable} this
- * @chainable
- */
-Runnable.prototype.timeout = function (ms) {
-  if (!arguments.length) {
-    return this._timeout;
-  }
-  if (typeof ms === 'string') {
-    ms = milliseconds(ms);
+    if (this.timer) {
+      this.resetTimeout();
+    }
+    return this;
   }
 
-  // Clamp to range
-  var range = [0, MAX_TIMEOUT];
-  ms = utils.clamp(ms, range);
-
-  // see #1652 for reasoning
-  if (ms === range[0] || ms === range[1]) {
-    this._timeout = 0;
-  } else {
-    this._timeout = ms;
+  /**
+   * Set or get slow `ms`.
+   *
+   * @private
+   * @param {number|string} ms
+   * @return {Runnable|number} ms or Runnable instance.
+   */
+  slow(ms) {
+    if (!arguments.length || typeof ms === 'undefined') {
+      return this._slow;
+    }
+    if (typeof ms === 'string') {
+      ms = milliseconds(ms);
+    }
+    debug('slow %d', ms);
+    this._slow = ms;
+    return this;
   }
-  debug('timeout %d', this._timeout);
 
-  if (this.timer) {
-    this.resetTimeout();
+  /**
+   * Halt and mark as pending.
+   *
+   * @memberof Mocha.Runnable
+   * @public
+   */
+  skip() {
+    this.pending = true;
+    throw new Pending('sync skip; aborting execution');
   }
-  return this;
-};
 
-/**
- * Set or get slow `ms`.
- *
- * @private
- * @param {number|string} ms
- * @return {Runnable|number} ms or Runnable instance.
- */
-Runnable.prototype.slow = function (ms) {
-  if (!arguments.length || typeof ms === 'undefined') {
-    return this._slow;
+  /**
+   * Check if this runnable or its parent suite is marked as pending.
+   *
+   * @private
+   */
+  isPending() {
+    return this.pending || (this.parent && this.parent.isPending());
   }
-  if (typeof ms === 'string') {
-    ms = milliseconds(ms);
+
+  /**
+   * Return `true` if this Runnable has failed.
+   * @return {boolean}
+   * @private
+   */
+  isFailed() {
+    return !this.isPending() && this.state === constants.STATE_FAILED;
   }
-  debug('slow %d', ms);
-  this._slow = ms;
-  return this;
-};
 
-/**
- * Halt and mark as pending.
- *
- * @memberof Mocha.Runnable
- * @public
- */
-Runnable.prototype.skip = function () {
-  this.pending = true;
-  throw new Pending('sync skip; aborting execution');
-};
-
-/**
- * Check if this runnable or its parent suite is marked as pending.
- *
- * @private
- */
-Runnable.prototype.isPending = function () {
-  return this.pending || (this.parent && this.parent.isPending());
-};
-
-/**
- * Return `true` if this Runnable has failed.
- * @return {boolean}
- * @private
- */
-Runnable.prototype.isFailed = function () {
-  return !this.isPending() && this.state === constants.STATE_FAILED;
-};
-
-/**
- * Return `true` if this Runnable has passed.
- * @return {boolean}
- * @private
- */
-Runnable.prototype.isPassed = function () {
-  return !this.isPending() && this.state === constants.STATE_PASSED;
-};
-
-/**
- * Set or get number of retries.
- *
- * @private
- */
-Runnable.prototype.retries = function (n) {
-  if (!arguments.length) {
-    return this._retries;
+  /**
+   * Return `true` if this Runnable has passed.
+   * @return {boolean}
+   * @private
+   */
+  isPassed() {
+    return !this.isPending() && this.state === constants.STATE_PASSED;
   }
-  this._retries = n;
-};
 
-/**
- * Set or get current retry
- *
- * @private
- */
-Runnable.prototype.currentRetry = function (n) {
-  if (!arguments.length) {
-    return this._currentRetry;
+  /**
+   * Set or get number of retries.
+   *
+   * @private
+   */
+  retries(n) {
+    if (!arguments.length) {
+      return this._retries;
+    }
+    this._retries = n;
   }
-  this._currentRetry = n;
-};
 
-/**
- * Return the full title generated by recursively concatenating the parent's
- * full title.
- *
- * @memberof Mocha.Runnable
- * @public
- * @return {string}
- */
-Runnable.prototype.fullTitle = function () {
-  return this.titlePath().join(' ');
-};
+  /**
+   * Set or get current retry
+   *
+   * @private
+   */
+  currentRetry(n) {
+    if (!arguments.length) {
+      return this._currentRetry;
+    }
+    this._currentRetry = n;
+  }
 
-/**
- * Return the title path generated by concatenating the parent's title path with the title.
- *
- * @memberof Mocha.Runnable
- * @public
- * @return {string[]}
- */
-Runnable.prototype.titlePath = function () {
-  return this.parent.titlePath().concat([this.title]);
-};
+  /**
+   * Return the full title generated by recursively concatenating the parent's
+   * full title.
+   *
+   * @memberof Mocha.Runnable
+   * @public
+   * @return {string}
+   */
+  fullTitle() {
+    return this.titlePath().join(' ');
+  }
 
-/**
- * Clear the timeout.
- *
- * @private
- */
-Runnable.prototype.clearTimeout = function () {
-  clearTimeout(this.timer);
-};
+  /**
+   * Return the title path generated by concatenating the parent's title path with the title.
+   *
+   * @memberof Mocha.Runnable
+   * @public
+   * @return {string[]}
+   */
+  titlePath() {
+    return this.parent.titlePath().concat([this.title]);
+  }
 
-/**
- * Reset the timeout.
- *
- * @private
- */
-Runnable.prototype.resetTimeout = function () {
-  var self = this;
-  var ms = this.timeout() || MAX_TIMEOUT;
+  /**
+   * Clear the timeout.
+   *
+   * @private
+   */
+  clearTimeout() {
+    clearTimeout(this.timer);
+  }
 
-  this.clearTimeout();
-  this.timer = setTimeout(function () {
-    if (self.timeout() === 0) {
+  /**
+   * Reset the timeout.
+   *
+   * @private
+   */
+  resetTimeout() {
+    var self = this;
+    var ms = this.timeout() || MAX_TIMEOUT;
+
+    this.clearTimeout();
+    this.timer = setTimeout(function () {
+      if (self.timeout() === 0) {
+        return;
+      }
+      self.callback(self._timeoutError(ms));
+      self.timedOut = true;
+    }, ms);
+  }
+
+  /**
+   * Set or get a list of whitelisted globals for this test run.
+   *
+   * @private
+   * @param {string[]} globals
+   */
+  globals(globals) {
+    if (!arguments.length) {
+      return this._allowedGlobals;
+    }
+    this._allowedGlobals = globals;
+  }
+
+  /**
+   * Run the test and invoke `fn(err)`.
+   *
+   * @param {Function} fn
+   * @private
+   */
+  run(fn) {
+    var self = this;
+    var start = new Date();
+    var ctx = this.ctx;
+    var finished;
+    var errorWasHandled = false;
+
+    if (this.isPending()) return fn();
+
+    // Sometimes the ctx exists, but it is not runnable
+    if (ctx && ctx.runnable) {
+      ctx.runnable(this);
+    }
+
+    // called multiple times
+    function multiple(err) {
+      if (errorWasHandled) {
+        return;
+      }
+      errorWasHandled = true;
+      self.emit('error', createMultipleDoneError(self, err));
+    }
+
+    // finished
+    function done(err) {
+      var ms = self.timeout();
+      if (self.timedOut) {
+        return;
+      }
+
+      if (finished) {
+        return multiple(err);
+      }
+
+      self.clearTimeout();
+      self.duration = new Date() - start;
+      finished = true;
+      if (!err && self.duration > ms && ms > 0) {
+        err = self._timeoutError(ms);
+      }
+      fn(err);
+    }
+
+    // for .resetTimeout() and Runner#uncaught()
+    this.callback = done;
+
+    if (this.fn && typeof this.fn.call !== 'function') {
+      done(
+        new TypeError(
+          'A runnable must be passed a function as its second argument.'
+        )
+      );
       return;
     }
-    self.callback(self._timeoutError(ms));
-    self.timedOut = true;
-  }, ms);
-};
 
-/**
- * Set or get a list of whitelisted globals for this test run.
- *
- * @private
- * @param {string[]} globals
- */
-Runnable.prototype.globals = function (globals) {
-  if (!arguments.length) {
-    return this._allowedGlobals;
-  }
-  this._allowedGlobals = globals;
-};
+    // explicit async with `done` argument
+    if (this.async) {
+      this.resetTimeout();
 
-/**
- * Run the test and invoke `fn(err)`.
- *
- * @param {Function} fn
- * @private
- */
-Runnable.prototype.run = function (fn) {
-  var self = this;
-  var start = new Date();
-  var ctx = this.ctx;
-  var finished;
-  var errorWasHandled = false;
+      // allows skip() to be used in an explicit async context
+      this.skip = function asyncSkip() {
+        this.pending = true;
+        done();
+        // halt execution, the uncaught handler will ignore the failure.
+        throw new Pending('async skip; aborting execution');
+      };
 
-  if (this.isPending()) return fn();
-
-  // Sometimes the ctx exists, but it is not runnable
-  if (ctx && ctx.runnable) {
-    ctx.runnable(this);
-  }
-
-  // called multiple times
-  function multiple(err) {
-    if (errorWasHandled) {
-      return;
-    }
-    errorWasHandled = true;
-    self.emit('error', createMultipleDoneError(self, err));
-  }
-
-  // finished
-  function done(err) {
-    var ms = self.timeout();
-    if (self.timedOut) {
+      try {
+        callFnAsync(this.fn);
+      } catch (err) {
+        // handles async runnables which actually run synchronously
+        errorWasHandled = true;
+        if (err instanceof Pending) {
+          return; // done() is already called in this.skip()
+        } else if (this.allowUncaught) {
+          throw err;
+        }
+        done(Runnable.toValueOrError(err));
+      }
       return;
     }
 
-    if (finished) {
-      return multiple(err);
-    }
-
-    self.clearTimeout();
-    self.duration = new Date() - start;
-    finished = true;
-    if (!err && self.duration > ms && ms > 0) {
-      err = self._timeoutError(ms);
-    }
-    fn(err);
-  }
-
-  // for .resetTimeout() and Runner#uncaught()
-  this.callback = done;
-
-  if (this.fn && typeof this.fn.call !== 'function') {
-    done(
-      new TypeError(
-        'A runnable must be passed a function as its second argument.'
-      )
-    );
-    return;
-  }
-
-  // explicit async with `done` argument
-  if (this.async) {
-    this.resetTimeout();
-
-    // allows skip() to be used in an explicit async context
-    this.skip = function asyncSkip() {
-      this.pending = true;
-      done();
-      // halt execution, the uncaught handler will ignore the failure.
-      throw new Pending('async skip; aborting execution');
-    };
-
+    // sync or promise-returning
     try {
-      callFnAsync(this.fn);
+      callFn(this.fn);
     } catch (err) {
-      // handles async runnables which actually run synchronously
       errorWasHandled = true;
       if (err instanceof Pending) {
-        return; // done() is already called in this.skip()
+        return done();
       } else if (this.allowUncaught) {
         throw err;
       }
       done(Runnable.toValueOrError(err));
     }
-    return;
-  }
 
-  // sync or promise-returning
-  try {
-    callFn(this.fn);
-  } catch (err) {
-    errorWasHandled = true;
-    if (err instanceof Pending) {
-      return done();
-    } else if (this.allowUncaught) {
-      throw err;
-    }
-    done(Runnable.toValueOrError(err));
-  }
-
-  function callFn(fn) {
-    var result = fn.call(ctx);
-    if (result && typeof result.then === 'function') {
-      self.resetTimeout();
-      result.then(
-        function () {
-          done();
-          // Return null so libraries like bluebird do not warn about
-          // subsequently constructed Promises.
-          return null;
-        },
-        function (reason) {
-          done(reason || new Error('Promise rejected with no or falsy reason'));
-        }
-      );
-    } else {
-      if (self.asyncOnly) {
-        return done(
-          new Error(
-            '--async-only option in use without declaring `done()` or returning a promise'
-          )
+    function callFn(fn) {
+      var result = fn.call(ctx);
+      if (result && typeof result.then === 'function') {
+        self.resetTimeout();
+        result.then(
+          function () {
+            done();
+            // Return null so libraries like bluebird do not warn about
+            // subsequently constructed Promises.
+            return null;
+          },
+          function (reason) {
+            done(
+              reason || new Error('Promise rejected with no or falsy reason')
+            );
+          }
         );
-      }
-
-      done();
-    }
-  }
-
-  function callFnAsync(fn) {
-    var result = fn.call(ctx, function (err) {
-      if (err instanceof Error || toString.call(err) === '[object Error]') {
-        return done(err);
-      }
-      if (err) {
-        if (Object.prototype.toString.call(err) === '[object Object]') {
+      } else {
+        if (self.asyncOnly) {
           return done(
-            new Error('done() invoked with non-Error: ' + JSON.stringify(err))
+            new Error(
+              '--async-only option in use without declaring `done()` or returning a promise'
+            )
           );
         }
-        return done(new Error('done() invoked with non-Error: ' + err));
+
+        done();
       }
-      if (result && utils.isPromise(result)) {
-        return done(
-          new Error(
-            'Resolution method is overspecified. Specify a callback *or* return a Promise; not both.'
-          )
-        );
-      }
+    }
 
-      done();
-    });
+    function callFnAsync(fn) {
+      var result = fn.call(ctx, function (err) {
+        if (err instanceof Error || toString.call(err) === '[object Error]') {
+          return done(err);
+        }
+        if (err) {
+          if (Object.prototype.toString.call(err) === '[object Object]') {
+            return done(
+              new Error('done() invoked with non-Error: ' + JSON.stringify(err))
+            );
+          }
+          return done(new Error('done() invoked with non-Error: ' + err));
+        }
+        if (result && utils.isPromise(result)) {
+          return done(
+            new Error(
+              'Resolution method is overspecified. Specify a callback *or* return a Promise; not both.'
+            )
+          );
+        }
+
+        done();
+      });
+    }
   }
-};
 
-/**
- * Instantiates a "timeout" error
- *
- * @param {number} ms - Timeout (in milliseconds)
- * @returns {Error} a "timeout" error
- * @private
- */
-Runnable.prototype._timeoutError = function (ms) {
-  let msg = `Timeout of ${ms}ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`;
-  if (this.file) {
-    msg += ' (' + this.file + ')';
+  /**
+   * Instantiates a "timeout" error
+   *
+   * @param {number} ms - Timeout (in milliseconds)
+   * @returns {Error} a "timeout" error
+   * @private
+   */
+  _timeoutError(ms) {
+    let msg = `Timeout of ${ms}ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`;
+    if (this.file) {
+      msg += ' (' + this.file + ')';
+    }
+    return createTimeoutError(msg, ms, this.file);
   }
-  return createTimeoutError(msg, ms, this.file);
-};
 
-var constants = utils.defineConstants(
+  /**
+   * Given `value`, return identity if truthy, otherwise create an "invalid exception" error and return that.
+   * @param {*} [value] - Value to return, if present
+   * @returns {*|Error} `value`, otherwise an `Error`
+   * @private
+   */
+  static toValueOrError(value) {
+    return (
+      value ||
+      createInvalidExceptionError(
+        'Runnable failed with falsy or undefined exception. Please throw an Error instead.',
+        value
+      )
+    );
+  }
+}
+
+const constants = utils.defineConstants(
   /**
    * {@link Runnable}-related constants.
    * @public
@@ -455,20 +464,8 @@ var constants = utils.defineConstants(
   }
 );
 
-/**
- * Given `value`, return identity if truthy, otherwise create an "invalid exception" error and return that.
- * @param {*} [value] - Value to return, if present
- * @returns {*|Error} `value`, otherwise an `Error`
- * @private
- */
-Runnable.toValueOrError = function (value) {
-  return (
-    value ||
-    createInvalidExceptionError(
-      'Runnable failed with falsy or undefined exception. Please throw an Error instead.',
-      value
-    )
-  );
-};
-
+// This should be a static in Runnable, but our current rollup version fails with:
+//[ !] (plugin at position 4) SyntaxError: Unexpected token (437:19) in ... mocha/lib/runnable.js
 Runnable.constants = constants;
+
+module.exports = Runnable;

--- a/lib/test.js
+++ b/lib/test.js
@@ -7,107 +7,99 @@ var isString = utils.isString;
 
 const {MOCHA_ID_PROP_NAME} = utils.constants;
 
-module.exports = Test;
-
-/**
- * Initialize a new `Test` with the given `title` and callback `fn`.
- *
- * @public
- * @class
- * @extends Runnable
- * @param {String} title - Test title (required)
- * @param {Function} [fn] - Test callback.  If omitted, the Test is considered "pending"
- */
-function Test(title, fn) {
-  if (!isString(title)) {
-    throw createInvalidArgumentTypeError(
-      'Test argument "title" should be a string. Received type "' +
-        typeof title +
-        '"',
-      'title',
-      'string'
-    );
+class Test extends Runnable {
+  /**
+   * @param {String} title - Test title (required)
+   * @param {Function} [fn] - Test callback.  If omitted, the Test is considered "pending"
+   */
+  constructor(title, fn) {
+    if (!isString(title)) {
+      throw createInvalidArgumentTypeError(
+        'Test argument "title" should be a string. Received type "' +
+          typeof title +
+          '"',
+        'title',
+        'string'
+      );
+    }
+    super(title, fn);
+    this.type = 'test';
+    this.reset();
   }
-  this.type = 'test';
-  Runnable.call(this, title, fn);
-  this.reset();
+
+  /**
+   * Resets the state initially or for a next run.
+   */
+  reset() {
+    Runnable.prototype.reset.call(this);
+    this.pending = !this.fn;
+    delete this.state;
+  }
+
+  /**
+   * Set or get retried test
+   *
+   * @private
+   */
+  retriedTest(n) {
+    if (!arguments.length) {
+      return this._retriedTest;
+    }
+    this._retriedTest = n;
+  }
+
+  /**
+   * Add test to the list of tests marked `only`.
+   *
+   * @protected
+   */
+  markOnly() {
+    this.parent.appendOnlyTest(this);
+  }
+
+  clone() {
+    var test = new Test(this.title, this.fn);
+    test.timeout(this.timeout());
+    test.slow(this.slow());
+    test.retries(this.retries());
+    test.currentRetry(this.currentRetry());
+    test.retriedTest(this.retriedTest() || this);
+    test.globals(this.globals());
+    test.parent = this.parent;
+    test.file = this.file;
+    test.ctx = this.ctx;
+    return test;
+  }
+
+  /**
+   * Returns an minimal object suitable for transmission over IPC.
+   * Functions are represented by keys beginning with `$$`.
+   * @protected
+   * @returns {Object}
+   */
+  serialize() {
+    return {
+      $$currentRetry: this._currentRetry,
+      $$fullTitle: this.fullTitle(),
+      $$isPending: Boolean(this.pending),
+      $$retriedTest: this._retriedTest || null,
+      $$slow: this._slow,
+      $$titlePath: this.titlePath(),
+      body: this.body,
+      duration: this.duration,
+      err: this.err,
+      parent: {
+        $$fullTitle: this.parent.fullTitle(),
+        [MOCHA_ID_PROP_NAME]: this.parent.id
+      },
+      speed: this.speed,
+      state: this.state,
+      title: this.title,
+      type: this.type,
+      file: this.file,
+      [MOCHA_ID_PROP_NAME]: this.id
+    };
+  }
 }
 
-/**
- * Inherit from `Runnable.prototype`.
- */
-utils.inherits(Test, Runnable);
-
-/**
- * Resets the state initially or for a next run.
- */
-Test.prototype.reset = function () {
-  Runnable.prototype.reset.call(this);
-  this.pending = !this.fn;
-  delete this.state;
-};
-
-/**
- * Set or get retried test
- *
- * @private
- */
-Test.prototype.retriedTest = function (n) {
-  if (!arguments.length) {
-    return this._retriedTest;
-  }
-  this._retriedTest = n;
-};
-
-/**
- * Add test to the list of tests marked `only`.
- *
- * @private
- */
-Test.prototype.markOnly = function () {
-  this.parent.appendOnlyTest(this);
-};
-
-Test.prototype.clone = function () {
-  var test = new Test(this.title, this.fn);
-  test.timeout(this.timeout());
-  test.slow(this.slow());
-  test.retries(this.retries());
-  test.currentRetry(this.currentRetry());
-  test.retriedTest(this.retriedTest() || this);
-  test.globals(this.globals());
-  test.parent = this.parent;
-  test.file = this.file;
-  test.ctx = this.ctx;
-  return test;
-};
-
-/**
- * Returns an minimal object suitable for transmission over IPC.
- * Functions are represented by keys beginning with `$$`.
- * @private
- * @returns {Object}
- */
-Test.prototype.serialize = function serialize() {
-  return {
-    $$currentRetry: this._currentRetry,
-    $$fullTitle: this.fullTitle(),
-    $$isPending: Boolean(this.pending),
-    $$retriedTest: this._retriedTest || null,
-    $$slow: this._slow,
-    $$titlePath: this.titlePath(),
-    body: this.body,
-    duration: this.duration,
-    err: this.err,
-    parent: {
-      $$fullTitle: this.parent.fullTitle(),
-      [MOCHA_ID_PROP_NAME]: this.parent.id
-    },
-    speed: this.speed,
-    state: this.state,
-    title: this.title,
-    type: this.type,
-    file: this.file,
-    [MOCHA_ID_PROP_NAME]: this.id
-  };
-};
+module.exports = Test;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: part of #5025
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches `Runnable` and the two classes that extend from it: `Hook` and `Test`.