### PR TITLE
chore: switch reporters from util.inherits to ES2015 classes

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -26,12 +26,6 @@ function getBrowserWindowSize() {
 }
 
 /**
- * Expose `Base`.
- */
-
-exports = module.exports = Base;
-
-/**
  * Check if both stdio streams are associated with a tty.
  */
 
@@ -43,10 +37,100 @@ var isatty = isBrowser || (process.stdout.isTTY && process.stderr.isTTY);
 var consoleLog = console.log;
 
 /**
+ * @description
+ * All other reporters generally inherit from this reporter.
+ */
+class Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    var failures = (this.failures = []);
+
+    if (!runner) {
+      throw new TypeError('Missing runner argument');
+    }
+    this.options = options || {};
+    this.runner = runner;
+    this.stats = runner.stats; // assigned so Reporters keep a closer reference
+
+    var maxDiffSizeOpt =
+      this.options.reporterOption && this.options.reporterOption.maxDiffSize;
+    if (maxDiffSizeOpt !== undefined && !isNaN(Number(maxDiffSizeOpt))) {
+      Base.maxDiffSize = Number(maxDiffSizeOpt);
+    }
+
+    runner.on(EVENT_TEST_PASS, function (test) {
+      if (test.duration > test.slow()) {
+        test.speed = 'slow';
+      } else if (test.duration > test.slow() / 2) {
+        test.speed = 'medium';
+      } else {
+        test.speed = 'fast';
+      }
+    });
+
+    runner.on(EVENT_TEST_FAIL, function (test, err) {
+      if (showDiff(err)) {
+        stringifyDiffObjs(err);
+      }
+      // more than one error per test
+      if (test.err && err instanceof Error) {
+        test.err.multiple = (test.err.multiple || []).concat(err);
+      } else {
+        test.err = err;
+      }
+      failures.push(test);
+    });
+  }
+
+  /**
+   * Outputs common epilogue used by many of the bundled reporters.
+   *
+   * @public
+   */
+  epilogue() {
+    var stats = this.stats;
+    var fmt;
+
+    Base.consoleLog();
+
+    // passes
+    fmt =
+      color('bright pass', ' ') +
+      color('green', ' %d passing') +
+      color('light', ' (%s)');
+
+    Base.consoleLog(fmt, stats.passes || 0, milliseconds(stats.duration));
+
+    // pending
+    if (stats.pending) {
+      fmt = color('pending', ' ') + color('pending', ' %d pending');
+
+      Base.consoleLog(fmt, stats.pending);
+    }
+
+    // failures
+    if (stats.failures) {
+      fmt = color('fail', '  %d failing');
+
+      Base.consoleLog(fmt, stats.failures);
+
+      Base.list(this.failures);
+      Base.consoleLog();
+    }
+
+    Base.consoleLog();
+  }
+}
+
+/**
  * Enable coloring by default, except in the browser interface.
  */
 
-exports.useColors =
+Base.useColors =
   !isBrowser &&
   (supportsColor.stdout || process.env.MOCHA_COLORS !== undefined);
 
@@ -54,18 +138,18 @@ exports.useColors =
  * Inline diffs instead of +/-
  */
 
-exports.inlineDiffs = false;
+Base.inlineDiffs = false;
 
 /**
  * Truncate diffs longer than this value to avoid slow performance
  */
-exports.maxDiffSize = 8192;
+Base.maxDiffSize = 8192;
 
 /**
  * Default color map.
  */
 
-exports.colors = {
+Base.colors = {
   pass: 90,
   fail: 31,
   'bright pass': 92,
@@ -93,7 +177,7 @@ exports.colors = {
  * Default symbol map.
  */
 
-exports.symbols = {
+Base.symbols = {
   ok: symbols.success,
   err: symbols.error,
   dot: '.',
@@ -112,26 +196,26 @@ exports.symbols = {
  * @param {string} str
  * @return {string}
  */
-var color = (exports.color = function (type, str) {
-  if (!exports.useColors) {
+var color = (Base.color = function (type, str) {
+  if (!Base.useColors) {
     return String(str);
   }
-  return '\u001b[' + exports.colors[type] + 'm' + str + '\u001b[0m';
+  return '\u001b[' + Base.colors[type] + 'm' + str + '\u001b[0m';
 });
 
 /**
  * Expose term window size, with some defaults for when stderr is not a tty.
  */
 
-exports.window = {
+Base.window = {
   width: 75
 };
 
 if (isatty) {
   if (isBrowser) {
-    exports.window.width = getBrowserWindowSize()[1];
+    Base.window.width = getBrowserWindowSize()[1];
   } else {
-    exports.window.width = process.stdout.getWindowSize(1)[0];
+    Base.window.width = process.stdout.getWindowSize(1)[0];
   }
 }
 
@@ -139,7 +223,7 @@ if (isatty) {
  * Expose some basic cursor interactions that are common among reporters.
  */
 
-exports.cursor = {
+Base.cursor = {
   hide: function () {
     isatty && process.stdout.write('\u001b[?25l');
   },
@@ -158,15 +242,15 @@ exports.cursor = {
 
   CR: function () {
     if (isatty) {
-      exports.cursor.deleteLine();
-      exports.cursor.beginningOfLine();
+      Base.cursor.deleteLine();
+      Base.cursor.beginningOfLine();
     } else {
       process.stdout.write('\r');
     }
   }
 };
 
-var showDiff = (exports.showDiff = function (err) {
+var showDiff = (Base.showDiff = function (err) {
   return (
     err &&
     err.showDiff !== false &&
@@ -194,16 +278,16 @@ function stringifyDiffObjs(err) {
  * @return {string} Diff
  */
 
-var generateDiff = (exports.generateDiff = function (actual, expected) {
+var generateDiff = (Base.generateDiff = function (actual, expected) {
   try {
-    var maxLen = exports.maxDiffSize;
+    var maxLen = Base.maxDiffSize;
     var skipped = 0;
     if (maxLen > 0) {
       skipped = Math.max(actual.length - maxLen, expected.length - maxLen);
       actual = actual.slice(0, maxLen);
       expected = expected.slice(0, maxLen);
     }
-    let result = exports.inlineDiffs
+    let result = Base.inlineDiffs
       ? inlineDiff(actual, expected)
       : unifiedDiff(actual, expected);
     if (skipped > 0) {
@@ -231,7 +315,7 @@ var generateDiff = (exports.generateDiff = function (actual, expected) {
  */
 var getFullErrorStack = function (err, seen) {
   if (seen && seen.has(err)) {
-    return { message: '', msg: '<circular>', stack: '' };
+    return {message: '', msg: '<circular>', stack: ''};
   }
 
   var message;
@@ -259,8 +343,11 @@ var getFullErrorStack = function (err, seen) {
     if (err.cause) {
       seen = seen || new Set();
       seen.add(err);
-      const causeStack = getFullErrorStack(err.cause, seen)
-      stack += '\n   Caused by: ' + causeStack.msg + (causeStack.stack ? '\n' + causeStack.stack : '');
+      const causeStack = getFullErrorStack(err.cause, seen);
+      stack +=
+        '\n   Caused by: ' +
+        causeStack.msg +
+        (causeStack.stack ? '\n' + causeStack.stack : '');
     }
   }
 
@@ -280,7 +367,7 @@ var getFullErrorStack = function (err, seen) {
  * @param {Object[]} failures - Each is Test instance with corresponding
  *     Error property
  */
-exports.list = function (failures) {
+Base.list = function (failures) {
   var multipleErr, multipleTest;
   Base.consoleLog();
   failures.forEach(function (test, i) {
@@ -302,14 +389,14 @@ exports.list = function (failures) {
       err = test.err;
     }
 
-    var { message, msg, stack } = getFullErrorStack(err);
+    var {message, msg, stack} = getFullErrorStack(err);
 
     // uncaught
     if (err.uncaught) {
       msg = 'Uncaught ' + msg;
     }
     // explicitly show diff
-    if (!exports.hideDiff && showDiff(err)) {
+    if (!Base.hideDiff && showDiff(err)) {
       stringifyDiffObjs(err);
       fmt =
         color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
@@ -336,98 +423,6 @@ exports.list = function (failures) {
 
     Base.consoleLog(fmt, i + 1, testTitle, msg, stack);
   });
-};
-
-/**
- * Constructs a new `Base` reporter instance.
- *
- * @description
- * All other reporters generally inherit from this reporter.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Base(runner, options) {
-  var failures = (this.failures = []);
-
-  if (!runner) {
-    throw new TypeError('Missing runner argument');
-  }
-  this.options = options || {};
-  this.runner = runner;
-  this.stats = runner.stats; // assigned so Reporters keep a closer reference
-
-  var maxDiffSizeOpt =
-    this.options.reporterOption && this.options.reporterOption.maxDiffSize;
-  if (maxDiffSizeOpt !== undefined && !isNaN(Number(maxDiffSizeOpt))) {
-    exports.maxDiffSize = Number(maxDiffSizeOpt);
-  }
-
-  runner.on(EVENT_TEST_PASS, function (test) {
-    if (test.duration > test.slow()) {
-      test.speed = 'slow';
-    } else if (test.duration > test.slow() / 2) {
-      test.speed = 'medium';
-    } else {
-      test.speed = 'fast';
-    }
-  });
-
-  runner.on(EVENT_TEST_FAIL, function (test, err) {
-    if (showDiff(err)) {
-      stringifyDiffObjs(err);
-    }
-    // more than one error per test
-    if (test.err && err instanceof Error) {
-      test.err.multiple = (test.err.multiple || []).concat(err);
-    } else {
-      test.err = err;
-    }
-    failures.push(test);
-  });
-}
-
-/**
- * Outputs common epilogue used by many of the bundled reporters.
- *
- * @public
- * @memberof Mocha.reporters
- */
-Base.prototype.epilogue = function () {
-  var stats = this.stats;
-  var fmt;
-
-  Base.consoleLog();
-
-  // passes
-  fmt =
-    color('bright pass', ' ') +
-    color('green', ' %d passing') +
-    color('light', ' (%s)');
-
-  Base.consoleLog(fmt, stats.passes || 0, milliseconds(stats.duration));
-
-  // pending
-  if (stats.pending) {
-    fmt = color('pending', ' ') + color('pending', ' %d pending');
-
-    Base.consoleLog(fmt, stats.pending);
-  }
-
-  // failures
-  if (stats.failures) {
-    fmt = color('fail', '  %d failing');
-
-    Base.consoleLog(fmt, stats.failures);
-
-    Base.list(this.failures);
-    Base.consoleLog();
-  }
-
-  Base.consoleLog();
 };
 
 /**
@@ -589,3 +584,5 @@ Base.abstract = true;
  * @property {string} msg
  * @property {string} stack
  */
+
+exports = module.exports = Base;

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -14,82 +14,79 @@ var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_SUITE_BEGIN = constants.EVENT_SUITE_BEGIN;
 var EVENT_SUITE_END = constants.EVENT_SUITE_END;
 
-/**
- * Expose `Doc`.
- */
+class Doc extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = Doc;
+    var indents = 2;
 
-/**
- * Constructs a new `Doc` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Doc(runner, options) {
-  Base.call(this, runner, options);
+    function indent() {
+      return Array(indents).join('  ');
+    }
 
-  var indents = 2;
+    runner.on(EVENT_SUITE_BEGIN, function (suite) {
+      if (suite.root) {
+        return;
+      }
+      ++indents;
+      Base.consoleLog('%s<section class="suite">', indent());
+      ++indents;
+      Base.consoleLog('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
+      Base.consoleLog('%s<dl>', indent());
+    });
 
-  function indent() {
-    return Array(indents).join('  ');
+    runner.on(EVENT_SUITE_END, function (suite) {
+      if (suite.root) {
+        return;
+      }
+      Base.consoleLog('%s</dl>', indent());
+      --indents;
+      Base.consoleLog('%s</section>', indent());
+      --indents;
+    });
+
+    runner.on(EVENT_TEST_PASS, function (test) {
+      Base.consoleLog('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
+      Base.consoleLog('%s  <dt>%s</dt>', indent(), utils.escape(test.file));
+      var code = utils.escape(utils.clean(test.body));
+      Base.consoleLog(
+        '%s  <dd><pre><code>%s</code></pre></dd>',
+        indent(),
+        code
+      );
+    });
+
+    runner.on(EVENT_TEST_FAIL, function (test, err) {
+      Base.consoleLog(
+        '%s  <dt class="error">%s</dt>',
+        indent(),
+        utils.escape(test.title)
+      );
+      Base.consoleLog(
+        '%s  <dt class="error">%s</dt>',
+        indent(),
+        utils.escape(test.file)
+      );
+      var code = utils.escape(utils.clean(test.body));
+      Base.consoleLog(
+        '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
+        indent(),
+        code
+      );
+      Base.consoleLog(
+        '%s  <dd class="error">%s</dd>',
+        indent(),
+        utils.escape(err)
+      );
+    });
   }
-
-  runner.on(EVENT_SUITE_BEGIN, function (suite) {
-    if (suite.root) {
-      return;
-    }
-    ++indents;
-    Base.consoleLog('%s<section class="suite">', indent());
-    ++indents;
-    Base.consoleLog('%s<h1>%s</h1>', indent(), utils.escape(suite.title));
-    Base.consoleLog('%s<dl>', indent());
-  });
-
-  runner.on(EVENT_SUITE_END, function (suite) {
-    if (suite.root) {
-      return;
-    }
-    Base.consoleLog('%s</dl>', indent());
-    --indents;
-    Base.consoleLog('%s</section>', indent());
-    --indents;
-  });
-
-  runner.on(EVENT_TEST_PASS, function (test) {
-    Base.consoleLog('%s  <dt>%s</dt>', indent(), utils.escape(test.title));
-    Base.consoleLog('%s  <dt>%s</dt>', indent(), utils.escape(test.file));
-    var code = utils.escape(utils.clean(test.body));
-    Base.consoleLog('%s  <dd><pre><code>%s</code></pre></dd>', indent(), code);
-  });
-
-  runner.on(EVENT_TEST_FAIL, function (test, err) {
-    Base.consoleLog(
-      '%s  <dt class="error">%s</dt>',
-      indent(),
-      utils.escape(test.title)
-    );
-    Base.consoleLog(
-      '%s  <dt class="error">%s</dt>',
-      indent(),
-      utils.escape(test.file)
-    );
-    var code = utils.escape(utils.clean(test.body));
-    Base.consoleLog(
-      '%s  <dd class="error"><pre><code>%s</code></pre></dd>',
-      indent(),
-      code
-    );
-    Base.consoleLog(
-      '%s  <dd class="error">%s</dd>',
-      indent(),
-      utils.escape(err)
-    );
-  });
 }
 
 Doc.description = 'HTML documentation';
+
+exports = module.exports = Doc;

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -7,7 +7,6 @@
  */
 
 var Base = require('./base');
-var inherits = require('../utils').inherits;
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
@@ -15,67 +14,55 @@ var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 
-/**
- * Expose `Dot`.
- */
+class Dot extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = Dot;
+    var self = this;
+    var width = (Base.window.width * 0.75) | 0;
+    var n = -1;
 
-/**
- * Constructs a new `Dot` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Dot(runner, options) {
-  Base.call(this, runner, options);
+    runner.on(EVENT_RUN_BEGIN, function () {
+      process.stdout.write('\n');
+    });
 
-  var self = this;
-  var width = (Base.window.width * 0.75) | 0;
-  var n = -1;
+    runner.on(EVENT_TEST_PENDING, function () {
+      if (++n % width === 0) {
+        process.stdout.write('\n  ');
+      }
+      process.stdout.write(Base.color('pending', Base.symbols.comma));
+    });
 
-  runner.on(EVENT_RUN_BEGIN, function () {
-    process.stdout.write('\n');
-  });
+    runner.on(EVENT_TEST_PASS, function (test) {
+      if (++n % width === 0) {
+        process.stdout.write('\n  ');
+      }
+      if (test.speed === 'slow') {
+        process.stdout.write(Base.color('bright yellow', Base.symbols.dot));
+      } else {
+        process.stdout.write(Base.color(test.speed, Base.symbols.dot));
+      }
+    });
 
-  runner.on(EVENT_TEST_PENDING, function () {
-    if (++n % width === 0) {
-      process.stdout.write('\n  ');
-    }
-    process.stdout.write(Base.color('pending', Base.symbols.comma));
-  });
+    runner.on(EVENT_TEST_FAIL, function () {
+      if (++n % width === 0) {
+        process.stdout.write('\n  ');
+      }
+      process.stdout.write(Base.color('fail', Base.symbols.bang));
+    });
 
-  runner.on(EVENT_TEST_PASS, function (test) {
-    if (++n % width === 0) {
-      process.stdout.write('\n  ');
-    }
-    if (test.speed === 'slow') {
-      process.stdout.write(Base.color('bright yellow', Base.symbols.dot));
-    } else {
-      process.stdout.write(Base.color(test.speed, Base.symbols.dot));
-    }
-  });
-
-  runner.on(EVENT_TEST_FAIL, function () {
-    if (++n % width === 0) {
-      process.stdout.write('\n  ');
-    }
-    process.stdout.write(Base.color('fail', Base.symbols.bang));
-  });
-
-  runner.once(EVENT_RUN_END, function () {
-    process.stdout.write('\n');
-    self.epilogue();
-  });
+    runner.once(EVENT_RUN_END, function () {
+      process.stdout.write('\n');
+      self.epilogue();
+    });
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(Dot, Base);
-
 Dot.description = 'dot matrix representation';
+
+exports = module.exports = Dot;

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -40,7 +40,6 @@ var statsTemplate =
 var playIcon = '&#x2023;';
 
 class HTML extends Base {
-  static browserOnly = true;
 
   /**
    * @public
@@ -286,6 +285,8 @@ class HTML extends Base {
     pre.style.display = 'none';
   }
 }
+
+HTML.browserOnly = true;
 
 /**
  * Makes a URL, preserving querystring ("search") parameters.

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -26,12 +26,6 @@ var escape = utils.escape;
 var Date = global.Date;
 
 /**
- * Expose `HTML`.
- */
-
-exports = module.exports = HTML;
-
-/**
  * Stats template.
  */
 
@@ -45,209 +39,251 @@ var statsTemplate =
 
 var playIcon = '&#x2023;';
 
-/**
- * Constructs a new `HTML` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function HTML(runner, options) {
-  Base.call(this, runner, options);
+class HTML extends Base {
+  static browserOnly = true;
 
-  var self = this;
-  var stats = this.stats;
-  var stat = fragment(statsTemplate);
-  var items = stat.getElementsByTagName('li');
-  var passes = items[1].getElementsByTagName('em')[0];
-  var passesLink = items[1].getElementsByTagName('a')[0];
-  var failures = items[2].getElementsByTagName('em')[0];
-  var failuresLink = items[2].getElementsByTagName('a')[0];
-  var duration = items[3].getElementsByTagName('em')[0];
-  var report = fragment('<ul id="mocha-report"></ul>');
-  var stack = [report];
-  var progressText = items[0].getElementsByTagName('div')[0];
-  var progressBar = items[0].getElementsByTagName('progress')[0];
-  var progressRing = [
-    items[0].getElementsByClassName('ring-flatlight')[0],
-    items[0].getElementsByClassName('ring-highlight')[0]];
-  var progressRingRadius = null; // computed CSS unavailable now, so set later
-  var root = document.getElementById('mocha');
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-  if (!root) {
-    return error('#mocha div missing, add it to your document');
-  }
+    var self = this;
+    var stats = this.stats;
+    var stat = fragment(statsTemplate);
+    var items = stat.getElementsByTagName('li');
+    var passes = items[1].getElementsByTagName('em')[0];
+    var passesLink = items[1].getElementsByTagName('a')[0];
+    var failures = items[2].getElementsByTagName('em')[0];
+    var failuresLink = items[2].getElementsByTagName('a')[0];
+    var duration = items[3].getElementsByTagName('em')[0];
+    var report = fragment('<ul id="mocha-report"></ul>');
+    var stack = [report];
+    var progressText = items[0].getElementsByTagName('div')[0];
+    var progressBar = items[0].getElementsByTagName('progress')[0];
+    var progressRing = [
+      items[0].getElementsByClassName('ring-flatlight')[0],
+      items[0].getElementsByClassName('ring-highlight')[0]
+    ];
+    var progressRingRadius = null; // computed CSS unavailable now, so set later
+    var root = document.getElementById('mocha');
 
-  // pass toggle
-  on(passesLink, 'click', function (evt) {
-    evt.preventDefault();
-    unhide();
-    var name = /pass/.test(report.className) ? '' : ' pass';
-    report.className = report.className.replace(/fail|pass/g, '') + name;
-    if (report.className.trim()) {
-      hideSuitesWithout('test pass');
-    }
-  });
-
-  // failure toggle
-  on(failuresLink, 'click', function (evt) {
-    evt.preventDefault();
-    unhide();
-    var name = /fail/.test(report.className) ? '' : ' fail';
-    report.className = report.className.replace(/fail|pass/g, '') + name;
-    if (report.className.trim()) {
-      hideSuitesWithout('test fail');
-    }
-  });
-
-  root.appendChild(stat);
-  root.appendChild(report);
-
-  runner.on(EVENT_SUITE_BEGIN, function (suite) {
-    if (suite.root) {
-      return;
+    if (!root) {
+      return error('#mocha div missing, add it to your document');
     }
 
-    // suite
-    var url = self.suiteURL(suite);
-    var el = fragment(
-      '<li class="suite"><h1><a href="%s">%s</a></h1></li>',
-      url,
-      escape(suite.title)
-    );
+    // pass toggle
+    on(passesLink, 'click', function (evt) {
+      evt.preventDefault();
+      unhide();
+      var name = /pass/.test(report.className) ? '' : ' pass';
+      report.className = report.className.replace(/fail|pass/g, '') + name;
+      if (report.className.trim()) {
+        hideSuitesWithout('test pass');
+      }
+    });
 
-    // container
-    stack[0].appendChild(el);
-    stack.unshift(document.createElement('ul'));
-    el.appendChild(stack[0]);
-  });
+    // failure toggle
+    on(failuresLink, 'click', function (evt) {
+      evt.preventDefault();
+      unhide();
+      var name = /fail/.test(report.className) ? '' : ' fail';
+      report.className = report.className.replace(/fail|pass/g, '') + name;
+      if (report.className.trim()) {
+        hideSuitesWithout('test fail');
+      }
+    });
 
-  runner.on(EVENT_SUITE_END, function (suite) {
-    if (suite.root) {
-      updateStats();
-      return;
-    }
-    stack.shift();
-  });
+    root.appendChild(stat);
+    root.appendChild(report);
 
-  runner.on(EVENT_TEST_PASS, function (test) {
-    var url = self.testURL(test);
-    var markup =
-      '<li class="test pass %e"><h2>%e<span class="duration">%ems</span> ' +
-      '<a href="%s" class="replay">' +
-      playIcon +
-      '</a></h2></li>';
-    var el = fragment(markup, test.speed, test.title, test.duration, url);
-    self.addCodeToggle(el, test.body);
-    appendToStack(el);
-    updateStats();
-  });
+    runner.on(EVENT_SUITE_BEGIN, function (suite) {
+      if (suite.root) {
+        return;
+      }
 
-  runner.on(EVENT_TEST_FAIL, function (test) {
-    var el = fragment(
-      '<li class="test fail"><h2>%e <a href="%e" class="replay">' +
+      // suite
+      var url = self.suiteURL(suite);
+      var el = fragment(
+        '<li class="suite"><h1><a href="%s">%s</a></h1></li>',
+        url,
+        escape(suite.title)
+      );
+
+      // container
+      stack[0].appendChild(el);
+      stack.unshift(document.createElement('ul'));
+      el.appendChild(stack[0]);
+    });
+
+    runner.on(EVENT_SUITE_END, function (suite) {
+      if (suite.root) {
+        updateStats();
+        return;
+      }
+      stack.shift();
+    });
+
+    runner.on(EVENT_TEST_PASS, function (test) {
+      var url = self.testURL(test);
+      var markup =
+        '<li class="test pass %e"><h2>%e<span class="duration">%ems</span> ' +
+        '<a href="%s" class="replay">' +
         playIcon +
-        '</a></h2></li>',
-      test.title,
-      self.testURL(test)
-    );
-    var stackString; // Note: Includes leading newline
-    var message = test.err.toString();
+        '</a></h2></li>';
+      var el = fragment(markup, test.speed, test.title, test.duration, url);
+      self.addCodeToggle(el, test.body);
+      appendToStack(el);
+      updateStats();
+    });
 
-    // <=IE7 stringifies to [Object Error]. Since it can be overloaded, we
-    // check for the result of the stringifying.
-    if (message === '[object Error]') {
-      message = test.err.message;
-    }
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      var el = fragment(
+        '<li class="test fail"><h2>%e <a href="%e" class="replay">' +
+          playIcon +
+          '</a></h2></li>',
+        test.title,
+        self.testURL(test)
+      );
+      var stackString; // Note: Includes leading newline
+      var message = test.err.toString();
 
-    if (test.err.stack) {
-      var indexOfMessage = test.err.stack.indexOf(test.err.message);
-      if (indexOfMessage === -1) {
-        stackString = test.err.stack;
+      // <=IE7 stringifies to [Object Error]. Since it can be overloaded, we
+      // check for the result of the stringifying.
+      if (message === '[object Error]') {
+        message = test.err.message;
+      }
+
+      if (test.err.stack) {
+        var indexOfMessage = test.err.stack.indexOf(test.err.message);
+        if (indexOfMessage === -1) {
+          stackString = test.err.stack;
+        } else {
+          stackString = test.err.stack.slice(
+            test.err.message.length + indexOfMessage
+          );
+        }
+      } else if (test.err.sourceURL && test.err.line !== undefined) {
+        // Safari doesn't give you a stack. Let's at least provide a source line.
+        stackString = '\n(' + test.err.sourceURL + ':' + test.err.line + ')';
+      }
+
+      stackString = stackString || '';
+
+      if (test.err.htmlMessage && stackString) {
+        el.appendChild(
+          fragment(
+            '<div class="html-error">%s\n<pre class="error">%e</pre></div>',
+            test.err.htmlMessage,
+            stackString
+          )
+        );
+      } else if (test.err.htmlMessage) {
+        el.appendChild(
+          fragment('<div class="html-error">%s</div>', test.err.htmlMessage)
+        );
       } else {
-        stackString = test.err.stack.slice(
-          test.err.message.length + indexOfMessage
+        el.appendChild(
+          fragment('<pre class="error">%e%e</pre>', message, stackString)
         );
       }
-    } else if (test.err.sourceURL && test.err.line !== undefined) {
-      // Safari doesn't give you a stack. Let's at least provide a source line.
-      stackString = '\n(' + test.err.sourceURL + ':' + test.err.line + ')';
+
+      self.addCodeToggle(el, test.body);
+      appendToStack(el);
+      updateStats();
+    });
+
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      var el = fragment(
+        '<li class="test pass pending"><h2>%e</h2></li>',
+        test.title
+      );
+      appendToStack(el);
+      updateStats();
+    });
+
+    function appendToStack(el) {
+      // Don't call .appendChild if #mocha-report was already .shift()'ed off the stack.
+      if (stack[0]) {
+        stack[0].appendChild(el);
+      }
     }
 
-    stackString = stackString || '';
+    function updateStats() {
+      // TODO: add to stats
+      var percent = ((stats.tests / runner.total) * 100) | 0;
+      progressBar.value = percent;
+      if (progressText) {
+        // setting a toFixed that is too low, makes small changes to progress not shown
+        // setting it too high, makes the progress text longer then it needs to
+        // to address this, calculate the toFixed based on the magnitude of total
+        var decimalPlaces = Math.ceil(Math.log10(runner.total / 100));
+        text(
+          progressText,
+          percent.toFixed(Math.min(Math.max(decimalPlaces, 0), 100)) + '%'
+        );
+      }
+      if (progressRing) {
+        var radius = parseFloat(
+          getComputedStyle(progressRing[0]).getPropertyValue('r')
+        );
+        var wholeArc = Math.PI * 2 * radius;
+        var highlightArc = percent * (wholeArc / 100);
+        // The progress ring is in 2 parts, the flatlight color and highlight color.
+        // Rendering both on top of the other, seems to make a 3rd color on the edges.
+        // To create 1 whole ring with 2 colors, both parts are inverse of the other.
+        progressRing[0].style[
+          'stroke-dasharray'
+        ] = `0,${highlightArc}px,${wholeArc}px`;
+        progressRing[1].style[
+          'stroke-dasharray'
+        ] = `${highlightArc}px,${wholeArc}px`;
+      }
 
-    if (test.err.htmlMessage && stackString) {
-      el.appendChild(
-        fragment(
-          '<div class="html-error">%s\n<pre class="error">%e</pre></div>',
-          test.err.htmlMessage,
-          stackString
-        )
-      );
-    } else if (test.err.htmlMessage) {
-      el.appendChild(
-        fragment('<div class="html-error">%s</div>', test.err.htmlMessage)
-      );
-    } else {
-      el.appendChild(
-        fragment('<pre class="error">%e%e</pre>', message, stackString)
-      );
-    }
-
-    self.addCodeToggle(el, test.body);
-    appendToStack(el);
-    updateStats();
-  });
-
-  runner.on(EVENT_TEST_PENDING, function (test) {
-    var el = fragment(
-      '<li class="test pass pending"><h2>%e</h2></li>',
-      test.title
-    );
-    appendToStack(el);
-    updateStats();
-  });
-
-  function appendToStack(el) {
-    // Don't call .appendChild if #mocha-report was already .shift()'ed off the stack.
-    if (stack[0]) {
-      stack[0].appendChild(el);
+      // update stats
+      var ms = new Date() - stats.start;
+      text(passes, stats.passes);
+      text(failures, stats.failures);
+      text(duration, (ms / 1000).toFixed(2));
     }
   }
 
-  function updateStats() {
-    // TODO: add to stats
-    var percent = ((stats.tests / runner.total) * 100) | 0;
-    progressBar.value = percent;
-    if (progressText) {
-      // setting a toFixed that is too low, makes small changes to progress not shown
-      // setting it too high, makes the progress text longer then it needs to
-      // to address this, calculate the toFixed based on the magnitude of total
-      var decimalPlaces = Math.ceil(Math.log10(runner.total / 100));
-      text(
-        progressText,
-        percent.toFixed(Math.min(Math.max(decimalPlaces, 0), 100)) + '%'
-      );
-    }
-    if (progressRing) {
-      var radius = parseFloat(getComputedStyle(progressRing[0]).getPropertyValue('r'));
-      var wholeArc = Math.PI * 2 * radius;
-      var highlightArc = percent * (wholeArc / 100);
-      // The progress ring is in 2 parts, the flatlight color and highlight color.
-      // Rendering both on top of the other, seems to make a 3rd color on the edges.
-      // To create 1 whole ring with 2 colors, both parts are inverse of the other.
-      progressRing[0].style['stroke-dasharray'] = `0,${highlightArc}px,${wholeArc}px`;
-      progressRing[1].style['stroke-dasharray'] = `${highlightArc}px,${wholeArc}px`;
-    }
+  /**
+   * Provide suite URL.
+   *
+   * @param {Object} [suite]
+   */
+  suiteURL(suite) {
+    return makeUrl(suite.fullTitle());
+  }
 
-    // update stats
-    var ms = new Date() - stats.start;
-    text(passes, stats.passes);
-    text(failures, stats.failures);
-    text(duration, (ms / 1000).toFixed(2));
+  /**
+   * Provide test URL.
+   *
+   * @param {Object} [test]
+   */
+  testURL(test) {
+    return makeUrl(test.fullTitle());
+  }
+
+  /**
+   * Adds code toggle functionality for the provided test's list element.
+   *
+   * @param {HTMLLIElement} el
+   * @param {string} contents
+   */
+  addCodeToggle(el, contents) {
+    var h2 = el.getElementsByTagName('h2')[0];
+
+    on(h2, 'click', function () {
+      pre.style.display = pre.style.display === 'none' ? 'block' : 'none';
+    });
+
+    var pre = fragment('<pre><code>%e</code></pre>', utils.clean(contents));
+    el.appendChild(pre);
+    pre.style.display = 'none';
   }
 }
 
@@ -272,42 +308,6 @@ function makeUrl(s) {
     encodeURIComponent(escapeRe(s))
   );
 }
-
-/**
- * Provide suite URL.
- *
- * @param {Object} [suite]
- */
-HTML.prototype.suiteURL = function (suite) {
-  return makeUrl(suite.fullTitle());
-};
-
-/**
- * Provide test URL.
- *
- * @param {Object} [test]
- */
-HTML.prototype.testURL = function (test) {
-  return makeUrl(test.fullTitle());
-};
-
-/**
- * Adds code toggle functionality for the provided test's list element.
- *
- * @param {HTMLLIElement} el
- * @param {string} contents
- */
-HTML.prototype.addCodeToggle = function (el, contents) {
-  var h2 = el.getElementsByTagName('h2')[0];
-
-  on(h2, 'click', function () {
-    pre.style.display = pre.style.display === 'none' ? 'block' : 'none';
-  });
-
-  var pre = fragment('<pre><code>%e</code></pre>', utils.clean(contents));
-  el.appendChild(pre);
-  pre.style.display = 'none';
-};
 
 /**
  * Display error `msg`.
@@ -392,4 +392,4 @@ function on(el, event, fn) {
   }
 }
 
-HTML.browserOnly = true;
+exports = module.exports = HTML;

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -13,47 +13,40 @@ var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 
-/**
- * Expose `JSONStream`.
- */
+class JSONStream extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = JSONStream;
+    var self = this;
+    var total = runner.total;
 
-/**
- * Constructs a new `JSONStream` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function JSONStream(runner, options) {
-  Base.call(this, runner, options);
+    runner.once(EVENT_RUN_BEGIN, function () {
+      writeEvent(['start', {total}]);
+    });
 
-  var self = this;
-  var total = runner.total;
+    runner.on(EVENT_TEST_PASS, function (test) {
+      writeEvent(['pass', clean(test)]);
+    });
 
-  runner.once(EVENT_RUN_BEGIN, function () {
-    writeEvent(['start', {total}]);
-  });
+    runner.on(EVENT_TEST_FAIL, function (test, err) {
+      test = clean(test);
+      test.err = err.message;
+      test.stack = err.stack || null;
+      writeEvent(['fail', test]);
+    });
 
-  runner.on(EVENT_TEST_PASS, function (test) {
-    writeEvent(['pass', clean(test)]);
-  });
-
-  runner.on(EVENT_TEST_FAIL, function (test, err) {
-    test = clean(test);
-    test.err = err.message;
-    test.stack = err.stack || null;
-    writeEvent(['fail', test]);
-  });
-
-  runner.once(EVENT_RUN_END, function () {
-    writeEvent(['end', self.stats]);
-  });
+    runner.once(EVENT_RUN_END, function () {
+      writeEvent(['end', self.stats]);
+    });
+  }
 }
+
+JSONStream.description = 'newline delimited JSON events';
 
 /**
  * Mocha event to be written to the output stream.
@@ -89,4 +82,4 @@ function clean(test) {
   };
 }
 
-JSONStream.description = 'newline delimited JSON events';
+exports = module.exports = JSONStream;

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -18,82 +18,75 @@ var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_TEST_END = constants.EVENT_TEST_END;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 
-/**
- * Expose `JSON`.
- */
+class JSONReporter extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options = {}) {
+    super(runner, options);
 
-exports = module.exports = JSONReporter;
+    var self = this;
+    var tests = [];
+    var pending = [];
+    var failures = [];
+    var passes = [];
+    var output;
 
-/**
- * Constructs a new `JSON` reporter instance.
- *
- * @public
- * @class JSON
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function JSONReporter(runner, options = {}) {
-  Base.call(this, runner, options);
-
-  var self = this;
-  var tests = [];
-  var pending = [];
-  var failures = [];
-  var passes = [];
-  var output;
-
-  if (options.reporterOption && options.reporterOption.output) {
-    if (utils.isBrowser()) {
-      throw createUnsupportedError('file output not supported in browser');
+    if (options.reporterOption && options.reporterOption.output) {
+      if (utils.isBrowser()) {
+        throw createUnsupportedError('file output not supported in browser');
+      }
+      output = options.reporterOption.output;
     }
-    output = options.reporterOption.output;
-  }
 
-  runner.on(EVENT_TEST_END, function (test) {
-    tests.push(test);
-  });
+    runner.on(EVENT_TEST_END, function (test) {
+      tests.push(test);
+    });
 
-  runner.on(EVENT_TEST_PASS, function (test) {
-    passes.push(test);
-  });
+    runner.on(EVENT_TEST_PASS, function (test) {
+      passes.push(test);
+    });
 
-  runner.on(EVENT_TEST_FAIL, function (test) {
-    failures.push(test);
-  });
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      failures.push(test);
+    });
 
-  runner.on(EVENT_TEST_PENDING, function (test) {
-    pending.push(test);
-  });
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      pending.push(test);
+    });
 
-  runner.once(EVENT_RUN_END, function () {
-    var obj = {
-      stats: self.stats,
-      tests: tests.map(clean),
-      pending: pending.map(clean),
-      failures: failures.map(clean),
-      passes: passes.map(clean)
-    };
+    runner.once(EVENT_RUN_END, function () {
+      var obj = {
+        stats: self.stats,
+        tests: tests.map(clean),
+        pending: pending.map(clean),
+        failures: failures.map(clean),
+        passes: passes.map(clean)
+      };
 
-    runner.testResults = obj;
+      runner.testResults = obj;
 
-    var json = JSON.stringify(obj, null, 2);
-    if (output) {
-      try {
-        fs.mkdirSync(path.dirname(output), {recursive: true});
-        fs.writeFileSync(output, json);
-      } catch (err) {
-        console.error(
-          `${Base.symbols.err} [mocha] writing output to "${output}" failed: ${err.message}\n`
-        );
+      var json = JSON.stringify(obj, null, 2);
+      if (output) {
+        try {
+          fs.mkdirSync(path.dirname(output), {recursive: true});
+          fs.writeFileSync(output, json);
+        } catch (err) {
+          console.error(
+            `${Base.symbols.err} [mocha] writing output to "${output}" failed: ${err.message}\n`
+          );
+          process.stdout.write(json);
+        }
+      } else {
         process.stdout.write(json);
       }
-    } else {
-      process.stdout.write(json);
-    }
-  });
+    });
+  }
 }
+
+JSON.description = 'single JSON object';
 
 /**
  * Return a plain-object representation of `test`
@@ -159,4 +152,4 @@ function errorJSON(err) {
   return res;
 }
 
-JSONReporter.description = 'single JSON object';
+exports = module.exports = JSONReporter;

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -7,7 +7,6 @@
  */
 
 var Base = require('./base');
-var inherits = require('../utils').inherits;
 var constants = require('../runner').constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
@@ -16,12 +15,6 @@ var STATE_FAILED = require('../runnable').constants.STATE_FAILED;
 
 var cursor = Base.cursor;
 var color = Base.color;
-
-/**
- * Expose `Landing`.
- */
-
-exports = module.exports = Landing;
 
 /**
  * Airplane color.
@@ -41,76 +34,70 @@ Base.colors['plane crash'] = 31;
 
 Base.colors.runway = 90;
 
-/**
- * Constructs a new `Landing` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Landing(runner, options) {
-  Base.call(this, runner, options);
+class Landing extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-  var self = this;
-  var width = (Base.window.width * 0.75) | 0;
-  var stream = process.stdout;
+    var self = this;
+    var width = (Base.window.width * 0.75) | 0;
+    var stream = process.stdout;
 
-  var plane = color('plane', '✈');
-  var crashed = -1;
-  var n = 0;
-  var total = 0;
+    var plane = color('plane', '✈');
+    var crashed = -1;
+    var n = 0;
+    var total = 0;
 
-  function runway() {
-    var buf = Array(width).join('-');
-    return '  ' + color('runway', buf);
-  }
-
-  runner.on(EVENT_RUN_BEGIN, function () {
-    stream.write('\n\n\n  ');
-    cursor.hide();
-  });
-
-  runner.on(EVENT_TEST_END, function (test) {
-    // check if the plane crashed
-    var col = crashed === -1 ? ((width * ++n) / ++total) | 0 : crashed;
-    // show the crash
-    if (test.state === STATE_FAILED) {
-      plane = color('plane crash', '✈');
-      crashed = col;
+    function runway() {
+      var buf = Array(width).join('-');
+      return '  ' + color('runway', buf);
     }
 
-    // render landing strip
-    stream.write('\u001b[' + (width + 1) + 'D\u001b[2A');
-    stream.write(runway());
-    stream.write('\n  ');
-    stream.write(color('runway', Array(col).join('⋅')));
-    stream.write(plane);
-    stream.write(color('runway', Array(width - col).join('⋅') + '\n'));
-    stream.write(runway());
-    stream.write('\u001b[0m');
-  });
-
-  runner.once(EVENT_RUN_END, function () {
-    cursor.show();
-    process.stdout.write('\n');
-    self.epilogue();
-  });
-
-  // if cursor is hidden when we ctrl-C, then it will remain hidden unless...
-  process.once('SIGINT', function () {
-    cursor.show();
-    process.nextTick(function () {
-      process.kill(process.pid, 'SIGINT');
+    runner.on(EVENT_RUN_BEGIN, function () {
+      stream.write('\n\n\n  ');
+      cursor.hide();
     });
-  });
+
+    runner.on(EVENT_TEST_END, function (test) {
+      // check if the plane crashed
+      var col = crashed === -1 ? ((width * ++n) / ++total) | 0 : crashed;
+      // show the crash
+      if (test.state === STATE_FAILED) {
+        plane = color('plane crash', '✈');
+        crashed = col;
+      }
+
+      // render landing strip
+      stream.write('\u001b[' + (width + 1) + 'D\u001b[2A');
+      stream.write(runway());
+      stream.write('\n  ');
+      stream.write(color('runway', Array(col).join('⋅')));
+      stream.write(plane);
+      stream.write(color('runway', Array(width - col).join('⋅') + '\n'));
+      stream.write(runway());
+      stream.write('\u001b[0m');
+    });
+
+    runner.once(EVENT_RUN_END, function () {
+      cursor.show();
+      process.stdout.write('\n');
+      self.epilogue();
+    });
+
+    // if cursor is hidden when we ctrl-C, then it will remain hidden unless...
+    process.once('SIGINT', function () {
+      cursor.show();
+      process.nextTick(function () {
+        process.kill(process.pid, 'SIGINT');
+      });
+    });
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(Landing, Base);
-
 Landing.description = 'Unicode landing strip';
+
+exports = module.exports = Landing;

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -7,7 +7,6 @@
  */
 
 var Base = require('./base');
-var inherits = require('../utils').inherits;
 var constants = require('../runner').constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
@@ -18,61 +17,49 @@ var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var color = Base.color;
 var cursor = Base.cursor;
 
-/**
- * Expose `List`.
- */
+class List extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = List;
+    var self = this;
+    var n = 0;
 
-/**
- * Constructs a new `List` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function List(runner, options) {
-  Base.call(this, runner, options);
+    runner.on(EVENT_RUN_BEGIN, function () {
+      Base.consoleLog();
+    });
 
-  var self = this;
-  var n = 0;
+    runner.on(EVENT_TEST_BEGIN, function (test) {
+      process.stdout.write(color('pass', '    ' + test.fullTitle() + ': '));
+    });
 
-  runner.on(EVENT_RUN_BEGIN, function () {
-    Base.consoleLog();
-  });
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      var fmt = color('checkmark', '  -') + color('pending', ' %s');
+      Base.consoleLog(fmt, test.fullTitle());
+    });
 
-  runner.on(EVENT_TEST_BEGIN, function (test) {
-    process.stdout.write(color('pass', '    ' + test.fullTitle() + ': '));
-  });
+    runner.on(EVENT_TEST_PASS, function (test) {
+      var fmt =
+        color('checkmark', '  ' + Base.symbols.ok) +
+        color('pass', ' %s: ') +
+        color(test.speed, '%dms');
+      cursor.CR();
+      Base.consoleLog(fmt, test.fullTitle(), test.duration);
+    });
 
-  runner.on(EVENT_TEST_PENDING, function (test) {
-    var fmt = color('checkmark', '  -') + color('pending', ' %s');
-    Base.consoleLog(fmt, test.fullTitle());
-  });
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      cursor.CR();
+      Base.consoleLog(color('fail', '  %d) %s'), ++n, test.fullTitle());
+    });
 
-  runner.on(EVENT_TEST_PASS, function (test) {
-    var fmt =
-      color('checkmark', '  ' + Base.symbols.ok) +
-      color('pass', ' %s: ') +
-      color(test.speed, '%dms');
-    cursor.CR();
-    Base.consoleLog(fmt, test.fullTitle(), test.duration);
-  });
-
-  runner.on(EVENT_TEST_FAIL, function (test) {
-    cursor.CR();
-    Base.consoleLog(color('fail', '  %d) %s'), ++n, test.fullTitle());
-  });
-
-  runner.once(EVENT_RUN_END, self.epilogue.bind(self));
+    runner.once(EVENT_RUN_END, self.epilogue.bind(self));
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(List, Base);
-
 List.description = 'like "spec" reporter but flat';
+
+exports = module.exports = List;

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -56,7 +56,7 @@ class List extends Base {
       Base.consoleLog(color('fail', '  %d) %s'), ++n, test.fullTitle());
     });
 
-    runner.once(EVENT_RUN_END, self.epilogue.bind(self));
+    runner.once(EVENT_RUN_END, (...args) => this.epilogue(...args));
   }
 }
 

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -20,93 +20,86 @@ var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 
 var SUITE_PREFIX = '$';
 
-/**
- * Expose `Markdown`.
- */
+class Markdown extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = Markdown;
+    var level = 0;
+    var buf = '';
 
-/**
- * Constructs a new `Markdown` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Markdown(runner, options) {
-  Base.call(this, runner, options);
+    function title(str) {
+      return Array(level).join('#') + ' ' + str;
+    }
 
-  var level = 0;
-  var buf = '';
+    function mapTOC(suite, obj) {
+      var ret = obj;
+      var key = SUITE_PREFIX + suite.title;
 
-  function title(str) {
-    return Array(level).join('#') + ' ' + str;
-  }
+      obj = obj[key] = obj[key] || {suite};
+      suite.suites.forEach(function (suite) {
+        mapTOC(suite, obj);
+      });
 
-  function mapTOC(suite, obj) {
-    var ret = obj;
-    var key = SUITE_PREFIX + suite.title;
+      return ret;
+    }
 
-    obj = obj[key] = obj[key] || {suite};
-    suite.suites.forEach(function (suite) {
-      mapTOC(suite, obj);
+    function stringifyTOC(obj, level) {
+      ++level;
+      var buf = '';
+      var link;
+      for (var key in obj) {
+        if (key === 'suite') {
+          continue;
+        }
+        if (key !== SUITE_PREFIX) {
+          link = ' - [' + key.substring(1) + ']';
+          link += '(#' + utils.slug(obj[key].suite.fullTitle()) + ')\n';
+          buf += Array(level).join('  ') + link;
+        }
+        buf += stringifyTOC(obj[key], level);
+      }
+      return buf;
+    }
+
+    function generateTOC(suite) {
+      var obj = mapTOC(suite, {});
+      return stringifyTOC(obj, 0);
+    }
+
+    generateTOC(runner.suite);
+
+    runner.on(EVENT_SUITE_BEGIN, function (suite) {
+      ++level;
+      var slug = utils.slug(suite.fullTitle());
+      buf += '<a name="' + slug + '"></a>' + '\n';
+      buf += title(suite.title) + '\n';
     });
 
-    return ret;
+    runner.on(EVENT_SUITE_END, function () {
+      --level;
+    });
+
+    runner.on(EVENT_TEST_PASS, function (test) {
+      var code = utils.clean(test.body);
+      buf += test.title + '.\n';
+      buf += '\n```js\n';
+      buf += code + '\n';
+      buf += '```\n\n';
+    });
+
+    runner.once(EVENT_RUN_END, function () {
+      process.stdout.write('# TOC\n');
+      process.stdout.write(generateTOC(runner.suite));
+      process.stdout.write(buf);
+    });
   }
-
-  function stringifyTOC(obj, level) {
-    ++level;
-    var buf = '';
-    var link;
-    for (var key in obj) {
-      if (key === 'suite') {
-        continue;
-      }
-      if (key !== SUITE_PREFIX) {
-        link = ' - [' + key.substring(1) + ']';
-        link += '(#' + utils.slug(obj[key].suite.fullTitle()) + ')\n';
-        buf += Array(level).join('  ') + link;
-      }
-      buf += stringifyTOC(obj[key], level);
-    }
-    return buf;
-  }
-
-  function generateTOC(suite) {
-    var obj = mapTOC(suite, {});
-    return stringifyTOC(obj, 0);
-  }
-
-  generateTOC(runner.suite);
-
-  runner.on(EVENT_SUITE_BEGIN, function (suite) {
-    ++level;
-    var slug = utils.slug(suite.fullTitle());
-    buf += '<a name="' + slug + '"></a>' + '\n';
-    buf += title(suite.title) + '\n';
-  });
-
-  runner.on(EVENT_SUITE_END, function () {
-    --level;
-  });
-
-  runner.on(EVENT_TEST_PASS, function (test) {
-    var code = utils.clean(test.body);
-    buf += test.title + '.\n';
-    buf += '\n```js\n';
-    buf += code + '\n';
-    buf += '```\n\n';
-  });
-
-  runner.once(EVENT_RUN_END, function () {
-    process.stdout.write('# TOC\n');
-    process.stdout.write(generateTOC(runner.suite));
-    process.stdout.write(buf);
-  });
 }
 
 Markdown.description = 'GitHub Flavored Markdown';
+
+exports = module.exports = Markdown;

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -30,7 +30,7 @@ class Min extends Base {
       process.stdout.write('\u001b[1;3H');
     });
 
-    runner.once(EVENT_RUN_END, this.epilogue.bind(this));
+    runner.once(EVENT_RUN_END, (...args) => this.epilogue(...args));
   }
 }
 

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -7,46 +7,33 @@
  */
 
 var Base = require('./base');
-var inherits = require('../utils').inherits;
 var constants = require('../runner').constants;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 
-/**
- * Expose `Min`.
- */
+class Min extends Base {
+  /**
+   * @description
+   * This minimal test reporter is best used with '--watch'.
+   *
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = Min;
+    runner.on(EVENT_RUN_BEGIN, function () {
+      // clear screen
+      process.stdout.write('\u001b[2J');
+      // set cursor position
+      process.stdout.write('\u001b[1;3H');
+    });
 
-/**
- * Constructs a new `Min` reporter instance.
- *
- * @description
- * This minimal test reporter is best used with '--watch'.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Min(runner, options) {
-  Base.call(this, runner, options);
-
-  runner.on(EVENT_RUN_BEGIN, function () {
-    // clear screen
-    process.stdout.write('\u001b[2J');
-    // set cursor position
-    process.stdout.write('\u001b[1;3H');
-  });
-
-  runner.once(EVENT_RUN_END, this.epilogue.bind(this));
+    runner.once(EVENT_RUN_END, this.epilogue.bind(this));
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(Min, Base);
-
 Min.description = 'essentially just a summary';
+
+exports = module.exports = Min;

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -8,260 +8,247 @@
 
 var Base = require('./base');
 var constants = require('../runner').constants;
-var inherits = require('../utils').inherits;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 
-/**
- * Expose `Dot`.
- */
+class NyanCat extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = NyanCat;
+    var self = this;
+    var width = (Base.window.width * 0.75) | 0;
+    var nyanCatWidth = (this.nyanCatWidth = 11);
 
-/**
- * Constructs a new `Nyan` reporter instance.
- *
- * @public
- * @class Nyan
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function NyanCat(runner, options) {
-  Base.call(this, runner, options);
+    this.colorIndex = 0;
+    this.numberOfLines = 4;
+    this.rainbowColors = self.generateColors();
+    this.scoreboardWidth = 5;
+    this.tick = 0;
+    this.trajectories = [[], [], [], []];
+    this.trajectoryWidthMax = width - nyanCatWidth;
 
-  var self = this;
-  var width = (Base.window.width * 0.75) | 0;
-  var nyanCatWidth = (this.nyanCatWidth = 11);
+    runner.on(EVENT_RUN_BEGIN, function () {
+      Base.cursor.hide();
+      self.draw();
+    });
 
-  this.colorIndex = 0;
-  this.numberOfLines = 4;
-  this.rainbowColors = self.generateColors();
-  this.scoreboardWidth = 5;
-  this.tick = 0;
-  this.trajectories = [[], [], [], []];
-  this.trajectoryWidthMax = width - nyanCatWidth;
+    runner.on(EVENT_TEST_PENDING, function () {
+      self.draw();
+    });
 
-  runner.on(EVENT_RUN_BEGIN, function () {
-    Base.cursor.hide();
-    self.draw();
-  });
+    runner.on(EVENT_TEST_PASS, function () {
+      self.draw();
+    });
 
-  runner.on(EVENT_TEST_PENDING, function () {
-    self.draw();
-  });
+    runner.on(EVENT_TEST_FAIL, function () {
+      self.draw();
+    });
 
-  runner.on(EVENT_TEST_PASS, function () {
-    self.draw();
-  });
+    runner.once(EVENT_RUN_END, function () {
+      Base.cursor.show();
+      for (var i = 0; i < self.numberOfLines; i++) {
+        process.stdout.write('\n');
+      }
+      self.epilogue();
+    });
+  }
 
-  runner.on(EVENT_TEST_FAIL, function () {
-    self.draw();
-  });
+  /**
+   * Draw the nyan cat
+   *
+   * @private
+   */
 
-  runner.once(EVENT_RUN_END, function () {
-    Base.cursor.show();
-    for (var i = 0; i < self.numberOfLines; i++) {
+  draw() {
+    this.appendRainbow();
+    this.drawScoreboard();
+    this.drawRainbow();
+    this.drawNyanCat();
+    this.tick = !this.tick;
+  }
+
+  /**
+   * Draw the "scoreboard" showing the number
+   * of passes, failures and pending tests.
+   *
+   * @private
+   */
+
+  drawScoreboard() {
+    var stats = this.stats;
+
+    function draw(type, n) {
+      process.stdout.write(' ');
+      process.stdout.write(Base.color(type, n));
       process.stdout.write('\n');
     }
-    self.epilogue();
-  });
+
+    draw('green', stats.passes);
+    draw('fail', stats.failures);
+    draw('pending', stats.pending);
+    process.stdout.write('\n');
+
+    this.cursorUp(this.numberOfLines);
+  }
+
+  /**
+   * Append the rainbow.
+   *
+   * @private
+   */
+
+  appendRainbow() {
+    var segment = this.tick ? '_' : '-';
+    var rainbowified = this.rainbowify(segment);
+
+    for (var index = 0; index < this.numberOfLines; index++) {
+      var trajectory = this.trajectories[index];
+      if (trajectory.length >= this.trajectoryWidthMax) {
+        trajectory.shift();
+      }
+      trajectory.push(rainbowified);
+    }
+  }
+
+  /**
+   * Draw the rainbow.
+   *
+   * @private
+   */
+
+  drawRainbow() {
+    var self = this;
+
+    this.trajectories.forEach(function (line) {
+      process.stdout.write('\u001b[' + self.scoreboardWidth + 'C');
+      process.stdout.write(line.join(''));
+      process.stdout.write('\n');
+    });
+
+    this.cursorUp(this.numberOfLines);
+  }
+
+  /**
+   * Draw the nyan cat
+   *
+   * @private
+   */
+  drawNyanCat() {
+    var self = this;
+    var startWidth = this.scoreboardWidth + this.trajectories[0].length;
+    var dist = '\u001b[' + startWidth + 'C';
+    var padding = '';
+
+    process.stdout.write(dist);
+    process.stdout.write('_,------,');
+    process.stdout.write('\n');
+
+    process.stdout.write(dist);
+    padding = self.tick ? '  ' : '   ';
+    process.stdout.write('_|' + padding + '/\\_/\\ ');
+    process.stdout.write('\n');
+
+    process.stdout.write(dist);
+    padding = self.tick ? '_' : '__';
+    var tail = self.tick ? '~' : '^';
+    process.stdout.write(tail + '|' + padding + this.face() + ' ');
+    process.stdout.write('\n');
+
+    process.stdout.write(dist);
+    padding = self.tick ? ' ' : '  ';
+    process.stdout.write(padding + '""  "" ');
+    process.stdout.write('\n');
+
+    this.cursorUp(this.numberOfLines);
+  }
+
+  /**
+   * Draw nyan cat face.
+   *
+   * @private
+   * @return {string}
+   */
+
+  face() {
+    var stats = this.stats;
+    if (stats.failures) {
+      return '( x .x)';
+    } else if (stats.pending) {
+      return '( o .o)';
+    } else if (stats.passes) {
+      return '( ^ .^)';
+    }
+    return '( - .-)';
+  }
+
+  /**
+   * Move cursor up `n`.
+   *
+   * @private
+   * @param {number} n
+   */
+
+  cursorUp(n) {
+    process.stdout.write('\u001b[' + n + 'A');
+  }
+
+  /**
+   * Move cursor down `n`.
+   *
+   * @private
+   * @param {number} n
+   */
+
+  cursorDown(n) {
+    process.stdout.write('\u001b[' + n + 'B');
+  }
+
+  /**
+   * Generate rainbow colors.
+   *
+   * @private
+   * @return {Array}
+   */
+  generateColors() {
+    var colors = [];
+
+    for (var i = 0; i < 6 * 7; i++) {
+      var pi3 = Math.floor(Math.PI / 3);
+      var n = i * (1.0 / 6);
+      var r = Math.floor(3 * Math.sin(n) + 3);
+      var g = Math.floor(3 * Math.sin(n + 2 * pi3) + 3);
+      var b = Math.floor(3 * Math.sin(n + 4 * pi3) + 3);
+      colors.push(36 * r + 6 * g + b + 16);
+    }
+
+    return colors;
+  }
+
+  /**
+   * Apply rainbow to the given `str`.
+   *
+   * @private
+   * @param {string} str
+   * @return {string}
+   */
+  rainbowify(str) {
+    if (!Base.useColors) {
+      return str;
+    }
+    var color = this.rainbowColors[this.colorIndex % this.rainbowColors.length];
+    this.colorIndex += 1;
+    return '\u001b[38;5;' + color + 'm' + str + '\u001b[0m';
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(NyanCat, Base);
-
-/**
- * Draw the nyan cat
- *
- * @private
- */
-
-NyanCat.prototype.draw = function () {
-  this.appendRainbow();
-  this.drawScoreboard();
-  this.drawRainbow();
-  this.drawNyanCat();
-  this.tick = !this.tick;
-};
-
-/**
- * Draw the "scoreboard" showing the number
- * of passes, failures and pending tests.
- *
- * @private
- */
-
-NyanCat.prototype.drawScoreboard = function () {
-  var stats = this.stats;
-
-  function draw(type, n) {
-    process.stdout.write(' ');
-    process.stdout.write(Base.color(type, n));
-    process.stdout.write('\n');
-  }
-
-  draw('green', stats.passes);
-  draw('fail', stats.failures);
-  draw('pending', stats.pending);
-  process.stdout.write('\n');
-
-  this.cursorUp(this.numberOfLines);
-};
-
-/**
- * Append the rainbow.
- *
- * @private
- */
-
-NyanCat.prototype.appendRainbow = function () {
-  var segment = this.tick ? '_' : '-';
-  var rainbowified = this.rainbowify(segment);
-
-  for (var index = 0; index < this.numberOfLines; index++) {
-    var trajectory = this.trajectories[index];
-    if (trajectory.length >= this.trajectoryWidthMax) {
-      trajectory.shift();
-    }
-    trajectory.push(rainbowified);
-  }
-};
-
-/**
- * Draw the rainbow.
- *
- * @private
- */
-
-NyanCat.prototype.drawRainbow = function () {
-  var self = this;
-
-  this.trajectories.forEach(function (line) {
-    process.stdout.write('\u001b[' + self.scoreboardWidth + 'C');
-    process.stdout.write(line.join(''));
-    process.stdout.write('\n');
-  });
-
-  this.cursorUp(this.numberOfLines);
-};
-
-/**
- * Draw the nyan cat
- *
- * @private
- */
-NyanCat.prototype.drawNyanCat = function () {
-  var self = this;
-  var startWidth = this.scoreboardWidth + this.trajectories[0].length;
-  var dist = '\u001b[' + startWidth + 'C';
-  var padding = '';
-
-  process.stdout.write(dist);
-  process.stdout.write('_,------,');
-  process.stdout.write('\n');
-
-  process.stdout.write(dist);
-  padding = self.tick ? '  ' : '   ';
-  process.stdout.write('_|' + padding + '/\\_/\\ ');
-  process.stdout.write('\n');
-
-  process.stdout.write(dist);
-  padding = self.tick ? '_' : '__';
-  var tail = self.tick ? '~' : '^';
-  process.stdout.write(tail + '|' + padding + this.face() + ' ');
-  process.stdout.write('\n');
-
-  process.stdout.write(dist);
-  padding = self.tick ? ' ' : '  ';
-  process.stdout.write(padding + '""  "" ');
-  process.stdout.write('\n');
-
-  this.cursorUp(this.numberOfLines);
-};
-
-/**
- * Draw nyan cat face.
- *
- * @private
- * @return {string}
- */
-
-NyanCat.prototype.face = function () {
-  var stats = this.stats;
-  if (stats.failures) {
-    return '( x .x)';
-  } else if (stats.pending) {
-    return '( o .o)';
-  } else if (stats.passes) {
-    return '( ^ .^)';
-  }
-  return '( - .-)';
-};
-
-/**
- * Move cursor up `n`.
- *
- * @private
- * @param {number} n
- */
-
-NyanCat.prototype.cursorUp = function (n) {
-  process.stdout.write('\u001b[' + n + 'A');
-};
-
-/**
- * Move cursor down `n`.
- *
- * @private
- * @param {number} n
- */
-
-NyanCat.prototype.cursorDown = function (n) {
-  process.stdout.write('\u001b[' + n + 'B');
-};
-
-/**
- * Generate rainbow colors.
- *
- * @private
- * @return {Array}
- */
-NyanCat.prototype.generateColors = function () {
-  var colors = [];
-
-  for (var i = 0; i < 6 * 7; i++) {
-    var pi3 = Math.floor(Math.PI / 3);
-    var n = i * (1.0 / 6);
-    var r = Math.floor(3 * Math.sin(n) + 3);
-    var g = Math.floor(3 * Math.sin(n + 2 * pi3) + 3);
-    var b = Math.floor(3 * Math.sin(n + 4 * pi3) + 3);
-    colors.push(36 * r + 6 * g + b + 16);
-  }
-
-  return colors;
-};
-
-/**
- * Apply rainbow to the given `str`.
- *
- * @private
- * @param {string} str
- * @return {string}
- */
-NyanCat.prototype.rainbowify = function (str) {
-  if (!Base.useColors) {
-    return str;
-  }
-  var color = this.rainbowColors[this.colorIndex % this.rainbowColors.length];
-  this.colorIndex += 1;
-  return '\u001b[38;5;' + color + 'm' + str + '\u001b[0m';
-};
-
 NyanCat.description = '"nyan cat"';
+
+exports = module.exports = NyanCat;

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -11,15 +11,8 @@ var constants = require('../runner').constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_TEST_END = constants.EVENT_TEST_END;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
-var inherits = require('../utils').inherits;
 var color = Base.color;
 var cursor = Base.cursor;
-
-/**
- * Expose `Progress`.
- */
-
-exports = module.exports = Progress;
 
 /**
  * General progress bar color.
@@ -27,78 +20,74 @@ exports = module.exports = Progress;
 
 Base.colors.progress = 90;
 
-/**
- * Constructs a new `Progress` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Progress(runner, options) {
-  Base.call(this, runner, options);
+class Progress extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-  var self = this;
-  var width = (Base.window.width * 0.5) | 0;
-  var total = runner.total;
-  var complete = 0;
-  var lastN = -1;
+    var self = this;
+    var width = (Base.window.width * 0.5) | 0;
+    var total = runner.total;
+    var complete = 0;
+    var lastN = -1;
 
-  // default chars
-  options = options || {};
-  var reporterOptions = options.reporterOptions || {};
+    // default chars
+    options = options || {};
+    var reporterOptions = options.reporterOptions || {};
 
-  options.open = reporterOptions.open || '[';
-  options.complete = reporterOptions.complete || '▬';
-  options.incomplete = reporterOptions.incomplete || Base.symbols.dot;
-  options.close = reporterOptions.close || ']';
-  options.verbose = reporterOptions.verbose || false;
+    options.open = reporterOptions.open || '[';
+    options.complete = reporterOptions.complete || '▬';
+    options.incomplete = reporterOptions.incomplete || Base.symbols.dot;
+    options.close = reporterOptions.close || ']';
+    options.verbose = reporterOptions.verbose || false;
 
-  // tests started
-  runner.on(EVENT_RUN_BEGIN, function () {
-    process.stdout.write('\n');
-    cursor.hide();
-  });
+    // tests started
+    runner.on(EVENT_RUN_BEGIN, function () {
+      process.stdout.write('\n');
+      cursor.hide();
+    });
 
-  // tests complete
-  runner.on(EVENT_TEST_END, function () {
-    complete++;
+    // tests complete
+    runner.on(EVENT_TEST_END, function () {
+      complete++;
 
-    var percent = complete / total;
-    var n = (width * percent) | 0;
-    var i = width - n;
+      var percent = complete / total;
+      var n = (width * percent) | 0;
+      var i = width - n;
 
-    if (n === lastN && !options.verbose) {
-      // Don't re-render the line if it hasn't changed
-      return;
-    }
-    lastN = n;
+      if (n === lastN && !options.verbose) {
+        // Don't re-render the line if it hasn't changed
+        return;
+      }
+      lastN = n;
 
-    cursor.CR();
-    process.stdout.write('\u001b[J');
-    process.stdout.write(color('progress', '  ' + options.open));
-    process.stdout.write(Array(n).join(options.complete));
-    process.stdout.write(Array(i).join(options.incomplete));
-    process.stdout.write(color('progress', options.close));
-    if (options.verbose) {
-      process.stdout.write(color('progress', ' ' + complete + ' of ' + total));
-    }
-  });
+      cursor.CR();
+      process.stdout.write('\u001b[J');
+      process.stdout.write(color('progress', '  ' + options.open));
+      process.stdout.write(Array(n).join(options.complete));
+      process.stdout.write(Array(i).join(options.incomplete));
+      process.stdout.write(color('progress', options.close));
+      if (options.verbose) {
+        process.stdout.write(
+          color('progress', ' ' + complete + ' of ' + total)
+        );
+      }
+    });
 
-  // tests are complete, output some stats
-  // and the failures if any
-  runner.once(EVENT_RUN_END, function () {
-    cursor.show();
-    process.stdout.write('\n');
-    self.epilogue();
-  });
+    // tests are complete, output some stats
+    // and the failures if any
+    runner.once(EVENT_RUN_END, function () {
+      cursor.show();
+      process.stdout.write('\n');
+      self.epilogue();
+    });
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(Progress, Base);
-
 Progress.description = 'a progress bar';
+
+exports = module.exports = Progress;

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -77,7 +77,7 @@ class Spec extends Base {
       Base.consoleLog(indent() + color('fail', '  %d) %s'), ++n, test.title);
     });
 
-    runner.once(EVENT_RUN_END, self.epilogue.bind(self));
+    runner.once(EVENT_RUN_END, (...args) => this.epilogue(...args));
   }
 }
 

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -15,85 +15,72 @@ var EVENT_SUITE_END = constants.EVENT_SUITE_END;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
-var inherits = require('../utils').inherits;
 var color = Base.color;
 
-/**
- * Expose `Spec`.
- */
+class Spec extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = Spec;
+    var self = this;
+    var indents = 0;
+    var n = 0;
 
-/**
- * Constructs a new `Spec` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function Spec(runner, options) {
-  Base.call(this, runner, options);
+    function indent() {
+      return Array(indents).join('  ');
+    }
 
-  var self = this;
-  var indents = 0;
-  var n = 0;
-
-  function indent() {
-    return Array(indents).join('  ');
-  }
-
-  runner.on(EVENT_RUN_BEGIN, function () {
-    Base.consoleLog();
-  });
-
-  runner.on(EVENT_SUITE_BEGIN, function (suite) {
-    ++indents;
-    Base.consoleLog(color('suite', '%s%s'), indent(), suite.title);
-  });
-
-  runner.on(EVENT_SUITE_END, function () {
-    --indents;
-    if (indents === 1) {
+    runner.on(EVENT_RUN_BEGIN, function () {
       Base.consoleLog();
-    }
-  });
+    });
 
-  runner.on(EVENT_TEST_PENDING, function (test) {
-    var fmt = indent() + color('pending', '  - %s');
-    Base.consoleLog(fmt, test.title);
-  });
+    runner.on(EVENT_SUITE_BEGIN, function (suite) {
+      ++indents;
+      Base.consoleLog(color('suite', '%s%s'), indent(), suite.title);
+    });
 
-  runner.on(EVENT_TEST_PASS, function (test) {
-    var fmt;
-    if (test.speed === 'fast') {
-      fmt =
-        indent() +
-        color('checkmark', '  ' + Base.symbols.ok) +
-        color('pass', ' %s');
+    runner.on(EVENT_SUITE_END, function () {
+      --indents;
+      if (indents === 1) {
+        Base.consoleLog();
+      }
+    });
+
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      var fmt = indent() + color('pending', '  - %s');
       Base.consoleLog(fmt, test.title);
-    } else {
-      fmt =
-        indent() +
-        color('checkmark', '  ' + Base.symbols.ok) +
-        color('pass', ' %s') +
-        color(test.speed, ' (%dms)');
-      Base.consoleLog(fmt, test.title, test.duration);
-    }
-  });
+    });
 
-  runner.on(EVENT_TEST_FAIL, function (test) {
-    Base.consoleLog(indent() + color('fail', '  %d) %s'), ++n, test.title);
-  });
+    runner.on(EVENT_TEST_PASS, function (test) {
+      var fmt;
+      if (test.speed === 'fast') {
+        fmt =
+          indent() +
+          color('checkmark', '  ' + Base.symbols.ok) +
+          color('pass', ' %s');
+        Base.consoleLog(fmt, test.title);
+      } else {
+        fmt =
+          indent() +
+          color('checkmark', '  ' + Base.symbols.ok) +
+          color('pass', ' %s') +
+          color(test.speed, ' (%dms)');
+        Base.consoleLog(fmt, test.title, test.duration);
+      }
+    });
 
-  runner.once(EVENT_RUN_END, self.epilogue.bind(self));
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      Base.consoleLog(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    });
+
+    runner.once(EVENT_RUN_END, self.epilogue.bind(self));
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(Spec, Base);
-
 Spec.description = 'hierarchical & verbose [default]';
+
+exports = module.exports = Spec;

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -15,69 +15,56 @@ var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var EVENT_TEST_END = constants.EVENT_TEST_END;
-var inherits = require('../utils').inherits;
 var sprintf = util.format;
 
-/**
- * Expose `TAP`.
- */
+class TAP extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
 
-exports = module.exports = TAP;
+    var self = this;
+    var n = 1;
 
-/**
- * Constructs a new `TAP` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function TAP(runner, options) {
-  Base.call(this, runner, options);
-
-  var self = this;
-  var n = 1;
-
-  var tapVersion = '12';
-  if (options && options.reporterOptions) {
-    if (options.reporterOptions.tapVersion) {
-      tapVersion = options.reporterOptions.tapVersion.toString();
+    var tapVersion = '12';
+    if (options && options.reporterOptions) {
+      if (options.reporterOptions.tapVersion) {
+        tapVersion = options.reporterOptions.tapVersion.toString();
+      }
     }
+
+    this._producer = createProducer(tapVersion);
+
+    runner.once(EVENT_RUN_BEGIN, function () {
+      self._producer.writeVersion();
+    });
+
+    runner.on(EVENT_TEST_END, function () {
+      ++n;
+    });
+
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      self._producer.writePending(n, test);
+    });
+
+    runner.on(EVENT_TEST_PASS, function (test) {
+      self._producer.writePass(n, test);
+    });
+
+    runner.on(EVENT_TEST_FAIL, function (test, err) {
+      self._producer.writeFail(n, test, err);
+    });
+
+    runner.once(EVENT_RUN_END, function () {
+      self._producer.writeEpilogue(runner.stats);
+    });
   }
-
-  this._producer = createProducer(tapVersion);
-
-  runner.once(EVENT_RUN_BEGIN, function () {
-    self._producer.writeVersion();
-  });
-
-  runner.on(EVENT_TEST_END, function () {
-    ++n;
-  });
-
-  runner.on(EVENT_TEST_PENDING, function (test) {
-    self._producer.writePending(n, test);
-  });
-
-  runner.on(EVENT_TEST_PASS, function (test) {
-    self._producer.writePass(n, test);
-  });
-
-  runner.on(EVENT_TEST_FAIL, function (test, err) {
-    self._producer.writeFail(n, test, err);
-  });
-
-  runner.once(EVENT_RUN_END, function () {
-    self._producer.writeEpilogue(runner.stats);
-  });
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(TAP, Base);
+TAP.description = 'TAP-compatible output';
 
 /**
  * Returns a TAP-safe title of `test`.
@@ -134,76 +121,76 @@ function createProducer(tapVersion) {
  * @description
  * <em>Only</em> to be used as an abstract base class.
  *
+ * @abstract
  * @private
- * @constructor
  */
-function TAPProducer() {}
+class TAPProducer {
+  /**
+   * Writes the TAP version to reporter output stream.
+   *
+   * @abstract
+   */
+  writeVersion() {}
 
-/**
- * Writes the TAP version to reporter output stream.
- *
- * @abstract
- */
-TAPProducer.prototype.writeVersion = function () {};
+  /**
+   * Writes the plan to reporter output stream.
+   *
+   * @abstract
+   * @param {number} ntests - Number of tests that are planned to run.
+   */
+  writePlan(ntests) {
+    println('%d..%d', 1, ntests);
+  }
 
-/**
- * Writes the plan to reporter output stream.
- *
- * @abstract
- * @param {number} ntests - Number of tests that are planned to run.
- */
-TAPProducer.prototype.writePlan = function (ntests) {
-  println('%d..%d', 1, ntests);
-};
+  /**
+   * Writes that test passed to reporter output stream.
+   *
+   * @abstract
+   * @param {number} n - Index of test that passed.
+   * @param {Test} test - Instance containing test information.
+   */
+  writePass(n, test) {
+    println('ok %d %s', n, title(test));
+  }
 
-/**
- * Writes that test passed to reporter output stream.
- *
- * @abstract
- * @param {number} n - Index of test that passed.
- * @param {Test} test - Instance containing test information.
- */
-TAPProducer.prototype.writePass = function (n, test) {
-  println('ok %d %s', n, title(test));
-};
+  /**
+   * Writes that test was skipped to reporter output stream.
+   *
+   * @abstract
+   * @param {number} n - Index of test that was skipped.
+   * @param {Test} test - Instance containing test information.
+   */
+  writePending(n, test) {
+    println('ok %d %s # SKIP -', n, title(test));
+  }
 
-/**
- * Writes that test was skipped to reporter output stream.
- *
- * @abstract
- * @param {number} n - Index of test that was skipped.
- * @param {Test} test - Instance containing test information.
- */
-TAPProducer.prototype.writePending = function (n, test) {
-  println('ok %d %s # SKIP -', n, title(test));
-};
+  /**
+   * Writes that test failed to reporter output stream.
+   *
+   * @abstract
+   * @param {number} n - Index of test that failed.
+   * @param {Test} test - Instance containing test information.
+   * @param {Error} err - Reason the test failed.
+   */
+  writeFail(n, test, err) {
+    println('not ok %d %s', n, title(test));
+  }
 
-/**
- * Writes that test failed to reporter output stream.
- *
- * @abstract
- * @param {number} n - Index of test that failed.
- * @param {Test} test - Instance containing test information.
- * @param {Error} err - Reason the test failed.
- */
-TAPProducer.prototype.writeFail = function (n, test, err) {
-  println('not ok %d %s', n, title(test));
-};
-
-/**
- * Writes the summary epilogue to reporter output stream.
- *
- * @abstract
- * @param {Object} stats - Object containing run statistics.
- */
-TAPProducer.prototype.writeEpilogue = function (stats) {
-  // :TBD: Why is this not counting pending tests?
-  println('# tests ' + (stats.passes + stats.failures));
-  println('# pass ' + stats.passes);
-  // :TBD: Why are we not showing pending results?
-  println('# fail ' + stats.failures);
-  this.writePlan(stats.passes + stats.failures + stats.pending);
-};
+  /**
+   * Writes the summary epilogue to reporter output stream.
+   *
+   * @abstract
+   * @param {Object} stats - Object containing run statistics.
+   */
+  writeEpilogue(stats) {
+    // :TBD: Why is this not counting pending tests?
+    println('# tests ' + (stats.passes + stats.failures));
+    println('# pass ' + stats.passes);
+    // :TBD: Why are we not showing pending results?
+    println('# fail ' + stats.failures);
+    this.writePlan(stats.passes + stats.failures + stats.pending);
+  }
+}
 
 /**
  * @summary
@@ -217,26 +204,21 @@ TAPProducer.prototype.writeEpilogue = function (stats) {
  * @extends TAPProducer
  * @see {@link https://testanything.org/tap-specification.html|Specification}
  */
-function TAP12Producer() {
+class TAP12Producer extends TAPProducer {
   /**
    * Writes that test failed to reporter output stream, with error formatting.
    * @override
    */
-  this.writeFail = function (n, test, err) {
-    TAPProducer.prototype.writeFail.call(this, n, test, err);
+  writeFail(n, test, err) {
+    super.writeFail(n, test, err);
     if (err.message) {
       println(err.message.replace(/^/gm, '  '));
     }
     if (err.stack) {
       println(err.stack.replace(/^/gm, '  '));
     }
-  };
+  }
 }
-
-/**
- * Inherit from `TAPProducer.prototype`.
- */
-inherits(TAP12Producer, TAPProducer);
 
 /**
  * @summary
@@ -250,21 +232,21 @@ inherits(TAP12Producer, TAPProducer);
  * @extends TAPProducer
  * @see {@link https://testanything.org/tap-version-13-specification.html|Specification}
  */
-function TAP13Producer() {
+class TAP13Producer extends TAPProducer {
   /**
    * Writes the TAP version to reporter output stream.
    * @override
    */
-  this.writeVersion = function () {
+  writeVersion() {
     println('TAP version 13');
-  };
+  }
 
   /**
    * Writes that test failed to reporter output stream, with error formatting.
    * @override
    */
-  this.writeFail = function (n, test, err) {
-    TAPProducer.prototype.writeFail.call(this, n, test, err);
+  writeFail(n, test, err) {
+    super.writeFail(n, test, err);
     var emitYamlBlock = err.message != null || err.stack != null;
     if (emitYamlBlock) {
       println(indent(1) + '---');
@@ -278,16 +260,11 @@ function TAP13Producer() {
       }
       println(indent(1) + '...');
     }
-  };
-
-  function indent(level) {
-    return Array(level + 1).join('  ');
   }
 }
 
-/**
- * Inherit from `TAPProducer.prototype`.
- */
-inherits(TAP13Producer, TAPProducer);
+function indent(level) {
+  return Array(level + 1).join('  ');
+}
 
-TAP.description = 'TAP-compatible output';
+exports = module.exports = TAP;

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -31,7 +31,6 @@ class XUnit extends Base {
    * @param {Runner} runner - Instance triggers reporter actions.
    * @param {Object} [options] - runner options
    */
-
   constructor(runner, options) {
     super(runner, options);
 

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -18,7 +18,6 @@ var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var STATE_FAILED = require('../runnable').constants.STATE_FAILED;
-var inherits = utils.inherits;
 var escape = utils.escape;
 
 /**
@@ -26,167 +25,156 @@ var escape = utils.escape;
  */
 var Date = global.Date;
 
-/**
- * Expose `XUnit`.
- */
+class XUnit extends Base {
+  /**
+   * @public
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
 
-exports = module.exports = XUnit;
+  constructor(runner, options) {
+    super(runner, options);
 
-/**
- * Constructs a new `XUnit` reporter instance.
- *
- * @public
- * @class
- * @memberof Mocha.reporters
- * @extends Mocha.reporters.Base
- * @param {Runner} runner - Instance triggers reporter actions.
- * @param {Object} [options] - runner options
- */
-function XUnit(runner, options) {
-  Base.call(this, runner, options);
+    var stats = this.stats;
+    var tests = [];
+    var self = this;
 
-  var stats = this.stats;
-  var tests = [];
-  var self = this;
+    // the name of the test suite, as it will appear in the resulting XML file
+    var suiteName;
 
-  // the name of the test suite, as it will appear in the resulting XML file
-  var suiteName;
+    // the default name of the test suite if none is provided
+    var DEFAULT_SUITE_NAME = 'Mocha Tests';
 
-  // the default name of the test suite if none is provided
-  var DEFAULT_SUITE_NAME = 'Mocha Tests';
+    if (options && options.reporterOptions) {
+      if (options.reporterOptions.output) {
+        if (!fs.createWriteStream) {
+          throw createUnsupportedError('file output not supported in browser');
+        }
 
-  if (options && options.reporterOptions) {
-    if (options.reporterOptions.output) {
-      if (!fs.createWriteStream) {
-        throw createUnsupportedError('file output not supported in browser');
+        fs.mkdirSync(path.dirname(options.reporterOptions.output), {
+          recursive: true
+        });
+        self.fileStream = fs.createWriteStream(options.reporterOptions.output);
       }
 
-      fs.mkdirSync(path.dirname(options.reporterOptions.output), {
-        recursive: true
-      });
-      self.fileStream = fs.createWriteStream(options.reporterOptions.output);
+      // get the suite name from the reporter options (if provided)
+      suiteName = options.reporterOptions.suiteName;
     }
 
-    // get the suite name from the reporter options (if provided)
-    suiteName = options.reporterOptions.suiteName;
-  }
+    // fall back to the default suite name
+    suiteName = suiteName || DEFAULT_SUITE_NAME;
 
-  // fall back to the default suite name
-  suiteName = suiteName || DEFAULT_SUITE_NAME;
-
-  runner.on(EVENT_TEST_PENDING, function (test) {
-    tests.push(test);
-  });
-
-  runner.on(EVENT_TEST_PASS, function (test) {
-    tests.push(test);
-  });
-
-  runner.on(EVENT_TEST_FAIL, function (test) {
-    tests.push(test);
-  });
-
-  runner.once(EVENT_RUN_END, function () {
-    self.write(
-      tag(
-        'testsuite',
-        {
-          name: suiteName,
-          tests: stats.tests,
-          failures: 0,
-          errors: stats.failures,
-          skipped: stats.tests - stats.failures - stats.passes,
-          timestamp: new Date().toUTCString(),
-          time: stats.duration / 1000 || 0
-        },
-        false
-      )
-    );
-
-    tests.forEach(function (t) {
-      self.test(t);
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      tests.push(test);
     });
 
-    self.write('</testsuite>');
-  });
+    runner.on(EVENT_TEST_PASS, function (test) {
+      tests.push(test);
+    });
+
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      tests.push(test);
+    });
+
+    runner.once(EVENT_RUN_END, function () {
+      self.write(
+        tag(
+          'testsuite',
+          {
+            name: suiteName,
+            tests: stats.tests,
+            failures: 0,
+            errors: stats.failures,
+            skipped: stats.tests - stats.failures - stats.passes,
+            timestamp: new Date().toUTCString(),
+            time: stats.duration / 1000 || 0
+          },
+          false
+        )
+      );
+
+      tests.forEach(function (t) {
+        self.test(t);
+      });
+
+      self.write('</testsuite>');
+    });
+  }
+
+  /**
+   * Override done to close the stream (if it's a file).
+   *
+   * @param failures
+   * @param {Function} fn
+   */
+  done(failures, fn) {
+    if (this.fileStream) {
+      this.fileStream.end(function () {
+        fn(failures);
+      });
+    } else {
+      fn(failures);
+    }
+  }
+
+  /**
+   * Write out the given line.
+   *
+   * @param {string} line
+   */
+  write(line) {
+    if (this.fileStream) {
+      this.fileStream.write(line + '\n');
+    } else if (typeof process === 'object' && process.stdout) {
+      process.stdout.write(line + '\n');
+    } else {
+      Base.consoleLog(line);
+    }
+  }
+
+  /**
+   * Output tag for the given `test.`
+   *
+   * @param {Test} test
+   */
+  test(test) {
+    Base.useColors = false;
+
+    var attrs = {
+      classname: test.parent.fullTitle(),
+      name: test.title,
+      file: test.file,
+      time: test.duration / 1000 || 0
+    };
+
+    if (test.state === STATE_FAILED) {
+      var err = test.err;
+      var diff =
+        !Base.hideDiff && Base.showDiff(err)
+          ? '\n' + Base.generateDiff(err.actual, err.expected)
+          : '';
+      this.write(
+        tag(
+          'testcase',
+          attrs,
+          false,
+          tag(
+            'failure',
+            {},
+            false,
+            escape(err.message) + escape(diff) + '\n' + escape(err.stack)
+          )
+        )
+      );
+    } else if (test.isPending()) {
+      this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    } else {
+      this.write(tag('testcase', attrs, true));
+    }
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-inherits(XUnit, Base);
-
-/**
- * Override done to close the stream (if it's a file).
- *
- * @param failures
- * @param {Function} fn
- */
-XUnit.prototype.done = function (failures, fn) {
-  if (this.fileStream) {
-    this.fileStream.end(function () {
-      fn(failures);
-    });
-  } else {
-    fn(failures);
-  }
-};
-
-/**
- * Write out the given line.
- *
- * @param {string} line
- */
-XUnit.prototype.write = function (line) {
-  if (this.fileStream) {
-    this.fileStream.write(line + '\n');
-  } else if (typeof process === 'object' && process.stdout) {
-    process.stdout.write(line + '\n');
-  } else {
-    Base.consoleLog(line);
-  }
-};
-
-/**
- * Output tag for the given `test.`
- *
- * @param {Test} test
- */
-XUnit.prototype.test = function (test) {
-  Base.useColors = false;
-
-  var attrs = {
-    classname: test.parent.fullTitle(),
-    name: test.title,
-    file: test.file,
-    time: test.duration / 1000 || 0
-  };
-
-  if (test.state === STATE_FAILED) {
-    var err = test.err;
-    var diff =
-      !Base.hideDiff && Base.showDiff(err)
-        ? '\n' + Base.generateDiff(err.actual, err.expected)
-        : '';
-    this.write(
-      tag(
-        'testcase',
-        attrs,
-        false,
-        tag(
-          'failure',
-          {},
-          false,
-          escape(err.message) + escape(diff) + '\n' + escape(err.stack)
-        )
-      )
-    );
-  } else if (test.isPending()) {
-    this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
-  } else {
-    this.write(tag('testcase', attrs, true));
-  }
-};
+XUnit.description = 'XUnit-compatible XML output';
 
 /**
  * HTML tag helper.
@@ -215,4 +203,4 @@ function tag(name, attrs, close, content) {
   return tag;
 }
 
-XUnit.description = 'XUnit-compatible XML output';
+exports = module.exports = XUnit;

--- a/test/reporters/doc.spec.js
+++ b/test/reporters/doc.spec.js
@@ -6,7 +6,7 @@ var reporters = require('../../').reporters;
 
 var Doc = reporters.Doc;
 var createMockRunner = helpers.createMockRunner;
-var makeRunReporter = helpers.createRunReporterFunction;
+var createRunReporterFunction = helpers.createRunReporterFunction;
 
 var EVENT_SUITE_BEGIN = events.EVENT_SUITE_BEGIN;
 var EVENT_SUITE_END = events.EVENT_SUITE_END;
@@ -16,7 +16,7 @@ var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
 describe('Doc reporter', function () {
   var runner;
   var options = {};
-  var runReporter = makeRunReporter(Doc);
+  var runReporter = createRunReporterFunction(Doc);
 
   afterEach(function () {
     runner = null;
@@ -32,7 +32,7 @@ describe('Doc reporter', function () {
           title: expectedTitle
         };
 
-        it('should log html with indents and expected title', function () {
+        it('should log html with indents and expected title', async function () {
           runner = createMockRunner(
             'suite',
             EVENT_SUITE_BEGIN,
@@ -40,7 +40,7 @@ describe('Doc reporter', function () {
             null,
             suite
           );
-          var stdout = runReporter(this, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           var expectedArray = [
             '    <section class="suite">\n',
             '      <h1>' + expectedTitle + '</h1>\n',
@@ -49,7 +49,7 @@ describe('Doc reporter', function () {
           expect(stdout, 'to equal', expectedArray);
         });
 
-        it('should escape title where necessary', function () {
+        it('should escape title where necessary', async function () {
           var suite = {
             root: false,
             title: unescapedTitle
@@ -64,7 +64,7 @@ describe('Doc reporter', function () {
             null,
             suite
           );
-          var stdout = runReporter(this, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           var expectedArray = [
             '    <section class="suite">\n',
             '      <h1>' + expectedTitle + '</h1>\n',
@@ -79,7 +79,7 @@ describe('Doc reporter', function () {
           root: true
         };
 
-        it('should not log any html', function () {
+        it('should not log any html', async function () {
           runner = createMockRunner(
             'suite',
             EVENT_SUITE_BEGIN,
@@ -87,7 +87,7 @@ describe('Doc reporter', function () {
             null,
             suite
           );
-          var stdout = runReporter(this, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           expect(stdout, 'to be empty');
         });
       });
@@ -99,7 +99,7 @@ describe('Doc reporter', function () {
           root: false
         };
 
-        it('should log expected html with indents', function () {
+        it('should log expected html with indents', async function () {
           runner = createMockRunner(
             'suite end',
             EVENT_SUITE_END,
@@ -107,7 +107,7 @@ describe('Doc reporter', function () {
             null,
             suite
           );
-          var stdout = runReporter(this, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           var expectedArray = ['  </dl>\n', '</section>\n'];
           expect(stdout, 'to equal', expectedArray);
         });
@@ -118,7 +118,7 @@ describe('Doc reporter', function () {
           root: true
         };
 
-        it('should not log any html', function () {
+        it('should not log any html', async function () {
           runner = createMockRunner(
             'suite end',
             EVENT_SUITE_END,
@@ -126,7 +126,7 @@ describe('Doc reporter', function () {
             null,
             suite
           );
-          var stdout = runReporter(this, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           expect(stdout, 'to be empty');
         });
       });
@@ -145,9 +145,9 @@ describe('Doc reporter', function () {
         }
       };
 
-      it('should log html with indents, expected title, and body', function () {
+      it('should log html with indents, expected title, and body', async function () {
         runner = createMockRunner('pass', EVENT_TEST_PASS, null, null, test);
-        var stdout = runReporter(this, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
         var expectedArray = [
           '    <dt>' + expectedTitle + '</dt>\n',
           '    <dt>' + expectedFile + '</dt>\n',
@@ -156,7 +156,7 @@ describe('Doc reporter', function () {
         expect(stdout, 'to equal', expectedArray);
       });
 
-      it('should escape title and body where necessary', function () {
+      it('should escape title and body where necessary', async function () {
         var unescapedTitle = '<div>' + expectedTitle + '</div>';
         var unescapedFile = '<div>' + expectedFile + '</div>';
         var unescapedBody = '<div>' + expectedBody + '</div>';
@@ -171,7 +171,7 @@ describe('Doc reporter', function () {
         var expectedEscapedBody =
           '&#x3C;div&#x3E;' + expectedBody + '&#x3C;/div&#x3E;';
         runner = createMockRunner('pass', EVENT_TEST_PASS, null, null, test);
-        var stdout = runReporter(this, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
         var expectedArray = [
           '    <dt>' + expectedEscapedTitle + '</dt>\n',
           '    <dt>' + expectedEscapedFile + '</dt>\n',
@@ -195,7 +195,7 @@ describe('Doc reporter', function () {
         }
       };
 
-      it('should log html with indents, expected title, body, and error', function () {
+      it('should log html with indents, expected title, body, and error', async function () {
         runner = createMockRunner(
           'fail two args',
           EVENT_TEST_FAIL,
@@ -204,7 +204,7 @@ describe('Doc reporter', function () {
           test,
           expectedError
         );
-        var stdout = runReporter(this, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
         var expectedArray = [
           '    <dt class="error">' + expectedTitle + '</dt>\n',
           '    <dt class="error">' + expectedFile + '</dt>\n',
@@ -216,7 +216,7 @@ describe('Doc reporter', function () {
         expect(stdout, 'to equal', expectedArray);
       });
 
-      it('should escape title, body, and error where necessary', function () {
+      it('should escape title, body, and error where necessary', async function () {
         var unescapedTitle = '<div>' + expectedTitle + '</div>';
         var unescapedFile = '<div>' + expectedFile + '</div>';
         var unescapedBody = '<div>' + expectedBody + '</div>';
@@ -241,7 +241,7 @@ describe('Doc reporter', function () {
           test,
           unescapedError
         );
-        var stdout = runReporter(this, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
         var expectedArray = [
           '    <dt class="error">' + expectedEscapedTitle + '</dt>\n',
           '    <dt class="error">' + expectedEscapedFile + '</dt>\n',

--- a/test/reporters/dot.spec.js
+++ b/test/reporters/dot.spec.js
@@ -8,7 +8,7 @@ var reporters = require('../../').reporters;
 var Base = reporters.Base;
 var Dot = reporters.Dot;
 var createMockRunner = helpers.createMockRunner;
-var makeRunReporter = helpers.createRunReporterFunction;
+var createRunReporterFunction = helpers.createRunReporterFunction;
 
 var EVENT_RUN_BEGIN = events.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = events.EVENT_RUN_END;
@@ -18,8 +18,7 @@ var EVENT_TEST_PENDING = events.EVENT_TEST_PENDING;
 
 describe('Dot reporter', function () {
   var windowWidthStub;
-  var runReporter = makeRunReporter(Dot);
-  var noop = function () {};
+  var runReporter = createRunReporterFunction(Dot);
 
   beforeEach(function () {
     windowWidthStub = sinon.stub(Base.window, 'width').value(0);
@@ -35,10 +34,10 @@ describe('Dot reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'start' event", function () {
-      it('should write a newline', function () {
+      it('should write a newline', async function () {
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
-        var stdout = runReporter({epilogue: noop}, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
         sinon.restore();
 
         var expectedArray = ['\n'];
@@ -52,10 +51,10 @@ describe('Dot reporter', function () {
           windowWidthStub.value(2);
         });
 
-        it('should write a newline followed by a comma', function () {
+        it('should write a newline followed by a comma', async function () {
           var runner = createMockRunner('pending', EVENT_TEST_PENDING);
           var options = {};
-          var stdout = runReporter({epilogue: noop}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           var expectedArray = ['\n  ', 'pending_' + Base.symbols.comma];
@@ -64,10 +63,10 @@ describe('Dot reporter', function () {
       });
 
       describe('when window width is less than or equal to 1', function () {
-        it('should write a comma', function () {
+        it('should write a comma', async function () {
           var runner = createMockRunner('pending', EVENT_TEST_PENDING);
           var options = {};
-          var stdout = runReporter({epilogue: noop}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           var expectedArray = ['pending_' + Base.symbols.comma];
@@ -90,7 +89,7 @@ describe('Dot reporter', function () {
         });
 
         describe('when test speed is fast', function () {
-          it('should write a newline followed by a dot', function () {
+          it('should write a newline followed by a dot', async function () {
             var runner = createMockRunner(
               'pass',
               EVENT_TEST_PASS,
@@ -99,7 +98,7 @@ describe('Dot reporter', function () {
               test
             );
             var options = {};
-            var stdout = runReporter({epilogue: noop}, runner, options);
+            var {stdout} = await runReporter({}, runner, options);
             sinon.restore();
 
             expect(test.speed, 'to equal', 'fast');
@@ -111,7 +110,7 @@ describe('Dot reporter', function () {
 
       describe('when window width is less than or equal to 1', function () {
         describe('when test speed is fast', function () {
-          it('should write a grey dot', function () {
+          it('should write a grey dot', async function () {
             var runner = createMockRunner(
               'pass',
               EVENT_TEST_PASS,
@@ -120,7 +119,7 @@ describe('Dot reporter', function () {
               test
             );
             var options = {};
-            var stdout = runReporter({epilogue: noop}, runner, options);
+            var {stdout} = await runReporter({}, runner, options);
             sinon.restore();
 
             expect(test.speed, 'to equal', 'fast');
@@ -130,7 +129,7 @@ describe('Dot reporter', function () {
         });
 
         describe('when test speed is medium', function () {
-          it('should write a yellow dot', function () {
+          it('should write a yellow dot', async function () {
             test.duration = 2;
             var runner = createMockRunner(
               'pass',
@@ -140,7 +139,7 @@ describe('Dot reporter', function () {
               test
             );
             var options = {};
-            var stdout = runReporter({epilogue: noop}, runner, options);
+            var {stdout} = await runReporter({}, runner, options);
             sinon.restore();
 
             expect(test.speed, 'to equal', 'medium');
@@ -150,7 +149,7 @@ describe('Dot reporter', function () {
         });
 
         describe('when test speed is slow', function () {
-          it('should write a bright yellow dot', function () {
+          it('should write a bright yellow dot', async function () {
             test.duration = 3;
             var runner = createMockRunner(
               'pass',
@@ -160,7 +159,7 @@ describe('Dot reporter', function () {
               test
             );
             var options = {};
-            var stdout = runReporter({epilogue: noop}, runner, options);
+            var {stdout} = await runReporter({}, runner, options);
             sinon.restore();
 
             expect(test.speed, 'to equal', 'slow');
@@ -183,7 +182,7 @@ describe('Dot reporter', function () {
           windowWidthStub.value(2);
         });
 
-        it('should write a newline followed by an exclamation mark', function () {
+        it('should write a newline followed by an exclamation mark', async function () {
           var runner = createMockRunner(
             'fail',
             EVENT_TEST_FAIL,
@@ -192,7 +191,7 @@ describe('Dot reporter', function () {
             test
           );
           var options = {};
-          var stdout = runReporter({epilogue: noop}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           var expectedArray = ['\n  ', 'fail_' + Base.symbols.bang];
@@ -201,7 +200,7 @@ describe('Dot reporter', function () {
       });
 
       describe('when window width is less than or equal to 1', function () {
-        it('should write an exclamation mark', function () {
+        it('should write an exclamation mark', async function () {
           var runner = createMockRunner(
             'fail',
             EVENT_TEST_FAIL,
@@ -210,7 +209,7 @@ describe('Dot reporter', function () {
             test
           );
           var options = {};
-          var stdout = runReporter({epilogue: noop}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           var expectedArray = ['fail_' + Base.symbols.bang];
@@ -220,13 +219,13 @@ describe('Dot reporter', function () {
     });
 
     describe("on 'end' event", function () {
-      it('should call epilogue', function () {
+      it('should call epilogue', async function () {
         var runner = createMockRunner('end', EVENT_RUN_END);
         var fakeThis = {
           epilogue: sinon.stub()
         };
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(fakeThis.epilogue.called, 'to be true');

--- a/test/reporters/json-stream.spec.js
+++ b/test/reporters/json-stream.spec.js
@@ -38,12 +38,12 @@ describe('JSON Stream reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'start' event", function () {
-      it('should write stringified start with expected total', function () {
+      it('should write stringified start with expected total', async function () {
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var expectedTotal = 12;
         runner.total = expectedTotal;
         var options = {};
-        var stdout = runReporter({}, runner, options);
+        var { stdout } = await runReporter({}, runner, options);
 
         expect(
           stdout[0],
@@ -54,7 +54,7 @@ describe('JSON Stream reporter', function () {
     });
 
     describe("on 'pass' event", function () {
-      it('should write stringified test data', function () {
+      it('should write stringified test data', async function () {
         var runner = createMockRunner(
           'pass',
           EVENT_TEST_PASS,
@@ -63,7 +63,7 @@ describe('JSON Stream reporter', function () {
           expectedTest
         );
         var options = {};
-        var stdout = runReporter({}, runner, options);
+        var { stdout } = await runReporter({}, runner, options);
 
         expect(
           stdout[0],
@@ -87,7 +87,7 @@ describe('JSON Stream reporter', function () {
 
     describe("on 'fail' event", function () {
       describe('when error stack exists', function () {
-        it('should write stringified test data with error data', function () {
+        it('should write stringified test data with error data',  async function () {
           expectedError.stack = expectedErrorStack;
           var runner = createMockRunner(
             'fail two args',
@@ -98,7 +98,7 @@ describe('JSON Stream reporter', function () {
             expectedError
           );
           var options = {};
-          var stdout = runReporter({}, runner, options);
+          var { stdout } = await runReporter({}, runner, options);
 
           expect(
             stdout[0],
@@ -125,7 +125,7 @@ describe('JSON Stream reporter', function () {
       });
 
       describe('when error stack does not exist', function () {
-        it('should write stringified test data with error data', function () {
+        it('should write stringified test data with error data',  async function () {
           expectedError.stack = null;
           var runner = createMockRunner(
             'fail two args',
@@ -136,7 +136,7 @@ describe('JSON Stream reporter', function () {
             expectedError
           );
           var options = {};
-          var stdout = runReporter(this, runner, options);
+          var { stdout } = await runReporter(this, runner, options);
 
           expect(
             stdout[0],
@@ -162,10 +162,10 @@ describe('JSON Stream reporter', function () {
     });
 
     describe("on 'end' event", function () {
-      it('should write summary statistics', function () {
+      it('should write summary statistics',  async function () {
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        var stdout = runReporter(this, runner, options);
+        var { stdout } = await runReporter(this, runner, options);
         expect(stdout[0], 'to match', /end/);
       });
     });

--- a/test/reporters/landing.spec.js
+++ b/test/reporters/landing.spec.js
@@ -43,23 +43,23 @@ describe('Landing reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'start' event", function () {
-      it('should write newlines', function () {
+      it('should write newlines', async function () {
         sinon.stub(Base.cursor, 'hide');
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
-        var stdout = runReporter({}, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
         sinon.restore();
 
         expect(stdout[0], 'to equal', '\n\n\n  ');
       });
 
-      it('should call cursor hide', function () {
+      it('should call cursor hide', async function () {
         var hideCursorStub = sinon.stub(Base.cursor, 'hide');
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
-        runReporter({}, runner, options);
+        await runReporter({}, runner, options);
         sinon.restore();
 
         expect(hideCursorStub.called, 'to be true');
@@ -68,7 +68,7 @@ describe('Landing reporter', function () {
 
     describe("on 'test end' event", function () {
       describe('when test passes', function () {
-        it('should write expected landing strip', function () {
+        it('should write expected landing strip', async function () {
           var test = {
             state: STATE_PASSED
           };
@@ -80,7 +80,7 @@ describe('Landing reporter', function () {
             test
           );
           var options = {};
-          var stdout = runReporter({}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           expect(stdout, 'to equal', expectedArray);
@@ -88,7 +88,7 @@ describe('Landing reporter', function () {
       });
 
       describe('when test fails', function () {
-        it('should write expected landing strip', function () {
+        it('should write expected landing strip', async function () {
           var test = {
             state: STATE_FAILED
           };
@@ -101,7 +101,7 @@ describe('Landing reporter', function () {
           );
           runner.total = 12;
           var options = {};
-          var stdout = runReporter({}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           expect(stdout, 'to equal', expectedArray);
@@ -110,7 +110,7 @@ describe('Landing reporter', function () {
     });
 
     describe("on 'end' event", function () {
-      it('should call cursor show and epilogue', function () {
+      it('should call cursor show and epilogue', async function () {
         var showCursorStub = sinon.stub(Base.cursor, 'show');
 
         var fakeThis = {
@@ -118,7 +118,7 @@ describe('Landing reporter', function () {
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(fakeThis.epilogue.calledOnce, 'to be true');

--- a/test/reporters/list.spec.js
+++ b/test/reporters/list.spec.js
@@ -40,7 +40,7 @@ describe('List reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'start' and 'test' events", function () {
-      it('should write expected newline and title', function () {
+      it('should write expected newline and title', async function () {
         var runner = createMockRunner(
           'start test',
           EVENT_RUN_BEGIN,
@@ -52,7 +52,7 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        var stdout = runReporter(fakeThis, runner, options);
+        var {stdout} = await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         var startString = '\n';
@@ -63,7 +63,7 @@ describe('List reporter', function () {
     });
 
     describe("on 'pending' event", function () {
-      it('should write expected title', function () {
+      it('should write expected title', async function () {
         var runner = createMockRunner(
           'pending test',
           EVENT_TEST_PENDING,
@@ -75,7 +75,7 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        var stdout = runReporter(fakeThis, runner, options);
+        var {stdout} = await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(stdout[0], 'to equal', '  - ' + expectedTitle + '\n');
@@ -89,7 +89,7 @@ describe('List reporter', function () {
         crStub = sinon.stub(Base.cursor, 'CR').callsFake(noop);
       });
 
-      it('should call cursor CR', function () {
+      it('should call cursor CR', async function () {
         var runner = createMockRunner(
           'pass',
           EVENT_TEST_PASS,
@@ -101,13 +101,13 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(crStub.called, 'to be true');
       });
 
-      it('should write expected symbol, title, and duration', function () {
+      it('should write expected symbol, title, and duration', async function () {
         var expectedOkSymbol = 'OK';
         sinon.stub(Base.symbols, 'ok').value(expectedOkSymbol);
 
@@ -122,7 +122,7 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        var stdout = runReporter(fakeThis, runner, options);
+        var {stdout} = await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(
@@ -146,7 +146,7 @@ describe('List reporter', function () {
         crStub = sinon.stub(Base.cursor, 'CR').callsFake(noop);
       });
 
-      it('should call cursor CR', function () {
+      it('should call cursor CR', async function () {
         var runner = createMockRunner(
           'fail',
           EVENT_TEST_FAIL,
@@ -158,13 +158,13 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(crStub.called, 'to be true');
       });
 
-      it('should write expected error number and title', function () {
+      it('should write expected error number and title', async function () {
         var expectedErrorCount = 1;
         var runner = createMockRunner(
           'fail',
@@ -177,7 +177,7 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        var stdout = runReporter(fakeThis, runner, options);
+        var {stdout} = await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(
@@ -187,7 +187,7 @@ describe('List reporter', function () {
         );
       });
 
-      it('should immediately construct fail strings', function () {
+      it('should immediately construct fail strings', async function () {
         var actual = {a: 'actual'};
         var expected = {a: 'expected'};
         var checked = false;
@@ -219,7 +219,7 @@ describe('List reporter', function () {
         var fakeThis = {
           epilogue: noop
         };
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(typeof err.actual, 'to be', 'string');
@@ -228,13 +228,13 @@ describe('List reporter', function () {
     });
 
     describe("on 'end' event", function () {
-      it('should call epilogue', function () {
+      it('should call epilogue', async function () {
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
         var fakeThis = {
           epilogue: sinon.spy()
         };
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(fakeThis.epilogue.calledOnce, 'to be true');

--- a/test/reporters/markdown.spec.js
+++ b/test/reporters/markdown.spec.js
@@ -22,7 +22,7 @@ describe('Markdown reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'suite' event", function () {
-      it("should write expected slugged titles on 'end' event", function () {
+      it("should write expected slugged titles on 'end' event", async function () {
         var expectedSuite = {
           title: expectedTitle,
           fullTitle: function () {
@@ -47,7 +47,7 @@ describe('Markdown reporter', function () {
         );
         runner.suite = expectedSuite;
         var options = {};
-        var stdout = runReporter({}, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
 
         var expectedArray = [
           '# TOC\n',
@@ -68,7 +68,7 @@ describe('Markdown reporter', function () {
     });
 
     describe("on 'pass' event", function () {
-      it("should write test code inside js code block, on 'end' event", function () {
+      it("should write test code inside js code block, on 'end' event", async function () {
         var expectedSuite = {
           title: expectedTitle,
           fullTitle: function () {
@@ -100,7 +100,7 @@ describe('Markdown reporter', function () {
         );
         runner.suite = expectedSuite;
         var options = {};
-        var stdout = runReporter({}, runner, options);
+        var {stdout} = await runReporter({}, runner, options);
 
         var expectedArray = [
           '# TOC\n',

--- a/test/reporters/min.spec.js
+++ b/test/reporters/min.spec.js
@@ -17,14 +17,14 @@ describe('Min reporter', function () {
   var noop = function () {};
 
   describe('event handlers', function () {
-    describe("on 'start' event", function () {
-      it('should clear screen then set cursor position', function () {
+    describe("on 'start' event", async function () {
+      it('should clear screen then set cursor position', async function () {
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
         var fakeThis = {
           epilogue: noop
         };
-        var stdout = runReporter(fakeThis, runner, options);
+        var { stdout } = await runReporter(fakeThis, runner, options);
 
         var expectedArray = ['\u001b[2J', '\u001b[1;3H'];
         expect(stdout, 'to equal', expectedArray);
@@ -32,13 +32,13 @@ describe('Min reporter', function () {
     });
 
     describe("on 'end' event", function () {
-      it('should call epilogue', function () {
+      it('should call epilogue', async function () {
         var fakeThis = {
           epilogue: sinon.stub().callsFake(noop)
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
 
         expect(fakeThis.epilogue.called, 'to be true');
       });

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -27,7 +27,7 @@ describe('Nyan reporter', function () {
     var runReporter = makeRunReporter(NyanCat);
 
     describe("on 'start' event", function () {
-      it('should call draw', function () {
+      it('should call draw', async function () {
         var fakeThis = {
           draw: sinon.stub().callsFake(noop),
           generateColors: noop
@@ -35,28 +35,28 @@ describe('Nyan reporter', function () {
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
 
         expect(fakeThis.draw.called, 'to be true');
       });
     });
 
     describe("on 'pending' event", function () {
-      it('should call draw', function () {
+      it('should call draw', async function () {
         var fakeThis = {
           draw: sinon.stub().callsFake(noop),
           generateColors: noop
         };
         var runner = createMockRunner('pending', EVENT_TEST_PENDING);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
 
         expect(fakeThis.draw.called, 'to be true');
       });
     });
 
     describe("on 'pass' event", function () {
-      it('should call draw', function () {
+      it('should call draw', async function () {
         var test = {
           duration: '',
           slow: noop
@@ -73,14 +73,14 @@ describe('Nyan reporter', function () {
           test
         );
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
 
         expect(fakeThis.draw.called, 'to be true');
       });
     });
 
     describe("on 'fail' event", function () {
-      it('should call draw', function () {
+      it('should call draw', async function () {
         var test = {
           err: ''
         };
@@ -96,14 +96,14 @@ describe('Nyan reporter', function () {
           test
         );
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
 
         expect(fakeThis.draw.called, 'to be true');
       });
     });
 
     describe("on 'end' event", function () {
-      it('should call epilogue', function () {
+      it('should call epilogue', async function () {
         var fakeThis = {
           draw: noop,
           epilogue: sinon.stub().callsFake(noop),
@@ -111,12 +111,12 @@ describe('Nyan reporter', function () {
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
 
         expect(fakeThis.epilogue.called, 'to be true');
       });
 
-      it('should write numberOfLines amount of newlines', function () {
+      it('should write numberOfLines amount of newlines', async function () {
         var expectedNumberOfLines = 4;
         var fakeThis = {
           draw: noop,
@@ -125,7 +125,7 @@ describe('Nyan reporter', function () {
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        var stdout = runReporter(fakeThis, runner, options);
+        var { stdout } = await runReporter(fakeThis, runner, options);
 
         var isBlankLine = function (value) {
           return value === '\n';
@@ -138,7 +138,7 @@ describe('Nyan reporter', function () {
         );
       });
 
-      it('should call Base show', function () {
+      it('should call Base show', async function () {
         var showCursorStub = sinon.stub(Base.cursor, 'show');
         var fakeThis = {
           draw: noop,
@@ -147,7 +147,7 @@ describe('Nyan reporter', function () {
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(showCursorStub.called, 'to be true');

--- a/test/reporters/progress.spec.js
+++ b/test/reporters/progress.spec.js
@@ -24,12 +24,12 @@ describe('Progress reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'start' event", function () {
-      it('should call cursor hide', function () {
+      it('should call cursor hide', async function () {
         var hideCursorStub = sinon.stub(Base.cursor, 'hide');
 
         var runner = createMockRunner('start', EVENT_RUN_BEGIN);
         var options = {};
-        runReporter({}, runner, options);
+        await runReporter({}, runner, options);
         sinon.restore();
 
         expect(hideCursorStub.called, 'to be true');
@@ -38,7 +38,7 @@ describe('Progress reporter', function () {
 
     describe("on 'test end' event", function () {
       describe('when line has changed', function () {
-        it('should write expected progress of open and close options', function () {
+        it('should write expected progress of open and close options', async function () {
           var crCursorStub = sinon.stub(Base.cursor, 'CR').callsFake(noop);
           sinon.stub(Base, 'useColors').value(false);
           sinon.stub(Base.window, 'width').value(5);
@@ -59,7 +59,7 @@ describe('Progress reporter', function () {
           var options = {
             reporterOptions: expectedOptions
           };
-          var stdout = runReporter({}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           var expectedArray = [
@@ -76,7 +76,7 @@ describe('Progress reporter', function () {
       });
 
       describe('when line has not changed', function () {
-        it('should not write anything', function () {
+        it('should not write anything', async function () {
           sinon.stub(Base, 'useColors').value(false);
           sinon.stub(Base.cursor, 'CR').callsFake(noop);
           sinon.stub(Base.window, 'width').value(-3);
@@ -85,7 +85,7 @@ describe('Progress reporter', function () {
           var runner = createMockRunner('test end', EVENT_TEST_END);
           runner.total = expectedTotal;
           var options = {};
-          var stdout = runReporter({}, runner, options);
+          var {stdout} = await runReporter({}, runner, options);
           sinon.restore();
 
           expect(stdout, 'to equal', []);
@@ -94,14 +94,14 @@ describe('Progress reporter', function () {
     });
 
     describe("on 'end' event", function () {
-      it('should call cursor show and epilogue', function () {
+      it('should call cursor show and epilogue', async function () {
         var showCursorStub = sinon.stub(Base.cursor, 'show');
         var fakeThis = {
           epilogue: sinon.spy()
         };
         var runner = createMockRunner('end', EVENT_RUN_END);
         var options = {};
-        runReporter(fakeThis, runner, options);
+        await runReporter(fakeThis, runner, options);
         sinon.restore();
 
         expect(fakeThis.epilogue.calledOnce, 'to be true');

--- a/test/reporters/spec.spec.js
+++ b/test/reporters/spec.spec.js
@@ -30,7 +30,7 @@ describe('Spec reporter', function () {
 
   describe('event handlers', function () {
     describe("on 'suite' event", function () {
-      it('should return title', function () {
+      it('should return title', async function () {
         var suite = {
           title: expectedTitle
         };
@@ -42,7 +42,7 @@ describe('Spec reporter', function () {
           suite
         );
         var options = {};
-        var stdout = runReporter({epilogue: noop}, runner, options);
+        var {stdout} = await runReporter({epilogue: noop}, runner, options);
         sinon.restore();
 
         var expectedArray = [expectedTitle + '\n'];
@@ -51,7 +51,7 @@ describe('Spec reporter', function () {
     });
 
     describe("on 'pending' event", function () {
-      it('should return title', function () {
+      it('should return title', async function () {
         var suite = {
           title: expectedTitle
         };
@@ -63,7 +63,7 @@ describe('Spec reporter', function () {
           suite
         );
         var options = {};
-        var stdout = runReporter({epilogue: noop}, runner, options);
+        var {stdout} = await runReporter({epilogue: noop}, runner, options);
         sinon.restore();
 
         var expectedArray = ['  - ' + expectedTitle + '\n'];
@@ -73,7 +73,7 @@ describe('Spec reporter', function () {
 
     describe("on 'pass' event", function () {
       describe('when test speed is slow', function () {
-        it('should return expected tick, title, and duration', function () {
+        it('should return expected tick, title, and duration', async function () {
           var expectedDuration = 2;
           var test = {
             title: expectedTitle,
@@ -90,7 +90,7 @@ describe('Spec reporter', function () {
             test
           );
           var options = {};
-          var stdout = runReporter({epilogue: noop}, runner, options);
+          var {stdout} = await runReporter({epilogue: noop}, runner, options);
           sinon.restore();
 
           var expectedString =
@@ -107,7 +107,7 @@ describe('Spec reporter', function () {
       });
 
       describe('when test speed is fast', function () {
-        it('should return expected tick, title without a duration', function () {
+        it('should return expected tick, title without a duration', async function () {
           var expectedDuration = 1;
           var test = {
             title: expectedTitle,
@@ -124,7 +124,7 @@ describe('Spec reporter', function () {
             test
           );
           var options = {};
-          var stdout = runReporter({epilogue: noop}, runner, options);
+          var {stdout} = await runReporter({epilogue: noop}, runner, options);
           sinon.restore();
 
           var expectedString =
@@ -135,7 +135,7 @@ describe('Spec reporter', function () {
     });
 
     describe("on 'fail' event", function () {
-      it('should return title and function count', function () {
+      it('should return title and function count', async function () {
         var functionCount = 1;
         var test = {
           title: expectedTitle
@@ -148,7 +148,7 @@ describe('Spec reporter', function () {
           test
         );
         var options = {};
-        var stdout = runReporter({epilogue: noop}, runner, options);
+        var {stdout} = await runReporter({epilogue: noop}, runner, options);
         sinon.restore();
 
         var expectedArray = [

--- a/test/reporters/tap.spec.js
+++ b/test/reporters/tap.spec.js
@@ -42,10 +42,10 @@ describe('TAP reporter', function () {
         var expectedSuite = 'some suite';
         var stdout = [];
 
-        before(function () {
+        before(async function () {
           var runner = createMockRunner('start', EVENT_RUN_BEGIN);
           runner.suite = expectedSuite;
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should not write a TAP specification version', function () {
@@ -56,7 +56,7 @@ describe('TAP reporter', function () {
       describe("on 'pending' event", function () {
         var stdout = [];
 
-        before(function () {
+        before(async function () {
           var test = createTest();
           var runner = createMockRunner(
             'start test',
@@ -66,7 +66,7 @@ describe('TAP reporter', function () {
             test
           );
           runner.suite = '';
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write expected message including count and title', function () {
@@ -79,7 +79,7 @@ describe('TAP reporter', function () {
       describe("on 'pass' event", function () {
         var stdout;
 
-        before(function () {
+        before(async function () {
           var test = createTest();
           var runner = createMockRunner(
             'start test',
@@ -89,7 +89,7 @@ describe('TAP reporter', function () {
             test
           );
           runner.suite = '';
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write expected message including count and title', function () {
@@ -106,7 +106,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has only message", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {
               message: expectedErrorMessage
@@ -127,7 +127,7 @@ describe('TAP reporter', function () {
               }
             };
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message and error message', function () {
@@ -142,7 +142,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has only stack", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {
               stack: expectedStack
@@ -156,7 +156,7 @@ describe('TAP reporter', function () {
               error
             );
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message and stack', function () {
@@ -171,7 +171,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has both message and stack", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {
               stack: expectedStack,
@@ -193,7 +193,7 @@ describe('TAP reporter', function () {
               }
             };
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message, error message, and stack', function () {
@@ -209,7 +209,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has neither message nor stack", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {};
             var runner = createMockRunner(
@@ -228,7 +228,7 @@ describe('TAP reporter', function () {
               }
             };
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message only', function () {
@@ -243,7 +243,7 @@ describe('TAP reporter', function () {
       describe("on 'end' event", function () {
         var stdout;
 
-        before(function () {
+        before(async function () {
           var test = createTest();
           var runner = createMockRunner(
             'fail end pass',
@@ -253,7 +253,7 @@ describe('TAP reporter', function () {
             test
           );
           runner.suite = '';
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write total tests, passes, failures, & plan', function () {
@@ -286,10 +286,10 @@ describe('TAP reporter', function () {
         var expectedSuite = 'some suite';
         var stdout;
 
-        before(function () {
+        before(async function () {
           var runner = createMockRunner('start', EVENT_RUN_BEGIN);
           runner.suite = expectedSuite;
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write the TAP specification version', function () {
@@ -302,7 +302,7 @@ describe('TAP reporter', function () {
       describe("on 'pending' event", function () {
         var stdout;
 
-        before(function () {
+        before(async function () {
           var test = createTest();
           var runner = createMockRunner(
             'start test',
@@ -312,7 +312,7 @@ describe('TAP reporter', function () {
             test
           );
           runner.suite = '';
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write expected message including count and title', function () {
@@ -325,7 +325,7 @@ describe('TAP reporter', function () {
       describe("on 'pass' event", function () {
         var stdout;
 
-        before(function () {
+        before(async function () {
           var test = createTest();
           var runner = createMockRunner(
             'start test',
@@ -335,7 +335,7 @@ describe('TAP reporter', function () {
             test
           );
           runner.suite = '';
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write expected message including count and title', function () {
@@ -352,7 +352,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has only message", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {
               message: expectedErrorMessage
@@ -373,7 +373,7 @@ describe('TAP reporter', function () {
               }
             };
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message and error message', function () {
@@ -391,7 +391,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has only stack", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {
               stack: expectedStack
@@ -405,7 +405,7 @@ describe('TAP reporter', function () {
               error
             );
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message and stack', function () {
@@ -423,7 +423,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has both message and stack", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {
               stack: expectedStack,
@@ -445,7 +445,7 @@ describe('TAP reporter', function () {
               }
             };
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message, error message, and stack', function () {
@@ -465,7 +465,7 @@ describe('TAP reporter', function () {
         describe("when 'error' has neither message nor stack", function () {
           var stdout;
 
-          before(function () {
+          before(async function () {
             var test = createTest();
             var error = {};
             var runner = createMockRunner(
@@ -484,7 +484,7 @@ describe('TAP reporter', function () {
               }
             };
             runner.suite = '';
-            stdout = runReporter({}, runner, options);
+            ({ stdout } = await runReporter({}, runner, options));
           });
 
           it('should write expected message only', function () {
@@ -499,7 +499,7 @@ describe('TAP reporter', function () {
       describe("on 'end' event", function () {
         var stdout;
 
-        before(function () {
+        before(async function () {
           var test = createTest();
           var runner = createMockRunner(
             'fail end pass',
@@ -509,7 +509,7 @@ describe('TAP reporter', function () {
             test
           );
           runner.suite = '';
-          stdout = runReporter({}, runner, options);
+          ({ stdout } = await runReporter({}, runner, options));
         });
 
         it('should write total tests, passes, failures & plan', function () {

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -11,6 +11,10 @@ var states = require('../../').Runnable.constants;
 
 const {createTempDir, touchFile} = require('../integration/helpers');
 
+var helpers = require('./helpers');
+var createMockRunner = helpers.createMockRunner;
+var makeRunReporter = helpers.createRunReporterFunction;
+
 var Base = reporters.Base;
 var XUnit = reporters.XUnit;
 
@@ -24,6 +28,7 @@ var STATE_FAILED = states.STATE_FAILED;
 var STATE_PASSED = states.STATE_PASSED;
 
 describe('XUnit reporter', function () {
+  var runReporter = makeRunReporter(XUnit);
   var runner;
   var noop = function () {};
 
@@ -58,11 +63,14 @@ describe('XUnit reporter', function () {
         fsCreateWriteStream = sinon.stub(fs, 'createWriteStream');
       });
 
-      it('should open given file for writing, recursively creating directories in pathname', function () {
-        var fakeThis = {
-          fileStream: null
+      it('should open given file for writing, recursively creating directories in pathname', async function () {
+        var runner = createMockRunner('start', events.EVENT_RUN_BEGIN);
+        var options = {
+          reporterOptions: {
+            output: expectedOutput
+          }
         };
-        XUnit.call(fakeThis, runner, options);
+        new XUnit(runner, options);
 
         var expectedDirectory = path.dirname(expectedOutput);
         expect(
@@ -113,7 +121,7 @@ describe('XUnit reporter', function () {
               output: invalidPath
             }
           };
-          var boundXUnit = XUnit.bind({}, runner, options);
+          var boundXUnit = () => new XUnit(runner, options);
           expect(
             boundXUnit,
             'to throw',
@@ -136,7 +144,7 @@ describe('XUnit reporter', function () {
         });
 
         it('should throw unsupported error', function () {
-          var boundXUnit = XUnit.bind({}, runner, options);
+          var boundXUnit = () => new XUnit(runner, options);
           expect(
             boundXUnit,
             'to throw',
@@ -152,20 +160,42 @@ describe('XUnit reporter', function () {
   });
 
   describe('event handlers', function () {
+    var fsMkdirSync;
+    var fsCreateWriteStream;
+
+    beforeEach(function () {
+      fsMkdirSync = sinon.stub(fs, 'mkdirSync');
+      fsCreateWriteStream = sinon.stub(fs, 'createWriteStream');
+    });
+
     describe("on 'pending', 'pass' and 'fail' events", function () {
-      it("should add test to tests called on 'end' event", function () {
+      it("should add test to tests called on 'end' event", async function () {
         var pendingTest = {
+          isPending: () => false,
+          parent: {
+            fullTitle: () => 'pending parent'
+          },
           name: 'pending',
           slow: noop
         };
         var failTest = {
+          isPending: () => false,
+          parent: {
+            fullTitle: () => 'fail parent'
+          },
           name: 'fail',
           slow: noop
         };
         var passTest = {
+          isPending: () => false,
+          parent: {
+            fullTitle: () => 'pass parent'
+          },
           name: 'pass',
           slow: noop
         };
+        var write = sinon.spy();
+        fsCreateWriteStream.returns({ write })
         runner.on = runner.once = function (event, callback) {
           if (event === EVENT_TEST_PENDING) {
             callback(pendingTest);
@@ -178,17 +208,19 @@ describe('XUnit reporter', function () {
           }
         };
 
-        var calledTests = [];
-        var fakeThis = {
-          write: noop,
-          test: function (test) {
-            calledTests.push(test);
+        var expectedOutput = path.join(path.sep, 'path', 'to', 'some-output');
+        var options = {
+          reporterOptions: {
+            output: expectedOutput
           }
         };
-        XUnit.call(fakeThis, runner);
+        const {reporter} = await runReporter({}, runner, options);
 
-        var expectedCalledTests = [pendingTest, passTest, failTest];
-        expect(calledTests, 'to equal', expectedCalledTests);
+        reporter.fileStream;
+        expect(write.getCalls().length, 'to equal', 5);
+        expect(write.getCall(1).args[0], 'to match', /pending parent/);
+        expect(write.getCall(2).args[0], 'to match', /pass parent/);
+        expect(write.getCall(3).args[0], 'to match', /fail parent/);
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5025
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches `Base`, the reporters that extend from it, and class-likes in those files.

This one is more involved than the others, as existing test helpers need to be updated. Not pushed to this PR branch yet.