### PR TITLE
ci: update to `windows-latest` in actions

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -63,7 +63,7 @@ jobs:
           - test-part: jsapi
             coverage: false
     with:
-      os: 'ubuntu-latest,windows-2019'
+      os: 'ubuntu-latest,windows-latest'
       node-versions: '14,16,18,20,22'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}


### PR DESCRIPTION
Ever since the original move to GitHub Actions almost 4 years ago its been `windows-2019` that's been in use.

I'm thinking we should always use `-latest` when possible