### PR TITLE
docs: update README, LICENSE and remove outdated

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2011-2022 OpenJS Foundation and contributors, https://openjsf.org
+Copyright (c) 2011-2024 OpenJS Foundation and contributors, https://openjsf.org
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 <p align="center">
-  <img src="https://cldup.com/xFVFxOioAU.svg" alt="Mocha test framework logo"/>
+  <img src="assets/mocha-logo.svg" alt="Mocha test framework logo"/>
 </p>
 
 <p align="center">☕️ Simple, flexible, fun JavaScript test framework for Node.js & The Browser ☕️</p>
 
-<p align="center">
-<a href="https://github.com/mochajs/mocha/actions?query=workflow%3ATests+branch%3Amain"><img src="https://github.com/mochajs/mocha/workflows/Tests/badge.svg?branch=main" alt="GitHub Actions Build Status"></a>
-<a href="https://coveralls.io/github/mochajs/mocha"><img src="https://coveralls.io/repos/github/mochajs/mocha/badge.svg" alt="Coverage Status"></a>
-<a href="https://discord.gg/KeDn2uXhER"><img alt="Chat - Discord" src="https://img.shields.io/badge/chat-Discord-5765F2.svg" /></a>
-<a href="https://github.com/mochajs/mocha#sponsors"><img src="https://opencollective.com/mochajs/tiers/sponsors/badge.svg" alt="OpenCollective Sponsors"></a>
-<a href="https://github.com/mochajs/mocha#backers"><img src="https://opencollective.com/mochajs/tiers/backers/badge.svg" alt="OpenCollective Backers"></a>
-</p>
+<div align="center">
 
-<p align="center">
 <a href="https://www.npmjs.com/package/mocha"><img src="https://img.shields.io/npm/v/mocha.svg" alt="NPM Version"></a>
 <a href="https://github.com/mochajs/mocha"><img src="https://img.shields.io/node/v/mocha.svg" alt="Node Version"></a>
-</p>
+[![GitHub Actions Build Status](https://github.com/mochajs/mocha/actions/workflows/mocha.yml/badge.svg)](https://github.com/mochajs/mocha/actions/workflows/mocha.yml)
+<a href="https://coveralls.io/github/mochajs/mocha"><img src="https://coveralls.io/repos/github/mochajs/mocha/badge.svg" alt="Coverage Status"></a>
 
-<p align="center"><br><img alt="Mocha Browser Support h/t SauceLabs" src="https://saucelabs.com/browser-matrix/mochajs.svg" width="354"></p>
+</div>
+
+<div align="center">
+
+<a href="https://discord.gg/KeDn2uXhER"><img alt="Chat - Discord" src="https://img.shields.io/badge/Chat-Discord-5765F2.svg" /></a>
+<a href="https://github.com/mochajs/mocha#sponsors"><img src="https://opencollective.com/mochajs/tiers/sponsors/badge.svg" alt="OpenCollective Sponsors"></a>
+<a href="https://github.com/mochajs/mocha#backers"><img src="https://opencollective.com/mochajs/tiers/backers/badge.svg" alt="OpenCollective Backers"></a>
+
+</div>
 
 ## Links
 
@@ -68,6 +70,4 @@ Finally, come [chat with the maintainers on Discord](https://discord.gg/KeDn2uXh
 
 ## License
 
-Copyright 2011-2022 OpenJS Foundation and contributors. Licensed [MIT](https://github.com/mochajs/mocha/blob/main/LICENSE).
-
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmochajs%2Fmocha?ref=badge_large)
+Copyright 2011-2024 OpenJS Foundation and contributors. Licensed [MIT](https://github.com/mochajs/mocha/blob/main/LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,9 @@ _So you wanna build the site?_
 
 [mochajs.org](https://mochajs.org) is built using [Eleventy](https://www.11ty.io/), a simple static site generator.
 
-## Prerequisites
-
-- Node.js v10.12.0 or greater
-
 ## Development
 
-1. Run `npm install` from working copy root to get Node.js deps.
+1. Run `npm install` / `npm ci` from working copy root to get Node.js deps.
 1. To serve the site and rebuild as changes are made, execute `npm run docs-watch`.
 1. To rebuild the site _once_, execute `npm run docs`.
 
@@ -19,11 +15,3 @@ _So you wanna build the site?_
 - The content lives in `docs/index.md`; everything else is markup, scripts, assets, etc.
 - This file (`docs/README.md`) should _not_ be included in the build.
 - `docs/_site_` is where the deployed site lives. This directories are _not_ under version control.
-
-## License
-
-:copyright: 2016-2018 [JS Foundation](https://js.foundation) and contributors.
-
-Content licensed [CC-BY-4.0](https://raw.githubusercontent.com/mochajs/mocha/main/docs/LICENSE-CC-BY-4.0).
-
-Code licensed [MIT](https://raw.githubusercontent.com/mochajs/mocha/main/LICENSE-MIT).


### PR DESCRIPTION
* Fixes the test badge
* Updates some copyright years
* Removes saucelabs and fossa embeds
* Uses local logo rather than logo from unknown CDN
* Reorders badges so that package related badges are on the top and community related ones below