### PR TITLE
fix: handle case of invalid package.json with no explicit config

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -195,6 +195,11 @@ const loadPkgRc = (args = {}) => {
           `Unable to read/parse ${filepath}: ${err}`,
           filepath
         );
+      } else if (err.toString().includes('SyntaxError')) {
+        throw createUnparsableFileError(
+          `Unable to parse ${filepath}: ${err}`,
+          filepath
+        );
       }
       debug('failed to read default package.json at %s; ignoring', filepath);
     }

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -181,8 +181,24 @@ const loadPkgRc = (args = {}) => {
   result = {};
   const filepath = args.package || findUp.sync(mocharc.package);
   if (filepath) {
+    let configData;
     try {
-      const pkg = JSON.parse(fs.readFileSync(filepath, 'utf8'));
+      configData = fs.readFileSync(filepath, 'utf8');
+    } catch (err) {
+      // If `args.package` was explicitly specified, throw an error
+      if (filepath == args.package) {
+        throw createUnparsableFileError(
+          `Unable to read ${filepath}: ${err}`,
+          filepath
+        );
+      } else {
+        debug('failed to read default package.json at %s; ignoring',
+              filepath);
+        return result;
+      }
+    }
+    try {
+      const pkg = JSON.parse(configData);
       if (pkg.mocha) {
         debug('`mocha` prop of package.json parsed: %O', pkg.mocha);
         result = pkg.mocha;
@@ -190,18 +206,11 @@ const loadPkgRc = (args = {}) => {
         debug('no config found in %s', filepath);
       }
     } catch (err) {
-      if (args.package) {
-        throw createUnparsableFileError(
-          `Unable to read/parse ${filepath}: ${err}`,
-          filepath
-        );
-      } else if (err.toString().includes('SyntaxError')) {
-        throw createUnparsableFileError(
-          `Unable to parse ${filepath}: ${err}`,
-          filepath
-        );
-      }
-      debug('failed to read default package.json at %s; ignoring', filepath);
+      // If JSON failed to parse, throw an error.
+      throw createUnparsableFileError(
+        `Unable to parse ${filepath}: ${err}`,
+        filepath
+      );
     }
   }
   return result;

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -206,8 +206,7 @@ describe('options', function () {
             // package.json
             readFileSync
               .onFirstCall()
-              // Note the extra comma
-              .returns('{"mocha": {"retries": 3, "_": ["foobar.spec.js"],}}');
+              .returns('{definitely-invalid');
             findConfig = sinon.stub().returns('/some/.mocharc.json');
             loadConfig = sinon.stub().returns({});
             findupSync = sinon.stub().returns(filepath);

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -149,7 +149,7 @@ describe('options', function () {
                 loadOptions('--package /something/wherever --require butts');
               },
               'to throw',
-              'Unable to read/parse /something/wherever: bad file message'
+              'Unable to read /something/wherever: bad file message'
             );
           });
         });

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -224,7 +224,7 @@ describe('options', function () {
                 loadOptions();
               },
               'to throw',
-              'Unable to parse /some/package.json: SyntaxError: Expected double-quoted property name in JSON at position 49'
+                /SyntaxError/,
             );
           });
         });

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -318,7 +318,7 @@ describe('options', function () {
           });
 
           it('should set config = false', function () {
-            expect(loadOptions(), 'to have property', 'config', false);
+            expect(result, 'to have property', 'config', false);
           });
         });
 

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -199,6 +199,37 @@ describe('options', function () {
           });
         });
 
+        describe('when path to package.json unspecified and package.json exists but is invalid', function () {
+          beforeEach(function () {
+            const filepath = '/some/package.json';
+            readFileSync = sinon.stub();
+            // package.json
+            readFileSync
+              .onFirstCall()
+              // Note the extra comma
+              .returns('{"mocha": {"retries": 3, "_": ["foobar.spec.js"],}}');
+            findConfig = sinon.stub().returns('/some/.mocharc.json');
+            loadConfig = sinon.stub().returns({});
+            findupSync = sinon.stub().returns(filepath);
+            loadOptions = proxyLoadOptions({
+              readFileSync,
+              findConfig,
+              loadConfig,
+              findupSync
+            });
+          });
+
+          it('should throw', function () {
+            expect(
+              () => {
+                loadOptions();
+              },
+              'to throw',
+              'Unable to parse /some/package.json: SyntaxError: Expected double-quoted property name in JSON at position 49'
+            );
+          });
+        });
+
         describe('when called with package = false (`--no-package`)', function () {
           let result;
           beforeEach(function () {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5141
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Handle the corner case which can happen if:

- You had a perfectly good `package.json` which npm was happy with
- You decided to put `mocha` configuration inside your `package.json`
- You left a stray comma in there, because you are used to more sensible configuration file formats ;-)
- Instead of running `npm test` you ran `mocha` directly (with `npx` or just `mocha.js`)

As detailed here: https://github.com/dhdaines/mocha-5141
