### PR TITLE
docs: adopt Collective Funds Guidelines 0.1

### DIFF
--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,16 @@
+# Fund Usage Guidelines
+
+This project follows [Collective Funds Guidelines 0.1](https://github.com/collective-funds/guidelines) with the below customizations.
+
+## Rates
+
+* TSC Members: $50.00 USD/hour
+* Project Contributors: $50.00 USD/hour
+
+## Additional notes
+
+The project funds are collected in the [Mocha collective](https://opencollective.com/mochajs) on [Open Collective](https://opencollective.com/) which is hosted by the [Open Source Collective](https://oscollective.org/).
+
+In additions to the [Collective Funds Guidelines](https://github.com/collective-funds/guidelines) this project abides by the [Open Source Collective](https://oscollective.org/)'s [Terms of Fiscal Sponsorship](https://docs.oscollective.org/getting-started/terms-of-fiscal-sponsorship).
+
+When/if the two are in conflict, the Terms of Fiscal Sponsorship is the one that will be followed.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 <a href="https://discord.gg/KeDn2uXhER"><img alt="Chat - Discord" src="https://img.shields.io/badge/Chat-Discord-5765F2.svg" /></a>
 <a href="https://github.com/mochajs/mocha#sponsors"><img src="https://opencollective.com/mochajs/tiers/sponsors/badge.svg" alt="OpenCollective Sponsors"></a>
 <a href="https://github.com/mochajs/mocha#backers"><img src="https://opencollective.com/mochajs/tiers/backers/badge.svg" alt="OpenCollective Backers"></a>
+[![Collective Funds Guidelines v0.1](https://img.shields.io/badge/collective_funds_guidelines-v0.1-D8E8D4?style=flat&labelColor=3A6457)](https://github.com/collective-funds/guidelines)
 
 </div>
 


### PR DESCRIPTION
These guidelines were created by us Mocha maintainers with intent of being used for Mocha.

When #5197 is merged, do a follow up that adds the collective funds guidelines badge to the README.