### PR TITLE
fix: ignore all node_modules and .git dirs by default

### DIFF
--- a/lib/mocharc.json
+++ b/lib/mocharc.json
@@ -6,5 +6,5 @@
   "slow": 75,
   "timeout": 2000,
   "ui": "bdd",
-  "watch-ignore": ["node_modules", ".git"]
+  "watch-ignore": ["**/node_modules", "**/.git"]
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5203 
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Just adds `**/` before the default ignore patterns so that all `node_modules` and `.git` dirs get ignored, not just ones in the root folder.
