### PR TITLE
feat: add ESM export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ docs/images/supporters
 docs/api
 mocha.js
 mocha.js.map
-mocha.mjs
-mocha.mjs.map
+esm/mocha.js
+esm/mocha.js.map
+esm/package.json
 .karma/
 !bin/mocha.js
 !lib/mocha.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ docs/images/supporters
 docs/api
 mocha.js
 mocha.js.map
+mocha.mjs
+mocha.mjs.map
 .karma/
 !bin/mocha.js
 !lib/mocha.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -151,7 +151,8 @@ module.exports = [
       'out/**',
       'test/integration/fixtures/**',
       '.karma/**',
-      'mocha.js'
+      'mocha.js',
+      'mocha.mjs'
     ],
   }
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -152,7 +152,7 @@ module.exports = [
       'test/integration/fixtures/**',
       '.karma/**',
       'mocha.js',
-      'mocha.mjs'
+      'esm/mocha.js'
     ],
   }
 ];

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -317,6 +317,10 @@ const chooseTestSuite = (cfg, value) => {
           {
             pattern: 'test/browser-specific/esm.spec.mjs',
             type: 'module'
+          },
+          {
+            pattern: 'test/browser-specific/esm-build.spec.mjs',
+            type: 'module'
           }
         ]
       });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">= 14.0.0"
   },
   "scripts": {
-    "build": "rollup -c ./rollup.config.js",
+    "build": "rollup -c ./rollup.config.js && echo '{\"type\":\"module\"}' > esm/package.json",
     "clean": "rimraf mocha.js mocha.js.map",
     "docs-clean": "rimraf docs/_site docs/api",
     "docs-watch": "eleventy --serve",
@@ -177,8 +177,9 @@
     "mocha.css",
     "mocha.js",
     "mocha.js.map",
-    "mocha.mjs",
-    "mocha.mjs.map",
+    "esm/mocha.js",
+    "esm/mocha.js.map",
+    "esm/package.json",
     "browser-entry.js"
   ],
   "browser": {

--- a/package.json
+++ b/package.json
@@ -177,6 +177,8 @@
     "mocha.css",
     "mocha.js",
     "mocha.js.map",
+    "mocha.mjs",
+    "mocha.mjs.map",
     "browser-entry.js"
   ],
   "browser": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ function getConfig (format) {
   const config = {
     input: './browser-entry.js',
     output: {
-      file: `./mocha${format === 'esm' ? '.mjs' : '.js'}`,
+      file: format === 'esm' ? './esm/mocha.js' : './mocha.js',
       format,
       sourcemap: true,
       name: 'mocha',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,37 +10,43 @@ import {visualizer} from 'rollup-plugin-visualizer';
 import pickFromPackageJson from './scripts/pick-from-package-json';
 import {version} from './package.json';
 
-const config = {
-  input: './browser-entry.js',
-  output: {
-    file: './mocha.js',
-    format: 'umd',
-    sourcemap: true,
-    name: 'mocha',
-    banner: `// mocha@${version} in javascript ES2018`
-  },
-  plugins: [
-    json(),
-    pickFromPackageJson({
-      keys: ['name', 'version', 'homepage', 'notifyLogo']
-    }),
-    commonjs(),
-    globals(),
-    nodePolyfills(),
-    nodeResolve({
-      browser: true
-    })
-  ],
-  onwarn: (warning, warn) => {
-    if (warning.code === 'CIRCULAR_DEPENDENCY') return;
+function getConfig (format) {
+  const config = {
+    input: './browser-entry.js',
+    output: {
+      file: `./mocha${format === 'esm' ? '.mjs' : '.js'}`,
+      format,
+      sourcemap: true,
+      name: 'mocha',
+      banner: `// mocha@${version} in javascript ES2018`
+    },
+    plugins: [
+      json(),
+      pickFromPackageJson({
+        keys: ['name', 'version', 'homepage', 'notifyLogo']
+      }),
+      commonjs(),
+      globals(),
+      nodePolyfills(),
+      nodeResolve({
+        browser: true
+      })
+    ],
+    onwarn: (warning, warn) => {
+      if (warning.code === 'CIRCULAR_DEPENDENCY') return;
 
-    // Use default for everything else
-    warn(warning);
+      // Use default for everything else
+      warn(warning);
+    }
+  };
+
+  if (!process.env.CI) {
+    config.plugins.push(visualizer());
   }
-};
-
-if (!process.env.CI) {
-  config.plugins.push(visualizer());
+  return config;
 }
 
-export default config;
+export default [
+  getConfig('umd'),
+  getConfig('esm')
+];

--- a/test/browser-specific/esm-build.spec.mjs
+++ b/test/browser-specific/esm-build.spec.mjs
@@ -1,0 +1,13 @@
+import './fixtures/esm-build.fixture.mjs';
+
+it('should register a global if it did not fail', function () {
+  expect(window.MOCHA_IS_OK, 'to be ok');
+});
+
+it('should have a global mocha', function () {
+  expect(window.mocha, 'not to be', undefined);
+});
+
+it('should have a global Mocha', function () {
+  expect(window.Mocha, 'not to be', undefined);
+});

--- a/test/browser-specific/fixtures/esm-build.fixture.mjs
+++ b/test/browser-specific/fixtures/esm-build.fixture.mjs
@@ -1,0 +1,4 @@
+/* eslint-disable-next-line import/no-absolute-path */
+import mocha from '/base/mocha.mjs';
+window.MOCHA_IS_OK = true;
+window.mocha = mocha;

--- a/test/browser-specific/fixtures/esm-build.fixture.mjs
+++ b/test/browser-specific/fixtures/esm-build.fixture.mjs
@@ -1,4 +1,4 @@
 /* eslint-disable-next-line import/no-absolute-path */
-import mocha from '/base/mocha.mjs';
+import mocha from '/base/esm/mocha.js';
 window.MOCHA_IS_OK = true;
 window.mocha = mocha;


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5211 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an ESM export through a new `mocha.mjs` file (making the regular file to be ESM would be a breaking change). It is not entirely modular, as the base script still sets a global `Mocha` and `mocha`, but it does export `mocha`.