### PR TITLE
fix: remove `:is()` from `mocha.css` to support older browsers (#5225)

### DIFF
--- a/mocha.css
+++ b/mocha.css
@@ -349,7 +349,8 @@ body {
   padding: 0;
 }
 
-#mocha-stats :is(.progress-element, .progress-text) {
+#mocha-stats .progress-element,
+#mocha-stats .progress-text {
   width: var(--ring-container-size);
   display: block;
   top: 12px;
@@ -374,7 +375,8 @@ body {
   height: var(--ring-container-size);
 }
 
-#mocha-stats :is(.ring-flatlight, .ring-highlight) {
+#mocha-stats .ring-flatlight,
+#mocha-stats .ring-highlight {
   --stroke-thickness: 1.65px;
   --center: calc(var(--ring-container-size) / 2);
   cx: var(--center);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5225
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Remove `:is` to prevent CSS breaking in older browsers.

This is also more consistent with older existent CSS which did not use `:is()` in the same file, such as [L318-L319](https://github.com/mochajs/mocha/blob/v10.7.3/mocha.css#L318-L319).
