### PR TITLE
fix: use accurate test links in HTML reporter

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -269,7 +269,7 @@ function makeUrl(s) {
     window.location.pathname +
     (search ? search + '&' : '?') +
     'grep=' +
-    encodeURIComponent(escapeRe(s))
+    encodeURIComponent(s)
   );
 }
 
@@ -279,7 +279,7 @@ function makeUrl(s) {
  * @param {Object} [suite]
  */
 HTML.prototype.suiteURL = function (suite) {
-  return makeUrl(suite.fullTitle());
+  return makeUrl('^' + escapeRe(suite.fullTitle()) + ' ');
 };
 
 /**
@@ -288,7 +288,7 @@ HTML.prototype.suiteURL = function (suite) {
  * @param {Object} [test]
  */
 HTML.prototype.testURL = function (test) {
-  return makeUrl(test.fullTitle());
+  return makeUrl('^' + escapeRe(test.fullTitle()) + '$');
 };
 
 /**


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5232
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fix inaccurate suite/test links that may hit unrelated tests:
- Add '^' and ' ' for a suite link so that a link for `Case1` won't hit `Case10 test1`.
- Add '^' and '$' for a test link so that a link for `CSS` won't hit `should fix invalid CSS`.
