### PR TITLE
docs: pin chai to version 4 in browser example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2120,7 +2120,7 @@ A typical setup might look something like the following, where we call `mocha.se
   <body>
     <div id="mocha"></div>
 
-    <script src="https://unpkg.com/chai/chai.js"></script>
+    <script src="https://unpkg.com/chai@4/chai.js"></script>
     <script src="https://unpkg.com/mocha/mocha.js"></script>
 
     <script class="mocha-init">


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5229
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I pinned `chai` to version 4 in the browser example. Since chai@5, the assertion library is distributed as a JavaScript module and doesn't add methods to the global scope. By pinning the version to the previous version 4 we make sure that the example still works.

We could update the example to use chai@5 as a module but I figure this would be a quick fix to the issue. 