### PR TITLE
chore: fix docs builds by ignoring gitignore again

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -46,6 +46,8 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.setLibrary('md', markdown);
 
+  eleventyConfig.setUseGitIgnore(false);
+
   return {
     passthroughFileCopy: true,
     dir: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5217
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The `docs/_site` directory isn't being populated with html files. I think it's because Eleventy is respecting `.gitignore` settings that exclude them. Adding this line back in -essentially reverting https://github.com/mochajs/mocha/pull/5191/files#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0L49- fixes it locally.