### PR TITLE
docs: downgrade example/tests chai to 4.5.0

### DIFF
--- a/docs/example/tests.html
+++ b/docs/example/tests.html
@@ -9,7 +9,7 @@
   <body>
     <div id="mocha"></div>
     <script src="https://unpkg.com/mocha/mocha.js"></script>
-    <script src="https://unpkg.com/chai/chai.js"></script>
+    <script src="https://unpkg.com/chai@4.5.0/chai.js"></script>
     <script>mocha.setup('bdd')</script>
     <script>expect = chai.expect</script>
     <script src="Array.js"></script>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5244
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Chai 5 does not support CJS. Chai 4 does. 4.5.0 is the latest in that major.

💖 