### PR TITLE
fix: catch exceptions setting Error.stackTraceLimit

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -42,7 +42,11 @@ exports.main = (argv = process.argv.slice(2), mochaArgs) => {
     module.paths.push(cwd(), path.resolve('node_modules'));
   }
 
-  Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
+  try {
+    Error.stackTraceLimit = Infinity; // configurable via --stack-trace-limit?
+  } catch (err) {
+    debug('unable to set Error.stackTraceLimit = Infinity', err);
+  }
 
   var args = mochaArgs || loadOptions(argv);
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5212
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When node is run with [--frozen-intrinsics], a `TypeError` is thrown when any intrinsic objects or their properties are modified.  This occurs when attempting to set `Error.stackTraceLimit`.  To avoid exiting due to an uncaught exception, catch the exception, debug log it, and continue.

[--frozen-intrinsics]: https://nodejs.org/api/cli.html#--frozen-intrinsics