### PR TITLE
docs: correct outdated `status: accepting prs` link in the Contributing Guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,7 +59,7 @@ We ask you please keep these goals in mind when making or proposing changes.
 
 _Excellent._ Here's how:
 
-- **Handy with JavaScript?** Please check out the issues labeled [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [`good first issue`](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+).
+- **Handy with JavaScript?** Please check out the issues labeled [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22) or [`good first issue`](https://github.com/mochajs/mocha/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+).
   Try `npx good-first-issue mocha`!
 - **Can you write ~~good~~ well?** The [documentation](https://mochajs.org) almost always needs some love.
   See the [doc-related issues](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22area%3A+documentation%22).


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: https://github.com/mochajs/mocha/issues/5266#issuecomment-2525202596
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Correct an incorrect/outdated `status: accepting prs` link in the Contributing Guidelines. I copied the new link from [line 82](https://github.com/mochajs/mocha/blob/4c558fb83ca5d7e260961b1ebfddcd377017a608/.github/CONTRIBUTING.md?plain=1#L82).
