### PR TITLE
refactor!: replace ansi-colors with smaller and faster ansis

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -22,7 +22,7 @@ const {
 } = require('./options');
 const lookupFiles = require('./lookup-files');
 const commands = require('./commands');
-const ansi = require('ansi-colors');
+const {blue, magenta, red, yellow} = require('ansis');
 const {repository, homepage, version, discord} = require('../../package.json');
 const {cwd} = require('../utils');
 
@@ -62,7 +62,7 @@ exports.main = (argv = process.argv.slice(2), mochaArgs) => {
     .fail((msg, err, yargs) => {
       debug('caught error sometime before command handler: %O', err);
       yargs.showHelp();
-      console.error(`\n${symbols.error} ${ansi.red('ERROR:')} ${msg}`);
+      console.error(`\n${symbols.error} ${red`ERROR:`} ${msg}`);
       process.exitCode = 1;
     })
     .help('help', 'Show usage information & exit')
@@ -72,9 +72,9 @@ exports.main = (argv = process.argv.slice(2), mochaArgs) => {
     .wrap(process.stdout.columns ? Math.min(process.stdout.columns, 80) : 80)
     .epilog(
       `Mocha Resources
-    Chat: ${ansi.magenta(discord)}
-  GitHub: ${ansi.blue(repository.url)}
-    Docs: ${ansi.yellow(homepage)}
+    Chat: ${magenta(discord)}
+  GitHub: ${blue(repository.url)}
+    Docs: ${yellow(homepage)}
       `
     )
     .parserConfiguration(YARGS_PARSER_CONFIG)

--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const ansi = require('ansi-colors');
+const {red, yellow} = require('ansis');
 const debug = require('debug')('mocha:cli:run:helpers');
 const minimatch = require('minimatch');
 const {NO_FILES_MATCH_PATTERN} = require('../errors').constants;
@@ -94,12 +94,12 @@ module.exports = ({
             unmatchedSpecFiles[0].pattern
           )}` // stringify to print escaped characters raw
         : 'Error: No test files found';
-    console.error(ansi.red(noneFoundMsg));
+    console.error(red(noneFoundMsg));
     process.exit(1);
   } else {
     // print messages as a warning
     unmatchedSpecFiles.forEach(warning => {
-      console.warn(ansi.yellow(`Warning: ${warning.message}`));
+      console.warn(yellow`Warning: ${warning.message}`);
     });
   }
 

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -8,7 +8,7 @@
  */
 
 const fs = require('fs');
-const ansi = require('ansi-colors');
+const {red} = require('ansis');
 const yargsParser = require('yargs-parser');
 const {
   types,
@@ -180,7 +180,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
     boolean: types.boolean.concat(nodeArgs.map(pair => pair[0]))
   });
   if (result.error) {
-    console.error(ansi.red(`Error: ${result.error.message}`));
+    console.error(red`Error: ${result.error.message}`);
     process.exit(1);
   }
 

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const ansi = require('ansi-colors');
+const {yellow} = require('ansis');
 const debug = require('debug')('mocha:cli:run:helpers');
 const {watchRun, watchParallelRun} = require('./watch-run');
 const collectFiles = require('./collect-files');
@@ -121,9 +121,7 @@ const handleUnmatchedFiles = (mocha, unmatchedFiles) => {
 
   unmatchedFiles.forEach(({pattern, absolutePath}) => {
     console.error(
-      ansi.yellow(
-        `Warning: Cannot find any files matching pattern "${pattern}" at the absolute path "${absolutePath}"`
-      )
+      yellow`Warning: Cannot find any files matching pattern "${pattern}" at the absolute path "${absolutePath}"`
     );
   });
   console.log(

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -8,7 +8,7 @@
  */
 
 const symbols = require('log-symbols');
-const ansi = require('ansi-colors');
+const {red} = require('ansis');
 const Mocha = require('../mocha');
 const {
   createUnsupportedError,
@@ -357,7 +357,7 @@ exports.builder = yargs =>
         Object.assign(argv, plugins);
       } catch (err) {
         // this could be a bad --require, bad reporter, ui, etc.
-        console.error(`\n${symbols.error} ${ansi.red('ERROR:')}`, err);
+        console.error(`\n${symbols.error} ${red`ERROR:`}`, err);
         yargs.exit(1);
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.0.2",
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^4.1.3",
+        "ansis": "3.4.0",
         "browser-stdout": "^1.3.1",
         "chokidar": "^3.5.3",
         "debug": "^4.3.5",
@@ -2265,14 +2265,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-red": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
@@ -2314,6 +2306,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.4.0.tgz",
+      "integrity": "sha512-zVESKSQhWaPhGaWiKj1k+UqvpC7vPBBgG3hjQEeIx2YGzylWt8qA3ziAzRuUtm0OnaGsZKjIvfl8D/sJTt/I0w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/anymatch": {
@@ -17896,11 +17897,6 @@
       "dev": true,
       "requires": {}
     },
-    "ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
-    },
     "ansi-red": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
@@ -17928,6 +17924,11 @@
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
       "dev": true
+    },
+    "ansis": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.4.0.tgz",
+      "integrity": "sha512-zVESKSQhWaPhGaWiKj1k+UqvpC7vPBBgG3hjQEeIx2YGzylWt8qA3ziAzRuUtm0OnaGsZKjIvfl8D/sJTt/I0w=="
     },
     "anymatch": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "version": "run-p version:* && git add -A ./AUTHORS ./CHANGELOG.md"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.3",
+    "ansis": "3.4.0",
     "browser-stdout": "^1.3.1",
     "chokidar": "^3.5.3",
     "debug": "^4.3.5",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5291
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR replaces the outdated [ansi-colors](https://www.npmjs.com/package/ansi-colors) (last update 3 years ago) package with smaller and faster [ansis](https://github.com/webdiscus/ansis).

### Benefits of `ansis`

- Supports both `ESM` and `CommonJS`
- Supports `Bun` and `Deno` runtimes
- Supports `TypeScript`
- Ansis is compatible with `ansi-colors` API, plus supports [named import](https://github.com/webdiscus/ansis#named-import):  `import { red,  yellow } from 'ansis'`
- Installed package size only `10 kB` (`ansi-colors` 26 kB), see [Compare the size of most popular packages](https://github.com/webdiscus/ansis#compare-size)
- 7-10x faster than `ansi-colors`, see [Benchmarks](https://github.com/webdiscus/ansis#benchmark)
- Using [named import](https://github.com/webdiscus/ansis#named-import) your code will be clean and more readable:
  ```diff
  - console.error(ansi.red(`Error: ${result.error.message}`));
  + console.error(red`Error: ${result.error.message}`); // <= shorter and more readable
  ```
- Supports [ANSI 256 colors](https://github.com/webdiscus/ansis#256-colors) and [TrueColor](https://github.com/webdiscus/ansis#truecolor) with [Fallback](https://github.com/webdiscus/ansis#fallback): `TrueColor → 256 colors → 16 colors → no colors`
- Supports [environment variables](https://github.com/webdiscus/ansis#cli-vars) `NO_COLOR` `FORCE_COLOR` and flags `--no-color` `--color`
- Both Ansis and Picocolors (does't support named import) are recommended by the [ES Tooling](https://github.com/es-tooling) community as smallest and fastest packages.

### Packages that already use `ansis`

- [nestjs/nest](https://github.com/nestjs/nest),
- [sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json)
- [facebook/stylex](https://github.com/facebook/stylex/blob/main/packages/cli/package.json)
- [salesforcecli/cli](https://github.com/salesforcecli/cli/blob/main/package.json)
- [grafana/faro-javascript-bundler-plugins](https://github.com/grafana/faro-javascript-bundler-plugins/blob/main/packages/faro-bundlers-shared/package.json)
- and [thousands others](https://github.com/webdiscus/ansis/network/dependents)

## Test

This PR does not require unit/integration tests.

But you can do the `manual test`.

### Install the fork

```
git clone https://github.com/webdiscus/mocha.git
cd mocha
git checkout switch-to-ansis
npm i
npm run build
```

### Test changed files

Cmd:
```
node ./bin/mocha.js -h
```
In console output will be displayed color text:
![Other Options](https://github.com/user-attachments/assets/47654fa5-98d9-4804-8aea-47e0b2da919d)

Cmd:
```
node ./bin/mocha.js -h --no-color
```
In console output will be displayed b&w text:
![Other Options](https://github.com/user-attachments/assets/8ba107ee-7fef-417e-8728-cd44bacceea5)

Cmd:
```
node ./bin/mocha.js -R
```
In console output will be displayed red text:
![Error Not enough arguments following R](https://github.com/user-attachments/assets/2eeffb9d-332f-4648-b3f5-d9afb2a23262)
