### PR TITLE
fix: improve error handling in global fixtures #5208

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1247,6 +1247,7 @@ Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
           err: err
         });
         console.error(err);
+        process.exit(1);
       }
     }
   }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -184,7 +184,7 @@ function Mocha(options = {}) {
   options = {...mocharc, ...options};
   this.files = [];
   this.options = options;
-  this.globalTeardownErrored = false;
+
   // root suite
   this.suite = new exports.Suite('', new exports.Context(), true);
   this._cleanReferencesAfterRun = true;
@@ -1192,7 +1192,7 @@ Mocha.prototype.runGlobalSetup = async function runGlobalSetup(context = {}) {
   const {globalSetup} = this.options;
   if (globalSetup && globalSetup.length) {
     debug('run(): global setup starting');
-    await this._runGlobalFixtures(globalSetup, context);
+    await this._runGlobalFixtures(globalSetup, context, "Global Setup");
     debug('run(): global setup complete');
   }
   return context;
@@ -1214,7 +1214,7 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
   const {globalTeardown} = this.options;
   if (globalTeardown && globalTeardown.length) {
     debug('run(): global teardown starting');
-    await this._runGlobalFixtures(globalTeardown, context);
+    await this._runGlobalFixtures(globalTeardown, context, "Global Teardown");
   }
   debug('run(): global teardown complete');
   return context;
@@ -1230,25 +1230,22 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
 Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
   fixtureFns = [],
   context = {},
+  phase
 ) {
   for (const fixtureFn of fixtureFns) {
     try {
       await fixtureFn.call(context);
     } catch (err) {
-      if(context.stats) {
-        context.stats.failures++;
-        context.failures++;
-       
-        const isSetup = this.options.globalSetup && this.options.globalSetup.includes(fixtureFn);
-        const phase = isSetup ? 'Global Setup' : 'Global Teardown';
+
+      context.stats.failures++;
+      context.failures++;
         
-        context.emit('fail', {
-          title: phase,
-          err: err
-        });
-        console.error(err);
-        process.exit(1);
-      }
+      context.emit('fail', {
+        title: phase,
+        err: err
+      });
+      console.error(err);
+      process.exit(1);
     }
   }
   return context;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1245,8 +1245,11 @@ Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
         title: phase,
         err: err
       });
+      
+      if (phase === "Global Setup") {
+        throw err;
+      }
       console.error(err);
-      process.exit(1);
     }
   }
   return context;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1225,19 +1225,23 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
  * @param {object} [context] - context object
  * @returns {Promise<object>} context object
  */
-Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
-  fixtureFns = [],
-  context = {}
-) {
-  for (const fixtureFn of fixtureFns) {
-    try {
-      await fixtureFn.call(context);
-    } catch (err) {
-      console.error(err.stack);
+  Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
+    fixtureFns = [],
+    context = {}
+  ) {
+    for (const fixtureFn of fixtureFns) {
+      try {
+        await fixtureFn.call(context);
+      } catch (err) {
+        if (this.runner) {
+          this.runner.failures += 1;
+        }
+        console.error('Global fixture error:', err.stack);
+
+      }
     }
-  }
-  return context;
-};
+    return context;
+  };
 
 /**
  * Toggle execution of any global setup fixture(s)

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1235,28 +1235,24 @@ Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
     try {
       await fixtureFn.call(context);
     } catch (err) {
-      console.error('Global fixture error:', err.stack);
-      this.globalTeardownErrored = true;
+      if(context.stats) {
+        context.stats.failures++;
+        context.failures++;
+       
+        const isSetup = this.options.globalSetup && this.options.globalSetup.includes(fixtureFn);
+        const phase = isSetup ? 'Global Setup' : 'Global Teardown';
+        
+        context.emit('fail', {
+          title: phase,
+          err: err
+        });
+        console.error(err);
+      }
     }
   }
   return context;
 };
 
-/**
- * Override of the original run method to handle global teardown errors.
- * @param {Function} [fn] - Callback function to be invoked when test run is complete
- * @returns {Runner} Runner instance
- * @public
- */
-const originalRun = Mocha.prototype.run;
-Mocha.prototype.run = function (fn) {
-  const self = this;
-  return originalRun.call(this, (exitCode) => {
-    // Combine test failures and teardown errors
-    const finalExitCode = exitCode > 0 || self.globalTeardownErrored ? 1 : 0;
-    if (fn) fn(finalExitCode);
-  });
-};
 
 /**
  * Toggle execution of any global setup fixture(s)

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1219,7 +1219,7 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
 };
 
 /**
- * Run global fixtures sequentially with context `context`
+ * Run global fixtures sequentially with context `context`.
  * @private
  * @param {MochaGlobalFixture[]} [fixtureFns] - Fixtures to run
  * @param {object} [context] - context object

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -184,6 +184,7 @@ function Mocha(options = {}) {
   options = {...mocharc, ...options};
   this.files = [];
   this.options = options;
+  this.globalTeardownErrored = false;
   // root suite
   this.suite = new exports.Suite('', new exports.Context(), true);
   this._cleanReferencesAfterRun = true;
@@ -987,6 +988,7 @@ Mocha.prototype.run = function (fn) {
   if (this.files.length && !this._lazyLoadFiles) {
     this.loadFiles();
   }
+
   var suite = this.suite;
   var options = this.options;
   options.files = this.files;
@@ -1225,24 +1227,37 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
  * @param {object} [context] - context object
  * @returns {Promise<object>} context object
  */
-  Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
-    fixtureFns = [],
-    context = {}
-  ) {
-    for (const fixtureFn of fixtureFns) {
-      try {
-        await fixtureFn.call(context);
-      } catch (err) {
-        console.error('Global fixture error:', err.stack);
 
-        if (this.runner) {
-          const falseHook = new this._Hook('globalTeardown', 'global teardown');
-          this.runner.failHook(falseHook, err);
-        }
-      }
+  Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
+  fixtureFns = [],
+  context = {},
+) {
+  for (const fixtureFn of fixtureFns) {
+    try {
+      await fixtureFn.call(context);
+    } catch (err) {
+      console.error('Global fixture error:', err.stack);
+      this.globalTeardownErrored = true;
     }
-    return context;
-  };
+  }
+  return context;
+};
+
+/**
+ * Override of the original run method to handle global teardown errors.
+ * @param {Function} [fn] - Callback function to be invoked when test run is complete
+ * @returns {Runner} Runner instance
+ * @public
+ */
+const originalRun = Mocha.prototype.run;
+Mocha.prototype.run = function (fn) {
+  const self = this;
+  return originalRun.call(this, (exitCode) => {
+    // Combine test failures and teardown errors
+    const finalExitCode = exitCode > 0 || self.globalTeardownErrored ? 1 : 0;
+    if (fn) fn(finalExitCode);
+  });
+};
 
 /**
  * Toggle execution of any global setup fixture(s)
@@ -1339,3 +1354,4 @@ Mocha.prototype.hasGlobalTeardownFixtures =
  * @param {Array<*>} impls - User-supplied implementations
  * @returns {Promise<*>|*}
  */
+

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -881,7 +881,7 @@ Mocha.prototype.failZero = function (failZero) {
  * @return {Mocha} this
  * @chainable
  */
-Mocha.prototype.passOnFailingTestSuite = function(passOnFailingTestSuite) {
+Mocha.prototype.passOnFailingTestSuite = function (passOnFailingTestSuite) {
   this.options.passOnFailingTestSuite = passOnFailingTestSuite === true;
   return this;
 };
@@ -1229,8 +1229,12 @@ Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
   fixtureFns = [],
   context = {}
 ) {
-  for await (const fixtureFn of fixtureFns) {
-    await fixtureFn.call(context);
+  for (const fixtureFn of fixtureFns) {
+    try {
+      await fixtureFn.call(context);
+    } catch (err) {
+      console.error(err.stack);
+    }
   }
   return context;
 };

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1225,6 +1225,7 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
  * @private
  * @param {MochaGlobalFixture[]} [fixtureFns] - Fixtures to run
  * @param {object} [context] - context object
+ * @params {string} [phase] - phase of the fixture
  * @returns {Promise<object>} context object
  */
 Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1233,11 +1233,12 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
       try {
         await fixtureFn.call(context);
       } catch (err) {
-        if (this.runner) {
-          this.runner.failures += 1;
-        }
         console.error('Global fixture error:', err.stack);
 
+        if (this.runner) {
+          const falseHook = new this._Hook('globalTeardown', 'global teardown');
+          this.runner.failHook(falseHook, err);
+        }
       }
     }
     return context;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -881,7 +881,7 @@ Mocha.prototype.failZero = function (failZero) {
  * @return {Mocha} this
  * @chainable
  */
-Mocha.prototype.passOnFailingTestSuite = function (passOnFailingTestSuite) {
+Mocha.prototype.passOnFailingTestSuite = function(passOnFailingTestSuite) {
   this.options.passOnFailingTestSuite = passOnFailingTestSuite === true;
   return this;
 };

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1227,8 +1227,7 @@ Mocha.prototype.runGlobalTeardown = async function runGlobalTeardown(
  * @param {object} [context] - context object
  * @returns {Promise<object>} context object
  */
-
-  Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
+Mocha.prototype._runGlobalFixtures = async function _runGlobalFixtures(
   fixtureFns = [],
   context = {},
 ) {

--- a/test/integration/fixtures/global-fixtures/failing-test.fixture.js
+++ b/test/integration/fixtures/global-fixtures/failing-test.fixture.js
@@ -1,0 +1,9 @@
+'use strict';
+
+
+describe('Test Suite', function() {
+    it('failing test', function() {
+      throw new Error('Test failure');
+    });
+});
+  

--- a/test/integration/fixtures/global-fixtures/global-setup.fixture.js
+++ b/test/integration/fixtures/global-fixtures/global-setup.fixture.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.mochaGlobalSetup = async function () { 
+    throw new Error('Setup problem');
+}

--- a/test/integration/fixtures/global-fixtures/global-teardown.fixture.js
+++ b/test/integration/fixtures/global-fixtures/global-teardown.fixture.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.mochaGlobalTeardown = async function () { 
+    throw new Error('Teardown problem');
+}

--- a/test/integration/fixtures/global-fixtures/passing-setup.fixture.js
+++ b/test/integration/fixtures/global-fixtures/passing-setup.fixture.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.mochaGlobalSetup = async function () {
+    // Success case
+  };
+  

--- a/test/integration/fixtures/global-fixtures/passing-teardown.fixture.js
+++ b/test/integration/fixtures/global-fixtures/passing-teardown.fixture.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.mochaGlobalTeardown = async function () {
+    // Success case
+  };
+  

--- a/test/integration/fixtures/global-fixtures/test.fixture.js
+++ b/test/integration/fixtures/global-fixtures/test.fixture.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('Test Suite', function() {
+  it('should pass', function() {
+    // This test passes
+  });
+});

--- a/test/integration/fixtures/global-teardown-error.js
+++ b/test/integration/fixtures/global-teardown-error.js
@@ -4,6 +4,6 @@ const { it } = require('../../../lib/mocha');
 
 it('should pass', () => {});
 
-exports.mochaTeardown = async function () {
+exports.mochaGlobalTeardown = async function () {
     throw new Error('Teardown problem')
 }

--- a/test/integration/fixtures/global-teardown-error.js
+++ b/test/integration/fixtures/global-teardown-error.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { it } = require('../../../lib/mocha');
+
+it('should pass', () => {});
+
+exports.mochaTeardown = async function () {
+    throw new Error('Teardown problem')
+}

--- a/test/integration/global-fixtures.spec.js
+++ b/test/integration/global-fixtures.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+describe('Run Global Fixtures Error Handling', function () {
+
+  const FIXTURES_DIR = 'test/integration/fixtures/global-fixtures/';
+
+  function runMochaWithFixture(setupFile, testFile) {
+    return spawnSync('node', [
+      'bin/mocha',
+      '--require', path.join(FIXTURES_DIR, setupFile),
+      path.join(FIXTURES_DIR, testFile)
+    ], { encoding: 'utf-8' });
+  }
+
+  function assertFailure(result, expectedMessage) {
+    assert.strictEqual(result.status, 1, 'Process should exit with 1');
+    assert(
+      result.stderr.includes(expectedMessage) || result.stdout.includes(expectedMessage),
+      `Should show error message: ${expectedMessage}`
+    );
+  }
+
+  it('should fail with non-zero exit code when global setup fails', function () {
+    const result = runMochaWithFixture('global-setup.fixture.js', 'failing-test.fixture.js');
+    assertFailure(result, 'Setup problem');
+  });
+
+  it('should fail with non-zero exit code when global teardown fails', function () {
+    const result = runMochaWithFixture('global-teardown.fixture.js', 'failing-test.fixture.js');
+    assertFailure(result, 'Teardown problem');
+  });
+
+  it('should combine failures with setup failures', function () {
+    const result = runMochaWithFixture('global-setup.fixture.js', 'failing-test.fixture.js');
+    assertFailure(result, 'Setup problem');
+  });
+
+  it('should combine failures with teardown failures', function () {
+    const result = runMochaWithFixture('global-teardown.fixture.js', 'failing-test.fixture.js');
+    assertFailure(result, 'Teardown problem');
+  });
+
+  it('should pass with zero exit code when no errors occur in setup', function () {
+    const result = runMochaWithFixture('passing-setup.fixture.js', 'test.fixture.js');
+    assert.strictEqual(result.status, 0, 'Process should exit with 0');
+  });
+
+  it('should pass with zero exit code when no errors occur in teardown', function () {
+    const result = runMochaWithFixture('passing-teardown.fixture.js', 'test.fixture.js');
+    assert.strictEqual(result.status, 0, 'Process should exit with 0');
+  });
+});

--- a/test/integration/global-teardown-errors.spec.js
+++ b/test/integration/global-teardown-errors.spec.js
@@ -1,22 +1,102 @@
 'use strict'
 
+const assert = require('assert');
+const path = require('path');
 const { spawnSync } = require('child_process');
-const { resolve} = require('path');
-const { expect } = require('chai');
+const fs = require('fs').promises;
 
-describe('global teardown errors', () => {
-  it('should fail with non-zero exit code and report the teardown error', () => {
+describe('Global Teardown Error Handling', function() {
+  this.timeout(5000);
 
-    const testFile = resolve(__dirname, './fixtures/global-teardown-error.js');
+  const setupFile = 'test/fixtures/global-teardown/setup.js';
+  const testFile = 'test/fixtures/global-teardown/test.js';
 
-    const result = spawnSync(process.execPath, [
-      './bin/mocha',
-      testFile,
-      '--reporter', 'spec'
-    ], { encoding: 'utf-8' });
+  before(async function() {
+    await fs.mkdir(path.dirname(setupFile), { recursive: true });
 
-    expect(result.status).to.equal(1);
-    expect(result.stderr).to.include('Global fixture error');
-    expect(result.stderr).to.include('Error: Teardown problem');
+    await fs.writeFile(setupFile, `
+      exports.mochaGlobalTeardown = async function () {
+        throw new Error('Teardown failure');
+      };
+    `);
+
+    await fs.writeFile(testFile, `
+      describe('Test Suite', function() {
+        it('passing test', function() {
+          // This test passes
+        });
+      });
+    `);
+  });
+
+  after(async function() {
+    await fs.rm(path.dirname(setupFile), { recursive: true, force: true });
+  });
+
+  it('should fail with non-zero exit code when global teardown fails', function() {
+    const result = spawnSync('node', [
+      'bin/mocha',
+      '--require', setupFile,
+      testFile
+    ], {
+      encoding: 'utf8'
+    });
+
+    assert.strictEqual(result.status, 1, 'Process should exit with code 1');
+
+    assert(result.stderr.includes('Teardown failure') || 
+           result.stdout.includes('Teardown failure'),
+           'Should show teardown error message');
+  });
+
+  it('should combine test failures with teardown failures', async function() {
+
+    await fs.writeFile(testFile, `
+      describe('Test Suite', function() {
+        it('failing test', function() {
+          throw new Error('Test failure');
+        });
+      });
+    `);
+
+    const result = spawnSync('node', [
+      'bin/mocha',
+      '--require', setupFile,
+      testFile
+    ], {
+      encoding: 'utf8'
+    });
+
+    assert.strictEqual(result.status, 1, 'Process should exit with code 1');
+
+    const output = result.stdout + result.stderr;
+    assert(output.includes('Test failure'), 'Should show test error');
+    assert(output.includes('Teardown failure'), 'Should show teardown error');
+  });
+
+  it('should pass with zero exit code when no errors occur', async function() {
+    await fs.writeFile(setupFile, `
+      exports.mochaGlobalTeardown = async function () {
+        // Success case
+      };
+    `);
+
+    await fs.writeFile(testFile, `
+      describe('Test Suite', function() {
+        it('passing test', function() {
+          // This test passes
+        });
+      });
+    `);
+
+    const result = spawnSync('node', [
+      'bin/mocha',
+      '--require', setupFile,
+      testFile
+    ], {
+      encoding: 'utf8'
+    });
+
+    assert.strictEqual(result.status, 0, 'Process should exit with code 0');
   });
 });

--- a/test/integration/global-teardown-errors.spec.js
+++ b/test/integration/global-teardown-errors.spec.js
@@ -16,7 +16,7 @@ describe('global teardown errors', () => {
     ], { encoding: 'utf-8' });
 
     expect(result.status).to.equal(1);
-    expect(result.stdout).to.include('Global Teardown Error:');
+    expect(result.stdout).to.include('Global fixture error');
     expect(result.stdout).to.include('Teardown problem');
   });
 });

--- a/test/integration/global-teardown-errors.spec.js
+++ b/test/integration/global-teardown-errors.spec.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { spawnSync } = require('child_process');
+const { resolve} = require('path');
+const { expect } = require('chai');
+
+describe('global teardown errors', () => {
+  it('should fail with non-zero exit code and report the teardown error', () => {
+
+    const testFile = resolve(__dirname, '../fixtures/global-teardown-errors.js');
+
+    const result = spawnSync(process.execPath, [
+      './bin/mocha',
+      testFile,
+      '--reporter', 'spec'
+    ], { encoding: 'utf-8' });
+
+    expect(result.status).to.equal(1);
+    expect(result.stdout).to.include('Global Teardown Error:');
+    expect(result.stdout).to.include('Teardown problem');
+  });
+});

--- a/test/integration/global-teardown-errors.spec.js
+++ b/test/integration/global-teardown-errors.spec.js
@@ -7,7 +7,7 @@ const { expect } = require('chai');
 describe('global teardown errors', () => {
   it('should fail with non-zero exit code and report the teardown error', () => {
 
-    const testFile = resolve(__dirname, '../fixtures/global-teardown-errors.js');
+    const testFile = resolve(__dirname, './fixtures/global-teardown-error.js');
 
     const result = spawnSync(process.execPath, [
       './bin/mocha',
@@ -16,7 +16,7 @@ describe('global teardown errors', () => {
     ], { encoding: 'utf-8' });
 
     expect(result.status).to.equal(1);
-    expect(result.stdout).to.include('Global fixture error');
-    expect(result.stdout).to.include('Teardown problem');
+    expect(result.stderr).to.include('Global fixture error');
+    expect(result.stderr).to.include('Error: Teardown problem');
   });
 });

--- a/test/unit/mocha.spec.js
+++ b/test/unit/mocha.spec.js
@@ -1072,7 +1072,8 @@ describe('Mocha', function () {
           await mocha.runGlobalSetup(context);
           expect(mocha._runGlobalFixtures, 'to have a call satisfying', [
             mocha.options.globalSetup,
-            context
+            context,
+            'Global Setup'
           ]);
         });
       });
@@ -1102,7 +1103,8 @@ describe('Mocha', function () {
           await mocha.runGlobalTeardown();
           expect(mocha._runGlobalFixtures, 'to have a call satisfying', [
             mocha.options.globalTeardown,
-            context
+            context,
+            'Global Teardown'
           ]);
         });
       });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5208
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Description
This PR addresses an issue with the handling of errors in global teardown functions. Previously, if a global teardown function threw an error, the error was not logged clearly, and the process exit code might not reflect the failure.

Changes Made
Updated the _runGlobalFixtures method in lib/mocha.js to:
Log errors with a clear and descriptive message.
Set the process exit code to 1 when a global teardown function fails.
Improved debugging output to aid in identifying which function caused the error.
New Behavior
When a global teardown function fails:
A descriptive error message is logged.
The process exits with a non-zero code, signaling the failure.
