### PR TITLE
chore: pin node-lts tests to 22.11.0

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -22,7 +22,8 @@ jobs:
   smoke:
     uses: ./.github/workflows/npm-script.yml
     with:
-      node-versions: '14,22,lts/*'
+      # The 22.11.0 is instead of lts per https://github.com/mochajs/mocha/issues/5278
+      node-versions: '18,20,22.11.0'
       npm-script: test-smoke
 
   test-node-lts:
@@ -64,7 +65,8 @@ jobs:
             coverage: false
     with:
       os: 'ubuntu-latest,windows-latest'
-      node-versions: '14,16,18,20,22'
+      # The 22.11.0 is instead of 22 per https://github.com/mochajs/mocha/issues/5278
+      node-versions: '14,16,18,20,22.11.0'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 

--- a/.github/workflows/npm-script.yml
+++ b/.github/workflows/npm-script.yml
@@ -54,7 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJson(needs.resolve-inputs.outputs.nodeVersions || '["lts/*"]') }}
+        # The 22.11.0 is instead of "lts/*" per https://github.com/mochajs/mocha/issues/5278
+        node_version: ${{ fromJson(needs.resolve-inputs.outputs.nodeVersions || '["22.11.0"]') }}
         os: ${{ fromJson(needs.resolve-inputs.outputs.os || '["ubuntu-latest"]') }}
         browser: ${{ fromJson(needs.resolve-inputs.outputs.browsers || '[""]') }}
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,8 @@ jobs:
           show-progress: false
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          # The 22.11.0 is instead of lts per https://github.com/mochajs/mocha/issues/5278
+          node-version: '22.11.0'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5278
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Since LTS version 22.12.0 is causing crashes, pins us to 22.11.0 for now.

We'll want a followup issue to remove the pin once a new LTS version of Node is released.