### PR TITLE
refactor: replace `fs-extra` with newer `fs` built-ins

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -66,7 +66,7 @@ jobs:
     with:
       os: 'ubuntu-latest,windows-latest'
       # The 22.11.0 is instead of 22 per https://github.com/mochajs/mocha/issues/5278
-      node-versions: '14,16,18,20,22.11.0'
+      node-versions: '18,20,22.11.0'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "cross-env": "^7.0.2",
         "eslint": "^8.56.0",
         "fail-on-errors-webpack-plugin": "^3.0.0",
-        "fs-extra": "^10.0.0",
         "globals": "^13.24.0",
         "installed-check": "^9.3.0",
         "jsdoc": "^3.6.7",
@@ -6656,20 +6655,6 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -21379,17 +21364,6 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
-    },
-    "fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "cross-env": "^7.0.2",
     "eslint": "^8.56.0",
     "fail-on-errors-webpack-plugin": "^3.0.0",
-    "fs-extra": "^10.0.0",
     "globals": "^13.24.0",
     "installed-check": "^9.3.0",
     "jsdoc": "^3.6.7",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -2,7 +2,8 @@
 
 const escapeRegExp = require('escape-string-regexp');
 const os = require('os');
-const fs = require('fs-extra');
+const fs = require('fs');
+const fsP = require('fs/promises');
 const {format} = require('util');
 const path = require('path');
 const Base = require('../../lib/reporters/base');
@@ -487,7 +488,7 @@ const touchRef = new Date();
  * @param {string} filepath - Path to file
  */
 function touchFile(filepath) {
-  fs.ensureDirSync(path.dirname(filepath));
+  fs.mkdirSync(path.dirname(filepath), { recursive: true });
   try {
     fs.utimesSync(filepath, touchRef, touchRef);
   } catch (e) {
@@ -519,8 +520,8 @@ function replaceFileContents(filepath, pattern, replacement) {
  */
 function copyFixture(fixtureName, dest) {
   const fixtureSource = resolveFixturePath(fixtureName);
-  fs.ensureDirSync(path.dirname(dest));
-  fs.copySync(fixtureSource, dest);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.cpSync(fixtureSource, dest);
 }
 
 /**
@@ -528,12 +529,12 @@ function copyFixture(fixtureName, dest) {
  * @returns {Promise<CreateTempDirResult>} Temp dir path and cleanup function
  */
 const createTempDir = async () => {
-  const dirpath = await fs.mkdtemp(path.join(os.tmpdir(), 'mocha-'));
+  const dirpath = await fsP.mkdtemp(path.join(os.tmpdir(), 'mocha-'));
   return {
     dirpath,
     removeTempDir: async () => {
       if (!process.env.MOCHA_TEST_KEEP_TEMP_DIRS) {
-        return fs.remove(dirpath);
+        return fs.rmSync(dirpath, { recursive: true, force: true });
       }
     }
   };

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const path = require('path');
 const {
   copyFixture,
@@ -131,7 +131,7 @@ describe('--watch', function () {
         [testFile, '--watch-files', 'lib/**/*.xyz'],
         tempDir,
         () => {
-          fs.removeSync(watchedFile);
+          fs.rmSync(watchedFile, { recursive: true, force: true });
         }
       ).then(results => {
         expect(results, 'to have length', 2);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5266
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This updates the codebase to remove two uses of `fs-extra` by newer `fs` built-in functions. The code changes are based on the implementation of `fs-extra@10.1.0` (which is the version of `fs-extra` recorded in the project's lockfile).