### PR TITLE
docs: improve third-party reporter docs

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -24,8 +24,10 @@ var MAX_TIMEOUT = Math.pow(2, 31) - 1;
 
 module.exports = Runnable;
 
+// Add "Additional properties" doc comment for hosted docs :)
 /**
  * Initialize a new `Runnable` with the given `title` and callback `fn`.
+ * Additional properties, like `getFullTitle()` and `slow()`, can be viewed in the runnable source.
  *
  * @class
  * @extends external:EventEmitter

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -27,7 +27,7 @@ module.exports = Runnable;
 // Add "Additional properties" doc comment for hosted docs :)
 /**
  * Initialize a new `Runnable` with the given `title` and callback `fn`.
- * Additional properties, like `getFullTitle()` and `slow()`, can be viewed in the runnable source.
+ * Additional properties, like `getFullTitle()` and `slow()`, can be viewed in the `Runnable` source.
  *
  * @class
  * @extends external:EventEmitter

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -24,7 +24,7 @@ var MAX_TIMEOUT = Math.pow(2, 31) - 1;
 
 module.exports = Runnable;
 
-// Add "Additional properties" doc comment for hosted docs :)
+// "Additional properties" doc comment added for hosted docs (mochajs.org/api)
 /**
  * Initialize a new `Runnable` with the given `title` and callback `fn`.
  * Additional properties, like `getFullTitle()` and `slow()`, can be viewed in the `Runnable` source.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -47,7 +47,39 @@ var globals = [
 
 var constants = utils.defineConstants(
   /**
-   * {@link Runner}-related constants.
+   * {@link Runner}-related constants. Used by reporters. Each event emits the corresponding object, unless otherwise indicated.
+   * @example
+   * const Mocha = require('mocha');
+   * const Base = Mocha.reporters.Base;
+   * const {
+   *   EVENT_HOOK_BEGIN,
+   *   EVENT_TEST_PASS,
+   *   EVENT_TEST_FAIL,
+   *   EVENT_TEST_END
+   * } = Mocha.Runner.constants
+   *
+   * function MyReporter(runner, options) {
+   *   Base.call(this, runner, options);
+   *
+   *   runner.on(EVENT_HOOK_BEGIN, function(hook) {
+   *     console.log('hook called: ', hook.title);
+   *   });
+   *
+   *   runner.on(EVENT_TEST_PASS, function(test) {
+   *     console.log('pass: %s', test.fullTitle());
+   *   });
+   *
+   *   runner.on(EVENT_TEST_FAIL, function(test, err) {
+   *     console.log('fail: %s -- error: %s', test.fullTitle(), err.message);
+   *   });
+   *
+   *   runner.on(EVENT_TEST_END, function() {
+   *     console.log('end: %d/%d', runner.stats.passes, runner.stats.tests);
+   *   });
+   * }
+   *
+   * module.exports = MyReporter;
+   *
    * @public
    * @memberof Runner
    * @readonly
@@ -97,7 +129,13 @@ var constants = utils.defineConstants(
      */
     EVENT_TEST_END: 'test end',
     /**
-     * Emitted when {@link Test} execution fails
+     * Emitted when {@link Test} execution fails. Includes an `err` object of type `Error`.
+     * @example
+     * runner.on(EVENT_TEST_FAIL, function(test, err) {
+     *   console.log('fail: %s -- error: %s', test.fullTitle(), err.message);
+     * });
+     *
+     *
      */
     EVENT_TEST_FAIL: 'fail',
     /**


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3104 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Document the `Runner.constants` value used by reporters
- Mention the "missing" documentation in `Runnable` class
  - `Runnable.prototype.xyz` calls are not published to the API doc site, leading to confusion about which properties are included in a `Runnable` object, like a `Test` or a `Hook`.
