### PR TITLE
fix: resolve ERR_REQUIRE_CYCLE_MODULE for never installed modules

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -39,47 +39,33 @@ exports.requireOrImport = async (file, esmDecorator) => {
     return formattedImport(file, esmDecorator);
   }
   try {
-    return dealWithExports(await formattedImport(file, esmDecorator));
-  } catch (err) {
+    return require(file);
+  } catch (requireErr) {
     if (
-      err.code === 'ERR_MODULE_NOT_FOUND' ||
-      err.code === 'ERR_UNKNOWN_FILE_EXTENSION' ||
-      err.code === 'ERR_UNSUPPORTED_DIR_IMPORT'
+      requireErr.code === 'ERR_REQUIRE_ESM' ||
+      (requireErr instanceof SyntaxError &&
+        requireErr
+          .toString()
+          .includes('Cannot use import statement outside a module'))
     ) {
+      // In Node.js environments after version 22.11, the `loadESMFromCJS` function 
+      // is used within the `require` function to handle cases where the target file 
+      // is in ESM (ECMAScript Module) format. If the Node.js version is after 22.11, 
+      // the code will import the module without any issues. For older versions, 
+      // this `if` statement is required to properly handle ESM modules.
+      // This `if` statement can be removed once all Node.js environments with current 
+      // support include the `loadESMFromCJS` function.
       try {
-        // Importing a file usually works, but the resolution of `import` is the ESM
-        // resolution algorithm, and not the CJS resolution algorithm. We may have
-        // failed because we tried the ESM resolution, so we try to `require` it.
-        return require(file);
-      } catch (requireErr) {
-        if (
-          requireErr.code === 'ERR_REQUIRE_ESM' ||
-          (requireErr instanceof SyntaxError &&
-            requireErr
-              .toString()
-              .includes('Cannot use import statement outside a module'))
-        ) {
-          // ERR_REQUIRE_ESM happens when the test file is a JS file, but via type:module is actually ESM,
-          // AND has an import to a file that doesn't exist.
-          // This throws an `ERR_MODULE_NOT_FOUND` error above,
-          // and when we try to `require` it here, it throws an `ERR_REQUIRE_ESM`.
-          // What we want to do is throw the original error (the `ERR_MODULE_NOT_FOUND`),
-          // and not the `ERR_REQUIRE_ESM` error, which is a red herring.
-          //
-          // SyntaxError happens when in an edge case: when we're using an ESM loader that loads
-          // a `test.ts` file (i.e. unrecognized extension), and that file includes an unknown
-          // import (which throws an ERR_MODULE_NOT_FOUND). `require`-ing it will throw the
-          // syntax error, because we cannot require a file that has `import`-s.
-          throw err;
-        } else {
-          throw requireErr;
-        }
+        return dealWithExports(await formattedImport(file, esmDecorator));
+      } catch (err) {
+        throw err;
       }
     } else {
-      throw err;
+      throw requireErr;
     }
   }
 };
+
 
 function dealWithExports(module) {
   if (module.default) {

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -42,7 +42,7 @@ exports.requireOrImport = async (file, esmDecorator) => {
     return require(file);
   } catch (requireErr) {
     if (
-      requireErr.code === 'ERR_REQUIRE_ESM' ||
+      requireErr.code === 'ERR_REQUIRE_ESM' ||  requireErr.code === 'ERR_INTERNAL_ASSERTION' ||
       (requireErr instanceof SyntaxError &&
         requireErr
           .toString()


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5290
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->


The requireOrImport function was originally set up to try importing a file as an ES module first, and if that failed, it would fall back to require. However, since Node.js version 22.12, the require function now automatically handles both ES modules (ESM) and CommonJS (CJS). This caused an issue where calling require after a failed import could lead to a cyclic dependency error.

in the updated code I have used require  first and if fails with requireErr.code === 'ERR_REQUIRE_ESM'  which only happens if version is <22.12.0 and  and target file is esm ,then use the older method.

https://nodejs.org/en/blog/release/v22.12.0

https://joyeecheung.github.io/blog/2024/03/18/require-esm-in-node-js
