### PR TITLE
fix: switch from ansi-colors to picocolors

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -20,7 +20,7 @@ const {
 } = require('./options');
 const lookupFiles = require('./lookup-files');
 const commands = require('./commands');
-const ansi = require('ansi-colors');
+const pc = require('picocolors');
 const {repository, homepage, version, discord} = require('../../package.json');
 const {cwd} = require('../utils');
 
@@ -60,7 +60,7 @@ exports.main = (argv = process.argv.slice(2), mochaArgs) => {
     .fail((msg, err, yargs) => {
       debug('caught error sometime before command handler: %O', err);
       yargs.showHelp();
-      console.error(`\n${symbols.error} ${ansi.red('ERROR:')} ${msg}`);
+      console.error(`\n${symbols.error} ${pc.red('ERROR:')} ${msg}`);
       process.exit(1);
     })
     .help('help', 'Show usage information & exit')
@@ -69,10 +69,10 @@ exports.main = (argv = process.argv.slice(2), mochaArgs) => {
     .alias('version', 'V')
     .wrap(process.stdout.columns ? Math.min(process.stdout.columns, 80) : 80)
     .epilog(
-      `${ansi.reset("Mocha Resources")}
-    Chat: ${ansi.magenta(discord)}
-  GitHub: ${ansi.blue(repository.url)}
-    Docs: ${ansi.yellow(homepage)}
+      `${pc.reset("Mocha Resources")}
+    Chat: ${pc.magenta(discord)}
+  GitHub: ${pc.blue(repository.url)}
+    Docs: ${pc.yellow(homepage)}
       `
     )
     .parserConfiguration(YARGS_PARSER_CONFIG)

--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const ansi = require('ansi-colors');
+const pc = require('picocolors');
 const debug = require('debug')('mocha:cli:run:helpers');
 const minimatch = require('minimatch');
 const {NO_FILES_MATCH_PATTERN} = require('../errors').constants;
@@ -94,12 +94,12 @@ module.exports = ({
             unmatchedSpecFiles[0].pattern
           )}` // stringify to print escaped characters raw
         : 'Error: No test files found';
-    console.error(ansi.red(noneFoundMsg));
+    console.error(pc.red(noneFoundMsg));
     process.exit(1);
   } else {
     // print messages as a warning
     unmatchedSpecFiles.forEach(warning => {
-      console.warn(ansi.yellow(`Warning: ${warning.message}`));
+      console.warn(pc.yellow(`Warning: ${warning.message}`));
     });
   }
 

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -8,7 +8,7 @@
  */
 
 const fs = require('node:fs');
-const ansi = require('ansi-colors');
+const pc = require('picocolors');
 const yargsParser = require('yargs-parser');
 const {
   types,
@@ -180,7 +180,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
     boolean: types.boolean.concat(nodeArgs.map(pair => pair[0]))
   });
   if (result.error) {
-    console.error(ansi.red(`Error: ${result.error.message}`));
+    console.error(pc.red(`Error: ${result.error.message}`));
     process.exit(1);
   }
 

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -9,7 +9,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const ansi = require('ansi-colors');
+const pc = require('picocolors');
 const debug = require('debug')('mocha:cli:run:helpers');
 const {watchRun, watchParallelRun} = require('./watch-run');
 const collectFiles = require('./collect-files');
@@ -121,7 +121,7 @@ const handleUnmatchedFiles = (mocha, unmatchedFiles) => {
 
   unmatchedFiles.forEach(({pattern, absolutePath}) => {
     console.error(
-      ansi.yellow(
+      pc.yellow(
         `Warning: Cannot find any files matching pattern "${pattern}" at the absolute path "${absolutePath}"`
       )
     );

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -8,7 +8,7 @@
  */
 
 const symbols = require('log-symbols');
-const ansi = require('ansi-colors');
+const pc = require('picocolors');
 const Mocha = require('../mocha');
 const {
   createUnsupportedError,
@@ -357,7 +357,7 @@ exports.builder = yargs =>
         Object.assign(argv, plugins);
       } catch (err) {
         // this could be a bad --require, bad reporter, ui, etc.
-        console.error(`\n${symbols.error} ${ansi.red('ERROR:')}`, err);
+        console.error(`\n${symbols.error} ${pc.red('ERROR:')}`, err);
         yargs.exit(1);
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "11.2.0",
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
         "chokidar": "^3.5.3",
         "debug": "^4.3.5",
@@ -22,6 +21,7 @@
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
@@ -2277,14 +2277,6 @@
       "dev": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-red": {
@@ -9170,13 +9162,6 @@
         "typescript": ">=5.0.4"
       }
     },
-    "node_modules/knip/node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/knip/node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -11965,6 +11950,12 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -15422,12 +15413,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/update-browserslist-db/node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
     "node_modules/upper-case-first": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
@@ -18004,11 +17989,6 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "requires": {}
-    },
-    "ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
     },
     "ansi-red": {
       "version": "0.1.1",
@@ -23300,12 +23280,6 @@
         "zod-validation-error": "^3.0.3"
       },
       "dependencies": {
-        "picocolors": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-          "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-          "dev": true
-        },
         "picomatch": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -25376,6 +25350,11 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -28057,14 +28036,6 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "picocolors": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-          "dev": true
-        }
       }
     },
     "upper-case-first": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "version": "run-p version:* && git add -A ./AUTHORS ./CHANGELOG.md"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.3",
     "browser-stdout": "^1.3.1",
     "chokidar": "^3.5.3",
     "debug": "^4.3.5",
@@ -107,6 +106,7 @@
     "log-symbols": "^4.1.0",
     "minimatch": "^5.1.6",
     "ms": "^2.1.3",
+    "picocolors": "^1.1.1",
     "serialize-javascript": "^6.0.2",
     "strip-json-comments": "^3.1.1",
     "supports-color": "^8.1.1",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5291
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per the issue, switches from [`ansi-colors`](https://www.npmjs.com/package/ansi-colors) to the smaller [`picocolors`](https://www.npmjs.com/package/picocolors) for colorization. It seems to be a drop-in replacement.