### PR TITLE
docs: add example/tests.html to docs-next

### DIFF
--- a/docs-next/public/example/Array.js
+++ b/docs-next/public/example/Array.js
@@ -1,0 +1,74 @@
+
+describe('Array', function(){
+  describe('.push()', function(){
+    it('should append a value', function(){
+      var arr = [];
+      arr.push('foo');
+      arr.push('bar');
+      expect(arr[0]).to.equal('foo');
+      expect(arr[1]).to.equal('bar');
+    })
+
+    it('should return the length', function(){
+      var arr = [];
+      var n = arr.push('foo');
+      expect(n).to.equal(1);
+      n = arr.push('bar');
+      expect(n).to.equal(2);
+    })
+
+    describe('with many arguments', function(){
+      it('should add the values', function(){
+        var arr = [];
+        arr.push('foo', 'bar');
+        expect(arr[0]).to.equal('foo');
+        expect(arr[1]).to.equal('bar');
+      })
+    })
+  })
+
+  describe('.unshift()', function(){
+    it('should prepend a value', function(){
+      var arr = [1,2,3];
+      arr.unshift('foo');
+      expect(arr[0]).to.equal('foo');
+      expect(arr[1]).to.equal(1);
+    })
+
+    it('should return the length', function(){
+      var arr = [];
+      var n = arr.unshift('foo');
+      expect(n).to.equal(1);
+      n = arr.unshift('bar');
+      expect(n).to.equal(2);
+    })
+
+    describe('with many arguments', function(){
+      it('should add the values', function(){
+        var arr = [];
+        arr.unshift('foo', 'bar');
+        expect(arr[0]).to.equal('foo');
+        expect(arr[1]).to.equal('bar');
+      })
+    })
+  })
+
+  describe('.pop()', function(){
+    it('should remove and return the last value', function(){
+      var arr = [1,2,3];
+      expect(arr.pop()).to.equal(3);
+      expect(arr.pop()).to.equal(2);
+      expect(arr).to.have.length(1);
+    })
+  })
+
+  describe('.shift()', function(){
+    it('should remove and return the first value', function(){
+      var arr = [1,2,3];
+      expect(arr.shift()).to.equal(1);
+      expect(arr.shift()).to.equal(2);
+      expect(arr).to.have.length(1);
+    })
+  })
+})
+

--- a/docs-next/public/example/Array.js
+++ b/docs-next/public/example/Array.js
@@ -1,7 +1,8 @@
+"use strict";
 
-describe('Array', function(){
-  describe('.push()', function(){
-    it('should append a value', function(){
+describe('Array', function () {
+  describe('.push()', function () {
+    it('should append a value', function () {
       var arr = [];
       arr.push('foo');
       arr.push('bar');
@@ -9,7 +10,7 @@ describe('Array', function(){
       expect(arr[1]).to.equal('bar');
     })
 
-    it('should return the length', function(){
+    it('should return the length', function () {
       var arr = [];
       var n = arr.push('foo');
       expect(n).to.equal(1);
@@ -17,8 +18,8 @@ describe('Array', function(){
       expect(n).to.equal(2);
     })
 
-    describe('with many arguments', function(){
-      it('should add the values', function(){
+    describe('with many arguments', function () {
+      it('should add the values', function () {
         var arr = [];
         arr.push('foo', 'bar');
         expect(arr[0]).to.equal('foo');
@@ -27,15 +28,15 @@ describe('Array', function(){
     })
   })
 
-  describe('.unshift()', function(){
-    it('should prepend a value', function(){
-      var arr = [1,2,3];
+  describe('.unshift()', function () {
+    it('should prepend a value', function () {
+      var arr = [1, 2, 3];
       arr.unshift('foo');
       expect(arr[0]).to.equal('foo');
       expect(arr[1]).to.equal(1);
     })
 
-    it('should return the length', function(){
+    it('should return the length', function () {
       var arr = [];
       var n = arr.unshift('foo');
       expect(n).to.equal(1);
@@ -43,8 +44,8 @@ describe('Array', function(){
       expect(n).to.equal(2);
     })
 
-    describe('with many arguments', function(){
-      it('should add the values', function(){
+    describe('with many arguments', function () {
+      it('should add the values', function () {
         var arr = [];
         arr.unshift('foo', 'bar');
         expect(arr[0]).to.equal('foo');
@@ -53,18 +54,18 @@ describe('Array', function(){
     })
   })
 
-  describe('.pop()', function(){
-    it('should remove and return the last value', function(){
-      var arr = [1,2,3];
+  describe('.pop()', function () {
+    it('should remove and return the last value', function () {
+      var arr = [1, 2, 3];
       expect(arr.pop()).to.equal(3);
       expect(arr.pop()).to.equal(2);
       expect(arr).to.have.length(1);
     })
   })
 
-  describe('.shift()', function(){
-    it('should remove and return the first value', function(){
-      var arr = [1,2,3];
+  describe('.shift()', function () {
+    it('should remove and return the first value', function () {
+      var arr = [1, 2, 3];
       expect(arr.shift()).to.equal(1);
       expect(arr.shift()).to.equal(2);
       expect(arr).to.have.length(1);

--- a/docs-next/public/example/tests.html
+++ b/docs-next/public/example/tests.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Mocha</title>
+    <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css">
+    <link rel="shortcut icon" href="../favicon.svg">
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="https://unpkg.com/mocha/mocha.js"></script>
+    <script src="https://unpkg.com/chai@4.5.0/chai.js"></script>
+    <script>mocha.setup('bdd')</script>
+    <script>expect = chai.expect</script>
+    <script src="Array.js"></script>
+    <script>
+      mocha.run();
+    </script>
+  </body>
+</html>

--- a/docs-next/src/content/docs/index.mdx
+++ b/docs-next/src/content/docs/index.mdx
@@ -52,6 +52,6 @@ Become a [backer](https://opencollective.com/mochajs#support) and support Mocha 
 
 In addition to chatting with us on [our Discord](https://discord.gg/KeDn2uXhER), for additional information such as using
 spies, mocking, and shared behaviours be sure to check out the [Mocha Wiki](https://github.com/mochajs/mocha/wiki) on GitHub.
-For a running example of Mocha, view [example/tests.html](https://mochajs.org/example/tests.html).
+For a running example of Mocha, view [example/tests.html](example/tests.html).
 
 For the JavaScript API, view the [API documentation](/api) or the [source](https://github.com/mochajs/mocha/blob/main/lib/mocha.js).


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5310
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Copies the file over to the [Astro `public/` directory](https://docs.astro.build/en/basics/project-structure/#public) with only one, minimal change: changing the favicon extension to the new site's `.svg`.

Note that the new link in `docs/index.mdx` doesn't work locally because the local site is still configured with a base path of `next/`. I couldn't figure out how to get the relative link to work for both a local base path and a deployed site. But this should point to the right link in production, I think.