### PR TITLE
fix: print error when internal cli error happens (more helpful than ERROR: null)

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -61,6 +61,7 @@ exports.main = (argv = process.argv.slice(2), mochaArgs) => {
       debug('caught error sometime before command handler: %O', err);
       yargs.showHelp();
       console.error(`\n${symbols.error} ${pc.red('ERROR:')} ${msg}`);
+      console.error(err);
       process.exit(1);
     })
     .help('help', 'Show usage information & exit')


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5078 / #5048 / others (the `ERROR: null` part of it)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
There have been issues where the reported error is "ERROR: null", which is very unhelpful. Here is an analysis of a specific example: https://github.com/mochajs/mocha/issues/5048#issuecomment-2833619212

Although the trigger for that error was fixed by #5074, the unhelpfulness of "ERROR: null" was not addressed.

To help with debugging, this patch prints the original error when this stage is unexpectedly reached.
