### PR TITLE
chore: move callback and object typedefs to a new types.d.ts

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -100,3 +100,8 @@ jobs:
   #   with:
   #     browsers: 'firefox@latest,chrome@latest,MicrosoftEdge@latest,safari@latest'
   #     npm-script: test-browser
+
+  tsc:
+    uses: ./.github/workflows/npm-script.yml
+    with:
+      npm-script: tsc

--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const pc = require('picocolors');
 const debug = require('debug')('mocha:cli:run:helpers');
 const minimatch = require('minimatch');
-const {NO_FILES_MATCH_PATTERN} = require('../errors').constants;
+const {NO_FILES_MATCH_PATTERN} = require('../error-constants').constants;
 const lookupFiles = require('./lookup-files');
 const {castArray} = require('../utils');
 
@@ -15,6 +15,11 @@ const {castArray} = require('../utils');
  * @see module:lib/cli/watch-run
  * @module
  * @private
+ */
+
+/**
+ * @typedef {import('../types.d.ts').FileCollectionOptions} FileCollectionOptions
+ * @typedef {import('../types.d.ts').FileCollectionResponse} FileCollectionResponse
  */
 
 /**
@@ -108,30 +113,3 @@ module.exports = ({
     unmatchedFiles
   };
 };
-
-/**
- * An object to configure how Mocha gathers test files
- * @private
- * @typedef {Object} FileCollectionOptions
- * @property {string[]} extension - File extensions to use
- * @property {string[]} spec - Files, dirs, globs to run
- * @property {string[]} ignore - Files, dirs, globs to ignore
- * @property {string[]} file - List of additional files to include
- * @property {boolean} recursive - Find files recursively
- * @property {boolean} sort - Sort test files
- */
-
-/**
- * Diagnostic object containing unmatched files
- * @typedef {Object} UnmatchedFile -
- * @property {string} absolutePath - A list of unmatched files derived from the file arguments passed in.
- * @property {string} pattern - A list of unmatched files derived from the file arguments passed in.
- *
- */
-
-/**
- * Response object containing a list of files to test and unmatched files.
- * @typedef {Object} FileCollectionResponse
- * @property {string[]} files - A list of files to test
- * @property {UnmatchedFile[]} unmatchedFiles - A list of unmatched files derived from the file arguments passed in.
- */

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -7,6 +7,13 @@
  * @private
  */
 
+/**
+ * @typedef {import('../mocha.js')} Mocha
+ * @typedef {import('../types.d.ts').MochaOptions} MochaOptions
+ * @typedef {import('../types.d.ts').UnmatchedFile} UnmatchedFile
+ * @typedef {import('../runner.js')} Runner
+ */
+
 const fs = require('node:fs');
 const path = require('node:path');
 const pc = require('picocolors');
@@ -17,7 +24,6 @@ const {format} = require('node:util');
 const {createInvalidLegacyPluginError} = require('../errors');
 const {requireOrImport} = require('../nodejs/esm-utils');
 const PluginLoader = require('../plugin-loader');
-const {UnmatchedFile} = require('./collect-files');
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
@@ -136,9 +142,7 @@ const handleUnmatchedFiles = (mocha, unmatchedFiles) => {
 /**
  * Collect and load test files, then run mocha instance.
  * @param {Mocha} mocha - Mocha instance
- * @param {Options} [opts] - Command line options
- * @param {boolean} [opts.exit] - Whether or not to force-exit after tests are complete
- * @param {boolean} [opts.passOnFailingTestSuite] - Whether or not to fail test run if tests were failed
+ * @param {MochaOptions} [opts] - Command line options
  * @param {Object} fileCollectParams - Parameters that control test
  *   file collection. See `lib/cli/collect-files.js`.
  * @returns {Promise<Runner>}
@@ -166,15 +170,15 @@ const singleRun = async (
 };
 
 /**
- * Collect files and run tests (using `BufferedRunner`).
+ * Collect files and run tests (using `Runner`).
  *
  * This is `async` for consistency.
  *
  * @param {Mocha} mocha - Mocha instance
- * @param {Options} options - Command line options
+ * @param {MochaOptions} options - Command line options
  * @param {Object} fileCollectParams - Parameters that control test
  *   file collection. See `lib/cli/collect-files.js`.
- * @returns {Promise<BufferedRunner>}
+ * @returns {Promise<Runner>}
  * @ignore
  * @private
  */
@@ -204,7 +208,7 @@ const parallelRun = async (mocha, options, fileCollectParams) => {
  * - `parallelRun`: run tests in parallel & exit
  * - `watchParallelRun`: run tests in parallel, rerunning as files change
  * @param {Mocha} mocha - Mocha instance
- * @param {Options} opts - Command line options
+ * @param {MochaOptions} options - Command line options
  * @private
  * @returns {Promise<Runner>}
  */

--- a/lib/cli/run-option-metadata.js
+++ b/lib/cli/run-option-metadata.js
@@ -9,7 +9,7 @@
 
 /**
  * Dictionary of yargs option types to list of options having said type
- * @type {{string:string[]}}
+ * @type {Record<string, string[]>}
  * @private
  */
 const TYPES = (exports.types = {
@@ -66,7 +66,7 @@ const TYPES = (exports.types = {
 /**
  * Option aliases keyed by canonical option name.
  * Arrays used to reduce
- * @type {{string:string[]}}
+ * @type {Record<string, string[]>}
  * @private
  */
 exports.aliases = {

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -9,6 +9,14 @@ const collectFiles = require('./collect-files');
 const glob = require('glob');
 
 /**
+ * @typedef {import('chokidar').FSWatcher} FSWatcher
+ * @typedef {import('../mocha.js')} Mocha
+ * @typedef {import('../types.d.ts').BeforeWatchRun} BeforeWatchRun
+ * @typedef {import('../types.d.ts').FileCollectionOptions} FileCollectionOptions
+ * @typedef {import('../types.d.ts').Rerunner} Rerunner
+ */
+
+/**
  * Exports the `watchRun` function that runs mocha in "watch" mode.
  * @see module:lib/cli/run-helpers
  * @module
@@ -402,20 +410,3 @@ const blastCache = watcher => {
   });
   debug('deleted %d file(s) from the require cache', files.length);
 };
-
-/**
- * Callback to be run before `mocha.run()` is called.
- * Optionally, it can return a new `Mocha` instance.
- * @callback BeforeWatchRun
- * @private
- * @param {{mocha: Mocha, watcher: FSWatcher}} options
- * @returns {Mocha}
- */
-
-/**
- * Object containing run control methods
- * @typedef {Object} Rerunner
- * @private
- * @property {Function} run - Calls `mocha.run()`
- * @property {Function} scheduleRun - Schedules another call to `run`
- */

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('./runnable.js')} Runnable
+ */
+
 /**
  * @module Context
  */

--- a/lib/error-constants.js
+++ b/lib/error-constants.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * When Mocha throws exceptions (or rejects `Promise`s), it attempts to assign a `code` property to the `Error` object, for easier handling. These are the potential values of `code`.
+ * @public
+ * @namespace
+ * @memberof module:lib/errors
+ */
+var constants = {
+  /**
+   * An unrecoverable error.
+   * @constant
+   * @default
+   */
+  FATAL: 'ERR_MOCHA_FATAL',
+
+  /**
+   * The type of an argument to a function call is invalid
+   * @constant
+   * @default
+   */
+  INVALID_ARG_TYPE: 'ERR_MOCHA_INVALID_ARG_TYPE',
+
+  /**
+   * The value of an argument to a function call is invalid
+   * @constant
+   * @default
+   */
+  INVALID_ARG_VALUE: 'ERR_MOCHA_INVALID_ARG_VALUE',
+
+  /**
+   * Something was thrown, but it wasn't an `Error`
+   * @constant
+   * @default
+   */
+  INVALID_EXCEPTION: 'ERR_MOCHA_INVALID_EXCEPTION',
+
+  /**
+   * An interface (e.g., `Mocha.interfaces`) is unknown or invalid
+   * @constant
+   * @default
+   */
+  INVALID_INTERFACE: 'ERR_MOCHA_INVALID_INTERFACE',
+
+  /**
+   * A reporter (.e.g, `Mocha.reporters`) is unknown or invalid
+   * @constant
+   * @default
+   */
+  INVALID_REPORTER: 'ERR_MOCHA_INVALID_REPORTER',
+
+  /**
+   * `done()` was called twice in a `Test` or `Hook` callback
+   * @constant
+   * @default
+   */
+  MULTIPLE_DONE: 'ERR_MOCHA_MULTIPLE_DONE',
+
+  /**
+   * No files matched the pattern provided by the user
+   * @constant
+   * @default
+   */
+  NO_FILES_MATCH_PATTERN: 'ERR_MOCHA_NO_FILES_MATCH_PATTERN',
+
+  /**
+   * Known, but unsupported behavior of some kind
+   * @constant
+   * @default
+   */
+  UNSUPPORTED: 'ERR_MOCHA_UNSUPPORTED',
+
+  /**
+   * Invalid state transition occurring in `Mocha` instance
+   * @constant
+   * @default
+   */
+  INSTANCE_ALREADY_RUNNING: 'ERR_MOCHA_INSTANCE_ALREADY_RUNNING',
+
+  /**
+   * Invalid state transition occurring in `Mocha` instance
+   * @constant
+   * @default
+   */
+  INSTANCE_ALREADY_DISPOSED: 'ERR_MOCHA_INSTANCE_ALREADY_DISPOSED',
+
+  /**
+   * Use of `only()` w/ `--forbid-only` results in this error.
+   * @constant
+   * @default
+   */
+  FORBIDDEN_EXCLUSIVITY: 'ERR_MOCHA_FORBIDDEN_EXCLUSIVITY',
+
+  /**
+   * To be thrown when a user-defined plugin implementation (e.g., `mochaHooks`) is invalid
+   * @constant
+   * @default
+   */
+  INVALID_PLUGIN_IMPLEMENTATION: 'ERR_MOCHA_INVALID_PLUGIN_IMPLEMENTATION',
+
+  /**
+   * To be thrown when a builtin or third-party plugin definition (the _definition_ of `mochaHooks`) is invalid
+   * @constant
+   * @default
+   */
+  INVALID_PLUGIN_DEFINITION: 'ERR_MOCHA_INVALID_PLUGIN_DEFINITION',
+
+  /**
+   * When a runnable exceeds its allowed run time.
+   * @constant
+   * @default
+   */
+  TIMEOUT: 'ERR_MOCHA_TIMEOUT',
+
+  /**
+   * Input file is not able to be parsed
+   * @constant
+   * @default
+   */
+  UNPARSABLE_FILE: 'ERR_MOCHA_UNPARSABLE_FILE'
+};
+
+module.exports = { constants };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,14 @@
 'use strict';
 
+/**
+ * @typedef {import('./mocha.js')} Mocha
+ * @typedef {import('./runnable.js')} Runnable
+ * @typedef {import('./types.d.ts').MochaTimeoutError} MochaTimeoutError
+ * @typedef {import('./types.d.ts').PluginDefinition} PluginDefinition
+ */
+
 const {format} = require('node:util');
+const { constants } = require('./error-constants.js');
 
 /**
  * Contains error codes, factory functions to create throwable error objects,
@@ -51,126 +59,6 @@ const warn = msg => {
   if (msg) {
     emitWarning(msg);
   }
-};
-
-/**
- * When Mocha throws exceptions (or rejects `Promise`s), it attempts to assign a `code` property to the `Error` object, for easier handling. These are the potential values of `code`.
- * @public
- * @namespace
- * @memberof module:lib/errors
- */
-var constants = {
-  /**
-   * An unrecoverable error.
-   * @constant
-   * @default
-   */
-  FATAL: 'ERR_MOCHA_FATAL',
-
-  /**
-   * The type of an argument to a function call is invalid
-   * @constant
-   * @default
-   */
-  INVALID_ARG_TYPE: 'ERR_MOCHA_INVALID_ARG_TYPE',
-
-  /**
-   * The value of an argument to a function call is invalid
-   * @constant
-   * @default
-   */
-  INVALID_ARG_VALUE: 'ERR_MOCHA_INVALID_ARG_VALUE',
-
-  /**
-   * Something was thrown, but it wasn't an `Error`
-   * @constant
-   * @default
-   */
-  INVALID_EXCEPTION: 'ERR_MOCHA_INVALID_EXCEPTION',
-
-  /**
-   * An interface (e.g., `Mocha.interfaces`) is unknown or invalid
-   * @constant
-   * @default
-   */
-  INVALID_INTERFACE: 'ERR_MOCHA_INVALID_INTERFACE',
-
-  /**
-   * A reporter (.e.g, `Mocha.reporters`) is unknown or invalid
-   * @constant
-   * @default
-   */
-  INVALID_REPORTER: 'ERR_MOCHA_INVALID_REPORTER',
-
-  /**
-   * `done()` was called twice in a `Test` or `Hook` callback
-   * @constant
-   * @default
-   */
-  MULTIPLE_DONE: 'ERR_MOCHA_MULTIPLE_DONE',
-
-  /**
-   * No files matched the pattern provided by the user
-   * @constant
-   * @default
-   */
-  NO_FILES_MATCH_PATTERN: 'ERR_MOCHA_NO_FILES_MATCH_PATTERN',
-
-  /**
-   * Known, but unsupported behavior of some kind
-   * @constant
-   * @default
-   */
-  UNSUPPORTED: 'ERR_MOCHA_UNSUPPORTED',
-
-  /**
-   * Invalid state transition occurring in `Mocha` instance
-   * @constant
-   * @default
-   */
-  INSTANCE_ALREADY_RUNNING: 'ERR_MOCHA_INSTANCE_ALREADY_RUNNING',
-
-  /**
-   * Invalid state transition occurring in `Mocha` instance
-   * @constant
-   * @default
-   */
-  INSTANCE_ALREADY_DISPOSED: 'ERR_MOCHA_INSTANCE_ALREADY_DISPOSED',
-
-  /**
-   * Use of `only()` w/ `--forbid-only` results in this error.
-   * @constant
-   * @default
-   */
-  FORBIDDEN_EXCLUSIVITY: 'ERR_MOCHA_FORBIDDEN_EXCLUSIVITY',
-
-  /**
-   * To be thrown when a user-defined plugin implementation (e.g., `mochaHooks`) is invalid
-   * @constant
-   * @default
-   */
-  INVALID_PLUGIN_IMPLEMENTATION: 'ERR_MOCHA_INVALID_PLUGIN_IMPLEMENTATION',
-
-  /**
-   * To be thrown when a builtin or third-party plugin definition (the _definition_ of `mochaHooks`) is invalid
-   * @constant
-   * @default
-   */
-  INVALID_PLUGIN_DEFINITION: 'ERR_MOCHA_INVALID_PLUGIN_DEFINITION',
-
-  /**
-   * When a runnable exceeds its allowed run time.
-   * @constant
-   * @default
-   */
-  TIMEOUT: 'ERR_MOCHA_TIMEOUT',
-
-  /**
-   * Input file is not able to be parsed
-   * @constant
-   * @default
-   */
-  UNPARSABLE_FILE: 'ERR_MOCHA_UNPARSABLE_FILE'
 };
 
 /**
@@ -528,7 +416,6 @@ const isMochaError = err =>
   Boolean(err && typeof err === 'object' && MOCHA_ERRORS.has(err.code));
 
 module.exports = {
-  constants,
   createFatalError,
   createForbiddenExclusivityError,
   createInvalidArgumentTypeError,
@@ -552,12 +439,3 @@ module.exports = {
   isMochaError,
   warn
 };
-
-/**
- * The error thrown when a Runnable times out
- * @memberof module:lib/errors
- * @typedef {Error} MochaTimeoutError
- * @property {constants.TIMEOUT} code - Error code
- * @property {number?} timeout Timeout in ms
- * @property {string?} file Filepath, if given
- */

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * @typedef {import('../suite.js')} Suite
+ */
+
 var Test = require('../test');
 var EVENT_FILE_PRE_REQUIRE =
   require('../suite').constants.EVENT_FILE_PRE_REQUIRE;

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -1,6 +1,11 @@
 'use strict';
 
 /**
+ * @typedef {import('../context.js')} Context
+ * @typedef {import('../mocha.js')} Mocha
+ */
+
+/**
  @module interfaces/common
 */
 

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -1,4 +1,7 @@
 'use strict';
+/**
+ * @typedef {import('../suite.js')} Suite
+ */
 
 var Test = require('../test');
 var EVENT_FILE_PRE_REQUIRE =

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * @typedef {import('../suite.js')} Suite
+ */
+
 var Test = require('../test');
 var EVENT_FILE_PRE_REQUIRE =
   require('../suite').constants.EVENT_FILE_PRE_REQUIRE;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -25,6 +25,14 @@ const {EVENT_FILE_PRE_REQUIRE, EVENT_FILE_POST_REQUIRE, EVENT_FILE_REQUIRE} =
   Suite.constants;
 var debug = require('debug')('mocha:mocha');
 
+/**
+ * @typedef {import('./types.d.ts').DoneCB} DoneCB
+ * @typedef {import('./types.d.ts').MochaGlobalFixture} MochaGlobalFixture
+ * @typedef {import('./types.d.ts').MochaOptions} MochaOptions
+ * @typedef {import('./types.d.ts').MochaRootHookObject} MochaRootHookObject
+ * @typedef {import('./types.d.ts').Reporter} Reporter
+ */
+
 exports = module.exports = Mocha;
 
 /**
@@ -148,37 +156,7 @@ exports.run = function (...args) {
  *
  * @public
  * @class Mocha
- * @param {Object} [options] - Settings object.
- * @param {boolean} [options.allowUncaught] - Propagate uncaught errors?
- * @param {boolean} [options.asyncOnly] - Force `done` callback or promise?
- * @param {boolean} [options.bail] - Bail after first test failure?
- * @param {boolean} [options.checkLeaks] - Check for global variable leaks?
- * @param {boolean} [options.color] - Color TTY output from reporter?
- * @param {boolean} [options.delay] - Delay root suite execution?
- * @param {boolean} [options.diff] - Show diff on failure?
- * @param {boolean} [options.dryRun] - Report tests without running them?
- * @param {boolean} [options.passOnFailingTestSuite] - Fail test run if tests were failed?
- * @param {boolean} [options.failZero] - Fail test run if zero tests?
- * @param {string} [options.fgrep] - Test filter given string.
- * @param {boolean} [options.forbidOnly] - Tests marked `only` fail the suite?
- * @param {boolean} [options.forbidPending] - Pending tests fail the suite?
- * @param {boolean} [options.fullTrace] - Full stacktrace upon failure?
- * @param {string[]} [options.global] - Variables expected in global scope.
- * @param {RegExp|string} [options.grep] - Test filter given regular expression.
- * @param {boolean} [options.inlineDiffs] - Display inline diffs?
- * @param {boolean} [options.invert] - Invert test filter matches?
- * @param {boolean} [options.noHighlighting] - Disable syntax highlighting?
- * @param {string|constructor} [options.reporter] - Reporter name or constructor.
- * @param {Object} [options.reporterOption] - Reporter settings object.
- * @param {number} [options.retries] - Number of times to retry failed tests.
- * @param {number} [options.slow] - Slow threshold value.
- * @param {number|string} [options.timeout] - Timeout threshold value.
- * @param {string} [options.ui] - Interface name.
- * @param {boolean} [options.parallel] - Run jobs in parallel.
- * @param {number} [options.jobs] - Max number of worker processes for parallel runs.
- * @param {MochaRootHookObject} [options.rootHooks] - Hooks to bootstrap the root suite with.
- * @param {string[]} [options.require] - Pathname of `rootHooks` plugin for parallel runs.
- * @param {boolean} [options.isWorker] - Should be `true` if `Mocha` process is running in a worker process.
+ * @param {MochaOptions} [options] - Settings object.
  */
 function Mocha(options = {}) {
   options = {...mocharc, ...options};
@@ -313,7 +291,7 @@ Mocha.prototype.addFile = function (file) {
  * @public
  * @see [CLI option](../#-reporter-name-r-name)
  * @see [Reporters](../#reporters)
- * @param {String|Function} reporterName - Reporter name or constructor.
+ * @param {String|Reporter} reporterName - Reporter name or constructor.
  * @param {Object} [reporterOptions] - Options used to configure the reporter.
  * @returns {Mocha} this
  * @chainable
@@ -954,14 +932,6 @@ Object.defineProperty(Mocha.prototype, 'version', {
 });
 
 /**
- * Callback to be invoked when test execution is complete.
- *
- * @private
- * @callback DoneCB
- * @param {number} failures - Number of failures that occurred.
- */
-
-/**
  * Runs root suite and invokes `fn()` when complete.
  *
  * @description
@@ -973,7 +943,7 @@ Object.defineProperty(Mocha.prototype, 'version', {
  * @see {@link Mocha#unloadFiles}
  * @see {@link Runner#run}
  * @param {DoneCB} [fn] - Callback invoked when test execution completed.
- * @returns {Runner} runner instance
+ * @returns {import("./runner.js")} runner instance
  * @example
  *
  * // exit with non-zero status if there were test failures
@@ -1283,52 +1253,3 @@ Mocha.prototype.hasGlobalTeardownFixtures =
   function hasGlobalTeardownFixtures() {
     return Boolean(this.options.globalTeardown.length);
   };
-
-/**
- * An alternative way to define root hooks that works with parallel runs.
- * @typedef {Object} MochaRootHookObject
- * @property {Function|Function[]} [beforeAll] - "Before all" hook(s)
- * @property {Function|Function[]} [beforeEach] - "Before each" hook(s)
- * @property {Function|Function[]} [afterAll] - "After all" hook(s)
- * @property {Function|Function[]} [afterEach] - "After each" hook(s)
- */
-
-/**
- * An function that returns a {@link MochaRootHookObject}, either sync or async.
-   @callback MochaRootHookFunction
- * @returns {MochaRootHookObject|Promise<MochaRootHookObject>}
- */
-
-/**
- * A function that's invoked _once_ which is either sync or async.
- * Can be a "teardown" or "setup".  These will all share the same context.
- * @callback MochaGlobalFixture
- * @returns {void|Promise<void>}
- */
-
-/**
- * An object making up all necessary parts of a plugin loader and aggregator
- * @typedef {Object} PluginDefinition
- * @property {string} exportName - Named export to use
- * @property {string} [optionName] - Option name for Mocha constructor (use `exportName` if omitted)
- * @property {PluginValidator} [validate] - Validator function
- * @property {PluginFinalizer} [finalize] - Finalizer/aggregator function
- */
-
-/**
- * A (sync) function to assert a user-supplied plugin implementation is valid.
- *
- * Defined in a {@link PluginDefinition}.
-
- * @callback PluginValidator
- * @param {*} value - Value to check
- * @this {PluginDefinition}
- * @returns {void}
- */
-
-/**
- * A function to finalize plugins impls of a particular ilk
- * @callback PluginFinalizer
- * @param {Array<*>} impls - User-supplied implementations
- * @returns {Promise<*>|*}
- */

--- a/lib/nodejs/buffered-worker-pool.js
+++ b/lib/nodejs/buffered-worker-pool.js
@@ -7,6 +7,12 @@
 
 'use strict';
 
+/**
+ * @typedef {import('workerpool').WorkerPoolOptions} WorkerPoolOptions
+ * @typedef {import('../types.d.ts').MochaOptions} MochaOptions
+ * @typedef {import('../types.d.ts').SerializedWorkerResult} SerializedWorkerResult
+ */
+
 const serializeJavascript = require('serialize-javascript');
 const workerpool = require('workerpool');
 const {deserialize} = require('./serializer');
@@ -20,7 +26,7 @@ const WORKER_PATH = require.resolve('./worker.js');
  *
  * This is helpful because we tend to same the same options over and over
  * over IPC.
- * @type {WeakMap<Options,string>}
+ * @type {WeakMap<MochaOptions,string>}
  */
 let optionsCache = new WeakMap();
 
@@ -113,7 +119,7 @@ class BufferedWorkerPool {
    * Handles serialization/deserialization.
    *
    * @param {string} filepath - Filepath of test
-   * @param {Options} [options] - Options for Mocha instance
+   * @param {MochaOptions} [options] - Options for Mocha instance
    * @private
    * @returns {Promise<SerializedWorkerResult>}
    */
@@ -153,7 +159,7 @@ class BufferedWorkerPool {
    * Given Mocha options object `opts`, serialize into a format suitable for
    * transmission over IPC.
    *
-   * @param {Options} [opts] - Mocha options
+   * @param {MochaOptions} [opts] - Mocha options
    * @private
    * @returns {string} Serialized options
    */

--- a/lib/nodejs/parallel-buffered-runner.js
+++ b/lib/nodejs/parallel-buffered-runner.js
@@ -6,6 +6,13 @@
 
 'use strict';
 
+/**
+ * @typedef {import('../types.d.ts').FileRunner} FileRunner
+ * @typedef {import('../types.d.ts').RunnerOptions} RunnerOptions
+ * @typedef {import('../types.d.ts').SerializedWorkerResult} SerializedWorkerResult
+ * @typedef {import('../types.d.ts').SigIntListener} SigIntListener
+ */
+
 const Runner = require('../runner');
 const {EVENT_RUN_BEGIN, EVENT_RUN_END} = Runner.constants;
 const debug = require('debug')('mocha:parallel:parallel-buffered-runner');
@@ -105,7 +112,7 @@ class ParallelBufferedRunner extends Runner {
   /**
    * Returns a mapping function to enqueue a file in the worker pool and return results of its execution.
    * @param {BufferedWorkerPool} pool - Worker pool
-   * @param {Options} options - Mocha options
+   * @param {RunnerOptions} options - Mocha options
    * @returns {FileRunner} Mapping function
    * @private
    */
@@ -270,9 +277,7 @@ class ParallelBufferedRunner extends Runner {
    *
    * @param {Function} callback - Called with an exit code corresponding to
    * number of test failures.
-   * @param {Object} [opts] - options
-   * @param {string[]} opts.files - Files to run
-   * @param {Options} opts.options - command-line options
+   * @param {RunnerOptions} [opts] - options
    */
   run(callback, {files, options = {}} = {}) {
     /**
@@ -416,18 +421,3 @@ class ParallelBufferedRunner extends Runner {
 }
 
 module.exports = ParallelBufferedRunner;
-
-/**
- * Listener function intended to be bound to `Process.SIGINT` event
- * @private
- * @callback SigIntListener
- * @returns {Promise<void>}
- */
-
-/**
- * A function accepting a test file path and returning the results of a test run
- * @private
- * @callback FileRunner
- * @param {string} filename - File to run
- * @returns {Promise<SerializedWorkerResult>}
- */

--- a/lib/nodejs/reporters/parallel-buffered.js
+++ b/lib/nodejs/reporters/parallel-buffered.js
@@ -7,6 +7,11 @@
 'use strict';
 
 /**
+ * @typedef {import('../../types.d.ts').BufferedEvent} BufferedEvent
+ * @typedef {import('../../runner.js')} Runner
+ */
+
+/**
  * Module dependencies.
  */
 
@@ -152,14 +157,5 @@ class ParallelBuffered extends Base {
     this.events = []; // defensive
   }
 }
-
-/**
- * Serializable event data from a `Runner`.  Keys of the `data` property
- * beginning with `__` will be converted into a function which returns the value
- * upon deserialization.
- * @typedef {Object} BufferedEvent
- * @property {string} name - Event name
- * @property {object} data - Event parameters
- */
 
 module.exports = ParallelBuffered;

--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -6,6 +6,11 @@
 
 'use strict';
 
+/**
+ * @typedef {import('../types.d.ts').SerializedEvent} SerializedEvent
+ * @typedef {import('../types.d.ts').SerializedWorkerResult} SerializedWorkerResult
+ */
+
 const {type, breakCircularDeps} = require('../utils');
 const {createInvalidArgumentTypeError} = require('../errors');
 // this is not named `mocha:parallel:serializer` because it's noisy and it's
@@ -393,22 +398,3 @@ exports.deserialize = function deserialize(value) {
 
 exports.SerializableEvent = SerializableEvent;
 exports.SerializableWorkerResult = SerializableWorkerResult;
-
-/**
- * The result of calling `SerializableEvent.serialize`, as received
- * by the deserializer.
- * @private
- * @typedef {Object} SerializedEvent
- * @property {object?} data - Optional serialized data
- * @property {object?} error - Optional serialized `Error`
- */
-
-/**
- * The result of calling `SerializableWorkerResult.serialize` as received
- * by the deserializer.
- * @private
- * @typedef {Object} SerializedWorkerResult
- * @property {number} failureCount - Number of failures
- * @property {SerializedEvent[]} events - Serialized events
- * @property {"SerializedWorkerResult"} __type - Symbol-like to denote the type of object this is
- */

--- a/lib/nodejs/worker.js
+++ b/lib/nodejs/worker.js
@@ -6,6 +6,11 @@
 
 'use strict';
 
+/**
+ * @typedef {import('../types.d.ts').BufferedEvent} BufferedEvent
+ * @typedef {import('../types.d.ts').MochaOptions} MochaOptions
+ */
+
 const {
   createInvalidArgumentTypeError,
   createInvalidArgumentValueError
@@ -36,7 +41,7 @@ if (workerpool.isMainThread) {
  * **This function only runs once per worker**; it overwrites itself with a no-op
  * before returning.
  *
- * @param {Options} argv - Command-line options
+ * @param {MochaOptions} argv - Command-line options
  */
 let bootstrap = async argv => {
   // globalSetup and globalTeardown do not run in workers

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('./types.d.ts').PluginDefinition} PluginDefinition
+ */
+
+/**
  * Provides a way to load "plugins" as provided by the user.
  *
  * Currently supports:
@@ -17,6 +21,10 @@ const {
   createInvalidPluginImplementationError
 } = require('./errors');
 const {castArray} = require('./utils');
+
+/**
+ * @typedef {import('./types.d.ts').PluginLoaderOptions} PluginLoaderOptions
+ */
 
 /**
  * Built-in plugin definitions.
@@ -277,10 +285,3 @@ class PluginLoader {
 }
 
 module.exports = PluginLoader;
-
-/**
- * Options for {@link PluginLoader}
- * @typedef {Object} PluginLoaderOptions
- * @property {PluginDefinition[]} [pluginDefs] - Plugin definitions
- * @property {string[]} [ignore] - A list of plugins to ignore when loading
- */

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -1,4 +1,11 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ * @typedef {import('../types.d.ts').FullErrorStack} FullErrorStack
+ */
+
 /**
  * @module Base
  */
@@ -580,12 +587,3 @@ function sameType(a, b) {
 Base.consoleLog = consoleLog;
 
 Base.abstract = true;
-
-/**
- * An object with all stack traces recursively mounted from each err.cause
- * @memberof module:lib/reporters/base
- * @typedef {Object} FullErrorStack
- * @property {string} message
- * @property {string} msg
- * @property {string} stack
- */

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Doc
  */

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Dot
  */

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /* eslint-env browser */
 /**
  * @module HTML

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -1,4 +1,10 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ */
+
 /**
  * @module JSONStream
  */
@@ -56,15 +62,10 @@ function JSONStream(runner, options) {
 }
 
 /**
- * Mocha event to be written to the output stream.
- * @typedef {Array} JSONStream~MochaEvent
- */
-
-/**
  * Writes Mocha event to reporter output stream.
  *
  * @private
- * @param {JSONStream~MochaEvent} event - Mocha event to be output.
+ * @param {unknown[]} event - Mocha event to be output.
  */
 function writeEvent(event) {
   process.stdout.write(JSON.stringify(event) + '\n');

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module JSON
  */

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Landing
  */

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module List
  */

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Markdown
  */

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Min
  */

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Nyan
  */

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ */
+
 /**
  * @module Progress
  */

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -1,4 +1,10 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ */
+
 /**
  * @module Spec
  */

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -1,4 +1,10 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ */
+
 /**
  * @module TAP
  */

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -1,4 +1,10 @@
 'use strict';
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ */
+
 /**
  * @module XUnit
  */

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,10 @@
 'use strict';
 
 /**
+ * @typedef {import('./types.d.ts').RunnerOptions} RunnerOptions
+ */
+
+/**
  * Module dependencies.
  * @private
  */
@@ -1068,9 +1072,7 @@ Runner.prototype._uncaught = function (err) {
  * @public
  * @memberof Runner
  * @param {Function} fn - Callback when finished
- * @param {Object} [opts] - For subclasses
- * @param {string[]} opts.files - Files to run
- * @param {Options} opts.options - command-line options
+ * @param {RunnerOptions} [opts] - For subclasses
  * @returns {Runner} Runner instance.
  */
 Runner.prototype.run = function (fn, opts = {}) {

--- a/lib/stats-collector.js
+++ b/lib/stats-collector.js
@@ -1,6 +1,11 @@
 'use strict';
 
 /**
+ * @typedef {import('./types.d.ts').StatsCollector} StatsCollector
+ * @typedef {import('./runner.js')} Runner
+ */
+
+/**
  * Provides a factory function for a {@link StatsCollector} object.
  * @module
  */
@@ -14,21 +19,6 @@ var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_TEST_END = constants.EVENT_TEST_END;
 
-/**
- * Test statistics collector.
- *
- * @public
- * @typedef {Object} StatsCollector
- * @property {number} suites - integer count of suites run.
- * @property {number} tests - integer count of tests run.
- * @property {number} passes - integer count of passing tests.
- * @property {number} pending - integer count of pending tests.
- * @property {number} failures - integer count of failed tests.
- * @property {Date} start - time when testing began.
- * @property {Date} end - time when testing concluded.
- * @property {number} duration - number of msecs that testing took.
- */
-
 var Date = global.Date;
 
 /**
@@ -40,7 +30,7 @@ var Date = global.Date;
  */
 function createStatsCollector(runner) {
   /**
-   * @type StatsCollector
+   * @type {StatsCollector}
    */
   var stats = {
     suites: 0,

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -1,6 +1,10 @@
 'use strict';
 
 /**
+ * @typedef {import('./test.js')} Test
+ */
+
+/**
  * Module dependencies.
  * @private
  */

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,378 @@
+/**
+ * These types are a preliminary step towards moving Mocha's TypeScript types into Mocha.
+ * They are not yet complete and are not yet fully used in the codebase.
+ * For now, if you're an external user, you should use the types from @types/mocha.
+ */
+
+import type {FSWatcher} from 'chokidar';
+
+import type {constants} from './error-constants.js';
+import type Mocha from './mocha.js';
+import Runner from './runner.js';
+
+/**
+ * Command-line options
+ */
+export interface MochaOptions {
+  /** Propagate uncaught errors? */
+  allowUncaught?: boolean;
+
+  /** Force `done` callback or promise? */
+  asyncOnly?: boolean;
+
+  /** Bail after first test failure? */
+  bail?: boolean;
+
+  /** Check for global variable leaks? */
+  checkLeaks?: boolean;
+
+  /** Color TTY output from reporter? */
+  color?: boolean;
+
+  /** Delay root suite execution? */
+  delay?: boolean;
+
+  /** Show diff on failure? */
+  diff?: boolean;
+
+  /** Report tests without running them? */
+  dryRun?: boolean;
+
+  /** Fail test run if tests were failed? */
+  passOnFailingTestSuite?: boolean;
+
+  /** Fail test run if zero tests? */
+  failZero?: boolean;
+
+  /** Test filter given string. */
+  fgrep?: string;
+
+  /** Tests marked `only` fail the suite? */
+  forbidOnly?: boolean;
+
+  /** Pending tests fail the suite? */
+  forbidPending?: boolean;
+
+  /** Full stacktrace upon failure? */
+  fullTrace?: boolean;
+
+  /** Variables expected in global scope. */
+  global?: string[];
+
+  /** Test filter given regular expression. */
+  grep?: RegExp;
+
+  /** Display inline diffs? */
+  inlineDiffs?: boolean;
+
+  /** Invert test filter matches? */
+  invert?: boolean;
+
+  /** Disable syntax highlighting? */
+  noHighlighting?: boolean;
+
+  /** - Reporter name or constructor. */
+  reporter?: string | Reporter;
+
+  /** Reporter settings object. */
+  reporterOption?: Object;
+
+  /** Number of times to retry failed tests. */
+  retries?: number;
+
+  /** Slow threshold value. */
+  slow?: number;
+
+  /** Timeout threshold value. */
+  timeout?: number | string;
+
+  /** Interface name. */
+  ui?: string;
+
+  /** Run jobs in parallel. */
+  parallel?: boolean;
+
+  /** Max number of worker processes for parallel runs. */
+  jobs?: number;
+
+  /** Hooks to bootstrap the root suite with. */
+  rootHooks?: MochaRootHookObject;
+
+  /** Pathname of `rootHooks` plugin for parallel runs. */
+  require?: string[];
+
+  /** Should be `true` if `Mocha` process is running in a worker process. */
+  isWorker?: boolean;
+
+  watch?: boolean;
+  extension?: string[];
+  recursive?: boolean;
+  sort?: boolean;
+  file?: string[];
+  spec?: string[];
+  ignore?: string[];
+}
+
+/**
+ * Callback to be invoked when test execution is complete.
+ *
+ * @private
+ * @param failures - Number of failures that occurred.
+ */
+export type DoneCB = (failures: number) => void;
+
+export interface RunnerOptions {
+  /** Files to run */
+  files?: string[];
+  /** Command-line options */
+  options?: object;
+}
+
+/**
+ * An alternative way to define root hooks that works with parallel runs.
+ */
+export interface MochaRootHookObject {
+  /** "Before all" hook(s) */
+  beforeAll?: Function | Function[];
+  /** "Before each" hook(s) */
+  beforeEach?: Function | Function[];
+  /** "After all" hook(s) */
+  afterAll?: Function | Function[];
+  /** "After each" hook(s)} */
+  afterEach?: Function | Function[];
+}
+
+/**
+ * A function that's invoked _once_ which is either sync or async.
+ * Can be a "teardown" or "setup".  These will all share the same context.
+ */
+export type MochaGlobalFixture = () => void | Promise<void>;
+
+/**
+ * An object making up all necessary parts of a plugin loader and aggregator
+ */
+export interface PluginDefinition {
+  /**
+   * Named export to use
+   */
+  exportName: string;
+  /**
+   * Option name for Mocha constructor (use `exportName` if omitted)
+   */
+  optionName?: string;
+  /**
+   * Validator function
+   */
+  validate?: PluginValidator;
+  /**
+   * Finalizer/aggregator function
+   */
+  finalize?: PluginFinalizer;
+}
+
+/**
+ * A (sync) function to assert a user-supplied plugin implementation is valid.
+ *
+ * Defined in a {@link PluginDefinition}.
+
+ * @param value Value to check
+ * @this {PluginDefinition}
+ */
+export type PluginValidator = (this: PluginDefinition, value: unknown) => void;
+
+/**
+ * A function to finalize plugins implementations of a particular ilk
+ * @param implementations User-supplied implementations
+ */
+export type PluginFinalizer = (
+  implementations: unknown[]
+) => Promise<unknown> | unknown;
+
+/**
+ * An object to configure how Mocha gathers test files
+ */
+export interface FileCollectionOptions {
+  /** File extensions to use */
+  extension?: string[];
+  /** Files, dirs, globs to run */
+  spec?: string[];
+  /** Files, dirs, globs to ignore */
+  ignore?: string[];
+  /** List of additional files to include */
+  file?: string[];
+  /** Find files recursively */
+  recursive?: boolean;
+  /** Sort test files */
+  sort?: boolean;
+}
+
+/**
+ * Diagnostic object containing unmatched files
+ */
+export interface UnmatchedFile {
+  /** A list of unmatched files derived from the file arguments passed in */
+  absolutePath: string;
+  /** A list of unmatched files derived from the file arguments passed in */
+  pattern: string;
+}
+
+/**
+ * Response object containing a list of files to test and unmatched files.
+ */
+export interface FileCollectionResponse {
+  /** A list of files to test */
+  files: string[];
+  /** A list of unmatched files derived from the file arguments passed in */
+  unmatchedFiles: UnmatchedFile[];
+}
+
+/**
+ * @private
+ */
+export interface BeforeWatchRunOptions {
+  mocha: Mocha;
+  watcher: FSWatcher;
+}
+
+/**
+ * Callback to be run before `mocha.run()` is called.
+ * Optionally, it can return a new `Mocha` instance.
+ * @private
+ */
+export type BeforeWatchRun = (options: BeforeWatchRunOptions) => Mocha;
+
+/**
+ * Object containing run control methods
+ * @private
+ */
+export interface Rerunner {
+  /** Calls `mocha.run()` */
+  run: Function;
+  /** Schedules another call to `run */
+  scheduleRun: Function;
+}
+
+export interface StatsCollector {
+  /** integer count of suites run */
+  suites: number;
+
+  /** integer count of tests run */
+  tests: number;
+
+  /** integer count of passing tests */
+  passes: number;
+
+  /** integer count of pending tests */
+  pending: number;
+
+  /** integer count of failed tests */
+  failures: number;
+
+  /** time when testing began */
+  start: Date;
+
+  /** time when testing concluded */
+  end: Date;
+
+  /** number of msecs that testing took */
+  duration: number;
+}
+
+export interface PluginLoaderOptions {
+  /**
+   * Plugin definitions
+   */
+  pluginDefs?: PluginDefinition;
+
+  /**
+   * A list of plugins to ignore when loading
+   */
+  ignore?: string[];
+}
+
+/**
+ * @memberof module:lib/errors
+ */
+export interface MochaTimeoutError extends Error {
+  code: typeof constants.TIMEOUT;
+
+  /**
+   * Timeout in ms
+   */
+  timeout?: number;
+
+  /**
+   * Filepath, if given
+   */
+  file?: string;
+}
+
+/**
+ * The result of calling `SerializableEvent.serialize`, as received
+ * by the deserializer.
+ * @private
+ */
+export interface SerializedEvent {
+  /** Optional serialized data */
+  data?: object;
+
+  /** Optional serialized `Error` */
+  error?: Error;
+}
+
+/**
+ * The result of calling `SerializableWorkerResult.serialize` as received
+ * by the deserializer.
+ * @private
+ */
+export interface SerializedWorkerResult {
+  /** Number of failures */
+  failureCount: number;
+
+  /** Serialized events */
+  events: SerializedEvent[];
+
+  /** Symbol-like to denote the type of object this is */
+  __type: 'SerializedWorkerResult';
+}
+
+/**
+ * Listener function intended to be bound to `Process.SIGINT` event
+ * @private
+ */
+export type SigIntListener = () => Promise<void>;
+
+/**
+ * A function accepting a test file path and returning the results of a test run
+ * @private
+ * @param filename - File to run
+ */
+export type FileRunner = (filename: string) => Promise<SerializedWorkerResult>;
+
+/**
+ * Serializable event data from a `Runner`.  Keys of the `data` property
+ * beginning with `__` will be converted into a function which returns the value
+ * upon deserialization.
+ */
+export interface BufferedEvent {
+  /** Event name */
+  name: string;
+
+  /** Event parameters */
+  data: object;
+}
+
+/**
+ * An object with all stack traces recursively mounted from each err.cause
+ * @memberof module:lib/reporters/base
+ */
+export interface FullErrorStack {
+  message: string;
+  msg: string;
+  stack: string;
+}
+
+export interface Reporter {
+  new (runner: Runner, options: MochaOptions): Reporter;
+  done?: (failures: number, callback: () => void) => void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,10 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-multi-entry": "^4.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "^22.15.3",
+        "@types/workerpool": "^6.4.7",
+        "@types/yargs": "^17.0.33",
         "chai": "^4.3.4",
         "coffeescript": "^2.6.1",
         "cross-env": "^7.0.2",
@@ -82,6 +86,7 @@
         "rollup-plugin-polyfill-node": "^0.8.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "sinon": "^9.0.3",
+        "typescript": "^5.8.3",
         "unexpected": "^11.14.0",
         "unexpected-eventemitter": "^2.2.0",
         "unexpected-map": "^2.0.0",
@@ -1684,10 +1689,11 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
-      "integrity": "sha512-EMpxUyystd3uZVByZap1DACsMXvb82ypQnGn89e1Y0a+LYu3JJscUd/gqhRsVFDkaD2MIiWo0MT8EfXr3DGRKw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -1704,10 +1710,11 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "8.1.0",
@@ -1718,12 +1725,6 @@
         "@types/minimatch": "^5.1.2",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/glob/node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
@@ -1778,10 +1779,11 @@
       "dev": true
     },
     "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -1790,10 +1792,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-      "dev": true
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -1837,6 +1843,33 @@
       "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
       "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
       "dev": true
+    },
+    "node_modules/@types/workerpool": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.7.tgz",
+      "integrity": "sha512-DI2U4obcMzFViyNjLw0xXspim++qkAJ4BWRdYPVMMFtOpTvMr6PAk3UTZEoSqnZnvgUkJ3ck97Ybk+iIfuJHMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.2",
@@ -1907,6 +1940,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@wdio/config/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@wdio/config/node_modules/@wdio/types": {
       "version": "7.33.0",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -1966,6 +2009,13 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/@wdio/config/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/logger": {
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.26.0.tgz",
@@ -2016,6 +2066,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@wdio/utils/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@wdio/utils/node_modules/@wdio/types": {
       "version": "7.33.0",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -2053,6 +2113,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/@wdio/utils/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -5177,6 +5244,16 @@
       "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==",
       "dev": true
     },
+    "node_modules/devtools/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/devtools/node_modules/@wdio/types": {
       "version": "7.33.0",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -5369,6 +5446,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/devtools/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/devtools/node_modules/uuid": {
       "version": "9.0.1",
@@ -11094,6 +11178,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/multimatch/node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/multimatch/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -15219,12 +15310,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15316,6 +15406,13 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unexpected": {
       "version": "11.15.1",
@@ -15786,6 +15883,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/webdriver/node_modules/@wdio/types": {
       "version": "7.33.0",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -15824,6 +15931,13 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/webdriver/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webdriverio": {
       "version": "7.33.0",
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.33.0.tgz",
@@ -15860,6 +15974,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/types": {
@@ -15955,6 +16079,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/webdriverio/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webpack": {
       "version": "5.76.1",
@@ -16080,12 +16211,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/webpack/node_modules/@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -17450,7 +17575,7 @@
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
+        "@types/estree": "^1.0.7",
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
       },
@@ -17600,12 +17725,12 @@
       }
     },
     "@types/eslint": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
-      "integrity": "sha512-EMpxUyystd3uZVByZap1DACsMXvb82ypQnGn89e1Y0a+LYu3JJscUd/gqhRsVFDkaD2MIiWo0MT8EfXr3DGRKw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
+        "@types/estree": "^1.0.7",
         "@types/json-schema": "*"
       }
     },
@@ -17615,14 +17740,14 @@
       "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
       "requires": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
+        "@types/eslint": "^9.6.1",
+        "@types/estree": "^1.0.7"
       }
     },
     "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true
     },
     "@types/glob": {
@@ -17633,14 +17758,6 @@
       "requires": {
         "@types/minimatch": "^5.1.2",
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-          "dev": true
-        }
       }
     },
     "@types/http-cache-semantics": {
@@ -17696,9 +17813,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "@types/ms": {
@@ -17708,10 +17825,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-      "dev": true
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.4",
@@ -17753,6 +17873,30 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
       "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+      "dev": true
+    },
+    "@types/workerpool": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.7.tgz",
+      "integrity": "sha512-DI2U4obcMzFViyNjLw0xXspim++qkAJ4BWRdYPVMMFtOpTvMr6PAk3UTZEoSqnZnvgUkJ3ck97Ybk+iIfuJHMg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
     "@types/yauzl": {
@@ -17809,6 +17953,15 @@
         "glob": "^8.0.3"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.87",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+          "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@wdio/types": {
           "version": "7.33.0",
           "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -17839,6 +17992,12 @@
           "dev": true,
           "optional": true,
           "peer": true
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+          "dev": true
         }
       }
     },
@@ -17880,6 +18039,15 @@
         "p-iteration": "^1.1.8"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.87",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+          "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@wdio/types": {
           "version": "7.33.0",
           "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -17897,6 +18065,12 @@
           "dev": true,
           "optional": true,
           "peer": true
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+          "dev": true
         }
       }
     },
@@ -20436,6 +20610,15 @@
         "uuid": "^9.0.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.87",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+          "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@wdio/types": {
           "version": "7.33.0",
           "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -20565,6 +20748,12 @@
           "dev": true,
           "optional": true,
           "peer": true
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+          "dev": true
         },
         "uuid": {
           "version": "9.0.1",
@@ -22703,7 +22892,7 @@
       "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "*"
+        "@types/estree": "^1.0.7"
       }
     },
     "is-regex": {
@@ -24790,6 +24979,12 @@
         "minimatch": "^3.0.4"
       },
       "dependencies": {
+        "@types/minimatch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+          "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+          "dev": true
+        },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -28030,11 +28225,10 @@
       }
     },
     "typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
-      "peer": true
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "1.0.34",
@@ -28087,6 +28281,12 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unexpected": {
@@ -28448,6 +28648,15 @@
         "lodash.merge": "^4.6.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.87",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+          "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@wdio/types": {
           "version": "7.33.0",
           "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -28465,6 +28674,12 @@
           "dev": true,
           "optional": true,
           "peer": true
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+          "dev": true
         }
       }
     },
@@ -28503,6 +28718,15 @@
         "webdriver": "7.33.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.87",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+          "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@wdio/types": {
           "version": "7.33.0",
           "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.33.0.tgz",
@@ -28555,6 +28779,12 @@
           "dev": true,
           "optional": true,
           "peer": true
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+          "dev": true
         }
       }
     },
@@ -28565,7 +28795,7 @@
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
+        "@types/estree": "^1.0.7",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -28588,14 +28818,6 @@
         "terser-webpack-plugin": "^5.1.3",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.51",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-          "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-          "dev": true
-        }
       }
     },
     "webpack-cli": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "test-node": "run-s test-coverage-clean test-node:* test-coverage-generate",
     "test-smoke": "node ./bin/mocha --no-config test/smoke/smoke.spec.js",
     "test": "run-s lint test-node test-browser",
+    "tsc": "tsc",
     "version:linkify-changelog": "node scripts/linkify-changelog.mjs",
     "version:update-authors": "node scripts/update-authors.js",
     "version": "run-p version:* && git add -A ./AUTHORS ./CHANGELOG.md"
@@ -125,6 +126,10 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
+    "@types/minimatch": "^5.1.2",
+    "@types/node": "^22.15.3",
+    "@types/workerpool": "^6.4.7",
+    "@types/yargs": "^17.0.33",
     "chai": "^4.3.4",
     "coffeescript": "^2.6.1",
     "cross-env": "^7.0.2",
@@ -163,6 +168,7 @@
     "rollup-plugin-polyfill-node": "^0.8.0",
     "rollup-plugin-visualizer": "^5.6.0",
     "sinon": "^9.0.3",
+    "typescript": "^5.8.3",
     "unexpected": "^11.14.0",
     "unexpected-eventemitter": "^2.2.0",
     "unexpected-map": "^2.0.0",
@@ -203,6 +209,8 @@
     "trailingComma": "none"
   },
   "overrides": {
+    "@types/eslint": "^9.6.1",
+    "@types/estree": "^1.0.7",
     "webdriverio": "^7.33.0"
   }
 }

--- a/test/integration/multiple-done.spec.js
+++ b/test/integration/multiple-done.spec.js
@@ -2,7 +2,7 @@
 
 var runMochaJSON = require('./helpers').runMochaJSON;
 var invokeMocha = require('./helpers').invokeMocha;
-var MULTIPLE_DONE = require('../../lib/errors').constants.MULTIPLE_DONE;
+var MULTIPLE_DONE = require('../../lib/error-constants').constants.MULTIPLE_DONE;
 
 describe('multiple calls to done()', function () {
   var res;

--- a/test/unit/plugin-loader.spec.js
+++ b/test/unit/plugin-loader.spec.js
@@ -3,7 +3,7 @@
 const PluginLoader = require('../../lib/plugin-loader');
 const sinon = require('sinon');
 const {INVALID_PLUGIN_DEFINITION, INVALID_PLUGIN_IMPLEMENTATION} =
-  require('../../lib/errors').constants;
+  require('../../lib/error-constants').constants;
 
 describe('plugin module', function () {
   describe('class PluginLoader', function () {

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -4,7 +4,7 @@ var Mocha = require('../../lib/mocha');
 var Runnable = Mocha.Runnable;
 var Suite = Mocha.Suite;
 var sinon = require('sinon');
-const {TIMEOUT} = require('../../lib/errors').constants;
+const {TIMEOUT} = require('../../lib/error-constants').constants;
 var STATE_FAILED = Runnable.constants.STATE_FAILED;
 
 describe('Runnable(title, fn)', function () {

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -7,7 +7,7 @@ const Pending = require('../../lib/pending');
 const {Suite, Runner, Test, Hook, Runnable} = Mocha;
 const {noop} = Mocha.utils;
 const {FATAL, MULTIPLE_DONE, UNSUPPORTED} =
-  require('../../lib/errors').constants;
+  require('../../lib/error-constants').constants;
 
 const {
   EVENT_HOOK_BEGIN,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "module": "Node16",
+    "resolveJsonModule": true,
+    "target": "ES2022",
+    "noEmit": true
+  },
+  "exclude": ["lib/browser"],
+  "include": ["lib"]
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5347
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Creates a new `lib/types.d.ts` and moves every `@callback` and `@typedef {Object}` to it. A new `tsconfig.json` & `tsc` script can be run to verify that the types in that file can be type checked.

Does not yet validate types in `.js` files (#4154, #4228). You can preview those by switching `tsconfig.json`'s `allowJs` to `checkJs`. I made sure there are no more _"`Cannot find name ...`"_ errors but fixing the rest of the ~650+ will be a lot more work. Much of the code will be much easier to get type-safe when it's ported from manual function prototypes to classes (#5025).  I also held off porting all the info from `@types/mocha` there to keep the changes minimal.

Moves error constants from `errors.js` to `error-constants.js` to avoid circular dependency errors.