### PR TITLE
docs: mention explicit browser support range

### DIFF
--- a/docs-next/src/content/docs/running/browsers.mdx
+++ b/docs-next/src/content/docs/running/browsers.mdx
@@ -37,13 +37,13 @@ A typical setup might look something like the following, where we call `mocha.se
 </html>
 ```
 
-Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js version was released.
-As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.18.0](https://nodejs.org/en/blog/release/v18.18.0)'s release on September 18, 2023:
+Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js major version was released.
+As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.10.0](https://nodejs.org/en/blog/release/v18.0.0)'s release on April 19, 2022:
 
-- [Chrome 117](https://developer.chrome.com/blog/new-in-chrome-117)
-- [Edge 117](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1170204531-september-15-2023)
-- [Firefox 117](https://www.mozilla.org/en-US/firefox/117.0/releasenotes)
-- [Safari 17](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes)
+- [Chrome 100](https://developer.chrome.com/blog/new-in-chrome-100)
+- [Edge 100](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118544-april-15)
+- [Firefox 99](https://www.mozilla.org/en-US/firefox/99.0/releasenotes)
+- [Safari 15.4](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)
 
 ## Grep
 

--- a/docs-next/src/content/docs/running/browsers.mdx
+++ b/docs-next/src/content/docs/running/browsers.mdx
@@ -37,6 +37,14 @@ A typical setup might look something like the following, where we call `mocha.se
 </html>
 ```
 
+Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js version was released.
+As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.18.0](https://nodejs.org/en/blog/release/v18.18.0)'s release on September 18, 2023:
+
+- [Chrome 117](https://developer.chrome.com/blog/new-in-chrome-117)
+- [Edge 117](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1170204531-september-15-2023)
+- [Firefox 117](https://www.mozilla.org/en-US/firefox/117.0/releasenotes)
+- [Safari 17](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes)
+
 ## Grep
 
 The browser may use the `--grep` as functionality.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2158,13 +2158,13 @@ A typical setup might look something like the following, where we call `mocha.se
 </html>
 ```
 
-Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js version was released.
-As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.18.0](https://nodejs.org/en/blog/release/v18.18.0)'s release on September 18, 2023:
+Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js major version was released.
+As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.10.0](https://nodejs.org/en/blog/release/v18.0.0)'s release on April 19, 2022:
 
-- [Chrome 117](https://developer.chrome.com/blog/new-in-chrome-117)
-- [Edge 117](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1170204531-september-15-2023)
-- [Firefox 117](https://www.mozilla.org/en-US/firefox/117.0/releasenotes)
-- [Safari 17](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes)
+- [Chrome 100](https://developer.chrome.com/blog/new-in-chrome-100)
+- [Edge 100](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118544-april-15)
+- [Firefox 99](https://www.mozilla.org/en-US/firefox/99.0/releasenotes)
+- [Safari 15.4](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)
 
 ### Grep
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2158,6 +2158,14 @@ A typical setup might look something like the following, where we call `mocha.se
 </html>
 ```
 
+Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js version was released.
+As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.18.0](https://nodejs.org/en/blog/release/v18.18.0)'s release on September 18, 2023:
+
+- [Chrome 117](https://developer.chrome.com/blog/new-in-chrome-117)
+- [Edge 117](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1170204531-september-15-2023)
+- [Firefox 117](https://www.mozilla.org/en-US/firefox/117.0/releasenotes)
+- [Safari 17](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes)
+
 ### Grep
 
 The browser may use the `--grep` as functionality. Append a query-string to your URL: `?grep=api`.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5226
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Goes with the same version support range strategy as https://github.com/mochajs/mocha/issues/5226#issuecomment-2445026404: the major versions of evergreen browsers as of the oldest supported Node.js.