### PR TITLE
feat: use require to load esm

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,7 +61,8 @@ module.exports = [
       'lib/nodejs/esm-utils.js',
       'rollup.config.js',
       'scripts/*.mjs',
-      'scripts/pick-from-package-json.js'
+      'scripts/pick-from-package-json.js',
+      'test/compiler-cjs/test.js'
     ],
     languageOptions: {
       sourceType: 'module'

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -34,7 +34,11 @@ const formattedImport = async (file, esmDecorator = forward) => {
 
 exports.doImport = async file => import(file);
 
-exports.requireOrImport = async (file, esmDecorator) => {
+// When require(esm) is not available, we need to use `import()` to load ESM modules.
+// In this case, CJS modules are loaded using `import()` as well. When Node.js' builtin
+// TypeScript support is enabled, `.ts` files are also loaded using `import()`, and
+// compilers based on `require.extensions` are omitted.
+const tryImportAndRequire = async (file, esmDecorator) => {
   if (path.extname(file) === '.mjs') {
     return formattedImport(file, esmDecorator);
   }
@@ -80,6 +84,30 @@ exports.requireOrImport = async (file, esmDecorator) => {
     }
   }
 };
+
+// Utilize Node.js' require(esm) feature to load ESM modules
+// and CJS modules. This keeps the require() features like `require.extensions`
+// and `require.cache` effective, while allowing us to load ESM modules
+// and CJS modules in the same way.
+const requireModule = async (file, esmDecorator) => {
+  try {
+    return require(file);
+  } catch (err) {
+    if (
+      err.code === 'ERR_REQUIRE_ASYNC_MODULE'
+    ) {
+      // Import if the module is async.
+      return formattedImport(file, esmDecorator);
+    }
+    throw err;
+  }
+}
+
+if (process.features.require_module) {
+  exports.requireOrImport = requireModule;
+} else {
+  exports.requireOrImport = tryImportAndRequire;
+}
 
 function dealWithExports(module) {
   if (module.default) {

--- a/test/compiler-cjs/test.js
+++ b/test/compiler-cjs/test.js
@@ -1,0 +1,9 @@
+const obj = { foo: 'bar' };
+
+describe('cjs written in esm', () => {
+  it('should work', () => {
+    expect(obj, 'to equal', { foo: 'bar' });
+  });
+});
+
+export const foo = 'bar';

--- a/test/compiler-cjs/test.js.compiled
+++ b/test/compiler-cjs/test.js.compiled
@@ -1,0 +1,9 @@
+const obj = { foo: 'bar' };
+
+describe('cjs written in esm', () => {
+  it('should work', () => {
+    expect(obj, 'to equal', { foo: 'bar' });
+  });
+});
+
+module.exports.foo = 'bar';

--- a/test/compiler-cjs/test.ts
+++ b/test/compiler-cjs/test.ts
@@ -1,0 +1,9 @@
+const obj: unknown = { foo: 'bar' };
+
+describe('cts written in esm', () => {
+  it('should work', () => {
+    expect(obj, 'to equal', { foo: 'bar' });
+  });
+});
+
+export const foo = 'bar';

--- a/test/compiler-cjs/test.ts.compiled
+++ b/test/compiler-cjs/test.ts.compiled
@@ -1,0 +1,9 @@
+const obj = { foo: 'bar' };
+
+describe('cts written in esm', () => {
+  it('should work', () => {
+    expect(obj, 'to equal', { foo: 'bar' });
+  });
+});
+
+module.exports.foo = 'bar';

--- a/test/compiler-fixtures/js.fixture.js
+++ b/test/compiler-fixtures/js.fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const fs = require('fs');
+
+const original = require.extensions['.js'];
+require.extensions['.js'] = function (module, filename) {
+  if (!filename.includes('compiler-cjs')) {
+    return original(module, filename);
+  }
+  const content = fs.readFileSync(filename + '.compiled', 'utf8');
+  return module._compile(content, filename);
+};

--- a/test/compiler-fixtures/ts.fixture.js
+++ b/test/compiler-fixtures/ts.fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const fs = require('fs');
+
+require.extensions['.ts'] = function (module, filename) {
+  const content = fs.readFileSync(filename + '.compiled', 'utf8');
+  return module._compile(content, filename);
+};

--- a/test/integration/compiler-cjs.spec.js
+++ b/test/integration/compiler-cjs.spec.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var exec = require('node:child_process').exec;
+var path = require('node:path');
+
+describe('support CJS require.extension compilers with esm syntax', function () {
+  it('should support .js extension', function (done) {
+    exec(
+      '"' +
+        process.execPath +
+        '" "' +
+        path.join('bin', 'mocha') +
+        '" -R json --require test/compiler-fixtures/js.fixture "test/compiler-cjs/*.js"',
+      {cwd: path.join(__dirname, '..', '..')},
+      function (error, stdout) {
+        if (error && !stdout) {
+          return done(error);
+        }
+        var results = JSON.parse(stdout);
+        expect(results, 'to have property', 'tests');
+        var titles = [];
+        for (var index = 0; index < results.tests.length; index += 1) {
+          expect(results.tests[index], 'to have property', 'fullTitle');
+          titles.push(results.tests[index].fullTitle);
+        }
+        expect(
+          titles,
+          'to contain',
+          'cjs written in esm should work',
+        ).and('to have length', 1);
+        done();
+      }
+    );
+  });
+
+  it('should support .ts extension', function (done) {
+    exec(
+      '"' +
+        process.execPath +
+        '" "' +
+        path.join('bin', 'mocha') +
+        '" -R json --require test/compiler-fixtures/ts.fixture "test/compiler-cjs/*.ts"',
+      {cwd: path.join(__dirname, '..', '..')},
+      function (error, stdout) {
+        if (error && !stdout) {
+          return done(error);
+        }
+        var results = JSON.parse(stdout);
+        expect(results, 'to have property', 'tests');
+        var titles = [];
+        for (var index = 0; index < results.tests.length; index += 1) {
+          expect(results.tests[index], 'to have property', 'fullTitle');
+          titles.push(results.tests[index].fullTitle);
+        }
+        expect(
+          titles,
+          'to contain',
+          'cts written in esm should work',
+        ).and('to have length', 1);
+        done();
+      }
+    );
+  });
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5314, fixes #5317
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This allows compilers based on `require.extensions` continue to work, like `ts-node` with Node.js built-in TypeScript support enabled.

Hopefully unblock https://github.com/nodejs/node/pull/57298.

Fixes: https://github.com/mochajs/mocha/issues/5314
Fixes: https://github.com/mochajs/mocha/issues/5317