### PR TITLE
Fix: watching files outside cwd

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -207,7 +207,7 @@ const createWatcher = (
   const tracker = new GlobFilesTracker(watchFiles, watchIgnore);
   tracker.regenerate();
 
-  const watcher = chokidar.watch('.', {
+  const watcher = chokidar.watch(watchFiles, {
     ignoreInitial: true
   });
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5355
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) (note that I was the one that added that tag!)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In #5256 we changed the watched path from `watchFiles` to `.` (cwd). Nobody commented on this, and it broke this behavior. Reverting that line fixes the reported issue in the provided repro
