### PR TITLE
feat!: detect illegally nested tests

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -3,6 +3,8 @@
 var Test = require('../test');
 var EVENT_FILE_PRE_REQUIRE =
   require('../suite').constants.EVENT_FILE_PRE_REQUIRE;
+var errors = require('../errors');
+var createUnsupportedError = errors.createUnsupportedError;
 
 /**
  * BDD-style interface:
@@ -84,6 +86,18 @@ module.exports = function bddInterface(suite) {
       if (suite.isPending()) {
         fn = null;
       }
+
+      // Check for nested test registration
+      if (global._mochaExecutionState && global._mochaExecutionState.currentRunnable) {
+        var currentRunnable = global._mochaExecutionState.currentRunnable;
+        if (currentRunnable.type === 'test') {
+          throw createUnsupportedError(
+            'Nested test "' + title + '" detected inside test "' + currentRunnable.title + '". ' +
+            'Nested tests are not allowed.'
+          );
+        }
+      }
+
       var test = new Test(title, fn);
       test.file = file;
       suite.addTest(test);

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -87,13 +87,7 @@ module.exports = function bddInterface(suite) {
         fn = null;
       }
 
-      // Check for nested test registration
-      var currentRunnable = suite.rootSuite().currentRunnable;
-      if (currentRunnable) {
-        throw createUnsupportedError(
-          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '".'
-        );
-      }
+      common.checkForNestedTest(suite, title);
 
       var test = new Test(title, fn);
       test.file = file;

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -88,14 +88,11 @@ module.exports = function bddInterface(suite) {
       }
 
       // Check for nested test registration
-      if (global._mochaExecutionState && global._mochaExecutionState.currentRunnable) {
-        var currentRunnable = global._mochaExecutionState.currentRunnable;
-        if (currentRunnable.type === 'test') {
-          throw createUnsupportedError(
-            'Nested test "' + title + '" detected inside test "' + currentRunnable.title + '". ' +
-            'Nested tests are not allowed.'
-          );
-        }
+      var currentRunnable = suite.rootSuite().currentRunnable;
+      if (currentRunnable) {
+        throw createUnsupportedError(
+          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '". '
+        );
       }
 
       var test = new Test(title, fn);

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -91,7 +91,7 @@ module.exports = function bddInterface(suite) {
       var currentRunnable = suite.rootSuite().currentRunnable;
       if (currentRunnable) {
         throw createUnsupportedError(
-          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '". '
+          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '".'
         );
       }
 

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -51,6 +51,22 @@ module.exports = function (suites, context, mocha) {
     },
 
     /**
+     * Check for nested test registration.
+     *
+     * @param {Suite} suite The suite to which a test is being added.
+     * @param {string} title The title of the test being added.
+     */
+    checkForNestedTest: function checkForNestedTests(suite, title) {
+      // Check for nested test registration
+      var currentRunnable = suite.rootSuite().currentRunnable;
+      if (currentRunnable) {
+        throw createUnsupportedError(
+          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '".'
+        );
+      }
+    },
+
+    /**
      * Execute before running tests.
      *
      * @param {string} name

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -56,8 +56,7 @@ module.exports = function (suites, context, mocha) {
      * @param {Suite} suite The suite to which a test is being added.
      * @param {string} title The title of the test being added.
      */
-    checkForNestedTest: function checkForNestedTests(suite, title) {
-      // Check for nested test registration
+    checkForNestedTest: function checkForNestedTest(suite, title) {
       var currentRunnable = suite.rootSuite().currentRunnable;
       if (currentRunnable) {
         throw createUnsupportedError(

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -3,6 +3,8 @@
 var Test = require('../test');
 var EVENT_FILE_PRE_REQUIRE =
   require('../suite').constants.EVENT_FILE_PRE_REQUIRE;
+var errors = require('../errors');
+var createUnsupportedError = errors.createUnsupportedError;
 
 /**
  * TDD-style interface:
@@ -84,6 +86,18 @@ module.exports = function (suite) {
       if (suite.isPending()) {
         fn = null;
       }
+
+      // Check for nested test registration
+      if (global._mochaExecutionState && global._mochaExecutionState.currentRunnable) {
+        var currentRunnable = global._mochaExecutionState.currentRunnable;
+        if (currentRunnable.type === 'test') {
+          throw createUnsupportedError(
+            'Nested test "' + title + '" detected inside test "' + currentRunnable.title + '". ' +
+            'Nested tests are not allowed.'
+          );
+        }
+      }
+
       var test = new Test(title, fn);
       test.file = file;
       suite.addTest(test);

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -87,13 +87,7 @@ module.exports = function (suite) {
         fn = null;
       }
 
-      // Check for nested test registration
-      var currentRunnable = suite.rootSuite().currentRunnable;
-      if (currentRunnable) {
-        throw createUnsupportedError(
-          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '".'
-        );
-      }
+      common.checkForNestedTest(suite, title);
 
       var test = new Test(title, fn);
       test.file = file;

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -88,14 +88,11 @@ module.exports = function (suite) {
       }
 
       // Check for nested test registration
-      if (global._mochaExecutionState && global._mochaExecutionState.currentRunnable) {
-        var currentRunnable = global._mochaExecutionState.currentRunnable;
-        if (currentRunnable.type === 'test') {
-          throw createUnsupportedError(
-            'Nested test "' + title + '" detected inside test "' + currentRunnable.title + '". ' +
-            'Nested tests are not allowed.'
-          );
-        }
+      var currentRunnable = suite.rootSuite().currentRunnable;
+      if (currentRunnable) {
+        throw createUnsupportedError(
+          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '". '
+        );
       }
 
       var test = new Test(title, fn);

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -91,7 +91,7 @@ module.exports = function (suite) {
       var currentRunnable = suite.rootSuite().currentRunnable;
       if (currentRunnable) {
         throw createUnsupportedError(
-          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '". '
+          'Nested test "' + title + '" detected inside "' + currentRunnable.title + '".'
         );
       }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -191,12 +191,6 @@ class Runner extends EventEmitter {
     this.total = suite.total();
     this.failures = 0;
 
-    // Initialize global execution state tracking for nested test detection
-    if (!global._mochaExecutionState) {
-      global._mochaExecutionState = {
-        currentRunnable: null
-      };
-    }
     /**
      * @type {Map<EventEmitter,Map<string,Set<EventListener>>>}
      */
@@ -207,11 +201,9 @@ class Runner extends EventEmitter {
           test.parent.tests && test.parent.tests.indexOf(test.retriedTest());
         if (idx > -1) test.parent.tests[idx] = test;
       }
+      // Clear current runnable for nested test detection when test ends
+      self.suite.rootSuite().currentRunnable = null;
       self.checkGlobals(test);
-      // Clear execution state when test ends
-      if (global._mochaExecutionState) {
-        global._mochaExecutionState.currentRunnable = null;
-      }
     });
     this.on(constants.EVENT_HOOK_END, function (hook) {
       self.checkGlobals(hook);
@@ -534,7 +526,8 @@ Runner.prototype.hook = function (name, fn) {
       return fn();
     }
     self.currentRunnable = hook;
-    global._mochaExecutionState.currentRunnable = hook;
+    // Store current runnable on root suite for nested test detection
+    self.suite.rootSuite().currentRunnable = hook;
 
     if (name === HOOK_TYPE_BEFORE_ALL) {
       hook.ctx.currentTest = hook.parent.tests[0];
@@ -847,7 +840,8 @@ Runner.prototype.runTests = function (suite, fn) {
         return hookErr(err, errSuite, false);
       }
       self.currentRunnable = self.test;
-      global._mochaExecutionState.currentRunnable = self.test;
+      // Store current runnable on root suite for nested test detection
+      self.suite.rootSuite().currentRunnable = self.test;
       self.runTest(function (err) {
         test = self.test;
         // conditional skip within it

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -190,6 +190,13 @@ class Runner extends EventEmitter {
     this.state = constants.STATE_IDLE;
     this.total = suite.total();
     this.failures = 0;
+
+    // Initialize global execution state tracking for nested test detection
+    if (!global._mochaExecutionState) {
+      global._mochaExecutionState = {
+        currentRunnable: null
+      };
+    }
     /**
      * @type {Map<EventEmitter,Map<string,Set<EventListener>>>}
      */
@@ -201,6 +208,10 @@ class Runner extends EventEmitter {
         if (idx > -1) test.parent.tests[idx] = test;
       }
       self.checkGlobals(test);
+      // Clear execution state when test ends
+      if (global._mochaExecutionState) {
+        global._mochaExecutionState.currentRunnable = null;
+      }
     });
     this.on(constants.EVENT_HOOK_END, function (hook) {
       self.checkGlobals(hook);
@@ -523,6 +534,7 @@ Runner.prototype.hook = function (name, fn) {
       return fn();
     }
     self.currentRunnable = hook;
+    global._mochaExecutionState.currentRunnable = hook;
 
     if (name === HOOK_TYPE_BEFORE_ALL) {
       hook.ctx.currentTest = hook.parent.tests[0];
@@ -835,6 +847,7 @@ Runner.prototype.runTests = function (suite, fn) {
         return hookErr(err, errSuite, false);
       }
       self.currentRunnable = self.test;
+      global._mochaExecutionState.currentRunnable = self.test;
       self.runTest(function (err) {
         test = self.test;
         // conditional skip within it

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -401,6 +401,21 @@ Suite.prototype.titlePath = function () {
 };
 
 /**
+ * Return the root suite by traversing up the parent chain.
+ *
+ * @memberof Suite
+ * @public
+ * @return {Suite}
+ */
+Suite.prototype.rootSuite = function () {
+  var suite = this;
+  while (suite.parent) {
+    suite = suite.parent;
+  }
+  return suite;
+};
+
+/**
  * Return the total number of tests.
  *
  * @memberof Suite

--- a/test/integration/fixtures/nested-tests/bdd-async-nested.fixture.js
+++ b/test/integration/fixtures/nested-tests/bdd-async-nested.fixture.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// BDD async nested test fixtures - should fail with nested test errors
+describe('Async Nested Tests', function() {
+  it('sync nested test', function() {
+    it('nested in sync', function() {
+      // Should fail immediately
+    });
+  });
+
+  it('callback nested test', function(done) {
+    setTimeout(function() {
+      it('nested in callback', function() {
+        // Should fail with uncaught error
+      });
+      done();
+    }, 10);
+  });
+
+  it('promise nested test', function() {
+    return new Promise(function(resolve) {
+      setTimeout(function() {
+        it('nested in promise', function() {
+          // Should fail with uncaught error
+        });
+        resolve();
+      }, 10);
+    });
+  });
+
+  it('async/await nested test', async function() {
+    await new Promise(resolve => setTimeout(resolve, 10));
+    it('nested in async', function() {
+      // Should fail
+    });
+  });
+});

--- a/test/integration/fixtures/nested-tests/bdd-hook-nested.fixture.js
+++ b/test/integration/fixtures/nested-tests/bdd-hook-nested.fixture.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// BDD hook nested test fixture - should fail with nested test error
+describe('Hook Nested Test Suite', function() {
+  before(function() {
+    // This should fail due to nested test inside hook
+    it('nested test in before hook', function() {
+      // This nested test should cause an error
+    });
+  });
+
+  it('normal test', function() {
+    // This should pass if no hook error
+  });
+});

--- a/test/integration/fixtures/nested-tests/bdd-nested.fixture.js
+++ b/test/integration/fixtures/nested-tests/bdd-nested.fixture.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// BDD nested test fixture - should fail with nested test error
+describe('Parent Suite', function() {
+  it('normal test', function() {
+    // This should pass
+  });
+
+  it('outer test with nested test', function() {
+    // This should fail due to nested test
+    it('inner nested test', function() {
+      // This nested test should cause an error
+    });
+  });
+
+  it('another normal test', function() {
+    // This should not run due to previous failure
+  });
+});

--- a/test/integration/fixtures/nested-tests/tdd-nested.fixture.js
+++ b/test/integration/fixtures/nested-tests/tdd-nested.fixture.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// TDD nested test fixture - should fail with nested test error
+suite('Parent Suite', function() {
+  test('normal test', function() {
+    // This should pass
+  });
+
+  test('outer test with nested test', function() {
+    // This should fail due to nested test
+    test('inner nested test', function() {
+      // This nested test should cause an error
+    });
+  });
+
+  test('another normal test', function() {
+    // This should not run due to previous failure
+  });
+});

--- a/test/integration/nested-tests.spec.js
+++ b/test/integration/nested-tests.spec.js
@@ -1,0 +1,171 @@
+'use strict';
+
+var path = require('node:path').posix;
+var helpers = require('./helpers');
+var runMocha = helpers.runMocha;
+var runMochaJSON = helpers.runMochaJSON;
+
+describe('nested test detection', function () {
+  var nestedTestErrorMessage = 'Nested tests are not allowed';
+
+  describe('BDD interface', function () {
+    it('should fail when nested tests are detected', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /inner nested test.*detected inside test.*outer test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+
+    it('should report correct test counts when nested tests fail', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-nested');
+      runMochaJSON(fixture, ['--ui', 'bdd'], function (err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, 'to have failed')
+          .and('to have passed test count', 2)  // 'normal test' and 'another normal test' should pass
+          .and('to have failed test count', 1); // 'outer test with nested test' should fail
+        done();
+      });
+    });
+  });
+
+  describe('TDD interface', function () {
+    it('should fail when nested tests are detected', function (done) {
+      var fixture = path.join('nested-tests', 'tdd-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'tdd'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /inner nested test.*detected inside test.*outer test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+
+    it('should report correct test counts when nested tests fail', function (done) {
+      var fixture = path.join('nested-tests', 'tdd-nested');
+      runMochaJSON(fixture, ['--ui', 'tdd'], function (err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, 'to have failed')
+          .and('to have passed test count', 2)  // 'normal test' and 'another normal test' should pass
+          .and('to have failed test count', 1); // 'outer test with nested test' should fail
+        done();
+      });
+    });
+  });
+
+  describe('async nested tests', function () {
+    it('should handle synchronous nested tests', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-async-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd', '--grep', 'sync nested test'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /nested in sync.*detected inside test.*sync nested test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+
+    it('should handle async/await nested tests', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-async-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd', '--grep', 'async/await nested test'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /nested in async.*detected inside test.*async\/await nested test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+
+    it('should handle callback-based nested tests as uncaught errors', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-async-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd', '--grep', 'callback nested test'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /Uncaught.*nested in callback.*detected inside test.*callback nested test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+
+    it('should handle promise-based nested tests as uncaught errors', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-async-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd', '--grep', 'promise nested test'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /Uncaught.*nested in promise.*detected inside test.*promise nested test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+  });
+
+  describe('error details', function () {
+    it('should provide helpful error messages with test names', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', /Error: Nested test "inner nested test"/);
+          expect(res, 'to have failed with output', /detected inside test "outer test with nested test"/);
+          expect(res, 'to have failed with output', /createUnsupportedError/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+  });
+});

--- a/test/integration/nested-tests.spec.js
+++ b/test/integration/nested-tests.spec.js
@@ -6,7 +6,7 @@ var runMocha = helpers.runMocha;
 var runMochaJSON = helpers.runMochaJSON;
 
 describe('nested test detection', function () {
-  var nestedTestErrorMessage = 'Nested tests are not allowed';
+  var nestedTestErrorMessage = 'Nested test ".*" detected inside';
 
   describe('BDD interface', function () {
     it('should fail when nested tests are detected', function (done) {
@@ -20,7 +20,7 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
-          expect(res, 'to have failed with output', /inner nested test.*detected inside test.*outer test/);
+          expect(res, 'to have failed with output', /inner nested test.*detected inside.*outer test/);
           done();
         },
         spawnOpts
@@ -53,7 +53,7 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
-          expect(res, 'to have failed with output', /inner nested test.*detected inside test.*outer test/);
+          expect(res, 'to have failed with output', /inner nested test.*detected inside.*outer test/);
           done();
         },
         spawnOpts
@@ -86,7 +86,7 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
-          expect(res, 'to have failed with output', /nested in sync.*detected inside test.*sync nested test/);
+          expect(res, 'to have failed with output', /nested in sync.*detected inside.*sync nested test/);
           done();
         },
         spawnOpts
@@ -104,7 +104,7 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
-          expect(res, 'to have failed with output', /nested in async.*detected inside test.*async\/await nested test/);
+          expect(res, 'to have failed with output', /nested in async.*detected inside.*async\/await nested test/);
           done();
         },
         spawnOpts
@@ -122,7 +122,7 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
-          expect(res, 'to have failed with output', /Uncaught.*nested in callback.*detected inside test.*callback nested test/);
+          expect(res, 'to have failed with output', /Uncaught.*nested in callback.*detected inside.*callback nested test/);
           done();
         },
         spawnOpts
@@ -140,7 +140,27 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
-          expect(res, 'to have failed with output', /Uncaught.*nested in promise.*detected inside test.*promise nested test/);
+          expect(res, 'to have failed with output', /Uncaught.*nested in promise.*detected inside.*promise nested test/);
+          done();
+        },
+        spawnOpts
+      );
+    });
+  });
+
+  describe('hook nested tests', function () {
+    it('should fail when nested tests are detected inside hooks', function (done) {
+      var fixture = path.join('nested-tests', 'bdd-hook-nested');
+      var spawnOpts = {stdio: 'pipe'};
+      runMocha(
+        fixture,
+        ['--ui', 'bdd'],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, 'to have failed with output', new RegExp(nestedTestErrorMessage));
+          expect(res, 'to have failed with output', /nested test in before hook.*detected inside.*"before all" hook/);
           done();
         },
         spawnOpts
@@ -160,7 +180,7 @@ describe('nested test detection', function () {
             return done(err);
           }
           expect(res, 'to have failed with output', /Error: Nested test "inner nested test"/);
-          expect(res, 'to have failed with output', /detected inside test "outer test with nested test"/);
+          expect(res, 'to have failed with output', /detected inside "outer test with nested test"/);
           expect(res, 'to have failed with output', /createUnsupportedError/);
           done();
         },


### PR DESCRIPTION
Throws if there is an it() call inside an it() call. Same for test().

<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #4525
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds some state to keep track of whether we are currently inside a test. If we are, and we enter a new test, throws an error.

### helpful failure messages

If a nested test is detected, the failure that is logged shows the name of both
the outer and inner test. For example:

> Error: Nested test "my inner test" detected inside test "my outer test". Nested tests are not allowed.

### new tests

I added a bunch of tests:

* Both BDD and TDD
* Three kinds of async tests: callback, promise, and async/await
* Test that the test names are included in the error message, as noted above

### global variable

I could find no existing state that was visible and allowed me to determine
whether we were already inside a test. Therefore, this PR creates a new global
variable, `global._mochaExecutionState`. If there is a better, non-global place
to store this, that would be great.

### old failing tests

I don’t know why, but `npm test` had some failing tests even before my changes.
They are unrelated to my proposed changes.

### minor code duplication and code complexity

Before my change, in lib/interfaces/{tdd.js,bdd.js} the main test functions,
context.test and context.it, were super short and simple. I don’t love the fact
that my change adds a bit of complexity to both (and it’s the same code in both
-- but on the other hand, those two functions already contain identical code).

### risk of breaking existing tests

I want to point out that even though this is a desirable feature, I think there
is significant risk of breaking people’s current tests. I became aware of this
nested-test issue when I worked at Asana, and over our very large codebase,
there were at least 20 tests that had this problem. It took a lot of work to
fix them all.

If Mocha just made this change, this breakage could cause people to avoid
upgrading to more recent versions.

Mitigation options to consider:

* Add an option to disable the nested-test checks. My suggestion would be that
  nested-test checks are ON by default, but can be turned off. This way, when
  someone upgrades Mocha, they may get errors, but they can still keep the new
  Mocha without having to stop and invest a lot of time in fixing their tests.
  Also, on by default means that if anyone uses Mocha in a new project, they
  will get the nested-test checks.
* Decide what Semver version bump is appropriate. If the new checks are on by
  default, then this could be considered a breaking change, which would mean a
  major version bump.