### PR TITLE
chore: enabled ESLint's no-unused-vars

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,8 +24,8 @@ module.exports = [
     rules: {
       'n/prefer-node-protocol': 'error',
       strict: ['error', 'global'],
+      'no-unused-vars': 'error',
 
-      'no-var': 'off',
       'n/no-process-exit': 'off',
       'n/no-unpublished-require': 'off',
       'n/no-unsupported-features/node-builtins': 'off',

--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('node:fs');
 const path = require('node:path');
 const pc = require('picocolors');
 const debug = require('debug')('mocha:cli:run:helpers');

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -17,7 +17,6 @@ const {format} = require('node:util');
 const {createInvalidLegacyPluginError} = require('../errors');
 const {requireOrImport} = require('../nodejs/esm-utils');
 const PluginLoader = require('../plugin-loader');
-const {UnmatchedFile} = require('./collect-files');
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -507,10 +507,9 @@ function createTimeoutError(msg, timeout, file) {
  * @public
  * @static
  * @param {string} message - Error message to be displayed.
- * @param {string} filename - File name
  * @returns {Error} Error with code {@link constants.UNPARSABLE_FILE}
  */
-function createUnparsableFileError(message, filename) {
+function createUnparsableFileError(message) {
   var err = new Error(message);
   err.code = constants.UNPARSABLE_FILE;
   return err;

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -92,7 +92,6 @@ function HTML(runner, options) {
     items[progressIndex].getElementsByClassName('ring-flatlight')[0],
     items[progressIndex].getElementsByClassName('ring-highlight')[0]
   ];
-  var progressRingRadius = null; // computed CSS unavailable now, so set later
   var root = document.getElementById('mocha');
 
   if (!root) {

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -97,7 +97,7 @@ function title(test) {
  * @param {string} format - `printf`-like format string
  * @param {...*} [varArgs] - Format string arguments
  */
-function println(format, varArgs) {
+function println() {
   var vargs = Array.from(arguments);
   vargs[0] += '\n';
   process.stdout.write(sprintf.apply(null, vargs));
@@ -184,9 +184,8 @@ TAPProducer.prototype.writePending = function (n, test) {
  * @abstract
  * @param {number} n - Index of test that failed.
  * @param {Test} test - Instance containing test information.
- * @param {Error} err - Reason the test failed.
  */
-TAPProducer.prototype.writeFail = function (n, test, err) {
+TAPProducer.prototype.writeFail = function (n, test) {
   println('not ok %d %s', n, title(test));
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1166,7 +1166,7 @@ Runner.prototype.run = function (fn, opts = {}) {
  *   }
  * }
  */
-Runner.prototype.linkPartialObjects = function (value) {
+Runner.prototype.linkPartialObjects = function () {
   return this;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -543,7 +543,7 @@ exports.noop = function () {};
  * @param {...*} [obj] - Arguments to `Object.assign()`.
  * @returns {Object} An object with no prototype, having `...obj` properties
  */
-exports.createMap = function (obj) {
+exports.createMap = function () {
   return Object.assign.apply(
     null,
     [Object.create(null)].concat(Array.prototype.slice.call(arguments))

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -292,7 +292,7 @@ function onlyConsoleOutput() {
   };
 }
 
-function onlyErrorTitle(line) {
+function onlyErrorTitle() {
   let foundErrorTitle = false;
   let foundError = false;
   return line => {

--- a/test/integration/options/posixExitCodes.spec.js
+++ b/test/integration/options/posixExitCodes.spec.js
@@ -4,7 +4,6 @@ var helpers = require('../helpers');
 var runMocha = helpers.runMocha;
 var os = require('node:os');
 
-const EXIT_SUCCESS = 0;
 const EXIT_FAILURE = 1;
 const SIGNAL_OFFSET = 128;
 

--- a/test/integration/reporters.spec.js
+++ b/test/integration/reporters.spec.js
@@ -49,7 +49,7 @@ describe('reporters', function () {
         '</testsuite>'
       ];
 
-      run('passing.fixture.js', args, function (err, result) {
+      run('passing.fixture.js', args, function (err) {
         if (err) return done(err);
 
         var xml = fs.readFileSync(tmpFile, 'utf8');

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -37,7 +37,7 @@ describe('Base reporter', function () {
     return diffStr;
   }
 
-  var gather = function (chunk, encoding, cb) {
+  var gather = function (chunk) {
     stdout.push(chunk);
   };
 
@@ -524,14 +524,14 @@ describe('Base reporter', function () {
       var err1 = {
         message: 'Error',
         stack: 'Error\nfoo\nbar',
-        showDiff: false,
+        showDiff: false
       };
       var err2 = {
         message: 'Cause1',
         stack: 'Cause1\nbar\nfoo',
         showDiff: false,
         cause: err1
-      }
+      };
       err1.cause = err2;
 
       var test = makeTest(err1);
@@ -552,7 +552,7 @@ describe('Base reporter', function () {
         stack: 'Error\nfoo\nbar',
         showDiff: false,
         cause: {
-          showDiff: false,
+          showDiff: false
         }
       };
 

--- a/test/reporters/helpers.js
+++ b/test/reporters/helpers.js
@@ -165,8 +165,7 @@ function makeExpectedTest(
   expectedFullTitle,
   expectedFile,
   expectedDuration,
-  currentRetry,
-  expectedBody
+  currentRetry
 ) {
   return {
     title: expectedTitle,
@@ -203,7 +202,7 @@ function createRunReporterFunction(ctor) {
     var stdoutWriteStub = sinon.stub(process.stdout, 'write');
     var stdout = [];
 
-    var gather = function (chunk, enc, callback) {
+    var gather = function (chunk) {
       stdout.push(chunk);
       if (tee) {
         origStdoutWrite.call(process.stdout, chunk);

--- a/test/reporters/nyan.spec.js
+++ b/test/reporters/nyan.spec.js
@@ -161,7 +161,7 @@ describe('Nyan reporter', function () {
 
     beforeEach(function () {
       stdoutWriteStub = sinon.stub(process.stdout, 'write');
-      stdoutWriteStub.callsFake(function (chunk, encoding, cb) {
+      stdoutWriteStub.callsFake(function (chunk) {
         stdout.push(chunk);
       });
       stdout = [];
@@ -260,7 +260,7 @@ describe('Nyan reporter', function () {
 
     beforeEach(function () {
       stdoutWriteStub = sinon.stub(process.stdout, 'write');
-      stdoutWriteStub.callsFake(function (chunk, encoding, cb) {
+      stdoutWriteStub.callsFake(function (chunk) {
         stdout.push(chunk);
       });
       stdout = [];
@@ -289,7 +289,7 @@ describe('Nyan reporter', function () {
 
     beforeEach(function () {
       stdoutWriteStub = sinon.stub(process.stdout, 'write');
-      stdoutWriteStub.callsFake(function (chunk, encoding, cb) {
+      stdoutWriteStub.callsFake(function (chunk) {
         stdout.push(chunk);
       });
       stdout = [];
@@ -452,7 +452,7 @@ describe('Nyan reporter', function () {
         return type + n;
       });
       var stdoutWriteStub = sinon.stub(process.stdout, 'write');
-      stdoutWriteStub.callsFake(function (chunk, encoding, cb) {
+      stdoutWriteStub.callsFake(function (chunk) {
         stdout.push(chunk);
       });
       stdout = [];
@@ -521,7 +521,7 @@ describe('Nyan reporter', function () {
 
     beforeEach(function () {
       var stdoutWriteStub = sinon.stub(process.stdout, 'write');
-      stdoutWriteStub.callsFake(function (chunk, encoding, cb) {
+      stdoutWriteStub.callsFake(function (chunk) {
         stdout.push(chunk);
       });
       stdout = [];

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -225,7 +225,7 @@ describe('XUnit reporter', function () {
               }
               cb();
             }),
-            write: function (chunk, encoding, cb) {}
+            write: function () {}
           }
         };
       });
@@ -544,7 +544,7 @@ describe('XUnit reporter', function () {
 
     before(function () {
       fileStream = {
-        write: function (chunk, encoding, cb) {
+        write: function (chunk) {
           lines.push(chunk);
         }
       };

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -173,6 +173,8 @@ describe('Runnable(title, fn)', function () {
     var run;
 
     beforeEach(function () {
+      // Runnable knows whether it's provided a 'done' parameter
+      // eslint-disable-next-line no-unused-vars
       run = new Runnable('foo', function (done) {});
     });
 
@@ -387,7 +389,7 @@ describe('Runnable(title, fn)', function () {
         });
 
         it('should not throw its own exception if passed a non-object', function (done) {
-          var runnable = new Runnable('foo', function (done) {
+          var runnable = new Runnable('foo', function () {
             /* eslint no-throw-literal: off */
             throw null;
           });
@@ -401,7 +403,7 @@ describe('Runnable(title, fn)', function () {
 
       describe('when an exception is thrown and is allowed to remain uncaught', function () {
         it('throws an error when it is allowed', function (done) {
-          var runnable = new Runnable('foo', function (done) {
+          var runnable = new Runnable('foo', function () {
             throw new Error('fail');
           });
           runnable.allowUncaught = true;
@@ -465,6 +467,8 @@ describe('Runnable(title, fn)', function () {
 
       it('should allow updating the timeout', function (done) {
         var spy = sinon.spy();
+        // Runnable knows whether it's provided a 'done' parameter
+        // eslint-disable-next-line no-unused-vars
         var runnable = new Runnable('foo', function (done) {
           setTimeout(spy, 1);
           setTimeout(spy, 100);
@@ -509,7 +513,7 @@ describe('Runnable(title, fn)', function () {
 
       describe('when the promise is fulfilled with a value', function () {
         var fulfilledPromise = {
-          then: function (fulfilled, rejected) {
+          then: function (fulfilled) {
             setTimeout(function () {
               fulfilled({});
             });
@@ -623,7 +627,7 @@ describe('Runnable(title, fn)', function () {
 
     describe('if async', function () {
       it('this.skip() should set runnable to pending', function (done) {
-        var runnable = new Runnable('foo', function (done) {
+        var runnable = new Runnable('foo', function () {
           // normally "this" but it gets around having to muck with a context
           runnable.skip();
         });
@@ -636,7 +640,7 @@ describe('Runnable(title, fn)', function () {
 
       it('this.skip() should halt synchronous execution', function (done) {
         var aborted = true;
-        var runnable = new Runnable('foo', function (done) {
+        var runnable = new Runnable('foo', function () {
           // normally "this" but it gets around having to muck with a context
           runnable.skip();
           /* istanbul ignore next */

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -879,7 +879,7 @@ describe('Runner', function () {
       it('async - should allow unhandled errors in hooks to propagate through', function (done) {
         // the `done` argument, although unused, it triggers the async path
         // see this.async in the Runnable constructor
-        suite.beforeEach(function (done) {
+        suite.beforeEach(function () {
           throw new Error('allow unhandled errors in async hooks');
         });
         var runner = new Runner(suite);

--- a/test/unit/throw.spec.js
+++ b/test/unit/throw.spec.js
@@ -30,7 +30,7 @@ describe('a test that throws', function () {
     uncaughtHandlers.forEach(function (listener) {
       process.on('uncaughtException', listener);
     });
-    sinon.restore(); 
+    sinon.restore();
   });
 
   describe('non-extensible', function () {
@@ -49,7 +49,7 @@ describe('a test that throws', function () {
     });
 
     it('should not pass if throwing sync and test is async', function (done) {
-      var test = new Test('im async and throw string sync', function (done2) {
+      var test = new Test('im async and throw string sync', function () {
         throw 'non-extensible';
       });
       suite.addTest(test);
@@ -63,7 +63,7 @@ describe('a test that throws', function () {
     });
 
     it('should not pass if throwing async and test is async', function (done) {
-      var test = new Test('im async and throw string async', function (done2) {
+      var test = new Test('im async and throw string async', function () {
         process.nextTick(function () {
           throw 'non-extensible';
         });
@@ -95,9 +95,7 @@ describe('a test that throws', function () {
     });
 
     it('should not pass if throwing sync and test is async', function (done) {
-      var test = new Test('im async and throw undefined sync', function (
-        done2
-      ) {
+      var test = new Test('im async and throw undefined sync', function () {
         throw undefined;
       });
       suite.addTest(test);
@@ -111,9 +109,7 @@ describe('a test that throws', function () {
     });
 
     it('should not pass if throwing async and test is async', function (done) {
-      var test = new Test('im async and throw undefined async', function (
-        done2
-      ) {
+      var test = new Test('im async and throw undefined async', function () {
         process.nextTick(function () {
           throw undefined;
         });
@@ -145,7 +141,7 @@ describe('a test that throws', function () {
     });
 
     it('should not pass if throwing sync and test is async', function (done) {
-      var test = new Test('im async and throw null sync', function (done2) {
+      var test = new Test('im async and throw null sync', function () {
         throw null;
       });
       suite.addTest(test);
@@ -159,7 +155,7 @@ describe('a test that throws', function () {
     });
 
     it('should not pass if throwing async and test is async', function (done) {
-      var test = new Test('im async and throw null async', function (done2) {
+      var test = new Test('im async and throw null async', function () {
         process.nextTick(function () {
           throw null;
         });
@@ -175,9 +171,9 @@ describe('a test that throws', function () {
     });
   });
 
-  describe('stack', function() {
-    it('should include the stack when throwing async', function(done) {
-      var test = new Test('im async and throw null async', function(done2) {
+  describe('stack', function () {
+    it('should include the stack when throwing async', function (done) {
+      var test = new Test('im async and throw null async', function () {
         process.nextTick(function throwError() {
           throw new Error('test error');
         });
@@ -186,7 +182,7 @@ describe('a test that throws', function () {
       runner = new Runner(suite);
       sinon.stub(runner, 'fail');
 
-      runner.on(EVENT_RUN_END, function() {
+      runner.on(EVENT_RUN_END, function () {
         try {
           expect(runner.fail, 'to have all calls satisfying', [
             expect.it('to be a', Runnable),


### PR DESCRIPTION
## Overview

It's been bugging me that we have a bunch of unused imports, parameters, and variables hanging around. [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) is enabled in basically every linter preset out there, including neostandard (#5301) and ESLint's recommended (#5281).  