### PR TITLE
docs: explain node import swallowing error

### DIFF
--- a/docs-next/src/content/docs/explainers/nodejs-native-esm-support.mdx
+++ b/docs-next/src/content/docs/explainers/nodejs-native-esm-support.mdx
@@ -29,5 +29,7 @@ More information can be found in the [Node.js documentation](https://nodejs.org/
 - [Watch mode](../running/cli#--watch--w) does not support ES Module test files
 - [Custom reporters](../reporters/third-party) and [custom interfaces](../interfaces/third-party) can only be CommonJS files
 - [Configuration file](../running/configuring) can only be a CommonJS file (`.mocharc.js` or `.mocharc.cjs`)
+- Mocha in Node.js version 24.4.0 or older [silently ignored top level errors in ESM files](https://github.com/mochajs/mocha/issues/5396).
+  If you cannot upgrade to a newer Node.js version, you can add `--no-experimental-require-module` to the `NODE_OPTIONS` environment variable.
 - When using module-level mocks via libs like `proxyquire`, `rewiremock` or `rewire`, hold off on using ES modules for your test files.
   You can switch to using `testdouble`, which does support ESM.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2131,6 +2131,8 @@ More information can be found in the [Node.js documentation](https://nodejs.org/
 - [Custom reporters](#third-party-reporters) and [custom interfaces](#interfaces)
   can only be CommonJS files
 - [Configuration file](#configuring-mocha-nodejs) can only be a CommonJS file (`.mocharc.js` or `.mocharc.cjs`)
+- Mocha in Node.js version 24.4.0 or older [silently ignored top level errors in ESM files](https://github.com/mochajs/mocha/issues/5396).
+  If you cannot upgrade to a newer Node.js version, you can add `--no-experimental-require-module` to the `NODE_OPTIONS` environment variable.
 - When using module-level mocks via libs like `proxyquire`, `rewiremock` or `rewire`,
   hold off on using ES modules for your test files. You can switch to using `testdouble`,
   which does support ESM.


### PR DESCRIPTION
Fixes: https://github.com/mochajs/mocha/issues/5396

## PR Checklist

- [x] Addresses an existing open issue: Fixes: #5396 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The fix landed in node js main nodejs/node#58957 I belive we now should update the ESM support section of the documentation since this error has been affecting even node LTS. I took the liberty to guess the next node.js version, shouldn't matter if they skip the 24.4.1 patch straight to a new minor, the point will still stand.

I was intentionally vague in the problem description and proposed workaround, and left a link to the original issue so if the person is curious to learn more / understand how the fix works. I want to optimize for the quick answers crowd, the curious crowd can delight itself reading the original issue.