### PR TITLE
chore: also test Node.js 24 in CI

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/npm-script.yml
     with:
       # The 22.11.0 is instead of lts per https://github.com/mochajs/mocha/issues/5278
-      node-versions: '18,20,22.11.0'
+      node-versions: '18,20,22.11.0,24'
       npm-script: test-smoke
 
   test-node-lts:
@@ -68,7 +68,7 @@ jobs:
       os: 'ubuntu-latest,windows-latest'
       # The 20.18.3 is instead of 20 per https://github.com/mochajs/mocha/issues/5052
       # The 22.11.0 is instead of 22 per https://github.com/mochajs/mocha/issues/5278
-      node-versions: '18,20.18.3,22.11.0'
+      node-versions: '18,20.18.3,22.11.0,24'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 
@@ -77,10 +77,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
 
   test-browser-local:
     uses: ./.github/workflows/npm-script.yml


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5367
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the latest Node.js major `24` to `mocha.yml`.

The repo still has existing test instability (#5361, #5376) but that's not related to this PR. This PR shouldn't add any new failures.

💖