### PR TITLE
docs: add banner from old site to new site, link from new to old

### DIFF
--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -1,21 +1,25 @@
 # Mocha Docs vNext: Built on Astro Starlight
 
-After `cd`ing into this directory:
+## Preview the new site on its own
 
 ```shell
+cd docs-next
 npm i
 npm run generate
 npm run dev
 ```
 
-To merge with the old site:
+## Build the new site into a folder with the old site
 
 ```shell
+cd docs-next
 npm i
 npm run build-with-old
 ```
 
-To preview the old and new site:
+## Preview the old and new site together
+
+First, build the new site into a folder with the old site above.
 
 ```shell
 cd .. # back to root dir

--- a/docs-next/src/content/docs/index.mdx
+++ b/docs-next/src/content/docs/index.mdx
@@ -16,7 +16,7 @@ import Supporters from "../../components/Supporters.astro";
 
 :::note[New Site Preview]
 Hello!
-Welcome to this preview of a revamped **mochajs.org** docs site!
+Welcome to this preview of a revamped [**mochajs.org**](https://mochajs.org) docs site!
 
 This is an early stage preview.
 If you see any **bugs** or **typos**, please mention them on [docs: add new website using Astro Starlight](https://github.com/mochajs/mocha/pull/5246).

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -296,6 +296,15 @@ footer {
   bottom: 0;
 }
 
+.admonition {
+  background: #f5f2f0; /* background of code blocks */
+  border: #8d6748 1px solid; /* color of link text */
+  border-radius: 4px;
+  margin-top: 8px;
+  padding: 8px;
+  text-align: center;
+}
+
 .sponsorship {
   display: flex;
   align-items: center;

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,7 @@ title: 'Mocha - the fun, simple, flexible JavaScript test framework'
 description: 'Mocha is a feature-rich JavaScript test framework running on Node.js and in the browser, making asynchronous testing simple and fun.'
 ---
 
-<div style="
-    background: #f5f2f0; /*background of code blocks*/
-    border: #8d6748 1px solid; /*color of link text*/
-    border-radius: 4px;
-    margin-top: 8px;
-    padding: 8px;
-    text-align: center;
-">This site has a new look, try it out at <a href="mochajs.org/next">mochajs.org/next</a>!</div>
+<div class="admonition">This site has a new look, try it out at <a href="mochajs.org/next">mochajs.org/next</a>!</div>
 
 Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in the browser, making asynchronous testing _simple_ and _fun_. Mocha tests run serially, allowing for flexible and accurate reporting, while mapping uncaught exceptions to the correct test cases. Hosted on [GitHub][github-mocha].
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ description: 'Mocha is a feature-rich JavaScript test framework running on Node.
 ---
 
 <div style="
-    background: #f5f2f0; /* background of code blocks */
-    border: #8d6748 1px solid; /* color of link text */
+    background: #f5f2f0; /*background of code blocks*/
+    border: #8d6748 1px solid; /*color of link text*/
     border-radius: 4px;
     margin-top: 8px;
     padding: 8px;

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,15 @@ title: 'Mocha - the fun, simple, flexible JavaScript test framework'
 description: 'Mocha is a feature-rich JavaScript test framework running on Node.js and in the browser, making asynchronous testing simple and fun.'
 ---
 
+<div style="
+    padding: 8px;
+    text-align: center;
+    background: #f5f2f0;
+    border: #8d6748 1px solid;
+    margin-top: 8px;
+    border-radius: 4px;
+">This site has a new look, try it out at <a href="mochajs.org/next">mochajs.org/next</a>!</div>
+
 Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in the browser, making asynchronous testing _simple_ and _fun_. Mocha tests run serially, allowing for flexible and accurate reporting, while mapping uncaught exceptions to the correct test cases. Hosted on [GitHub][github-mocha].
 
 <nav class="badges">

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,12 @@ description: 'Mocha is a feature-rich JavaScript test framework running on Node.
 ---
 
 <div style="
+    background: #f5f2f0; /* background of code blocks */
+    border: #8d6748 1px solid; /* color of link text */
+    border-radius: 4px;
+    margin-top: 8px;
     padding: 8px;
     text-align: center;
-    background: #f5f2f0;
-    border: #8d6748 1px solid;
-    margin-top: 8px;
-    border-radius: 4px;
 ">This site has a new look, try it out at <a href="mochajs.org/next">mochajs.org/next</a>!</div>
 
 Mocha is a feature-rich JavaScript test framework running on [Node.js][] and in the browser, making asynchronous testing _simple_ and _fun_. Mocha tests run serially, allowing for flexible and accurate reporting, while mapping uncaught exceptions to the correct test cases. Hosted on [GitHub][github-mocha].


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5304
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Current site now has a custom banner:

<img width="1626" height="1318" alt="image" src="https://github.com/user-attachments/assets/17d64faa-c621-4aef-8ac6-442555164791" />

New site's `mochajs.org` bold text is now a link back to the current homepage:

<img width="942" height="965" alt="image" src="https://github.com/user-attachments/assets/688394bc-a0f4-411d-bfba-607cb7bd95dd" />

Minor cleanup of `docs-next/readme.md` as well :)
