### PR TITLE
docs: document merging of special `spec` option

### DIFF
--- a/docs-next/src/content/docs/running/configuring.mdx
+++ b/docs-next/src/content/docs/running/configuring.mdx
@@ -62,6 +62,8 @@ In case of conflict, the priority is:
 Options which can safely be repeated (e.g., `--require`) will be _concatenated_, with higher-priority configuration sources appearing earlier in the list.
 For example, a `.mocharc.json` containing `"require": "bar"`, coupled with execution of `mocha --require foo`, would cause Mocha to require `foo`, then `bar`, in that order.
 
+This also includes `spec`. For example, a `.mocharc.json` containing `"spec": ["**/*.test.js"]` coupled with execution of `mocha bar.spec.js` would be the same as runninng `mocha bar.spec.js **/*.test.js`, and it would still run all `.test.js` files. To workaround this, you can comment out the `spec` property or use a different config file via `--config`.
+
 ## Extending Configuration
 
 Configurations can inherit from other modules using the `extends` keyword.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2291,7 +2291,9 @@ Mocha will also _merge_ any options found in `package.json` into its run-time co
 1. Configuration file (`.mocharc.js`, `.mocharc.yml`, etc.)
 1. `mocha` property of `package.json`
 
-Options which can safely be repeated (e.g., `--require`) will be _concatenated_, with higher-priority configuration sources appearing earlier in the list. For example, a `.mocharc.json` containing `"require": "bar"`, coupled with execution of `mocha --require foo`, would cause Mocha to require `foo`, then `bar`, in that order.
+Options which can safely be repeated (e.g., `--require`) will be _concatenated_, with higher-priority configuration sources appearing earlier in the list. For example, a `.mocharc.json` containing `"require": "bar"` coupled with execution of `mocha --require foo` would cause Mocha to require `foo`, then `bar`, in that order.
+
+This also includes `spec`. For example, a `.mocharc.json` containing `"spec": ["**/*.test.js"]` coupled with execution of `mocha bar.spec.js` would be the same as runninng `mocha bar.spec.js **/*.test.js`, and it would still run all `.test.js` files. To workaround this, you can comment out the `spec` property or use a different config file via `--config`.
 
 ### Extending Configuration
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5412
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`mocha bar.spec.js` doesn't necessarily run **only** `bar.spec.js`, it just ensures that that file/glob is matched along with whatever is in the config file. This can be misleading, so we're updating the docs to clarity.
