### PR TITLE
docs: migrate Spies wiki page to explainers

### DIFF
--- a/docs-next/astro.config.ts
+++ b/docs-next/astro.config.ts
@@ -102,6 +102,10 @@ export default defineConfig({
               label: "Run cycle overview",
               slug: "explainers/run-cycle-overview",
             },
+            {
+              label: "Spies",
+              slug: "explainers/spies",
+            },
             { label: "Test duration", slug: "explainers/test-duration" },
             {
               label: "Test fixture decision tree",

--- a/docs-next/src/content/docs/explainers/spies.mdx
+++ b/docs-next/src/content/docs/explainers/spies.mdx
@@ -1,0 +1,62 @@
+---
+description: How to use spies with Mocha for testing callbacks and function calls
+title: Spies
+---
+
+# Spies
+
+Mocha does not come equipped with spies, though libraries like Sinon provide this behaviour if desired. The following is an example of Mocha utilizing Sinon and Should.js to test an EventEmitter:
+
+```javascript
+var sinon = require('sinon'),
+    EventEmitter = require('events').EventEmitter;
+
+describe('EventEmitter', function() {
+  describe('#emit()', function() {
+    it('should invoke the callback', function() {
+      var spy = sinon.spy(),
+          emitter = new EventEmitter();
+
+      emitter.on('foo', spy);
+      emitter.emit('foo');
+      spy.called.should.equal.true;
+    })
+
+    it('should pass arguments to the callbacks', function() {
+      var spy = sinon.spy(),
+          emitter = new EventEmitter();
+
+      emitter.on('foo', spy);
+      emitter.emit('foo', 'bar', 'baz');
+      sinon.assert.calledOnce(spy);
+      sinon.assert.calledWith(spy, 'bar', 'baz');
+    })
+  })
+})
+```
+
+The following is the same test, performed without any special spy library, simply utilizing the Mocha `done([err])` callback as a means to assert that the callback has occurred, otherwise resulting in a timeout. Note that Mocha only allows `done()` to be invoked once, and will otherwise error.
+
+```javascript
+describe('EventEmitter', function() {
+  describe('#emit()', function() {
+    it('should invoke the callback', function(done) {
+      var emitter = new EventEmitter();
+
+      emitter.on('foo', done);
+      emitter.emit('foo');
+    })
+
+    it('should pass arguments to the callbacks', function(done) {
+      var emitter = new EventEmitter();
+
+      emitter.on('foo', function(a, b) {
+        a.should.equal('bar');
+        b.should.equal('baz');
+        done();
+      });
+      emitter.emit('foo', 'bar', 'baz');
+    })
+  })
+})
+```

--- a/docs-next/src/content/docs/explainers/spies.mdx
+++ b/docs-next/src/content/docs/explainers/spies.mdx
@@ -3,8 +3,6 @@ description: How to use spies with Mocha for testing callbacks and function call
 title: Spies
 ---
 
-# Spies
-
 Mocha does not come equipped with spies, though libraries like Sinon provide this behaviour if desired. The following is an example of Mocha utilizing Sinon and Should.js to test an EventEmitter:
 
 ```javascript

--- a/docs-next/src/content/docs/explainers/spies.mdx
+++ b/docs-next/src/content/docs/explainers/spies.mdx
@@ -3,7 +3,7 @@ description: How to use spies with Mocha for testing callbacks and function call
 title: Spies
 ---
 
-Mocha does not come equipped with spies, though libraries like Sinon provide this behaviour if desired. The following is an example of Mocha utilizing Sinon and Should.js to test an EventEmitter:
+Mocha does not come equipped with spies, though libraries like [Sinon](https://github.com/sinonjs/sinon) provide this behaviour if desired. The following is an example of Mocha utilizing Sinon and [Should.js](https://github.com/shouldjs/should.js) to test an EventEmitter:
 
 ```javascript
 var sinon = require('sinon'),
@@ -33,7 +33,7 @@ describe('EventEmitter', function() {
 })
 ```
 
-The following is the same test, performed without any special spy library, simply utilizing the Mocha `done([err])` callback as a means to assert that the callback has occurred, otherwise resulting in a timeout. Note that Mocha only allows `done()` to be invoked once, and will otherwise error.
+The following is the same test, performed without any special spy library, utilizing the Mocha `done([err])` callback as a means to assert that the callback has occurred, otherwise resulting in a timeout. Note that Mocha only allows `done()` to be invoked once, and will otherwise error.
 
 ```javascript
 describe('EventEmitter', function() {


### PR DESCRIPTION
- Direct migration of wiki/Spies content to docs-next
- Part of #5248 wiki migration effort

<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: works on #5248 (edit by @mark-wiemer)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This is a direct migration of the [Spies wiki page](https://github.com/mochajs/mocha/wiki/Spies) to `docs-next/src/content/docs/explainers/spies.mdx`.

- Added to docs-next (will add to legacy docs in follow-up)  
- Content placed in explainers section