### PR TITLE
fix: load mjs files correctly

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -1,5 +1,6 @@
 const path = require('node:path');
 const url = require('node:url');
+const debug = require('debug')('mocha:esm-utils');
 
 const forward = x => x;
 
@@ -99,8 +100,12 @@ const requireModule = async (file, esmDecorator) => {
     // Import if require fails.
     return dealWithExports(await formattedImport(file, esmDecorator));
   }
-}
+};
 
+// We only assign this `requireOrImport` function once based on Node version
+// We check for file extensions in `requireModule` and `tryImportAndRequire`
+debug('Node version: %s', process.versions.node);
+debug('process.features.require_module: %s', process.features.require_module);
 if (process.features.require_module) {
   exports.requireOrImport = requireModule;
 } else {

--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -90,6 +90,9 @@ const tryImportAndRequire = async (file, esmDecorator) => {
 // and `require.cache` effective, while allowing us to load ESM modules
 // and CJS modules in the same way.
 const requireModule = async (file, esmDecorator) => {
+  if (path.extname(file) === '.mjs') {
+    return formattedImport(file, esmDecorator);
+  }
   try {
     return require(file);
   } catch (err) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5425
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

mjs files were sometimes loaded like cjs files despite their extension. In some versions of Node (including Node 20.19.4) this causes breaking issues caught by our tests. A separate PR will bump Node versions in CI.
