### PR TITLE
chore: bump CI to use 20.19.4, 22.18.0, 24.6.0

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -66,9 +66,8 @@ jobs:
     with:
       os: 'ubuntu-latest,windows-latest'
       # We pin exact versions here per https://github.com/mochajs/mocha/issues/5052
-      # Use 20.18.3 per https://github.com/mochajs/mocha/issues/5278
       # Ref https://nodejs.org/en/about/previous-releases
-      node-versions: '18.20.8,20.18.3,22.17.1,24.4.1'
+      node-versions: '18.20.8,20.19.4,22.17.1,24.4.1'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -67,7 +67,7 @@ jobs:
       os: 'ubuntu-latest,windows-latest'
       # We pin exact versions here per https://github.com/mochajs/mocha/issues/5052
       # Ref https://nodejs.org/en/about/previous-releases
-      node-versions: '18.20.8,20.19.4,22.17.1,24.4.1'
+      node-versions: '18.20.8,20.19.4,22.18.0,24.6.0'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 

--- a/test/integration/plugins/root-hooks.spec.js
+++ b/test/integration/plugins/root-hooks.spec.js
@@ -153,7 +153,7 @@ describe('root hooks', function () {
         // (introduced in Node 20.10.0, 21.1.0)
         // newer versions of Node no longer fail :)
         if (isNewerVersion(process.versions.node)) {
-          return true; // skip test on newer Node versions
+          return true; // skip suite on newer Node versions
         }
 
         const filename =
@@ -200,7 +200,7 @@ describe('root hooks', function () {
 
       describe('on newer versions, should work', function () {
         if (!isNewerVersion(process.versions.node)) {
-          return true; // skip test on older Node versions
+          return true; // skip suite on older Node versions
         }
 
         const filename =
@@ -227,7 +227,7 @@ describe('root hooks', function () {
             invokeMochaAsync(
               [
                 '--require=' + require.resolve(filename), // as object
-                 // enabled by default in these newer versions, but clearer to use it explicitly
+                // enabled by default in these newer versions, but clearer to use it explicitly
                 '--experimental-detect-module'
               ],
               'pipe'

--- a/test/node-unit/reporters/parallel-buffered.spec.js
+++ b/test/node-unit/reporters/parallel-buffered.spec.js
@@ -102,7 +102,14 @@ describe('ParallelBuffered', function () {
     describe('on EVENT_RUN_END', function () {
       it('should remove all listeners', function () {
         runner.emit(EVENT_RUN_END);
-        expect(runner.listeners(), 'to be empty');
+        if (process.version.startsWith('v20.19')) {
+          // Node 20.19.x returns `undefined` instead of `[]` due to a bug
+          // Fix is in Node 22 and 24, but not yet backported as of writing
+          // https://github.com/nodejs/node/issues/56263
+          expect(runner.listeners(), 'to be undefined');
+        } else {
+          expect(runner.listeners(), 'to be empty');
+        }
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5278
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

OK, the issue wasn't technically open, but we had worked around it by simply not bumping CI. This PR expects Node 20.19.x to be buggy for now and links to the relevant Node issue where it should be fixed. No updates there since January though, so bumping anyway.