### PR TITLE
Repo: Unify caught errors as err

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -79,8 +79,8 @@ process.on = function (e, fn) {
   }
 };
 
-process.listeners = function (e) {
-  if (e === 'uncaughtException') {
+process.listeners = function (err) {
+  if (err === 'uncaughtException') {
     return uncaughtExceptionHandlers;
   }
   return [];

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -285,8 +285,8 @@ exports.validateLegacyPlugin = (opts, pluginType, map = {}) => {
       // Try to load reporters from a cwd-relative path
       try {
         map[pluginId] = require(path.resolve(pluginId));
-      } catch (e) {
-        throw createUnknownError(e);
+      } catch (err) {
+        throw createUnknownError(err);
       }
     }
   }

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -314,8 +314,8 @@ const createRerunner = (mocha, watcher, {beforeRun} = {}) => {
           console.error(`${logSymbols.info} [mocha] waiting for changes...`);
         }
       });
-    } catch (e) {
-      console.error(e.stack);
+    } catch (err) {
+      console.error(err.stack);
     }
   };
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -346,8 +346,8 @@ Mocha.prototype.reporter = function (reporterName, reporterOptions) {
         // Try to load reporters from a cwd-relative path
         try {
           reporter = require(path.resolve(reporterName));
-        } catch (e) {
-          throw createInvalidReporterError(e.message, reporterName);
+        } catch (err) {
+          throw createInvalidReporterError(err.message, reporterName);
         }
       }
     }

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -504,7 +504,7 @@ function touchFile(filepath) {
   fs.mkdirSync(path.dirname(filepath), { recursive: true });
   try {
     fs.utimesSync(filepath, touchRef, touchRef);
-  } catch (e) {
+  } catch (err) {
     const fd = fs.openSync(filepath, 'a');
     fs.closeSync(fd);
   }


### PR DESCRIPTION
closed https://github.com/mochajs/mocha/issues/5258

<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR updates inconsistent error variable naming in `mocha.js`.
Previously, some `catch` blocks used `e` while others used `err`.
For consistency and clarity, all error variables are now standardized to `err`.

Example change:

```js
try {
  map[pluginId] = require(path.resolve(pluginId));
} catch (err) {
  throw createUnknownError(err);
}
```

This improves readability and aligns with common Node.js error-handling conventions. 