### PR TITLE
chore: mark coverage upload CI job as optional

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -75,6 +75,10 @@ jobs:
     needs: test-node-all
     if: always()
     runs-on: ubuntu-latest
+    # Uploading coverage is optional. Job won't fail just because this step fails.
+    # Ref https://github.com/mochajs/mocha/issues/5436
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontinue-on-error
+    continue-on-error: true
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -75,7 +75,7 @@ jobs:
     needs: test-node-all
     if: always()
     runs-on: ubuntu-latest
-    # Uploading coverage is optional. Job won't fail just because this step fails.
+    # Uploading coverage is optional. Run won't fail just because this job fails.
     # Ref https://github.com/mochajs/mocha/issues/5436
     # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontinue-on-error
     continue-on-error: true


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5436
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

[GitHub Docs for `continue-on-error`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontinue-on-error):

"Prevents a workflow run from failing when a job fails. Set to `true` to allow a workflow run to pass when this job fails."

Nice :)
