### PR TITLE
fix: throw an useful error on syntax error

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -101,7 +101,12 @@ const requireModule = async (file, esmDecorator) => {
     try {
       return dealWithExports(await formattedImport(file, esmDecorator));
     } catch (importErr) {
-      if (importErr.code === 'ERR_INTERNAL_ASSERTION') {
+      if (
+        importErr.code === 'ERR_INTERNAL_ASSERTION' ||
+        importErr.code === 'ERR_MODULE_NOT_FOUND' ||
+        importErr.code === 'ERR_UNKNOWN_FILE_EXTENSION' ||
+        importErr.code === 'ERR_UNSUPPORTED_DIR_IMPORT'
+      ) {
         throw requireErr;
       }
       throw importErr;


### PR DESCRIPTION
Align `tryImportAndRequire` and `requireModule` functions to throw the initial error message.

<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

When a typescript based project uses mocha and NodeJS 20.19 or later and there is a syntax error in one of the typescript files, mocha will produce an unhelpful error message:

```
$ yarn mocha -r ts-node/register test/index.spec.ts
yarn run v1.22.22
$ /tmp/mocha-demo/node_modules/.bin/mocha -r ts-node/register test/index.spec.ts

 Exception during run: TypeError: Unknown file extension ".ts" for /home/svenssot/tmp/mocha/test/index.spec.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:189:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:232:36)
    at defaultLoad (node:internal/modules/esm/load:145:22)
    at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:477:45)
    at async ModuleJob._link (node:internal/modules/esm/module_job:110:19) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With this PR applied, the error message is instead what was previously shown with NodeJS 20.18 and below:

```
$ yarn mocha -r ts-node/register test/index.spec.ts
yarn run v1.22.22
$ /tmp/mocha-demo/node_modules/.bin/mocha -r ts-node/register test/index.spec.ts

 Exception during run: test/index.spec.ts:4:1 - error TS1005: '}' expected.

4


  test/index.spec.ts:1:23
    1 describe('foo', () => {
                            ~
    The parser expected to find a '}' to match the '{' token here.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

In both these cases, I've used the following content in test/index.spec.ts:

```typescript
describe('foo', () => {
    it('bar', () => {
    //});
});
```