### PR TITLE
feat: remove supports-color dependency

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -16,7 +16,7 @@
 var diff = require('diff');
 var milliseconds = require('ms');
 var utils = require('../utils');
-var supportsColor = require('supports-color');
+var pc = require('picocolors');
 var symbols = require('log-symbols');
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
@@ -55,7 +55,7 @@ var consoleLog = console.log;
 
 exports.useColors =
   !isBrowser &&
-  (supportsColor.stdout || process.env.MOCHA_COLORS !== undefined);
+  (pc.isColorSupported || process.env.MOCHA_COLORS !== undefined);
 
 /**
  * Inline diffs instead of +/-

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
         "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
@@ -15189,6 +15188,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -28547,6 +28547,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "picocolors": "^1.1.1",
     "serialize-javascript": "^6.0.2",
     "strip-json-comments": "^3.1.1",
-    "supports-color": "^8.1.1",
     "workerpool": "^9.2.0",
     "yargs": "^17.7.2",
     "yargs-parser": "^21.1.1",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/mochajs/mocha/issues/5470
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR removes the `supports-color` dependency and instead uses the `isColorSupported` export from picocolors. This saves on install size and ensures consistency between our use of color and picocolors' use of it.