### PR TITLE
feat!: bump minimum Node.js version from 18.18.0 to 20.19.0

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -67,7 +67,7 @@ jobs:
       os: 'ubuntu-latest,windows-latest'
       # We pin exact versions here per https://github.com/mochajs/mocha/issues/5052
       # Ref https://nodejs.org/en/about/previous-releases
-      node-versions: '18.20.8,20.19.4,22.18.0,24.6.0'
+      node-versions: '20.19.4,22.18.0,24.6.0'
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 

--- a/docs-next/src/content/docs/getting-started.mdx
+++ b/docs-next/src/content/docs/getting-started.mdx
@@ -12,7 +12,7 @@ First, install the [`mocha` package](https://www.npmjs.com/package/mocha) as a d
 <PackageManagers dev type="add" pkg="mocha" />
 
 :::note
-As of v11.0.0, Mocha requires [Node.js](https://nodejs.org) `^18.18.0 || ^20.9.0 || >=21.1.0`.
+As of v12.0.0, Mocha requires [Node.js](https://nodejs.org) `^20.19.0 || >=22.12.0`.
 :::
 
 ## 2. Test File

--- a/docs-next/src/content/docs/running/browsers.mdx
+++ b/docs-next/src/content/docs/running/browsers.mdx
@@ -9,7 +9,7 @@ Every release of Mocha will have new builds of `./mocha.js` and `./mocha.css` fo
 A typical setup might look something like the following, where we call `mocha.setup('bdd')` to use the **BDD** interface before loading the test scripts, running them `onload` with `mocha.run()`.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -38,12 +38,12 @@ A typical setup might look something like the following, where we call `mocha.se
 ```
 
 Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js major version was released.
-As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.10.0](https://nodejs.org/en/blog/release/v18.0.0)'s release on April 19, 2022:
+As of Mocha v12.0.0, that includes the following browser versions that were stable as of [Node.js 20.0.0](https://nodejs.org/en/blog/release/v20.0.0)'s release on April 18, 2023:
 
-- [Chrome 100](https://developer.chrome.com/blog/new-in-chrome-100)
-- [Edge 100](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118544-april-15)
-- [Firefox 99](https://www.mozilla.org/en-US/firefox/99.0/releasenotes)
-- [Safari 15.4](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)
+- [Chrome 112](https://developer.chrome.com/blog/new-in-chrome-112)
+- [Edge 112](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1120172248-april-14-2023)
+- [Firefox 112](https://www.mozilla.org/en-US/firefox/112.0/releasenotes)
+- [Safari 16.4](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes)
 
 ## Grep
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ or as a development dependency for your project:
 $ npm install --save-dev mocha
 ```
 
-> As of v11.0.0, Mocha requires [Node.js](https://nodejs.org) `^18.18.0 || ^20.9.0 || >=21.1.0`.
+> As of v12.0.0, Mocha requires [Node.js](https://nodejs.org) `^20.19.0 || >=22.12.0`.
 
 ## Getting Started
 
@@ -2175,12 +2175,12 @@ A typical setup might look something like the following, where we call `mocha.se
 ```
 
 Mocha supports the latest major versions of evergreen browsers available when Mocha's oldest supported Node.js major version was released.
-As of Mocha v11.0.0, that includes the following browser versions that were stable as of [Node.js 18.10.0](https://nodejs.org/en/blog/release/v18.0.0)'s release on April 19, 2022:
+As of Mocha v12.0.0, that includes the following browser versions that were stable as of [Node.js 20.0.0](https://nodejs.org/en/blog/release/v20.0.0)'s release on April 18, 2023:
 
-- [Chrome 100](https://developer.chrome.com/blog/new-in-chrome-100)
-- [Edge 100](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118544-april-15)
-- [Firefox 99](https://www.mozilla.org/en-US/firefox/99.0/releasenotes)
-- [Safari 15.4](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)
+- [Chrome 112](https://developer.chrome.com/blog/new-in-chrome-112)
+- [Edge 112](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1120172248-april-14-2023)
+- [Firefox 112](https://www.mozilla.org/en-US/firefox/112.0/releasenotes)
+- [Safari 16.4](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes)
 
 ### Grep
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "webpack-cli": "^4.9.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "scripts": {
     "build": "rollup -c ./rollup.config.js",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5358
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies the change in `package.json`'s `"engines"` > `"node"`, as well as docs.

💖