### PR TITLE
feat: bump supports-color from 8 to 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
+        "supports-color": "^10.2.2",
         "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
@@ -9022,6 +9022,22 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.0.tgz",
@@ -15188,14 +15204,12 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
@@ -23820,6 +23834,17 @@
         "@types/node": "*",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jiti": {
@@ -28545,12 +28570,9 @@
       }
     },
     "supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "picocolors": "^1.1.1",
     "serialize-javascript": "^6.0.2",
     "strip-json-comments": "^3.1.1",
-    "supports-color": "^8.1.1",
+    "supports-color": "^10.2.2",
     "workerpool": "^9.2.0",
     "yargs": "^17.7.2",
     "yargs-parser": "^21.1.1",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5335
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Bumps the package from `^8.1.1` to `^10.2.2`.

Interestingly, this increases the lockfile size for local dependencies. This is because `supports-color@5.5.0` is still referenced by:

```plaintext
mocha@11.7.4 /Users/josh/repos/mocha
├─┬ karma-mocha-reporter@2.2.5
│ └─┬ chalk@2.4.2
│   └── supports-color@5.5.0
└─┬ nyc@15.1.0
  └─┬ istanbul-lib-instrument@4.0.3
    └─┬ @babel/core@7.21.3
      └─┬ @babel/code-frame@7.22.13
        ├─┬ @babel/highlight@7.22.20
        │ └─┬ chalk@2.4.2
        │   └── supports-color@5.5.0
        └─┬ chalk@2.4.2
          └── supports-color@5.5.0
```

* Karma is tracked in #5253
* `nyc` is tracked in #5481

💖