### PR TITLE
reporters/base: ensure internal errors are handled as mocha errors

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -18,6 +18,9 @@ var milliseconds = require('ms');
 var utils = require('../utils');
 var supportsColor = require('supports-color');
 var symbols = require('log-symbols');
+const {
+  createFatalError,
+} = require('../errors');
 var constants = require('../runner').constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
@@ -384,16 +387,23 @@ function Base(runner, options) {
   });
 
   runner.on(EVENT_TEST_FAIL, function (test, err) {
-    if (showDiff(err)) {
-      stringifyDiffObjs(err);
+    try {
+      if (showDiff(err)) {
+        stringifyDiffObjs(err);
+      }
+      // more than one error per test
+      if (test.err && err instanceof Error) {
+        test.err.multiple = (test.err.multiple || []).concat(err);
+      } else {
+        test.err = err;
+      }
+      failures.push(test);
+    } catch(err2) {
+      throw createFatalError(
+        `Error handling event: '${EVENT_TEST_FAIL}'`,
+        err2
+      );
     }
-    // more than one error per test
-    if (test.err && err instanceof Error) {
-      test.err.multiple = (test.err.multiple || []).concat(err);
-    } else {
-      test.err = err;
-    }
-    failures.push(test);
   });
 }
 

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -13,6 +13,7 @@ var makeTest = helpers.makeTest;
 var Mocha = require('../../');
 var Suite = Mocha.Suite;
 var Runner = Mocha.Runner;
+const { FATAL } = require('../../lib/error-constants').constants;
 
 describe('Base reporter', function () {
   var stdout;
@@ -624,6 +625,22 @@ describe('Base reporter', function () {
 
       expect(baseConsoleLog, 'was called');
       expect(console.log, 'was not called');
+    });
+  });
+
+  describe('error handling in event handling', function () {
+    it('should convert unexpected errors to mocha fatal errors', function () {
+      const suite = new Suite('Dummy suite', 'root');
+      const runner = new Runner(suite);
+      const base = new Base(runner);
+
+      try {
+        // It's hard to simulate an unexpected error in the EVENT_TEST_FAIL handling, so
+        // we do it here by triggering the event without the expected additional arguments
+        runner.emit(Runner.constants.EVENT_TEST_FAIL);
+      } catch(err) {
+        assert.deepEqual(err.code, FATAL);
+      }
     });
   });
 });


### PR DESCRIPTION
Closes #5507

## PR Checklist

- [x] Addresses an existing open issue: fixes #5507
- [no, it's in triage] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

As demonstrated in https://github.com/mochajs/mocha/issues/5505, a test which throws an unhandled promise rejection inside runner code would previously cause the mocha process to exit with status code 0.

**TODO** This PR ensures that any error generated internally when processing test failures is converted into a mocha fatal error, which should then fail the test site.