### PR TITLE
fix: correct assertion import syntax in getting-started guide

### DIFF
--- a/docs-next/src/content/docs/getting-started.mdx
+++ b/docs-next/src/content/docs/getting-started.mdx
@@ -21,7 +21,7 @@ Create the following `example.test.js` file under a `test/` directory:
 
 ```js
 // test/example.test.js
-import { assert } from "node:assert";
+import assert from "node:assert";
 
 describe("Array", function () {
   describe("#indexOf()", function () {


### PR DESCRIPTION
Change named import to default import for node:assert in docs-next/src/content/docs/getting-started.mdx to match Node’s default export and avoid runtime error.

fixes #5517