### PR TITLE
feat: add mocha.mjs export

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,7 +89,7 @@ module.exports = [
     },
   },
   {
-    files: ["test/**/*.mjs"],
+    files: ["**/*.mjs"],
     languageOptions: {
       sourceType: "module",
     },

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -1,4 +1,4 @@
-// this build file is not committed to the repo
+// this built file is not committed to the repo
 /* eslint-disable-next-line n/no-missing-import */
 import "./mocha.js";
 

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -2,27 +2,50 @@
 /* eslint-disable-next-line n/no-missing-import */
 import "./mocha.js";
 
-const { mocha } = globalThis;
+const {mocha, Mocha} = globalThis;
 
-mocha.ui();
+const mochaExports = {
+  afterEach: (...args) => globalThis.afterEach?.(...args),
+  after: (...args) => globalThis.after?.(...args),
+  beforeEach: (...args) => globalThis.beforeEach?.(...args),
+  before: (...args) => globalThis.before?.(...args),
+  describe: (...args) => globalThis.describe?.(...args),
+  it: (...args) => globalThis.it?.(...args),
+  xdescribe: (...args) => globalThis.xdescribe?.(...args),
+  xit: (...args) => globalThis.xit?.(...args),
+  setup: (...args) => mocha.setup?.(...args),
+  suiteSetup: (...args) => globalThis.suiteSetup?.(...args),
+  suiteTeardown: (...args) => globalThis.suiteTeardown?.(...args),
+  suite: (...args) => globalThis.suite?.(...args),
+  teardown: (...args) => globalThis.teardown?.(...args),
+  test: (...args) => globalThis.test?.(...args),
+  xspecify: (...args) => globalThis.xspecify?.(...args),
+  specify: (...args) => globalThis.specify?.(...args),
+  context: (...args) => globalThis.context?.(...args),
+  xcontext: (...args) => globalThis.xcontext?.(...args),
+  run: mocha.run.bind(mocha)
+};
 
-const after = globalThis.after.bind(mocha);
-const afterEach = globalThis.afterEach.bind(mocha);
-const before = globalThis.before.bind(mocha);
-const beforeEach = globalThis.beforeEach.bind(mocha);
-const context = globalThis.context.bind(mocha);
-const describe = globalThis.describe.bind(mocha);
-const it = globalThis.it.bind(mocha);
-const specify = globalThis.specify.bind(mocha);
-const xcontext = globalThis.xcontext.bind(mocha);
-const xdescribe = globalThis.xdescribe.bind(mocha);
-const xit = globalThis.xit.bind(mocha);
-const xspecify = globalThis.xspecify.bind(mocha);
+export default Mocha;
 
-const run = mocha.run.bind(mocha);
-const setup = mocha.setup.bind(mocha);
+// Export the mocha instance (in browser, this has setup/run methods)
+export { mocha };
 
-export {
+// Re-export class/utility exports from the Mocha module
+export const {
+  utils,
+  interfaces,
+  reporters,
+  Runnable,
+  Context,
+  Runner,
+  Suite,
+  Hook,
+  Test,
+} = Mocha;
+
+// Re-export test interface functions
+export const {
   after,
   afterEach,
   before,
@@ -32,9 +55,14 @@ export {
   it,
   run,
   setup,
+  suiteSetup,
+  suiteTeardown,
+  suite,
+  teardown,
+  test,
   specify,
   xcontext,
   xdescribe,
   xit,
   xspecify,
-};
+} = mochaExports;

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -5,25 +5,25 @@ import "./mocha.js";
 const {mocha, Mocha} = globalThis;
 
 const mochaExports = {
-  afterEach: (...args) => globalThis.afterEach?.(...args),
   after: (...args) => globalThis.after?.(...args),
-  beforeEach: (...args) => globalThis.beforeEach?.(...args),
+  afterEach: (...args) => globalThis.afterEach?.(...args),
   before: (...args) => globalThis.before?.(...args),
+  beforeEach: (...args) => globalThis.beforeEach?.(...args),
+  context: (...args) => globalThis.context?.(...args),
   describe: (...args) => globalThis.describe?.(...args),
   it: (...args) => globalThis.it?.(...args),
-  xdescribe: (...args) => globalThis.xdescribe?.(...args),
-  xit: (...args) => globalThis.xit?.(...args),
+  run: mocha.run.bind(mocha),
   setup: (...args) => mocha.setup?.(...args),
+  suite: (...args) => globalThis.suite?.(...args),
   suiteSetup: (...args) => globalThis.suiteSetup?.(...args),
   suiteTeardown: (...args) => globalThis.suiteTeardown?.(...args),
-  suite: (...args) => globalThis.suite?.(...args),
   teardown: (...args) => globalThis.teardown?.(...args),
   test: (...args) => globalThis.test?.(...args),
-  xspecify: (...args) => globalThis.xspecify?.(...args),
   specify: (...args) => globalThis.specify?.(...args),
-  context: (...args) => globalThis.context?.(...args),
   xcontext: (...args) => globalThis.xcontext?.(...args),
-  run: mocha.run.bind(mocha)
+  xdescribe: (...args) => globalThis.xdescribe?.(...args),
+  xit: (...args) => globalThis.xit?.(...args),
+  xspecify: (...args) => globalThis.xspecify?.(...args),
 };
 
 export default Mocha;
@@ -55,9 +55,9 @@ export const {
   it,
   run,
   setup,
+  suite,
   suiteSetup,
   suiteTeardown,
-  suite,
   teardown,
   test,
   specify,

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -1,0 +1,24 @@
+import "./mocha.js"
+
+const { mocha } = globalThis;
+
+const describe = mocha.describe.bind(mocha);
+const context = mocha.context.bind(mocha);
+const it = mocha.it.bind(mocha);
+const specify = mocha.specify.bind(mocha);
+const xdescribe = mocha.xdescribe.bind(mocha);
+const xcontext = mocha.xcontext.bind(mocha);
+const xit = mocha.xit.bind(mocha);
+const xspecify = mocha.xspecify.bind(mocha);
+const before = mocha.before.bind(mocha);
+const beforeEach = mocha.beforeEach.bind(mocha);
+const afterEach = mocha.afterEach.bind(mocha);
+const after = mocha.after.bind(mocha);
+
+const setup = mocha.setup.bind(mocha);
+const run = mocha.run.bind(mocha);
+
+export {
+  describe, context, it, specify, xdescribe, xcontext,
+  xit, xspecify, before, beforeEach, afterEach, after, setup, run
+};

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -1,3 +1,4 @@
+// this build file is not committed to the repo
 /* eslint-disable-next-line n/no-missing-import */
 import "./mocha.js";
 

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -3,20 +3,24 @@
 import "./mocha.js";
 
 const { mocha } = globalThis;
-const after = mocha.after.bind(mocha);
-const afterEach = mocha.afterEach.bind(mocha);
-const before = mocha.before.bind(mocha);
-const beforeEach = mocha.beforeEach.bind(mocha);
-const context = mocha.context.bind(mocha);
-const describe = mocha.describe.bind(mocha);
-const it = mocha.it.bind(mocha);
+
+mocha.ui();
+
+const after = globalThis.after.bind(mocha);
+const afterEach = globalThis.afterEach.bind(mocha);
+const before = globalThis.before.bind(mocha);
+const beforeEach = globalThis.beforeEach.bind(mocha);
+const context = globalThis.context.bind(mocha);
+const describe = globalThis.describe.bind(mocha);
+const it = globalThis.it.bind(mocha);
+const specify = globalThis.specify.bind(mocha);
+const xcontext = globalThis.xcontext.bind(mocha);
+const xdescribe = globalThis.xdescribe.bind(mocha);
+const xit = globalThis.xit.bind(mocha);
+const xspecify = globalThis.xspecify.bind(mocha);
+
 const run = mocha.run.bind(mocha);
 const setup = mocha.setup.bind(mocha);
-const specify = mocha.specify.bind(mocha);
-const xcontext = mocha.xcontext.bind(mocha);
-const xdescribe = mocha.xdescribe.bind(mocha);
-const xit = mocha.xit.bind(mocha);
-const xspecify = mocha.xspecify.bind(mocha);
 
 export {
   after,

--- a/mocha.mjs
+++ b/mocha.mjs
@@ -1,24 +1,35 @@
-import "./mocha.js"
+/* eslint-disable-next-line n/no-missing-import */
+import "./mocha.js";
 
 const { mocha } = globalThis;
-
-const describe = mocha.describe.bind(mocha);
-const context = mocha.context.bind(mocha);
-const it = mocha.it.bind(mocha);
-const specify = mocha.specify.bind(mocha);
-const xdescribe = mocha.xdescribe.bind(mocha);
-const xcontext = mocha.xcontext.bind(mocha);
-const xit = mocha.xit.bind(mocha);
-const xspecify = mocha.xspecify.bind(mocha);
+const after = mocha.after.bind(mocha);
+const afterEach = mocha.afterEach.bind(mocha);
 const before = mocha.before.bind(mocha);
 const beforeEach = mocha.beforeEach.bind(mocha);
-const afterEach = mocha.afterEach.bind(mocha);
-const after = mocha.after.bind(mocha);
-
-const setup = mocha.setup.bind(mocha);
+const context = mocha.context.bind(mocha);
+const describe = mocha.describe.bind(mocha);
+const it = mocha.it.bind(mocha);
 const run = mocha.run.bind(mocha);
+const setup = mocha.setup.bind(mocha);
+const specify = mocha.specify.bind(mocha);
+const xcontext = mocha.xcontext.bind(mocha);
+const xdescribe = mocha.xdescribe.bind(mocha);
+const xit = mocha.xit.bind(mocha);
+const xspecify = mocha.xspecify.bind(mocha);
 
 export {
-  describe, context, it, specify, xdescribe, xcontext,
-  xit, xspecify, before, beforeEach, afterEach, after, setup, run
+  after,
+  afterEach,
+  before,
+  beforeEach,
+  context,
+  describe,
+  it,
+  run,
+  setup,
+  specify,
+  xcontext,
+  xdescribe,
+  xit,
+  xspecify,
 };

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "mocha.css",
     "mocha.js",
     "mocha.js.map",
+    "mocha.mjs",
     "browser-entry.js"
   ],
   "browser": {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5211
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds an ESM export file for use in the browser.

The other non-underscored (private) keys I saw on the global `mocha` object which I wasn't sure which I might include were the following:

`files`, `options`, `suite`, `isWorker`,  `throwError`,  `ui`

---

2026-08-27: updating to stop using brittle filename (already changed to mocha.js):

https://github.com/googleapis/release-please#how-can-i-fix-release-notes

BEGIN_COMMIT_OVERRIDE
feat: add ESM export for browsers
END_COMMIT_OVERRIDE