### PR TITLE
fix: preserve TypeScript compilation errors instead of masking as MOD…

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -46,6 +46,20 @@ const tryImportAndRequire = async (file, esmDecorator) => {
   try {
     return dealWithExports(await formattedImport(file, esmDecorator));
   } catch (err) {
+    // Check if this is a TypeScript compilation error (from ts-node or similar)
+    // These often have detailed diagnostic information that we should preserve
+    const isTypescriptError =
+      err.message &&
+      (err.message.includes("TS") ||
+        err.message.includes("TypeScript") ||
+        err.message.includes("Type '") ||
+        /:\(\d+,\d+\):/.test(err.message)); // TypeScript error format like (line,col)
+
+    // If it's likely a TypeScript compilation error, don't mask it with fallback attempts
+    if (isTypescriptError && err.code === "ERR_MODULE_NOT_FOUND") {
+      throw err;
+    }
+
     if (
       err.code === "ERR_MODULE_NOT_FOUND" ||
       err.code === "ERR_UNKNOWN_FILE_EXTENSION" ||
@@ -98,6 +112,21 @@ const requireModule = async (file, esmDecorator) => {
     return require(file);
   } catch (requireErr) {
     debug("requireModule caught err: %O", requireErr.message);
+
+    // Check if this is a TypeScript compilation error (from ts-node or similar)
+    // These often have detailed diagnostic information that we should preserve
+    const isTypescriptError =
+      requireErr.message &&
+      (requireErr.message.includes("TS") ||
+        requireErr.message.includes("TypeScript") ||
+        requireErr.message.includes("Type '") ||
+        /:\(\d+,\d+\):/.test(requireErr.message)); // TypeScript error format like (line,col)
+
+    // If it's a TypeScript compilation error, throw it immediately without trying import()
+    if (isTypescriptError) {
+      throw requireErr;
+    }
+
     try {
       return dealWithExports(await formattedImport(file, esmDecorator));
     } catch (importErr) {


### PR DESCRIPTION
#5555 
When ts-node or similar TypeScript compilers encounter a type error,
the error was being caught and masked by fallback module loading logic,
resulting in unhelpful "Cannot find module" messages instead of the
actual TypeScript diagnostics.

This fix detects TypeScript compilation errors by checking for TS-specific
patterns in error messages and throws them immediately without attempting
fallback mechanisms, preserving the full diagnostic information for users.

Fixes issue where TypeScript errors in imported modules showed as
"Cannot find module" rather than displaying the actual type error.