### PR TITLE
docs: fix light mode Astro accent text color

### DIFF
--- a/docs-next/src/style/custom.css
+++ b/docs-next/src/style/custom.css
@@ -12,7 +12,6 @@
   --sl-color-accent-high: #d4c6bb;
   --sl-color-accent-text: var(--sl-color-mocha-vibrant);
   --sl-color-accent: var(--sl-color-mocha-light);
-  --sl-color-text-accent: var(--sl-color-mocha-vibrant);
   --sl-color-white: #f3ede7;
   --sl-color-gray-1: #f1eadf;
   --sl-color-gray-2: #cfc6c4;


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5584
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the custom override that was making things too light. Astro now has the default behavior we prefer. Yay, progress!