### PR TITLE
fix(docs-next): backer's logo is consistent regardless of size

### DIFF
--- a/docs-next/src/components/Supporters.astro
+++ b/docs-next/src/components/Supporters.astro
@@ -58,9 +58,13 @@ interface Props {
 
   .supporters-small img.supporter-image {
     height: 2rem;
+    width: 2rem;
+    object-fit: contain;
   }
 
   .supporters-medium img.supporter-image {
     height: 4rem;
+    width: 4rem;
+    object-fit: contain;
   }
 </style>


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5451 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Backer's logos are now shown consistently and uniformly regardless of their avatar's size.

Before
<img width="1119" height="687" alt="image" src="https://github.com/user-attachments/assets/a6b9ec4f-f3c0-456a-8d83-b3f541985b14" />


After
<img width="1059" height="687" alt="image" src="https://github.com/user-attachments/assets/8d606692-cf77-411c-bf11-642b5d0372e9" />
