### PR TITLE
docs: fix v3_older changelog duplicate headings

### DIFF
--- a/docs/changelogs/CHANGELOG_V3_older.md
+++ b/docs/changelogs/CHANGELOG_V3_older.md
@@ -621,11 +621,9 @@ Thanks to everyone who contributed, and our fabulous [sponsors and backers](http
 - Fix for --watch+only() issue ([#888](https://github.com/mochajs/mocha/issues/888) )
 - fix: respect err.showDiff, add Base reporter test ([#810](https://github.com/mochajs/mocha/issues/810))
 
-# 1.21.4 / 2014-07-27
+# 1.21.4 / 2014-08-06
 
 - fix: disabling timeouts with this.timeout(0) ([#1301](https://github.com/mochajs/mocha/issues/1301))
-
-<!-- Ref https://github.com/mochajs/mocha/issues/5595 -->
 
 # 1.21.1-3 / 2014-07-27
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5595
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

A review of historic tags in the current repository and it was discovered that one of the duplicate tags represented a newer version. 

I made changes to remove the duplicate header suppression and also updated the value of the tag associated with the commits.
