### PR TITLE
chore(ci): revert "chore(ci): use OIDC token for trusted publishing to `npm`"

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,4 +44,6 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts --force --no-fund --no-audit
 
-      - run: npm publish --access public --tag=next
+      - run: npm publish --provenance --access public --tag=next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Reverts mochajs/mocha#5610, ref https://github.com/mochajs/mocha/issues/5611