### PR TITLE
chore: add blank Prettier ruleset for monorepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,5 +198,6 @@
     "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.7",
     "webdriverio": "^7.33.0"
-  }
+  },
+  "prettier": {}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5621
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Monorepos previously would use Prettier rules defined outside Mocha, since Mocha didn't define its own. See issue for details.
