### PR TITLE
import() fallback prevention

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -1,6 +1,7 @@
 const path = require("node:path");
 const url = require("node:url");
 const debug = require("debug")("mocha:esm-utils");
+const { isMochaError } = require("../errors");
 
 const forward = (x) => x;
 
@@ -99,6 +100,9 @@ const requireModule = async (file, esmDecorator) => {
   } catch (requireErr) {
     debug("requireModule caught err: %O", requireErr.message);
     if (requireErr.name === "TSError") {
+      throw requireErr;
+    }
+    if (isMochaError(requireErr)) {
       throw requireErr;
     }
     try {

--- a/test/node-unit/esm-utils.spec.js
+++ b/test/node-unit/esm-utils.spec.js
@@ -48,6 +48,20 @@ describe("esm-utils", function () {
         },
       );
     });
+
+    it("should surface Mocha errors rather than falling back to `import(...)`", async function () {
+      return expect(
+        () =>
+          esmUtils.requireOrImport(
+            "../../test/node-unit/fixtures/mock-mocha-forbidden-exclusivity-err.ts",
+          ),
+        "to be rejected with error satisfying",
+        {
+          code: "ERR_MOCHA_FORBIDDEN_EXCLUSIVITY",
+          message: /`\.only` is not supported in parallel mode/,
+        },
+      );
+    });
   });
 
   describe("loadFilesAsync()", function () {

--- a/test/node-unit/fixtures/mock-mocha-forbidden-exclusivity-err.ts
+++ b/test/node-unit/fixtures/mock-mocha-forbidden-exclusivity-err.ts
@@ -1,0 +1,10 @@
+/*
+ Mock file that simulates a Mocha FORBIDDEN_EXCLUSIVITY error
+ This error is thrown when .only is used in parallel mode
+ */
+const { createForbiddenExclusivityError } = require('../../../lib/errors');
+
+// Simulate a mocha instance in worker mode
+const mockMocha = { isWorker: true };
+
+throw createForbiddenExclusivityError(mockMocha);


### PR DESCRIPTION
<!-- Hi, thanks for sending a PR to mocha! 
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #5579
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues/5579)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

# Overview

## Problem
When using Mocha in parallel mode with TypeScript via ts-node (CJS mode), if a test file contains `.only` and triggers a `FORBIDDEN_EXCLUSIVITY` error, the actual error message was buried. Instead of showing:

```
`.only` is not supported in parallel mode
```

Users would see a confusing module loading error:

```
Cannot use import statement outside a module
```

## Root Cause
In `lib/nodejs/esm-utils.js`, the `requireModule` function had a fallback mechanism: when `require()` failed, it would attempt to use dynamic `import()`. This was intended to handle ESM/CJS interop issues.

However, when a Mocha-specific error (like `FORBIDDEN_EXCLUSIVITY`) was thrown during `require()`, it wasn't recognized as a "real" error that should be surfaced immediately. Instead, the code fell through to the `import()` fallback, which bypassed ts-node's CJS loader and produced a misleading syntax error.

## Solution
Added a check to detect Mocha errors using the existing `isMochaError()` utility function. When a Mocha error is caught during `require()`, it's now thrown immediately instead of falling back to `import()`.

This follows the same pattern established in PR #5572, which added similar handling for ts-node's `TSError`.

## Changes Made

### Files Modified:
1. **lib/nodejs/esm-utils.js** - Added Mocha error detection
2. **test/node-unit/esm-utils.spec.js** - Added test case
3. **test/node-unit/fixtures/mock-mocha-forbidden-exclusivity-err.ts** - Created test fixture

### Code Changes:
- Imported `isMochaError` from `../errors`
- Added check: `if (isMochaError(requireErr)) { throw requireErr; }`
- Positioned after the existing `TSError` check for consistency

## Testing
- Created a test fixture that simulates the `FORBIDDEN_EXCLUSIVITY` error
- Added test case verifying Mocha errors are surfaced correctly
- All 580 existing tests continue to pass
