### PR TITLE
replace escape-string-regexp with tiny-escape

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -6,7 +6,7 @@
  * MIT Licensed
  */
 
-var escapeRe = require("escape-string-regexp");
+var escapeRe = require("tiny-escape");
 var path = require("node:path");
 var builtinReporters = require("./reporters");
 var utils = require("./utils");

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -13,7 +13,7 @@
 
 var Base = require("./base");
 var utils = require("../utils");
-var escapeRe = require("escape-string-regexp");
+var escapeRe = require("tiny-escape");
 var constants = require("../runner").constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chokidar": "^5.0.0",
         "debug": "^4.3.5",
         "diff": "^8.0.3",
-        "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^13.0.0",
         "he": "^1.2.0",
@@ -26,6 +25,7 @@
         "serialize-javascript": "^7.0.2",
         "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
+        "tiny-escape": "^1.1.0",
         "workerpool": "^10.0.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
@@ -4001,6 +4001,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10114,6 +10115,12 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/tiny-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-escape/-/tiny-escape-1.1.0.tgz",
+      "integrity": "sha512-lXGDmGlKA8CsZxunDDAK7IqCSjhAxK5JrTUHACHnTrmWjkgsSs4Z3uA/90MtX40yJ2GNpp+tNWZZ7e9qW1rLEA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "chokidar": "^5.0.0",
     "debug": "^4.3.5",
     "diff": "^8.0.3",
-    "escape-string-regexp": "^4.0.0",
+    "tiny-escape": "^1.1.0",
     "find-up": "^5.0.0",
     "glob": "^13.0.0",
     "he": "^1.2.0",

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { version } = require("../package.json");
-const escapeRe = require("escape-string-regexp");
+const escapeRe = require("tiny-escape");
 
 module.exports = {
   name: "unexpected-mocha-internal",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const escapeRegExp = require("escape-string-regexp");
+const escapeRegExp = require("tiny-escape");
 const os = require("node:os");
 const fs = require("node:fs");
 const fsP = require("node:fs/promises");


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5773
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

Note: #5746 is a Renovate bot PR to bump escape-string-regexp to v5, which can't land because v5 is ESM-only. This PR offers an alternative path that doesn't need the label.

## Overview

`escape-string-regexp` v5 is ESM-only, so the Renovate PR to upgrade from v4 (#5746) can't land while mocha is still CommonJS (#5400).

[`tiny-escape`](https://www.npmjs.com/package/tiny-escape) has the same API and ships both ESM and CJS. 192 bytes gzipped, zero deps, TypeScript types included.

This unblocks the upgrade without waiting for the CJS-to-ESM migration.

All tests pass (lint, test-node, test-browser).