### PR TITLE
error when using --watch with ESM in serial mode

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -21,7 +21,10 @@ const debug = require("debug")("mocha:cli:run:helpers");
 const { watchRun, watchParallelRun } = require("./watch-run");
 const collectFiles = require("./collect-files");
 const { format } = require("node:util");
-const { createInvalidLegacyPluginError } = require("../errors");
+const {
+  createInvalidLegacyPluginError,
+  createUnsupportedError,
+} = require("../errors");
 const { requireOrImport } = require("../nodejs/esm-utils");
 const PluginLoader = require("../plugin-loader");
 
@@ -206,6 +209,79 @@ const parallelRun = async (mocha, options, fileCollectParams) => {
 };
 
 /**
+ * Checks whether any of the given file paths are ES modules.
+ *
+ * A file is considered ESM if:
+ * - It has a `.mjs` or `.mts` extension
+ * - It has a `.js`, `.ts`, `.jsx`, or `.tsx` extension and the nearest
+ *   `package.json` has `"type": "module"`
+ *
+ * @param {string[]} filePaths - Absolute file paths to check
+ * @returns {boolean} `true` if any file is ESM
+ * @private
+ */
+function containsESM(filePaths) {
+  /** @type {Map<string, boolean>} */
+  const packageTypeCache = new Map();
+
+  for (const filePath of filePaths) {
+    const ext = path.extname(filePath);
+
+    if (ext === ".mjs" || ext === ".mts") {
+      debug("detected ESM file by extension: %s", filePath);
+      return true;
+    }
+
+    if (ext === ".js" || ext === ".ts" || ext === ".jsx" || ext === ".tsx") {
+      if (isDirectoryESM(path.dirname(filePath), packageTypeCache)) {
+        debug("detected ESM file via package.json type:module: %s", filePath);
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Determines whether a directory is within an ESM package by searching
+ * for the nearest `package.json` with `"type": "module"`.
+ *
+ * Results are cached per directory for efficiency.
+ *
+ * @param {string} dir - Directory path to check
+ * @param {Map<string, boolean>} cache - Cache of directory → isESM results
+ * @returns {boolean} `true` if the nearest `package.json` has `"type": "module"`
+ * @private
+ */
+function isDirectoryESM(dir, cache) {
+  if (cache.has(dir)) {
+    return cache.get(dir);
+  }
+
+  const packageJsonPath = path.join(dir, "package.json");
+
+  try {
+    const raw = fs.readFileSync(packageJsonPath, "utf8");
+    const packageJson = JSON.parse(raw);
+    const isESM = packageJson.type === "module";
+    cache.set(dir, isESM);
+    return isESM;
+  } catch {
+    // No package.json in this directory (or not valid JSON); traverse up
+    const parentDir = path.dirname(dir);
+    if (parentDir === dir) {
+      // Reached filesystem root
+      cache.set(dir, false);
+      return false;
+    }
+    const result = isDirectoryESM(parentDir, cache);
+    cache.set(dir, result);
+    return result;
+  }
+}
+
+/**
  * Actually run tests.  Delegates to one of four different functions:
  * - `singleRun`: run tests in serial & exit
  * - `watchRun`: run tests in serial, rerunning as files change
@@ -236,6 +312,24 @@ exports.runMocha = async (mocha, options) => {
     sort,
     spec,
   };
+
+  if (watch && !parallel) {
+    const { files } = collectFiles(fileCollectParams);
+
+    // Also resolve any --require paths that point to local files
+    const requires = options.require || [];
+    const requirePaths = requires
+      .filter((mod) => fs.existsSync(mod) || fs.existsSync(`${mod}.js`))
+      .map((mod) => path.resolve(mod));
+
+    if (containsESM([...files, ...requirePaths])) {
+      throw createUnsupportedError(
+        "--watch is incompatible with ESM files in serial mode, " +
+          "because changed modules will not be reloaded.\n" +
+          "Use --watch --parallel --jobs 1 for watch mode with ESM.",
+      );
+    }
+  }
 
   let run;
   if (watch) {

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -4,6 +4,8 @@ const fs = require("node:fs");
 const path = require("node:path");
 const {
   copyFixture,
+  invokeMochaAsync,
+  resolveFixturePath,
   runMochaWatchJSONAsync,
   sleep,
   runMochaWatchAsync,
@@ -557,6 +559,63 @@ describe("--watch", function () {
           output: expect.it("not to match", /MaxListenersExceededWarning/),
         },
       );
+    });
+  });
+
+  describe("when used with ESM files in serial mode", function () {
+    it("should error out for .mjs test files", async function () {
+      return expect(
+        invokeMochaAsync(
+          ["--watch", resolveFixturePath("esm/esm-success.fixture.mjs")],
+          "pipe",
+        )[1],
+        "when fulfilled",
+        "to contain output",
+        /incompatible with ESM/,
+      );
+    });
+
+    it("should error out for .js files with type:module in package.json", async function () {
+      return expect(
+        invokeMochaAsync(
+          ["--watch", resolveFixturePath("esm/js-folder/esm-in-js.fixture.js")],
+          "pipe",
+        )[1],
+        "when fulfilled",
+        "to contain output",
+        /incompatible with ESM/,
+      );
+    });
+
+    it("should suggest --parallel --jobs 1 in error message", async function () {
+      return expect(
+        invokeMochaAsync(
+          ["--watch", resolveFixturePath("esm/esm-success.fixture.mjs")],
+          "pipe",
+        )[1],
+        "when fulfilled",
+        "to contain output",
+        /--parallel --jobs 1/,
+      );
+    });
+
+    it("should not error when --parallel is also used", async function () {
+      const testFile = resolveFixturePath("esm/esm-success.fixture.mjs");
+      // Using invokeMochaAsync with --parallel should NOT produce the ESM error.
+      // We just check the output does not contain the incompatibility message.
+      // The process will eventually be killed since --watch keeps running.
+      const [proc, resultPromise] = invokeMochaAsync(
+        ["--watch", "--parallel", testFile],
+        { stdio: "pipe" },
+      );
+
+      // Give it a moment to start, then kill it
+      await sleep(2000);
+      proc.kill("SIGINT");
+
+      return expect(resultPromise, "when fulfilled", "to satisfy", {
+        output: expect.it("not to contain", "incompatible with ESM"),
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5590
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Hey so this PR adds an error when someone tries to use `--watch` with ESM files in serial mode

The problem is that watch mode silently fails on reruns because Node.js caches ES modules and theres no way to invalidate that cache unlike `require.cache` for CJS. The first run works fine which makes it confusing because you dont get any feedback that things are broken

What I did here is detect ESM files before entering watch serial mode by checking for `.mjs`/`.mts` extensions and also looking at the nearest `package.json` for `type: module` on `.js`/`.ts` files. If ESM is found and `--parallel` isnt set it throws an `ERR_MOCHA_UNSUPPORTED` error pointing users to use `--watch --parallel --jobs 1` instead

This follows what @mark-wiemer suggested in the issue about erroring rather than just warning

Added 4 integration tests covering `.mjs` files, `type:module` packages, the error message content and making sure `--parallel` bypasses the check
