### PR TITLE
docs: add "failing workaround" and new dash to sec-vuln-reports.mdx

### DIFF
--- a/docs-next/src/content/docs/explainers/security-vulnerability-reports.mdx
+++ b/docs-next/src/content/docs/explainers/security-vulnerability-reports.mdx
@@ -4,12 +4,13 @@ title: Security Vulnerability Reports
 ---
 
 {/* Use `ldquo` (left double quote) HTML because Astro wrongly makes it right quote otherwise */}
+{/* Use `rdquo` for consistency (in case we change settings later and don't notice this) */}
 
-## &ldquo;`npm audit` or GitHub Advisories reported a vulnerability in a package Mocha depends on!"
+## &ldquo;`npm audit` or GitHub Advisories reported a vulnerability in a package Mocha depends on!&rdquo;
 
 We probably know already 🙂
 
-First and foremost, please check [Mocha issue 5070](https://github.com/mochajs/mocha/issues/5070), which tracks all reported potential security issues.
+First and foremost, please check [Mocha issue 5781: Security Dashboard](https://github.com/mochajs/mocha/issues/5781), which tracks all reported potential security issues.
 
 Second, please read the vulnerability to see if it actually applies to Mocha in your configuration (or any reasonable configuration you can imagine/test). As a test framework, Mocha is very unlikely to be affected by security vulnerabilities, as it only runs code that you as a developer provide to it.
 
@@ -31,3 +32,9 @@ Most security vulnerabilities in dependencies are relevant for production applic
 ## What if there's a real security issue?
 
 If you believe you've found a genuine security vulnerability that affects Mocha itself (not just a transitive dependency), please report it responsibly through our [security policy](https://github.com/mochajs/mocha/blob/main/SECURITY.md).
+
+## My build is failing, how do I workaround this?
+
+We encourage you to find or add manual workarounds for any system that blocks PRs on `npm audit` or similar warnings. Any system that automatically blocks a process should have a manual override for known false positives.
+
+If you can't make workaround your system, you're welcome to clone Mocha, update dependencies, rebuild from source, and use that instead of the publicly-available version. And if you have a fix for us, we're happy to review PRs!


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5690
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Add workaround details and link to new security dashboard (#5781)
