### PR TITLE
docs: cleanup third party UI code examples for issue 5570

### DIFF
--- a/docs-next/src/content/docs/explainers/third-party-uis.mdx
+++ b/docs-next/src/content/docs/explainers/third-party-uis.mdx
@@ -10,15 +10,23 @@ Creating a Third Party UI involves listening for the `pre-require` event emitted
 In this first brief example, we'll create an interface with only a single function: `test`
 
 ```javascript
-var Mocha = require("mocha");
-((Suite = require("mocha/lib/suite")), (Test = require("mocha/lib/test")));
+import Mocha from 'mocha'
+import MochaInterface from 'mocha/lib/interfaces/common.js';
 
+const Test = Mocha.Test;
 /**
  * A simple UI that only exposes a single function: test
  */
-module.exports = Mocha.interfaces["simple-ui"] = function (suite) {
-  suite.on("pre-require", function (context, file, mocha) {
-    var common = require("mocha/lib/interfaces/common")([suite], context);
+function SimpleUI(suite) {
+  suite.on('pre-require', function(
+    context,
+    file,
+    mocha
+  ) {
+    const common = MochaInterface(
+      [suite],
+      context
+    );
 
     context.run = mocha.options.delay && common.runWithSuite(suite);
 
@@ -26,8 +34,8 @@ module.exports = Mocha.interfaces["simple-ui"] = function (suite) {
      * Describes a specification or test-case with the given `title`
      * and callback `fn` acting as a thunk.
      */
-    context.test = function (title, fn) {
-      var test = new Test(title, fn);
+    context.test = function(title, fn) {
+      const test = new Test(title, fn);
       test.file = file;
       suite.addTest(test);
 
@@ -35,6 +43,10 @@ module.exports = Mocha.interfaces["simple-ui"] = function (suite) {
     };
   });
 };
+
+Mocha.interfaces['simple-ui'] = SimpleUI;
+
+export default SimpleUI;
 ```
 
 ```javascript
@@ -68,21 +80,23 @@ $ mocha --require ./simple-ui.js --ui simple-ui test.js
 In this next example, we'll be extending the [TDD interface](https://github.com/mochajs/mocha/blob/master/lib/interfaces/tdd.js) with a comment function that simply prints the passed text. That is, `comment('This is a comment');` would print the string.
 
 ```javascript
-var Mocha = require("mocha");
-((Suite = require("mocha/lib/suite")),
-  (Test = require("mocha/lib/test")),
-  (escapeRe = require("escape-string-regexp")));
+import Mocha from 'mocha';
+import MochaInterface from 'mocha/lib/interfaces/common.js';
+import escapeStringRegexp from 'escape-string-regexp';
+
+const Test = Mocha.Test;
+const Suite = Mocha.Suite;
 
 /**
  * This example is identical to the TDD interface, but with the addition of a
  * "comment" function:
  * https://github.com/mochajs/mocha/blob/master/lib/interfaces/tdd.js
  */
-module.exports = Mocha.interfaces["example-ui"] = function (suite) {
+function ExampleUI(suite) {
   var suites = [suite];
 
   suite.on("pre-require", function (context, file, mocha) {
-    var common = require("mocha/lib/interfaces/common")(suites, context);
+    var common = MochaInterface([suite], context);
 
     /**
      * Use all existing hook logic common to UIs. Common logic can be found in
@@ -178,7 +192,7 @@ module.exports = Mocha.interfaces["example-ui"] = function (suite) {
       var test, reString;
 
       test = context.test(title, fn);
-      reString = "^" + escapeRe(test.fullTitle()) + "$";
+      reString = "^" + escapeStringRegexp(test.fullTitle()) + "$";
       mocha.grep(new RegExp(reString));
     };
 
@@ -188,6 +202,10 @@ module.exports = Mocha.interfaces["example-ui"] = function (suite) {
     context.test.skip = common.test.skip;
   });
 };
+
+Mocha.interfaces['example-ui'] = ExampleUI;
+
+export default ExampleUI;
 ```
 
 ```javascript


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5570 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Refactors the Third-Party UI examples in the documentation to replace commonjs with ESM. 

Converts all ```require()``` usage to ```import```
```module.exports = ...``` is replaced with ```export default ...```
The unused import ```Suite``` is removed.


<!-- Description of what is changed and how the code change does that. -->
