### PR TITLE
chore: fix supporters file extension in knip config

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -8,9 +8,7 @@
     "index.js!",
     "lib/cli/index.js!",
   ],
-  "project": [
-    "{bin,lib,scripts,test}/**/*.{js,ts,mjs,cjs}"
-  ],
+  "project": ["{bin,lib,scripts,test}/**/*.{js,ts,mjs,cjs}"],
   "ignore": [
     "test/integration/fixtures/esm/type-module/test-that-imports-non-existing-module.fixture.js",
     "test/integration/fixtures/options/watch/test-with-dependency.fixture.js",
@@ -22,9 +20,7 @@
     "non-existent-package",
   ],
   "mocha": {
-    "entry": [
-      "test/**/*.{js,ts,mjs,cjs}"
-    ],
+    "entry": ["test/**/*.{js,ts,mjs,cjs}"],
   },
   "webpack": {
     "config": "test/browser-specific/fixtures/webpack/webpack.config.js",


### PR DESCRIPTION
## Description

Fixes a configuration warning in Knip by updating `.knip.jsonc` to correctly reference `docs/_data/supporters.cjs` instead of `.js`. 

This is a minor chore to silence the active "Configuration hints (1): Refine entry pattern" warning emitted during `npm run lint:knip`.

## Prerequisites
- [x] Addresses an existing open issue: fixes #5676
- [x] That issue was marked as status: accepting prs
- [x] Steps in CONTRIBUTING.md were taken

## Type of Change
- [x] Chore (minor, safe refactoring, linting or documentation updates)

## Validation
- [x] `npm run lint:knip` runs perfectly clean.
