### PR TITLE
feat: include actual test duration in timeout error messages

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -237,7 +237,8 @@ class Runnable extends EventEmitter {
       if (self.timeout() === 0) {
         return;
       }
-      self.callback(self._timeoutError(ms));
+      var elapsed = self._start ? new Date() - self._start : undefined;
+      self.callback(self._timeoutError(ms, elapsed));
       self.timedOut = true;
     }, ms);
   }
@@ -263,7 +264,7 @@ class Runnable extends EventEmitter {
    */
   run(fn) {
     var self = this;
-    var start = new Date();
+    var start = (this._start = new Date());
     var ctx = this.ctx;
     var finished;
     var errorWasHandled = false;
@@ -299,7 +300,7 @@ class Runnable extends EventEmitter {
       self.duration = new Date() - start;
       finished = true;
       if (!err && self.duration > ms && ms > 0) {
-        err = self._timeoutError(ms);
+        err = self._timeoutError(ms, self.duration);
       }
       fn(err);
     }
@@ -421,8 +422,12 @@ class Runnable extends EventEmitter {
    * @returns {Error} a "timeout" error
    * @private
    */
-  _timeoutError(ms) {
-    let msg = `Timeout of ${ms}ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`;
+  _timeoutError(ms, duration) {
+    let msg = `Timeout of ${ms}ms exceeded.`;
+    if (duration != null) {
+      msg += ` Test ran for ${duration}ms.`;
+    }
+    msg += ` For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`;
     if (this.file) {
       msg += " (" + this.file + ")";
     }

--- a/test/unit/runnable.spec.js
+++ b/test/unit/runnable.spec.js
@@ -623,6 +623,36 @@ describe("Runnable(title, fn)", function () {
           });
         });
       });
+
+      it("should include actual elapsed duration in timeout error message (hard timeout)", function (done) {
+        var runnable = new Runnable("foo", function (done) {
+          setTimeout(done, 100);
+        });
+        runnable.timeout(10);
+        runnable.run(function (err) {
+          expect(
+            err.message,
+            "to match",
+            /Timeout of 10ms exceeded\. Test ran for \d+ms\./,
+          );
+          done();
+        });
+      });
+
+      it("should include actual elapsed duration in timeout error message (soft timeout)", function (done) {
+        var runnable = new Runnable("foo", function (innerDone) {
+          setTimeout(innerDone, 60);
+        });
+        runnable.timeout(50);
+        runnable.run(function (err) {
+          expect(
+            err.message,
+            "to match",
+            /Timeout of 50ms exceeded\. Test ran for \d+ms\./,
+          );
+          done();
+        });
+      });
     });
 
     describe("if async", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5543
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Timeout errors currently report only the configured limit:

```
Error: Timeout of 2000ms exceeded. For async tests and hooks...
```

This makes it impossible to tell at a glance whether a test barely exceeded the threshold or ran for many times longer — two scenarios that call for very different debugging strategies.

This change adds the actual elapsed duration to the message when available:

```
Error: Timeout of 2000ms exceeded. Test ran for 2001ms. For async tests and hooks...
```

### Two timeout paths

Mocha has two distinct timeout paths, both now covered:

**Hard timeout** — the timer fires while the test is still running (e.g. a hung async test). Elapsed time is captured at the moment the timer fires, so the reported duration will be at or just above the configured limit:
```
Error: Timeout of 2000ms exceeded. Test ran for 2001ms. For async tests...
```

**Soft timeout** — the test completes (calls `done()` or resolves its promise), but the elapsed time already exceeded the threshold. Here the reported duration can be significantly higher than the limit:
```
Error: Timeout of 2000ms exceeded. Test ran for 2488ms. For async tests...
```

### Implementation

- `run()` stores the start time as `this._start` so it is accessible outside the local scope
- The hard-timeout path computes elapsed time at the moment the timer fires and passes it to `_timeoutError()`
- The soft-timeout path already has `self.duration` computed and passes it directly
- `_timeoutError()` accepts an optional `duration` parameter and inserts `Test ran for Xms.` only when a value is present, keeping the message unchanged for any call sites that do not provide one

Two new unit tests cover both timeout paths.