### PR TITLE
chore: add workflow to handle stale items

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,24 +15,24 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-label: "status: stale"
-          stale-pr-label: "status: stale"
+          close-issue-message: >
+            This issue has been automatically closed after waiting 4 weeks with no response from the author.
+            If you have more information to provide, please feel free to reopen this issue or open a new one.
+          close-pr-message: >
+            This pull request has been automatically closed after waiting 4 weeks with no response from the author.
+            If you have more information to provide, please feel free to reopen this pull request or open a new one.
+          days-before-close: 14
+          days-before-stale: 14
           only-labels: "status: waiting for author"
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          stale-issue-label: "status: stale"
           stale-issue-message: >
             This issue has been waiting for a response from the author for 2 weeks with no activity.
             If there is no further activity in the next 2 weeks, this issue will be automatically closed.
             Maintainers: to keep this issue open indefinitely, remove the "status: waiting for author" label.
-          close-issue-message: >
-            This issue has been automatically closed after waiting 4 weeks with no response from the author.
-            If you have more information to provide, please feel free to reopen this issue or open a new one.
+          stale-pr-label: "status: stale"
           stale-pr-message: >
             This pull request has been waiting for a response from the author for 2 weeks with no activity.
             If there is no further activity in the next 2 weeks, this pull request will be automatically closed.
             Maintainers: to keep this pull request open indefinitely, remove the "status: waiting for author" label.
-          close-pr-message: >
-            This pull request has been automatically closed after waiting 4 weeks with no response from the author.
-            If you have more information to provide, please feel free to reopen this pull request or open a new one.
-          days-before-stale: 14
-          days-before-close: 14
-          remove-stale-when-updated: true
-          operations-per-run: 100


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5541
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

After 14 days, marks "waiting for author" items as stale. 14 days after that, closes those items. If the issue is updated before the item is closed, the stale tag is removed and the timer is reset.
