### PR TITLE
fix: support file: URLs in loadFilesAsync

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -148,6 +148,22 @@ function dealWithExports(module) {
   }
 }
 
+const resolveFile = (file) => {
+  if (URL.canParse(file)) {
+    const parsed = new URL(file);
+    // Single-letter "protocols" (e.g. "d:") are Windows drive letters, not URL schemes
+    if (parsed.protocol.length > 2) {
+      if (parsed.protocol === "file:") {
+        return url.fileURLToPath(parsed);
+      }
+      throw new Error(
+        `Unsupported URL protocol "${parsed.protocol}". Only "file:" URLs are supported.`,
+      );
+    }
+  }
+  return path.resolve(file);
+};
+
 exports.loadFilesAsync = async (
   files,
   preLoadFunc,
@@ -157,7 +173,7 @@ exports.loadFilesAsync = async (
   for (const file of files) {
     preLoadFunc(file);
     const result = await exports.requireOrImport(
-      path.resolve(file),
+      resolveFile(file),
       esmDecorator,
     );
     postLoadFunc(file, result);

--- a/test/node-unit/esm-utils.spec.js
+++ b/test/node-unit/esm-utils.spec.js
@@ -101,5 +101,48 @@ describe("esm-utils", function () {
         `${url.pathToFileURL("/foo/bar.mjs").toString()}?foo=bar`,
       );
     });
+
+    it("should support file: URLs passed to loadFilesAsync", async function () {
+      const fileUrl = url.pathToFileURL("/foo/bar.mjs").toString();
+      await esmUtils.loadFilesAsync(
+        [fileUrl],
+        () => {},
+        () => {},
+      );
+
+      expect(esmUtils.doImport.firstCall.args[0].toString(), "to be", fileUrl);
+    });
+
+    it("should treat Windows drive-letter paths as regular file paths", async function () {
+      // URL.canParse("C:/foo/bar.mjs") returns true on all platforms,
+      // but "c:" is a drive letter, not a URL scheme — must fall through to path.resolve
+      await esmUtils.loadFilesAsync(
+        ["C:/foo/bar.mjs"],
+        () => {},
+        () => {},
+      );
+
+      expect(
+        esmUtils.doImport.firstCall.args[0].toString(),
+        "to contain",
+        "C:",
+      );
+    });
+
+    it("should throw for unsupported URL protocols", async function () {
+      return expect(
+        () =>
+          esmUtils.loadFilesAsync(
+            ["https://example.com/suite.js"],
+            () => {},
+            () => {},
+          ),
+        "to be rejected with error satisfying",
+        {
+          message:
+            'Unsupported URL protocol "https:". Only "file:" URLs are supported.',
+        },
+      );
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4993
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`mocha.addFile()` accepts file paths, but passing a `file:` URL caused `path.resolve()` to mangle it into an invalid path like `/project/file:/project/suite.js`.

`URL.canParse()` is now used to detect URLs before resolving. `file:` URLs are converted to paths via `url.fileURLToPath()`. Any other protocol throws a clear error rather than silently producing a broken path.

The cache-busting use case mentioned in #4993 (using unique query parameters to force re-execution of ESM modules) is considered out of scope for this fix and is not addressed here. That problem is tracked in #4374.