### PR TITLE
refactor: remove unreachable `process.nextTick` fallback for `Runner.immediately`

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -242,12 +242,12 @@ class Runner extends EventEmitter {
 }
 
 /**
- * Wrapper for setImmediate, process.nextTick, or browser polyfill.
+ * Wrapper for setImmediate or browser polyfill.
  *
  * @param {Function} fn
  * @private
  */
-Runner.immediately = global.setImmediate || process.nextTick;
+Runner.immediately = global.setImmediate;
 
 /**
  * Replacement for `target.on(eventName, listener)` that does bookkeeping to remove them when this runner instance is disposed.


### PR DESCRIPTION
`global.setImmediate` has existed since Node 0.9.1. The `process.nextTick` fallback in `Runner.immediately` is unreachable.
    
`browser-entry.js` overrides `Runner.immediately` independently.

This change simplifies the codebase by eliminating unnecessary polyfills.

## PR Checklist

- [x] Addresses an existing open issue: #5357
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

### Alternate Designs

No alternate designs were considered as the removal of the polyfill is straightforward and aligns with the current Node.js version requirements.

### Why should this be in core?

This change is useful in maintaining a clean and efficient codebase, ensuring that it leverages the capabilities of the latest Node.js versions without redundant legacy code.

### Benefits

The primary benefit of this change is the reduction of code complexity and the reliance on modern Node.js features, whic lead to improved maintainability.

### Possible Drawbacks

There are no significant drawbacks anticipated from this change, as it only affects the code path for environments running Node.js versions that are already supported.

### Applicable issues

* This change is part of the Mocha 12 Release Plan: #5357
* It does not introduce breaking changes, as it only removes deprecated code.

