### PR TITLE
refactor: remove `repeat()` polyfill

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -217,8 +217,7 @@ exports.stringify = function (value) {
       ).replace(/,(\n|$)/g, "$1");
     }
 
-    // IE7/IE8 has a bizarre String constructor; needs to be coerced
-    // into an array and back to obj.
+    // Boxed String objects (new String("foo")): expand into character-indexed object.
     if (typeHint === "string" && typeof value === "object") {
       value = value.split("").reduce(function (acc, char, idx) {
         acc[idx] = char;
@@ -265,11 +264,6 @@ function jsonStringify(object, spaces, depth) {
     typeof object.length === "number"
       ? object.length
       : Object.keys(object).length;
-  // `.repeat()` polyfill
-  function repeat(s, n) {
-    return new Array(n).join(s);
-  }
-
   function _stringify(val) {
     switch (canonicalType(val)) {
       case "null":
@@ -318,7 +312,7 @@ function jsonStringify(object, spaces, depth) {
     --length;
     str +=
       "\n " +
-      repeat(" ", space) +
+      " ".repeat(space - 1) +
       (Array.isArray(object) ? "" : '"' + i + '": ') + // key
       _stringify(object[i]) + // value
       (length ? "," : ""); // comma
@@ -327,7 +321,7 @@ function jsonStringify(object, spaces, depth) {
   return (
     str +
     // [], {}
-    (str.length !== 1 ? "\n" + repeat(" ", space - 1) + end : end)
+    (str.length !== 1 ? "\n" + " ".repeat(Math.max(0, space - 2)) + end : end)
   );
 }
 


### PR DESCRIPTION
`String.prototype.repeat` has existed since ES2015 / Node 4.

The custom `repeat()` used `new Array(n).join(s)` which produces n-1 copies — the replacement preserves this semantic with `.repeat(n-1)`.

Also updates a misleading IE7/IE8 comment on boxed String handling.

## PR Checklist

- [x] Addresses an existing open issue: fixes #5357
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken
