### PR TITLE
docs: document parent directory lookup for config files

### DIFF
--- a/docs/src/content/docs/running/configuring.mdx
+++ b/docs/src/content/docs/running/configuring.mdx
@@ -23,6 +23,10 @@ Mocha will use the file's extension to determine how to parse the file, and will
 
 You can specify a custom `package.json` location as well, using the `--package <path>` option.
 
+## Parent Directory Lookup
+
+If Mocha does not find a configuration file in the current working directory, it will search parent directories until one is found or the filesystem root is reached. The same applies when looking for `package.json`. This means a config file placed in a repository root will be used automatically when running Mocha from any subdirectory.
+
 ## Ignoring Config Files
 
 To skip looking for config files, use `--no-config`.


### PR DESCRIPTION
Addresses #4976. Documents that Mocha searches parent directories for configuration files and `package.json`.

## PR Checklist

* [x] Addresses an existing open issue: fixes #4976
* [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
* [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a "Parent Directory Lookup" section to `docs/src/content/docs/running/configuring.mdx`, between "Custom Locations" and "Ignoring Config Files".

Mocha uses `find-up` to locate both config files (`findConfig()` in `lib/cli/config.js`) and `package.json` (`lib/cli/options.js`), walking parent directories until a match or the filesystem root. This behavior was undocumented.

Docs build verified: 65 pages, 0 errors.