### PR TITLE
docs: clarify --delay option behavior

### DIFF
--- a/docs/src/content/docs/features/hooks.mdx
+++ b/docs/src/content/docs/features/hooks.mdx
@@ -97,7 +97,9 @@ Delayed root suites are incompatible with [parallel mode](/features/parallel-mod
 
 If you need to perform asynchronous operations before any of your suites are run (e.g. for dynamically generating tests), you may delay the root suite.
 Run `mocha` with the `--delay` flag.
-This will attach a special callback function, `run()`, to the global context:
+This will attach a special callback function, `run()`, to the global context.
+
+With `--delay`, Mocha loads your test file and executes its top-level code as usual, but waits to _run_ tests until you call `run()`. Place your `describe()` and `it()` calls inside the asynchronous code so that suites are registered after setup completes, then call `run()` to begin execution:
 
 ```js
 const assert = require("assert");

--- a/docs/src/content/docs/features/hooks.mdx
+++ b/docs/src/content/docs/features/hooks.mdx
@@ -99,7 +99,8 @@ If you need to perform asynchronous operations before any of your suites are run
 Run `mocha` with the `--delay` flag.
 This will attach a special callback function, `run()`, to the global context.
 
-With `--delay`, Mocha loads your test file and executes its top-level code as usual, but waits to _run_ tests until you call `run()`. Place your `describe()` and `it()` calls inside the asynchronous code so that suites are registered after setup completes, then call `run()` to begin execution:
+With `--delay`, Mocha loads your test file and executes its top-level code as usual, but waits to run tests until you call `run()`.
+Place your `describe()` and `it()` calls inside the asynchronous code so that suites are registered after setup completes, then call `run()` to begin execution:
 
 ```js
 const assert = require("assert");

--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -138,7 +138,7 @@ See [further explanation and workarounds](https://github.com/mochajs/mocha/wiki/
 
 ### `--delay`
 
-Delay initial execution of root suite.
+Delay running of tests until you call `run()` in your test files. Use this when you need to perform asynchronous setup before registering suites and tests.
 
 See [Delayed Root Suite](/features/hooks#delayed-root-suite).
 


### PR DESCRIPTION
Addresses #5004. Clarifies that `--delay` defers test execution (not file loading), and that `describe()`/`it()` calls must be placed inside asynchronous setup code.

## PR Checklist

* [x] Addresses an existing open issue: fixes #5004
* [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
* [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Two files changed:

- **`docs/src/content/docs/features/hooks.mdx`**: Rewrites the prose in the "Delayed Root Suite" section. The previous wording ("This will attach a special callback function, `run()`, to the global context:") did not explain what `--delay` actually defers. New text explains that Mocha loads and executes top-level code as usual but waits to _run_ tests until `run()` is called, and instructs readers to place `describe()`/`it()` inside async code. The example code is unchanged — it was already correct.

- **`docs/src/content/docs/running/cli.mdx`**: Changes the `--delay` one-liner from "Delay initial execution of root suite" to "Delay running of tests until you call `run()` in your test files."

Verified against `lib/interfaces/common.js` (`runWithSuite` triggers `suite.run()`) and `lib/interfaces/bdd.js` (`context.run` attached only when `delay` option is set). Docs build verified: 65 pages, 0 errors.