### PR TITLE
docs: clarify that parallel mode does not provide test isolation

### DIFF
--- a/docs/src/content/docs/features/parallel-mode.mdx
+++ b/docs/src/content/docs/features/parallel-mode.mdx
@@ -105,7 +105,7 @@ mocha --file "./test/setup.js" "./test/**/*.spec.js"
 
 **The above example does not work in parallel mode.**
 
-When Mocha runs in parallel mode, **test files do not share the same process,** nor do they share the same instance of Mocha.
+When Mocha runs in parallel mode, **each test file gets its own instance of Mocha.**
 Consequently, a hypothetical root hook defined in test file _A_ **will not be present** in test file _B_.
 
 Here are a couple suggested workarounds:
@@ -151,6 +151,15 @@ It may help to use a conditional in a `.mocharc.js` to check for `process.env.CI
 
 It's unlikely (but not impossible) to see a performance gain from a [job count](/running/cli#--jobs-count--j-count) _greater than_ the number of available CPU cores.
 That said, _play around with the job count_--there's no one-size-fits all, and the unique characteristics of your tests will determine the optimal number of jobs; it may even be that fewer is faster!
+
+## Test Isolation Is Not Provided
+
+In parallel mode, Mocha uses a pool of worker processes. Each worker may run multiple test files sequentially within the same process. This means test files assigned to the same worker share process-level state, including the Node.js module cache and global variables.
+
+Mocha does **not** provide an option to spawn a fresh process for each test file. If your tests require strict process-level isolation (for example, because they patch globals, modify the module system, or have other irreversible side effects), consider:
+
+- Invoking `mocha` separately for each test file and merging results externally.
+- Using a test runner that provides process-level isolation per test file.
 
 ## Parallel Mode Worker IDs
 


### PR DESCRIPTION
Addresses #5356. Corrects a misleading claim about process sharing in parallel mode and documents that test isolation is not provided.

## PR Checklist

* [x] Addresses an existing open issue: fixes #5356
* [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
* [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

One file changed — `docs/src/content/docs/features/parallel-mode.mdx`:

1. **Fixed misleading claim** (line 108): Changed "test files do not share the same process, nor do they share the same instance of Mocha" to "each test file gets its own instance of Mocha." The original was wrong — Mocha uses a `workerpool` pool with `workerType: "process"` (`lib/nodejs/buffered-worker-pool.js`), so workers *are* reused and multiple files *can* share a process. Each file does get a fresh `new Mocha(opts)` instance (`lib/nodejs/worker.js`).

2. **Added "Test Isolation Is Not Provided" section**: Documents that workers may run multiple test files sequentially, sharing process-level state (module cache, globals). Notes that Mocha provides no option to spawn a fresh process per file.

Docs build verified: 65 pages, 0 errors.