### PR TITLE
reporters: rename xunit to junit, deprecate old xunit name

### DIFF
--- a/docs/src/content/docs/reporters/junit.mdx
+++ b/docs/src/content/docs/reporters/junit.mdx
@@ -1,0 +1,16 @@
+---
+description: The JUnit test reporter for Mocha.
+title: JUnit
+---
+
+Alias: `JUnit`, `junit`
+
+The JUnit reporter outputs a JUnit-compatible XML document, often applicable in CI servers.
+
+By default, it will output to the console.
+To write directly to a file, use `--reporter-option output=filename.xml`.
+
+To specify custom report title, use `--reporter-option suiteName="Custom name"`.
+
+The reporter shows absolute file paths by default.
+To show relative paths instead, use `--reporter-option showRelativePaths`.

--- a/docs/src/content/docs/reporters/xunit.mdx
+++ b/docs/src/content/docs/reporters/xunit.mdx
@@ -1,11 +1,22 @@
 ---
-description: The XUnit test reporter for Mocha.
-title: XUnit
+description: The XUnit test reporter for Mocha (deprecated).
+title: XUnit (deprecated)
 ---
+
+import { Aside } from "@astrojs/starlight/components";
+
+<Aside type="caution" title="Deprecated">
+  The `xunit` reporter is deprecated. Use `junit` instead. The `xunit` reporter
+  currently emits JUnit-compatible XML, not actual xUnit XML. In a future major
+  version, the `xunit` reporter will be repurposed to emit actual xUnit XML
+  format. See [GitHub issue #4758](https://github.com/mochajs/mocha/issues/4758)
+  for details.
+</Aside>
 
 Alias: `XUnit`, `xunit`
 
-The XUnit reporter outputs an XUnit-compatible XML document, often applicable in CI servers.
+The XUnit reporter is a deprecated alias for the [JUnit reporter](./junit).
+It outputs a JUnit-compatible XML document, often applicable in CI servers.
 
 By default, it will output to the console.
 To write directly to a file, use `--reporter-option output=filename.xml`.

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -298,8 +298,8 @@ Mocha.prototype.addFile = function (file) {
  * @throws {Error} if requested reporter cannot be loaded
  * @example
  *
- * // Use XUnit reporter and direct its output to file
- * mocha.reporter('xunit', { output: '/path/to/testspec.xunit.xml' });
+ * // Use JUnit reporter and direct its output to file
+ * mocha.reporter('junit', { output: '/path/to/testspec.junit.xml' });
  */
 Mocha.prototype.reporter = function (reporterName, reporterOptions) {
   if (typeof reporterName === "function") {
@@ -336,7 +336,7 @@ Mocha.prototype.reporter = function (reporterName, reporterOptions) {
     this._reporter = reporter;
   }
   this.options.reporterOption = reporterOptions;
-  // alias option name is used in built-in reporters xunit/tap/progress
+  // alias option name is used in built-in reporters junit/tap/progress
   this.options.reporterOptions = reporterOptions;
   return this;
 };

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -12,6 +12,7 @@ exports.List = exports.list = require("./list");
 exports.Min = exports.min = require("./min");
 exports.Spec = exports.spec = require("./spec");
 exports.Nyan = exports.nyan = require("./nyan");
+exports.JUnit = exports.junit = require("./junit");
 exports.XUnit = exports.xunit = require("./xunit");
 exports.Markdown = exports.markdown = require("./markdown");
 exports.Progress = exports.progress = require("./progress");

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -1,0 +1,227 @@
+"use strict";
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ */
+
+/**
+ * @module JUnit
+ */
+/**
+ * module dependencies.
+ */
+
+var Base = require("./base");
+var utils = require("../utils");
+var fs = require("node:fs");
+var path = require("node:path");
+var errors = require("../errors");
+var createUnsupportedError = errors.createUnsupportedError;
+var constants = require("../runner").constants;
+var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
+var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
+var EVENT_RUN_END = constants.EVENT_RUN_END;
+var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
+var STATE_FAILED = require("../runnable").constants.STATE_FAILED;
+var escape = utils.escape;
+
+/**
+ * save timer refereneces to avoid Sinon interfering (see GH-237).
+ */
+var Date = global.Date;
+
+class JUnit extends Base {
+  static description = "JUnit-compatible XML output";
+
+  /**
+   * Constructs a new `JUnit` reporter instance.
+   *
+   * @public
+   * @memberof Mocha.reporters
+   * @extends Mocha.reporters.Base
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
+
+    var stats = this.stats;
+    var tests = [];
+    var self = this;
+
+    // The name of the test suite, as it will appear in the resulting XML file
+    var suiteName;
+
+    // the default name of the test suite if none is provided
+    var DEFAULT_SUITE_NAME = "Mocha Tests";
+
+    if (options && options.reporterOptions) {
+      if (options.reporterOptions.output) {
+        if (!fs.createWriteStream) {
+          throw createUnsupportedError("file output not supported in browser");
+        }
+
+        fs.mkdirSync(path.dirname(options.reporterOptions.output), {
+          recursive: true,
+        });
+        self.fileStream = fs.createWriteStream(options.reporterOptions.output);
+      }
+
+      // get the suite name from the reporter options (if provided)
+      suiteName = options.reporterOptions.suiteName;
+    }
+
+    // Fall back to the default suite name
+    suiteName = suiteName || DEFAULT_SUITE_NAME;
+
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      tests.push(test);
+    });
+
+    runner.on(EVENT_TEST_PASS, function (test) {
+      tests.push(test);
+    });
+
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      tests.push(test);
+    });
+
+    runner.once(EVENT_RUN_END, function () {
+      self.write(
+        tag(
+          "testsuite",
+          {
+            name: suiteName,
+            tests: stats.tests,
+            failures: 0,
+            errors: stats.failures,
+            skipped: stats.tests - stats.failures - stats.passes,
+            timestamp: new Date().toUTCString(),
+            time: stats.duration / 1000 || 0,
+          },
+          false,
+        ),
+      );
+
+      tests.forEach(function (t) {
+        self.test(t, options);
+      });
+
+      self.write("</testsuite>");
+    });
+  }
+
+  /**
+   * Overide done to close the stream (if it's a file).
+   *
+   * @param failures
+   * @param {Function} fn
+   */
+  done(failures, fn) {
+    if (this.fileStream) {
+      this.fileStream.end(function () {
+        fn(failures);
+      });
+    } else {
+      fn(failures);
+    }
+  }
+
+  /**
+   * Write out the given line.
+   *
+   * @param {string} line
+   */
+  write(line) {
+    if (this.fileStream) {
+      this.fileStream.write(line + "\n");
+    } else if (typeof process === "object" && process.stdout) {
+      process.stdout.write(line + "\n");
+    } else {
+      Base.consoleLog(line);
+    }
+  }
+
+  /**
+   * output tag for the given `test.`
+   *
+   * @param {Test} test
+   */
+  test(test, options) {
+    Base.useColors = false;
+
+    var attrs = {
+      classname: test.parent.fullTitle(),
+      name: test.title,
+      file: testFilePath(test.file, options),
+      time: test.duration / 1000 || 0,
+    };
+
+    if (test.state === STATE_FAILED) {
+      var err = test.err;
+      var diff =
+        !Base.hideDiff && Base.showDiff(err)
+          ? "\n" + Base.generateDiff(err.actual, err.expected)
+          : "";
+      this.write(
+        tag(
+          "testcase",
+          attrs,
+          false,
+          tag(
+            "failure",
+            {},
+            false,
+            escape(err.message) + escape(diff) + "\n" + escape(err.stack),
+          ),
+        ),
+      );
+    } else if (test.isPending()) {
+      this.write(tag("testcase", attrs, false, tag("skipped", {}, true)));
+    } else {
+      this.write(tag("testcase", attrs, true));
+    }
+  }
+}
+
+/**
+ * HTML tag helper.
+ *
+ * @param name
+ * @param attrs
+ * @param close
+ * @param content
+ * @return {string}
+ */
+function tag(name, attrs, close, content) {
+  var end = close ? "/>" : ">";
+  var pairs = [];
+  var tag;
+
+  for (var key in attrs) {
+    if (Object.prototype.hasOwnProperty.call(attrs, key)) {
+      pairs.push(key + '="' + escape(attrs[key]) + '"');
+    }
+  }
+
+  tag = "<" + name + (pairs.length ? " " + pairs.join(" ") : "") + end;
+  if (content) {
+    tag += content + "</" + name + end;
+  }
+  return tag;
+}
+
+function testFilePath(filepath, options) {
+  if (
+    options &&
+    options.reporterOptions &&
+    options.reporterOptions.showRelativePaths
+  ) {
+    return path.relative(process.cwd(), filepath);
+  }
+
+  return filepath;
+}
+
+exports = module.exports = JUnit;

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -1,227 +1,39 @@
 "use strict";
 
 /**
- * @typedef {import('../runner.js')} Runner
- * @typedef {import('../test.js')} Test
- */
-
-/**
  * @module XUnit
  */
-/**
- * Module dependencies.
- */
 
-var Base = require("./base");
-var utils = require("../utils");
-var fs = require("node:fs");
-var path = require("node:path");
-var errors = require("../errors");
-var createUnsupportedError = errors.createUnsupportedError;
-var constants = require("../runner").constants;
-var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
-var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
-var EVENT_RUN_END = constants.EVENT_RUN_END;
-var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
-var STATE_FAILED = require("../runnable").constants.STATE_FAILED;
-var escape = utils.escape;
+var JUnit = require("./junit");
+var { deprecate } = require("../errors");
 
 /**
- * Save timer references to avoid Sinon interfering (see GH-237).
+ * @deprecated Use the `junit` reporter instead. The `xunit` reporter will be
+ * repurposed in a future major version to emit actual xUnit XML.
+ * See https://github.com/mochajs/mocha/issues/4758
  */
-var Date = global.Date;
-
-class XUnit extends Base {
-  static description = "XUnit-compatible XML output";
+class XUnit extends JUnit {
+  static description =
+    "JUnit-compatible XML output (deprecated: use 'junit' instead)";
 
   /**
    * Constructs a new `XUnit` reporter instance.
    *
    * @public
    * @memberof Mocha.reporters
-   * @extends Mocha.reporters.Base
-   * @param {Runner} runner - Instance triggers reporter actions.
+   * @extends Mocha.reporters.JUnit
+   * @param {import('../runner.js')} runner - Instance triggers reporter actions.
    * @param {Object} [options] - runner options
    */
   constructor(runner, options) {
+    deprecate(
+      'The "xunit" reporter is deprecated. Use "junit" instead. ' +
+        'The "xunit" reporter will be repurposed in a future major version ' +
+        "to emit actual xUnit XML format. " +
+        "See https://github.com/mochajs/mocha/issues/4758",
+    );
     super(runner, options);
-
-    var stats = this.stats;
-    var tests = [];
-    var self = this;
-
-    // the name of the test suite, as it will appear in the resulting XML file
-    var suiteName;
-
-    // the default name of the test suite if none is provided
-    var DEFAULT_SUITE_NAME = "Mocha Tests";
-
-    if (options && options.reporterOptions) {
-      if (options.reporterOptions.output) {
-        if (!fs.createWriteStream) {
-          throw createUnsupportedError("file output not supported in browser");
-        }
-
-        fs.mkdirSync(path.dirname(options.reporterOptions.output), {
-          recursive: true,
-        });
-        self.fileStream = fs.createWriteStream(options.reporterOptions.output);
-      }
-
-      // get the suite name from the reporter options (if provided)
-      suiteName = options.reporterOptions.suiteName;
-    }
-
-    // fall back to the default suite name
-    suiteName = suiteName || DEFAULT_SUITE_NAME;
-
-    runner.on(EVENT_TEST_PENDING, function (test) {
-      tests.push(test);
-    });
-
-    runner.on(EVENT_TEST_PASS, function (test) {
-      tests.push(test);
-    });
-
-    runner.on(EVENT_TEST_FAIL, function (test) {
-      tests.push(test);
-    });
-
-    runner.once(EVENT_RUN_END, function () {
-      self.write(
-        tag(
-          "testsuite",
-          {
-            name: suiteName,
-            tests: stats.tests,
-            failures: 0,
-            errors: stats.failures,
-            skipped: stats.tests - stats.failures - stats.passes,
-            timestamp: new Date().toUTCString(),
-            time: stats.duration / 1000 || 0,
-          },
-          false,
-        ),
-      );
-
-      tests.forEach(function (t) {
-        self.test(t, options);
-      });
-
-      self.write("</testsuite>");
-    });
   }
-
-  /**
-   * Override done to close the stream (if it's a file).
-   *
-   * @param failures
-   * @param {Function} fn
-   */
-  done(failures, fn) {
-    if (this.fileStream) {
-      this.fileStream.end(function () {
-        fn(failures);
-      });
-    } else {
-      fn(failures);
-    }
-  }
-
-  /**
-   * Write out the given line.
-   *
-   * @param {string} line
-   */
-  write(line) {
-    if (this.fileStream) {
-      this.fileStream.write(line + "\n");
-    } else if (typeof process === "object" && process.stdout) {
-      process.stdout.write(line + "\n");
-    } else {
-      Base.consoleLog(line);
-    }
-  }
-
-  /**
-   * Output tag for the given `test.`
-   *
-   * @param {Test} test
-   */
-  test(test, options) {
-    Base.useColors = false;
-
-    var attrs = {
-      classname: test.parent.fullTitle(),
-      name: test.title,
-      file: testFilePath(test.file, options),
-      time: test.duration / 1000 || 0,
-    };
-
-    if (test.state === STATE_FAILED) {
-      var err = test.err;
-      var diff =
-        !Base.hideDiff && Base.showDiff(err)
-          ? "\n" + Base.generateDiff(err.actual, err.expected)
-          : "";
-      this.write(
-        tag(
-          "testcase",
-          attrs,
-          false,
-          tag(
-            "failure",
-            {},
-            false,
-            escape(err.message) + escape(diff) + "\n" + escape(err.stack),
-          ),
-        ),
-      );
-    } else if (test.isPending()) {
-      this.write(tag("testcase", attrs, false, tag("skipped", {}, true)));
-    } else {
-      this.write(tag("testcase", attrs, true));
-    }
-  }
-}
-
-/**
- * HTML tag helper.
- *
- * @param name
- * @param attrs
- * @param close
- * @param content
- * @return {string}
- */
-function tag(name, attrs, close, content) {
-  var end = close ? "/>" : ">";
-  var pairs = [];
-  var tag;
-
-  for (var key in attrs) {
-    if (Object.prototype.hasOwnProperty.call(attrs, key)) {
-      pairs.push(key + '="' + escape(attrs[key]) + '"');
-    }
-  }
-
-  tag = "<" + name + (pairs.length ? " " + pairs.join(" ") : "") + end;
-  if (content) {
-    tag += content + "</" + name + end;
-  }
-  return tag;
-}
-
-function testFilePath(filepath, options) {
-  if (
-    options &&
-    options.reporterOptions &&
-    options.reporterOptions.showRelativePaths
-  ) {
-    return path.relative(process.cwd(), filepath);
-  }
-
-  return filepath;
 }
 
 exports = module.exports = XUnit;

--- a/test/reporters/junit.spec.js
+++ b/test/reporters/junit.spec.js
@@ -1,0 +1,691 @@
+"use strict";
+
+var EventEmitter = require("events").EventEmitter;
+var fs = require("fs");
+var path = require("path");
+var sinon = require("sinon");
+var createStatsCollector = require("../../lib/stats-collector");
+var events = require("../../").Runner.constants;
+var reporters = require("../../").reporters;
+var states = require("../../").Runnable.constants;
+
+const { createTempDir, touchFile } = require("../integration/helpers");
+
+var helpers = require("./helpers");
+var createMockRunner = helpers.createMockRunner;
+var makeRunReporter = helpers.createRunReporterFunction;
+
+var Base = reporters.Base;
+var JUnit = reporters.JUnit;
+
+var EVENT_RUN_END = events.EVENT_RUN_END;
+var EVENT_TEST_END = events.EVENT_TEST_END;
+var EVENT_TEST_FAIL = events.EVENT_TEST_FAIL;
+var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
+var EVENT_TEST_PENDING = events.EVENT_TEST_PENDING;
+
+var STATE_FAILED = states.STATE_FAILED;
+var STATE_PASSED = states.STATE_PASSED;
+
+describe("JUnit reporter", function () {
+  var runReporter = makeRunReporter(JUnit);
+  var runner;
+  var noop = function () {};
+
+  var expectedLine = "some-line";
+  var expectedClassName = "fullTitle";
+  var expectedTitle = "some title";
+  var expectedFile = "testFile.spec.js";
+  var expectedMessage = "some message";
+  var expectedDiff =
+    "\n      + expected - actual\n\n      -foo\n      +bar\n      ";
+  var expectedStack = "some-stack";
+
+  beforeEach(function () {
+    runner = { on: noop, once: noop };
+    createStatsCollector(runner);
+  });
+
+  describe("when 'reporterOptions.output' is provided", function () {
+    var expectedOutput = path.join(path.sep, "path", "to", "some-output");
+    var options = {
+      reporterOptions: {
+        output: expectedOutput,
+      },
+    };
+
+    describe("when fileStream can be created", function () {
+      var fsMkdirSync;
+      var fsCreateWriteStream;
+
+      beforeEach(function () {
+        fsMkdirSync = sinon.stub(fs, "mkdirSync");
+        fsCreateWriteStream = sinon.stub(fs, "createWriteStream");
+      });
+
+      it("should open given file for writing, recursively creating directories in pathname", async function () {
+        var runner = createMockRunner("start", events.EVENT_RUN_BEGIN);
+        var options = {
+          reporterOptions: {
+            output: expectedOutput,
+          },
+        };
+        new JUnit(runner, options);
+
+        var expectedDirectory = path.dirname(expectedOutput);
+        expect(
+          fsMkdirSync.calledWith(expectedDirectory, {
+            recursive: true,
+          }),
+          "to be true",
+        );
+
+        expect(fsCreateWriteStream.calledWith(expectedOutput), "to be true");
+      });
+
+      afterEach(function () {
+        sinon.restore();
+      });
+    });
+
+    describe("when fileStream cannot be created", function () {
+      describe("when given an invalid pathname", function () {
+        /**
+         * @type {string}
+         */
+        let tmpdir;
+
+        /**
+         * @type {import('../integration/helpers').RemoveTempDirCallback}
+         */
+        let cleanup;
+        var invalidPath;
+
+        beforeEach(async function () {
+          const { dirpath, removeTempDir } = await createTempDir();
+          tmpdir = dirpath;
+          cleanup = removeTempDir;
+
+          //create path where file "some-file" used as directory
+          invalidPath = path.join(
+            tmpdir,
+            "some-file",
+            path.basename(expectedOutput),
+          );
+          touchFile(path.dirname(invalidPath));
+        });
+
+        it("should throw system error", function () {
+          var options = {
+            reporterOptions: {
+              output: invalidPath,
+            },
+          };
+          var boundJUnit = () => new JUnit(runner, options);
+          expect(
+            boundJUnit,
+            "to throw",
+            expect.it("to be an", Error).and("to satisfy", {
+              syscall: "mkdir",
+              code: "EEXIST",
+              path: path.dirname(invalidPath),
+            }),
+          );
+        });
+
+        afterEach(function () {
+          cleanup();
+        });
+      });
+
+      describe("when run in browser", function () {
+        beforeEach(function () {
+          sinon.stub(fs, "createWriteStream").value(false);
+        });
+
+        it("should throw unsupported error", function () {
+          var boundJUnit = () => new JUnit(runner, options);
+          expect(
+            boundJUnit,
+            "to throw",
+            "file output not supported in browser",
+          );
+        });
+
+        afterEach(function () {
+          sinon.restore();
+        });
+      });
+    });
+  });
+
+  describe("event handlers", function () {
+    var fsCreateWriteStream;
+
+    beforeEach(function () {
+      sinon.stub(fs, "mkdirSync");
+      fsCreateWriteStream = sinon.stub(fs, "createWriteStream");
+    });
+
+    describe("on 'pending', 'pass' and 'fail' events", function () {
+      it("should add test to tests called on 'end' event", async function () {
+        var pendingTest = {
+          isPending: () => false,
+          parent: {
+            fullTitle: () => "pending parent",
+          },
+          name: "pending",
+          slow: noop,
+        };
+        var failTest = {
+          isPending: () => false,
+          parent: {
+            fullTitle: () => "fail parent",
+          },
+          name: "fail",
+          slow: noop,
+        };
+        var passTest = {
+          isPending: () => false,
+          parent: {
+            fullTitle: () => "pass parent",
+          },
+          name: "pass",
+          slow: noop,
+        };
+        var write = sinon.spy();
+        fsCreateWriteStream.returns({ write });
+        runner.on = runner.once = function (event, callback) {
+          if (event === EVENT_TEST_PENDING) {
+            callback(pendingTest);
+          } else if (event === EVENT_TEST_PASS) {
+            callback(passTest);
+          } else if (event === EVENT_TEST_FAIL) {
+            callback(failTest);
+          } else if (event === EVENT_RUN_END) {
+            callback();
+          }
+        };
+
+        var expectedOutput = path.join(path.sep, "path", "to", "some-output");
+        var options = {
+          reporterOptions: {
+            output: expectedOutput,
+          },
+        };
+        const { reporter } = await runReporter({}, runner, options);
+
+        reporter.fileStream;
+        expect(write.getCalls().length, "to equal", 5);
+        expect(write.getCall(1).args[0], "to match", /pending parent/);
+        expect(write.getCall(2).args[0], "to match", /pass parent/);
+        expect(write.getCall(3).args[0], "to match", /fail parent/);
+      });
+    });
+  });
+
+  describe("#done", function () {
+    var junit;
+    var options = {
+      reporterOptions: {},
+    };
+    var expectedNFailures = 13;
+    var callback;
+
+    beforeEach(function () {
+      callback = sinon.spy();
+    });
+
+    afterEach(function () {
+      callback = null;
+      junit = null;
+      sinon.restore();
+    });
+
+    describe("when output directed to file", function () {
+      var fakeThis;
+
+      beforeEach(function () {
+        junit = new JUnit(runner, options);
+
+        fakeThis = {
+          fileStream: {
+            end: sinon.stub().callsFake(function (cb) {
+              if (typeof arguments[0] === "function") {
+                cb = arguments[0];
+              }
+              cb();
+            }),
+            write: function () {},
+          },
+        };
+      });
+
+      it("should run completion callback via 'fileStream.end'", function () {
+        junit.done.call(fakeThis, expectedNFailures, callback);
+
+        expect(fakeThis.fileStream.end.calledOnce, "to be true");
+        expect(callback.calledOnce, "to be true");
+        expect(callback.calledWith(expectedNFailures), "to be true");
+      });
+    });
+
+    describe("when output directed to stdout (or console)", function () {
+      var fakeThis;
+
+      beforeEach(function () {
+        junit = new JUnit(runner, options);
+        fakeThis = {};
+      });
+
+      it("should run completion callback", function () {
+        junit.done.call(fakeThis, expectedNFailures, callback);
+
+        expect(callback.calledOnce, "to be true");
+        expect(callback.calledWith(expectedNFailures), "to be true");
+      });
+    });
+  });
+
+  describe("#write", function () {
+    // :todo: Method should be named 'writeln', not 'write'
+    describe("when output directed to file", function () {
+      var fileStream = {
+        write: sinon.spy(),
+      };
+
+      it("should call 'fileStream.write' with line and newline", function () {
+        var junit = new JUnit(runner);
+        var fakeThis = { fileStream };
+        junit.write.call(fakeThis, expectedLine);
+
+        expect(fileStream.write.calledWith(expectedLine + "\n"), "to be true");
+      });
+    });
+
+    describe("when output directed to stdout", function () {
+      it("should call 'process.stdout.write' with line and newline", function () {
+        var junit = new JUnit(runner);
+        var fakeThis = { fileStream: false };
+        var stdoutWriteStub = sinon.stub(process.stdout, "write");
+        junit.write.call(fakeThis, expectedLine);
+        stdoutWriteStub.restore();
+
+        expect(stdoutWriteStub.calledWith(expectedLine + "\n"), "to be true");
+      });
+    });
+
+    describe("when output directed to console", function () {
+      it("should call 'Base.consoleLog' with line", function () {
+        // :todo: JUnit needs a trivialy testable means to force console.log()
+        var realProcess = process;
+        process = false; // eslint-disable-line no-global-assign
+
+        var junit = new JUnit(runner);
+        var fakeThis = { fileStream: false };
+        var consoleLogStub = sinon.stub(Base, "consoleLog");
+        junit.write.call(fakeThis, expectedLine);
+        consoleLogStub.restore();
+
+        process = realProcess; // eslint-disable-line no-global-assign
+
+        expect(consoleLogStub.calledWith(expectedLine), "to be true");
+      });
+    });
+  });
+
+  describe("#test", function () {
+    var expectedWrite;
+    var fakeThis = {
+      write: function (str) {
+        expectedWrite = str;
+      },
+    };
+
+    beforeEach(function () {
+      sinon.stub(Base, "useColors").value(false);
+    });
+
+    afterEach(function () {
+      sinon.restore();
+      expectedWrite = null;
+    });
+
+    describe("on test failure", function () {
+      it("should write expected tag with error details", function () {
+        var junit = new JUnit(runner);
+        var expectedTest = {
+          state: STATE_FAILED,
+          title: expectedTitle,
+          file: expectedFile,
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            },
+          },
+          duration: 1000,
+          err: {
+            actual: "foo",
+            expected: "bar",
+            message: expectedMessage,
+            stack: expectedStack,
+          },
+        };
+
+        junit.test.call(fakeThis, expectedTest);
+        sinon.restore();
+
+        var expectedTag =
+          '<testcase classname="' +
+          expectedClassName +
+          '" name="' +
+          expectedTitle +
+          '" file="' +
+          expectedFile +
+          '" time="1"><failure>' +
+          expectedMessage +
+          "\n" +
+          expectedDiff +
+          "\n" +
+          expectedStack +
+          "</failure></testcase>";
+        expect(expectedWrite, "to be", expectedTag);
+      });
+
+      it("should handle non-string diff values", function () {
+        var runner = new EventEmitter();
+        createStatsCollector(runner);
+        var junit = new JUnit(runner);
+
+        var expectedTest = {
+          state: STATE_FAILED,
+          title: expectedTitle,
+          file: expectedFile,
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            },
+          },
+          duration: 1000,
+          err: {
+            actual: 1,
+            expected: 2,
+            message: expectedMessage,
+            stack: expectedStack,
+          },
+        };
+
+        sinon.stub(junit, "write").callsFake(function (str) {
+          expectedWrite += str;
+        });
+
+        runner.emit(EVENT_TEST_FAIL, expectedTest, expectedTest.err);
+        runner.emit(EVENT_RUN_END);
+        sinon.restore();
+
+        var expectedDiff =
+          "\n      + expected - actual\n\n      -1\n      +2\n      ";
+
+        expect(expectedWrite, "to contain", expectedDiff);
+      });
+    });
+
+    describe("on test pending", function () {
+      it("should write expected tag", function () {
+        var junit = new JUnit(runner);
+        var expectedTest = {
+          isPending: function () {
+            return true;
+          },
+          title: expectedTitle,
+          file: expectedFile,
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            },
+          },
+          duration: 1000,
+        };
+
+        junit.test.call(fakeThis, expectedTest);
+        sinon.restore();
+
+        var expectedTag =
+          '<testcase classname="' +
+          expectedClassName +
+          '" name="' +
+          expectedTitle +
+          '" file="' +
+          expectedFile +
+          '" time="1"><skipped/></testcase>';
+        expect(expectedWrite, "to be", expectedTag);
+      });
+    });
+
+    describe("on test in any other state", function () {
+      it("should write expected tag", function () {
+        var junit = new JUnit(runner);
+        var expectedTest = {
+          isPending: function () {
+            return false;
+          },
+          title: expectedTitle,
+          file: expectedFile,
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            },
+          },
+          duration: false,
+        };
+
+        junit.test.call(fakeThis, expectedTest);
+        sinon.restore();
+
+        var expectedTag =
+          '<testcase classname="' +
+          expectedClassName +
+          '" name="' +
+          expectedTitle +
+          '" file="' +
+          expectedFile +
+          '" time="0"/>';
+        expect(expectedWrite, "to be", expectedTag);
+      });
+    });
+
+    it("should write expected summary statistics", function () {
+      var numTests = 0;
+      var numPass = 0;
+      var numFail = 0;
+      var simpleError = {
+        actual: "foo",
+        expected: "bar",
+        message: expectedMessage,
+        stack: expectedStack,
+      };
+      var generateTest = function (passed) {
+        numTests++;
+        if (passed) {
+          numPass++;
+        } else {
+          numFail++;
+        }
+        return {
+          title: [expectedTitle, numTests].join(": "),
+          state: passed ? STATE_PASSED : STATE_FAILED,
+          isPending: function () {
+            return false;
+          },
+          slow: function () {
+            return false;
+          },
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            },
+          },
+          duration: 1000,
+        };
+      };
+
+      var runner = new EventEmitter();
+      createStatsCollector(runner);
+      var junit = new JUnit(runner);
+      expectedWrite = "";
+      sinon.stub(junit, "write").callsFake(function (str) {
+        expectedWrite += str;
+      });
+
+      //3 tests, no failures (i.e tests that could not run), and 2 errors
+      runner.emit(EVENT_TEST_PASS, generateTest(true));
+      runner.emit(EVENT_TEST_END);
+      runner.emit(EVENT_TEST_FAIL, generateTest(false), simpleError);
+      runner.emit(EVENT_TEST_END);
+      runner.emit(EVENT_TEST_FAIL, generateTest(false), simpleError);
+      runner.emit(EVENT_TEST_END);
+      runner.emit(EVENT_RUN_END);
+
+      sinon.restore();
+
+      var expectedNumPass = 1;
+      var expectedNumFail = 2;
+      var expectedNumTests = 3;
+
+      expect(expectedNumPass, "to be", numPass);
+      expect(expectedNumFail, "to be", numFail);
+      expect(expectedNumTests, "to be", numTests);
+
+      // note: Mocha test "fail" is a JUnit "error"
+      var expectedTag =
+        '<testsuite name="Mocha Tests" tests="3" failures="0" errors="2" skipped="0"';
+
+      expect(expectedWrite, "to contain", expectedTag);
+      expect(expectedWrite, "to contain", "</testsuite>");
+    });
+  });
+
+  describe("suite name", function () {
+    //capture the events that the reporter subscribes to
+    var events = {};
+    // capture output lines (will contain the resulting XML of JUnit reporter)
+    var lines = [];
+    // file stream into which the JUnit reporter will write
+    var fileStream;
+
+    before(function () {
+      fileStream = {
+        write: function (chunk) {
+          lines.push(chunk);
+        },
+      };
+    });
+
+    beforeEach(function () {
+      lines = [];
+      events = {};
+
+      runner.on = runner.once = function (eventName, eventHandler) {
+        // Capture the event handler
+        events[eventName] = eventHandler;
+      };
+    });
+
+    it("should use custom name if provided via reporter options", function () {
+      var customSuiteName = "Mocha Is Great!";
+      var options = {
+        reporterOptions: {
+          suiteName: customSuiteName,
+        },
+      };
+
+      var junit = new JUnit(runner, options);
+      junit.fileStream = fileStream;
+
+      // trigger end event to force JUnit reporter to write its output
+      events[EVENT_RUN_END]();
+
+      expect(lines[0], "to contain", customSuiteName);
+    });
+
+    it("should use default name otherwise", function () {
+      var defaultSuiteName = "Mocha Tests";
+      var options = {
+        reporterOptions: {},
+      };
+
+      var junit = new JUnit(runner, options);
+      junit.fileStream = fileStream;
+
+      //trigger end event to force JUnit reporter to write its output
+      events[EVENT_RUN_END]();
+
+      expect(lines[0], "to contain", defaultSuiteName);
+    });
+  });
+
+  describe("showRelativePaths reporter option", function () {
+    const projectPath = path.join("home", "username", "demo-project");
+    const relativeTestPath = path.join("tests", "demo-test.spec.js");
+    const absoluteTestPath = path.join(projectPath, relativeTestPath);
+
+    var expectedWrite = "";
+    const fakeThis = {
+      write: function (str) {
+        expectedWrite = expectedWrite + str;
+      },
+    };
+
+    const failingTest = {
+      state: STATE_FAILED,
+      title: expectedTitle,
+      file: absoluteTestPath,
+      parent: {
+        fullTitle: function () {
+          return expectedClassName;
+        },
+      },
+      duration: 1000,
+      err: {
+        actual: "foo",
+        expected: "bar",
+        message: expectedMessage,
+        stack: expectedStack,
+      },
+    };
+
+    beforeEach(function () {
+      sinon.stub(process, "cwd").returns(projectPath);
+    });
+
+    afterEach(function () {
+      sinon.restore();
+      expectedWrite = "";
+    });
+
+    it("shows relative paths for tests if showRelativePaths reporter option is set", function () {
+      const options = {
+        reporterOptions: {
+          showRelativePaths: true,
+        },
+      };
+      const junit = new JUnit(runner, options);
+
+      junit.test.call(fakeThis, failingTest, options);
+
+      expect(expectedWrite, "not to contain", absoluteTestPath);
+      expect(expectedWrite, "to contain", relativeTestPath);
+    });
+
+    it("shows absolute paths for tests by default", function () {
+      const options = {};
+      const junit = new JUnit(runner);
+
+      junit.test.call(fakeThis, failingTest, options);
+
+      expect(expectedWrite, "to contain", absoluteTestPath);
+      // double quote included to insure printed paths don't start with relative path. Example printed line: <testcase classname="suite" name="test" file="some/tesfile.js" time="0"/>
+      expect(expectedWrite, "not to contain", `"${relativeTestPath}`);
+    });
+  });
+});

--- a/test/reporters/xunit.spec.js
+++ b/test/reporters/xunit.spec.js
@@ -1,691 +1,84 @@
 "use strict";
 
-var EventEmitter = require("events").EventEmitter;
-var fs = require("fs");
-var path = require("path");
 var sinon = require("sinon");
 var createStatsCollector = require("../../lib/stats-collector");
-var events = require("../../").Runner.constants;
 var reporters = require("../../").reporters;
-var states = require("../../").Runnable.constants;
+var errors = require("../../lib/errors");
 
-const { createTempDir, touchFile } = require("../integration/helpers");
-
-var helpers = require("./helpers");
-var createMockRunner = helpers.createMockRunner;
-var makeRunReporter = helpers.createRunReporterFunction;
-
-var Base = reporters.Base;
 var XUnit = reporters.XUnit;
+var JUnit = reporters.JUnit;
 
-var EVENT_RUN_END = events.EVENT_RUN_END;
-var EVENT_TEST_END = events.EVENT_TEST_END;
-var EVENT_TEST_FAIL = events.EVENT_TEST_FAIL;
-var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
-var EVENT_TEST_PENDING = events.EVENT_TEST_PENDING;
-
-var STATE_FAILED = states.STATE_FAILED;
-var STATE_PASSED = states.STATE_PASSED;
-
-describe("XUnit reporter", function () {
-  var runReporter = makeRunReporter(XUnit);
+describe("XUnit reporter (deprecated)", function () {
   var runner;
   var noop = function () {};
-
-  var expectedLine = "some-line";
-  var expectedClassName = "fullTitle";
-  var expectedTitle = "some title";
-  var expectedFile = "testFile.spec.js";
-  var expectedMessage = "some message";
-  var expectedDiff =
-    "\n      + expected - actual\n\n      -foo\n      +bar\n      ";
-  var expectedStack = "some-stack";
 
   beforeEach(function () {
     runner = { on: noop, once: noop };
     createStatsCollector(runner);
   });
 
-  describe("when 'reporterOptions.output' is provided", function () {
-    var expectedOutput = path.join(path.sep, "path", "to", "some-output");
-    var options = {
-      reporterOptions: {
-        output: expectedOutput,
+  afterEach(function () {
+    sinon.restore();
+    // clear the deprecation cache so each test starts fresh
+    errors.deprecate.cache = {};
+  });
+
+  it("should be a subclass of JUnit", function () {
+    var xunit = new XUnit(runner);
+    expect(xunit, "to be a", JUnit);
+  });
+
+  it("should emit a deprecation warning on construction", function () {
+    var emitWarnStub = sinon.stub(process, "emitWarning");
+
+    new XUnit(runner);
+
+    expect(emitWarnStub.calledOnce, "to be true");
+    expect(emitWarnStub.firstCall.args[0], "to contain", "deprecated");
+    expect(emitWarnStub.firstCall.args[0], "to contain", "junit");
+    expect(emitWarnStub.firstCall.args[1], "to be", "DeprecationWarning");
+  });
+
+  it("should only emit the deprecation warning once", function () {
+    var emitWarnStub = sinon.stub(process, "emitWarning");
+
+    new XUnit(runner);
+    new XUnit(runner);
+
+    expect(emitWarnStub.calledOnce, "to be true");
+  });
+
+  it("should produce identical output to JUnit reporter", function () {
+    var xunitOutput = "";
+    var junitOutput = "";
+
+    var xunit = new XUnit(runner);
+    sinon.stub(xunit, "write").callsFake(function (str) {
+      xunitOutput += str;
+    });
+
+    var junit = new JUnit(runner);
+    sinon.stub(junit, "write").callsFake(function (str) {
+      junitOutput += str;
+    });
+
+    var test = {
+      isPending: function () {
+        return false;
       },
-    };
-
-    describe("when fileStream can be created", function () {
-      var fsMkdirSync;
-      var fsCreateWriteStream;
-
-      beforeEach(function () {
-        fsMkdirSync = sinon.stub(fs, "mkdirSync");
-        fsCreateWriteStream = sinon.stub(fs, "createWriteStream");
-      });
-
-      it("should open given file for writing, recursively creating directories in pathname", async function () {
-        var runner = createMockRunner("start", events.EVENT_RUN_BEGIN);
-        var options = {
-          reporterOptions: {
-            output: expectedOutput,
-          },
-        };
-        new XUnit(runner, options);
-
-        var expectedDirectory = path.dirname(expectedOutput);
-        expect(
-          fsMkdirSync.calledWith(expectedDirectory, {
-            recursive: true,
-          }),
-          "to be true",
-        );
-
-        expect(fsCreateWriteStream.calledWith(expectedOutput), "to be true");
-      });
-
-      afterEach(function () {
-        sinon.restore();
-      });
-    });
-
-    describe("when fileStream cannot be created", function () {
-      describe("when given an invalid pathname", function () {
-        /**
-         * @type {string}
-         */
-        let tmpdir;
-
-        /**
-         * @type {import('../integration/helpers').RemoveTempDirCallback}
-         */
-        let cleanup;
-        var invalidPath;
-
-        beforeEach(async function () {
-          const { dirpath, removeTempDir } = await createTempDir();
-          tmpdir = dirpath;
-          cleanup = removeTempDir;
-
-          // Create path where file 'some-file' used as directory
-          invalidPath = path.join(
-            tmpdir,
-            "some-file",
-            path.basename(expectedOutput),
-          );
-          touchFile(path.dirname(invalidPath));
-        });
-
-        it("should throw system error", function () {
-          var options = {
-            reporterOptions: {
-              output: invalidPath,
-            },
-          };
-          var boundXUnit = () => new XUnit(runner, options);
-          expect(
-            boundXUnit,
-            "to throw",
-            expect.it("to be an", Error).and("to satisfy", {
-              syscall: "mkdir",
-              code: "EEXIST",
-              path: path.dirname(invalidPath),
-            }),
-          );
-        });
-
-        afterEach(function () {
-          cleanup();
-        });
-      });
-
-      describe("when run in browser", function () {
-        beforeEach(function () {
-          sinon.stub(fs, "createWriteStream").value(false);
-        });
-
-        it("should throw unsupported error", function () {
-          var boundXUnit = () => new XUnit(runner, options);
-          expect(
-            boundXUnit,
-            "to throw",
-            "file output not supported in browser",
-          );
-        });
-
-        afterEach(function () {
-          sinon.restore();
-        });
-      });
-    });
-  });
-
-  describe("event handlers", function () {
-    var fsCreateWriteStream;
-
-    beforeEach(function () {
-      sinon.stub(fs, "mkdirSync");
-      fsCreateWriteStream = sinon.stub(fs, "createWriteStream");
-    });
-
-    describe("on 'pending', 'pass' and 'fail' events", function () {
-      it("should add test to tests called on 'end' event", async function () {
-        var pendingTest = {
-          isPending: () => false,
-          parent: {
-            fullTitle: () => "pending parent",
-          },
-          name: "pending",
-          slow: noop,
-        };
-        var failTest = {
-          isPending: () => false,
-          parent: {
-            fullTitle: () => "fail parent",
-          },
-          name: "fail",
-          slow: noop,
-        };
-        var passTest = {
-          isPending: () => false,
-          parent: {
-            fullTitle: () => "pass parent",
-          },
-          name: "pass",
-          slow: noop,
-        };
-        var write = sinon.spy();
-        fsCreateWriteStream.returns({ write });
-        runner.on = runner.once = function (event, callback) {
-          if (event === EVENT_TEST_PENDING) {
-            callback(pendingTest);
-          } else if (event === EVENT_TEST_PASS) {
-            callback(passTest);
-          } else if (event === EVENT_TEST_FAIL) {
-            callback(failTest);
-          } else if (event === EVENT_RUN_END) {
-            callback();
-          }
-        };
-
-        var expectedOutput = path.join(path.sep, "path", "to", "some-output");
-        var options = {
-          reporterOptions: {
-            output: expectedOutput,
-          },
-        };
-        const { reporter } = await runReporter({}, runner, options);
-
-        reporter.fileStream;
-        expect(write.getCalls().length, "to equal", 5);
-        expect(write.getCall(1).args[0], "to match", /pending parent/);
-        expect(write.getCall(2).args[0], "to match", /pass parent/);
-        expect(write.getCall(3).args[0], "to match", /fail parent/);
-      });
-    });
-  });
-
-  describe("#done", function () {
-    var xunit;
-    var options = {
-      reporterOptions: {},
-    };
-    var expectedNFailures = 13;
-    var callback;
-
-    beforeEach(function () {
-      callback = sinon.spy();
-    });
-
-    afterEach(function () {
-      callback = null;
-      xunit = null;
-      sinon.restore();
-    });
-
-    describe("when output directed to file", function () {
-      var fakeThis;
-
-      beforeEach(function () {
-        xunit = new XUnit(runner, options);
-
-        fakeThis = {
-          fileStream: {
-            end: sinon.stub().callsFake(function (chunk, encoding, cb) {
-              if (typeof arguments[0] === "function") {
-                cb = arguments[0];
-              }
-              cb();
-            }),
-            write: function () {},
-          },
-        };
-      });
-
-      it("should run completion callback via 'fileStream.end'", function () {
-        xunit.done.call(fakeThis, expectedNFailures, callback);
-
-        expect(fakeThis.fileStream.end.calledOnce, "to be true");
-        expect(callback.calledOnce, "to be true");
-        expect(callback.calledWith(expectedNFailures), "to be true");
-      });
-    });
-
-    describe("when output directed to stdout (or console)", function () {
-      var fakeThis;
-
-      beforeEach(function () {
-        xunit = new XUnit(runner, options);
-        fakeThis = {};
-      });
-
-      it("should run completion callback", function () {
-        xunit.done.call(fakeThis, expectedNFailures, callback);
-
-        expect(callback.calledOnce, "to be true");
-        expect(callback.calledWith(expectedNFailures), "to be true");
-      });
-    });
-  });
-
-  describe("#write", function () {
-    // :TODO: Method should be named 'writeln', not 'write'
-    describe("when output directed to file", function () {
-      var fileStream = {
-        write: sinon.spy(),
-      };
-
-      it("should call 'fileStream.write' with line and newline", function () {
-        var xunit = new XUnit(runner);
-        var fakeThis = { fileStream };
-        xunit.write.call(fakeThis, expectedLine);
-
-        expect(fileStream.write.calledWith(expectedLine + "\n"), "to be true");
-      });
-    });
-
-    describe("when output directed to stdout", function () {
-      it("should call 'process.stdout.write' with line and newline", function () {
-        var xunit = new XUnit(runner);
-        var fakeThis = { fileStream: false };
-        var stdoutWriteStub = sinon.stub(process.stdout, "write");
-        xunit.write.call(fakeThis, expectedLine);
-        stdoutWriteStub.restore();
-
-        expect(stdoutWriteStub.calledWith(expectedLine + "\n"), "to be true");
-      });
-    });
-
-    describe("when output directed to console", function () {
-      it("should call 'Base.consoleLog' with line", function () {
-        // :TODO: XUnit needs a trivially testable means to force console.log()
-        var realProcess = process;
-        process = false; // eslint-disable-line no-global-assign
-
-        var xunit = new XUnit(runner);
-        var fakeThis = { fileStream: false };
-        var consoleLogStub = sinon.stub(Base, "consoleLog");
-        xunit.write.call(fakeThis, expectedLine);
-        consoleLogStub.restore();
-
-        process = realProcess; // eslint-disable-line no-global-assign
-
-        expect(consoleLogStub.calledWith(expectedLine), "to be true");
-      });
-    });
-  });
-
-  describe("#test", function () {
-    var expectedWrite;
-    var fakeThis = {
-      write: function (str) {
-        expectedWrite = str;
-      },
-    };
-
-    beforeEach(function () {
-      sinon.stub(Base, "useColors").value(false);
-    });
-
-    afterEach(function () {
-      sinon.restore();
-      expectedWrite = null;
-    });
-
-    describe("on test failure", function () {
-      it("should write expected tag with error details", function () {
-        var xunit = new XUnit(runner);
-        var expectedTest = {
-          state: STATE_FAILED,
-          title: expectedTitle,
-          file: expectedFile,
-          parent: {
-            fullTitle: function () {
-              return expectedClassName;
-            },
-          },
-          duration: 1000,
-          err: {
-            actual: "foo",
-            expected: "bar",
-            message: expectedMessage,
-            stack: expectedStack,
-          },
-        };
-
-        xunit.test.call(fakeThis, expectedTest);
-        sinon.restore();
-
-        var expectedTag =
-          '<testcase classname="' +
-          expectedClassName +
-          '" name="' +
-          expectedTitle +
-          '" file="' +
-          expectedFile +
-          '" time="1"><failure>' +
-          expectedMessage +
-          "\n" +
-          expectedDiff +
-          "\n" +
-          expectedStack +
-          "</failure></testcase>";
-        expect(expectedWrite, "to be", expectedTag);
-      });
-
-      it("should handle non-string diff values", function () {
-        var runner = new EventEmitter();
-        createStatsCollector(runner);
-        var xunit = new XUnit(runner);
-
-        var expectedTest = {
-          state: STATE_FAILED,
-          title: expectedTitle,
-          file: expectedFile,
-          parent: {
-            fullTitle: function () {
-              return expectedClassName;
-            },
-          },
-          duration: 1000,
-          err: {
-            actual: 1,
-            expected: 2,
-            message: expectedMessage,
-            stack: expectedStack,
-          },
-        };
-
-        sinon.stub(xunit, "write").callsFake(function (str) {
-          expectedWrite += str;
-        });
-
-        runner.emit(EVENT_TEST_FAIL, expectedTest, expectedTest.err);
-        runner.emit(EVENT_RUN_END);
-        sinon.restore();
-
-        var expectedDiff =
-          "\n      + expected - actual\n\n      -1\n      +2\n      ";
-
-        expect(expectedWrite, "to contain", expectedDiff);
-      });
-    });
-
-    describe("on test pending", function () {
-      it("should write expected tag", function () {
-        var xunit = new XUnit(runner);
-        var expectedTest = {
-          isPending: function () {
-            return true;
-          },
-          title: expectedTitle,
-          file: expectedFile,
-          parent: {
-            fullTitle: function () {
-              return expectedClassName;
-            },
-          },
-          duration: 1000,
-        };
-
-        xunit.test.call(fakeThis, expectedTest);
-        sinon.restore();
-
-        var expectedTag =
-          '<testcase classname="' +
-          expectedClassName +
-          '" name="' +
-          expectedTitle +
-          '" file="' +
-          expectedFile +
-          '" time="1"><skipped/></testcase>';
-        expect(expectedWrite, "to be", expectedTag);
-      });
-    });
-
-    describe("on test in any other state", function () {
-      it("should write expected tag", function () {
-        var xunit = new XUnit(runner);
-        var expectedTest = {
-          isPending: function () {
-            return false;
-          },
-          title: expectedTitle,
-          file: expectedFile,
-          parent: {
-            fullTitle: function () {
-              return expectedClassName;
-            },
-          },
-          duration: false,
-        };
-
-        xunit.test.call(fakeThis, expectedTest);
-        sinon.restore();
-
-        var expectedTag =
-          '<testcase classname="' +
-          expectedClassName +
-          '" name="' +
-          expectedTitle +
-          '" file="' +
-          expectedFile +
-          '" time="0"/>';
-        expect(expectedWrite, "to be", expectedTag);
-      });
-    });
-
-    it("should write expected summary statistics", function () {
-      var numTests = 0;
-      var numPass = 0;
-      var numFail = 0;
-      var simpleError = {
-        actual: "foo",
-        expected: "bar",
-        message: expectedMessage,
-        stack: expectedStack,
-      };
-      var generateTest = function (passed) {
-        numTests++;
-        if (passed) {
-          numPass++;
-        } else {
-          numFail++;
-        }
-        return {
-          title: [expectedTitle, numTests].join(": "),
-          state: passed ? STATE_PASSED : STATE_FAILED,
-          isPending: function () {
-            return false;
-          },
-          slow: function () {
-            return false;
-          },
-          parent: {
-            fullTitle: function () {
-              return expectedClassName;
-            },
-          },
-          duration: 1000,
-        };
-      };
-
-      var runner = new EventEmitter();
-      createStatsCollector(runner);
-      var xunit = new XUnit(runner);
-      expectedWrite = "";
-      sinon.stub(xunit, "write").callsFake(function (str) {
-        expectedWrite += str;
-      });
-
-      // 3 tests, no failures (i.e. tests that could not run), and 2 errors
-      runner.emit(EVENT_TEST_PASS, generateTest(true));
-      runner.emit(EVENT_TEST_END);
-      runner.emit(EVENT_TEST_FAIL, generateTest(false), simpleError);
-      runner.emit(EVENT_TEST_END);
-      runner.emit(EVENT_TEST_FAIL, generateTest(false), simpleError);
-      runner.emit(EVENT_TEST_END);
-      runner.emit(EVENT_RUN_END);
-
-      sinon.restore();
-
-      var expectedNumPass = 1;
-      var expectedNumFail = 2;
-      var expectedNumTests = 3;
-
-      expect(expectedNumPass, "to be", numPass);
-      expect(expectedNumFail, "to be", numFail);
-      expect(expectedNumTests, "to be", numTests);
-
-      // :NOTE: Mocha test "fail" is an XUnit "error"
-      var expectedTag =
-        '<testsuite name="Mocha Tests" tests="3" failures="0" errors="2" skipped="0"';
-
-      expect(expectedWrite, "to contain", expectedTag);
-      expect(expectedWrite, "to contain", "</testsuite>");
-    });
-  });
-
-  describe("suite name", function () {
-    // Capture the events that the reporter subscribes to
-    var events = {};
-    // Capture output lines (will contain the resulting XML of XUnit reporter)
-    var lines = [];
-    // File stream into which the XUnit reporter will write
-    var fileStream;
-
-    before(function () {
-      fileStream = {
-        write: function (chunk) {
-          lines.push(chunk);
-        },
-      };
-    });
-
-    beforeEach(function () {
-      lines = [];
-      events = {};
-
-      runner.on = runner.once = function (eventName, eventHandler) {
-        // Capture the event handler
-        events[eventName] = eventHandler;
-      };
-    });
-
-    it("should use custom name if provided via reporter options", function () {
-      var customSuiteName = "Mocha Is Great!";
-      var options = {
-        reporterOptions: {
-          suiteName: customSuiteName,
-        },
-      };
-
-      var xunit = new XUnit(runner, options);
-      xunit.fileStream = fileStream;
-
-      // Trigger end event to force XUnit reporter to write its output
-      events[EVENT_RUN_END]();
-
-      expect(lines[0], "to contain", customSuiteName);
-    });
-
-    it("should use default name otherwise", function () {
-      var defaultSuiteName = "Mocha Tests";
-      var options = {
-        reporterOptions: {},
-      };
-
-      var xunit = new XUnit(runner, options);
-      xunit.fileStream = fileStream;
-
-      // Trigger end event to force XUnit reporter to write its output
-      events[EVENT_RUN_END]();
-
-      expect(lines[0], "to contain", defaultSuiteName);
-    });
-  });
-
-  describe("showRelativePaths reporter option", function () {
-    const projectPath = path.join("home", "username", "demo-project");
-    const relativeTestPath = path.join("tests", "demo-test.spec.js");
-    const absoluteTestPath = path.join(projectPath, relativeTestPath);
-
-    var expectedWrite = "";
-    const fakeThis = {
-      write: function (str) {
-        expectedWrite = expectedWrite + str;
-      },
-    };
-
-    const failingTest = {
-      state: STATE_FAILED,
-      title: expectedTitle,
-      file: absoluteTestPath,
+      title: "some test",
+      file: "test.js",
       parent: {
         fullTitle: function () {
-          return expectedClassName;
+          return "some suite";
         },
       },
-      duration: 1000,
-      err: {
-        actual: "foo",
-        expected: "bar",
-        message: expectedMessage,
-        stack: expectedStack,
-      },
+      duration: 500,
     };
 
-    beforeEach(function () {
-      sinon.stub(process, "cwd").returns(projectPath);
-    });
+    xunit.test(test);
+    junit.test(test);
 
-    afterEach(function () {
-      sinon.restore();
-      expectedWrite = "";
-    });
-
-    it("shows relative paths for tests if showRelativePaths reporter option is set", function () {
-      const options = {
-        reporterOptions: {
-          showRelativePaths: true,
-        },
-      };
-      const xunit = new XUnit(runner, options);
-
-      xunit.test.call(fakeThis, failingTest, options);
-
-      expect(expectedWrite, "not to contain", absoluteTestPath);
-      expect(expectedWrite, "to contain", relativeTestPath);
-    });
-
-    it("shows absolute paths for tests by default", function () {
-      const options = {};
-      const xunit = new XUnit(runner);
-
-      xunit.test.call(fakeThis, failingTest, options);
-
-      expect(expectedWrite, "to contain", absoluteTestPath);
-      // Double quote included to ensure printed paths don't start with relative path. Example printed line: <testcase classname="suite" name="test" file="some/tesfile.js" time="0"/>
-      expect(expectedWrite, "not to contain", `"${relativeTestPath}`);
-    });
+    expect(xunitOutput, "to be", junitOutput);
   });
 });


### PR DESCRIPTION
## PR Checklist
- [x] Addresses an existing open issue: fixes #4758
- [x] That issue was marked as `status: accepting prs`
- [x] Steps in CONTRIBUTING.md were taken

## Overview
The `xunit` reporter has always emitted JUnit XML (`<testsuite>`/`<testcase>`) rather than actual xUnit.net XML. This renames the reporter to `junit` and turns `xunit` into a deprecated wrapper that emits a `DeprecationWarning` via `process.emitWarning` (suppresible with `--no-warnings`).