### PR TITLE
fix: make delay and grep work reliably

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -35,7 +35,8 @@ module.exports = function bddInterface(suite) {
     context.after = common.after;
     context.beforeEach = common.beforeEach;
     context.afterEach = common.afterEach;
-    context.run = mocha.options.delay && common.runWithSuite(suite);
+    context.run = mocha.options.delay && common.run;
+    context.enableDelay = mocha.options.delay && common.enableDelay;
     /**
      * Describe a "suite" with the given `title`
      * and callback `fn` containing nested suites

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -84,7 +84,7 @@ module.exports = function (suites, context, mocha) {
      * @return {Function} A function which runs the root suite
      */
     run: function run(identifier) {
-        getDelayedRunCoordinator().ready(identifier);
+      getDelayedRunCoordinator().ready(identifier);
     },
 
     /**

--- a/lib/interfaces/common.js
+++ b/lib/interfaces/common.js
@@ -41,6 +41,40 @@ module.exports = function (suites, context, mocha) {
     );
   }
 
+  /**
+   * Returns a coordinator object for managing delayed test execution.
+   * Used when the --delay flag is enabled to defer root suite execution until all files are ready.
+   * The coordinator tracks pending files and triggers root suite execution when all are ready.
+   *
+   * @private
+   * @returns {Object} A coordinator object with register() and ready() methods
+   */
+  function getDelayedRunCoordinator() {
+    if (!mocha._delayedRunCoordinator) {
+      var pendingFiles = new Set();
+
+      function maybeStartRoot() {
+        if (pendingFiles.size) {
+          return;
+        }
+
+        mocha.suite.run();
+      }
+
+      mocha._delayedRunCoordinator = {
+        register: function register(identifier) {
+          pendingFiles.add(identifier);
+        },
+
+        ready: function ready(identifier) {
+          pendingFiles.delete(identifier);
+          maybeStartRoot();
+        },
+      };
+    }
+    return mocha._delayedRunCoordinator;
+  }
+
   return {
     /**
      * This is only present if flag --delay is passed into Mocha. It triggers
@@ -49,10 +83,18 @@ module.exports = function (suites, context, mocha) {
      * @param {Suite} suite The root suite.
      * @return {Function} A function which runs the root suite
      */
-    runWithSuite: function runWithSuite(suite) {
-      return function run() {
-        suite.run();
-      };
+    run: function run(identifier) {
+        getDelayedRunCoordinator().ready(identifier);
+    },
+
+    /**
+     * Registers an identifier with the delayed run coordinator, preventing test execution
+     * until the corresponding ready() call is made. Only used when --delay flag is enabled.
+     *
+     * @param {string} identifier - A unique identifier for the file or test source
+     */
+    enableDelay: function enableDelay(identifier) {
+      getDelayedRunCoordinator().register(identifier);
     },
 
     /**

--- a/lib/interfaces/qunit.js
+++ b/lib/interfaces/qunit.js
@@ -42,7 +42,8 @@ module.exports = function qUnitInterface(suite) {
     context.after = common.after;
     context.beforeEach = common.beforeEach;
     context.afterEach = common.afterEach;
-    context.run = mocha.options.delay && common.runWithSuite(suite);
+    context.run = mocha.options.delay && common.run;
+    context.enableDelay = mocha.options.delay && common.enableDelay;
     /**
      * Describe a "suite" with the given `title`.
      */

--- a/lib/interfaces/tdd.js
+++ b/lib/interfaces/tdd.js
@@ -43,7 +43,8 @@ module.exports = function (suite) {
     context.teardown = common.afterEach;
     context.suiteSetup = common.before;
     context.suiteTeardown = common.after;
-    context.run = mocha.options.delay && common.runWithSuite(suite);
+    context.run = mocha.options.delay && common.run;
+    context.enableDelay = mocha.options.delay && common.enableDelay;
 
     /**
      * Describe a "suite" with the given `title` and callback `fn` containing

--- a/test/integration/fixtures/options/delay-grep.fixture.js
+++ b/test/integration/fixtures/options/delay-grep.fixture.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var assert = require('assert');
+
+enableDelay("delay-grep");
+
+describe('suite1', function () {
+
+  it('should match grep1', function () {
+    assert(true);
+  });
+
+  it('should not match', function () {
+    assert(true);
+  });
+});
+
+describe('suite2', function () {
+
+  it('should match grep1', function () {
+    assert(true);
+  });
+
+  it('should not match', function () {
+    assert(true);
+  });
+});
+
+describe('suite3', function () {
+
+  it('should match grep1', function () {
+    assert(true);
+  });
+
+  it('should not match', function () {
+    assert(true);
+  });
+});
+
+setTimeout(function () {
+  run("delay-grep");
+}, 100);

--- a/test/integration/fixtures/options/delay-never-run.fixture.js
+++ b/test/integration/fixtures/options/delay-never-run.fixture.js
@@ -1,0 +1,9 @@
+'use strict';
+
+setTimeout(function () {
+  describe('suite3', function () {
+    it('suite3 should never run', function () {
+      throw new Error('suite3 should not run');
+    });
+  });
+}, 100);

--- a/test/integration/fixtures/options/delay-per-suite.fixture.js
+++ b/test/integration/fixtures/options/delay-per-suite.fixture.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var assert = require('assert');
+
+global.__delayPerSuiteEvents = global.__delayPerSuiteEvents || [];
+
+
+describe('suite1', function () {
+  enableDelay("suite1");
+  it('suite1 waits for suite2', function () {
+    assert.ok(
+      global.__delayPerSuiteEvents.indexOf('suite2-ready') !== -1,
+      'suite2 should be ready before root starts',
+    );
+    global.__delayPerSuiteEvents.push('suite1-test');
+  });
+});
+
+describe('suite2', function () {
+  enableDelay("suite2");
+  it('suite2 runs after suite1 is ready', function () {
+    global.__delayPerSuiteEvents.push('suite2-test');
+  });
+});
+
+setTimeout(function () {
+  global.__delayPerSuiteEvents.push('suite2-ready');
+  run("suite2");
+}, 50);
+
+setTimeout(function () {
+  global.__delayPerSuiteEvents.push('suite1-ready');
+  run("suite1");
+}, 100);

--- a/test/integration/options/delay-grep.spec.js
+++ b/test/integration/options/delay-grep.spec.js
@@ -1,0 +1,117 @@
+"use strict";
+
+var path = require("node:path").posix;
+var helpers = require("../helpers");
+var runMochaJSON = helpers.runMochaJSON;
+
+describe("--delay with --grep", function () {
+  var args = ["--delay", "--grep", "grep1"];
+
+  it("should run delayed tests matching grep pattern across multiple files", function (done) {
+    var fixture = path.join("options", "delay-grep");
+    runMochaJSON(fixture, args, function (err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      // Should have 3 tests that match (1 from each suite)
+      expect(res, "to have passed")
+        .and("to have passed test count", 3)
+        .and(
+          "to have passed tests",
+          "should match grep1",
+          "should match grep1",
+          "should match grep1",
+        );
+      done();
+    });
+  });
+
+  it("should not run tests that don't match the grep pattern", function (done) {
+    var fixture = path.join("options", "delay-grep");
+    runMochaJSON(fixture, args, function (err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      // The "should not match" tests should not be included
+      expect(res, "not to have run test", "should not match");
+      done();
+    });
+  });
+
+  it("should work with --invert flag", function (done) {
+    var fixture = path.join("options", "delay-grep");
+    runMochaJSON(
+      fixture,
+      ["--delay", "--grep", "grep1", "--invert"],
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        // Should have 3 tests that don't match "grep1" (the "should not match" ones)
+        expect(res, "to have passed")
+          .and("to have passed test count", 3)
+          .and("to have passed test", "should not match");
+        done();
+      },
+    );
+  });
+
+  it("should work with regex patterns", function (done) {
+    var fixture = path.join("options", "delay-grep");
+    runMochaJSON(
+      fixture,
+      ["--delay", "--grep", "/match/"],
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        // Should match both "should match grep1" and "should not match"
+        expect(res, "to have passed")
+          .and("to have passed test count", 6)
+          .and("not to have pending tests");
+        done();
+      },
+    );
+  });
+
+  it("should handle case-insensitive regex patterns", function (done) {
+    var fixture = path.join("options", "delay-grep");
+    runMochaJSON(
+      fixture,
+      ["--delay", "--grep", "/MATCH/i"],
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        // Should match both "should match grep1" and "should not match"
+        // Case-insensitive matching should find all tests with 'match' in name
+        expect(res, "to have passed")
+          .and("to have passed test count", 6)
+          .and("not to have pending tests");
+        done();
+      },
+    );
+  });
+
+  it("should return 0 tests when pattern matches nothing", function (done) {
+    var fixture = path.join("options", "delay-grep");
+    runMochaJSON(
+      fixture,
+      ["--delay", "--grep", "nonexistent"],
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        // Should report 0 tests since no tests match
+        expect(res, "not to have tests");
+        done();
+      },
+    );
+  });
+});

--- a/test/integration/options/delay.spec.js
+++ b/test/integration/options/delay.spec.js
@@ -2,6 +2,9 @@
 
 var path = require("node:path").posix;
 var helpers = require("../helpers");
+var invokeMochaAsync = helpers.invokeMochaAsync;
+var resolveFixturePath = helpers.resolveFixturePath;
+var sleep = helpers.sleep;
 var runMochaJSON = helpers.runMochaJSON;
 
 describe("--delay", function () {
@@ -50,5 +53,42 @@ describe("--delay", function () {
       );
       done();
     });
+  });
+
+  it("should wait for every delayed child suite before starting the root suite", function (done) {
+    var fixture = path.join("options", "delay-per-suite");
+    runMochaJSON(fixture, args, function (err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res, "to have passed")
+        .and("to have passed test count", 2)
+        .and(
+          "to have passed tests",
+          "suite2 runs after suite1 is ready",
+          "suite1 waits for suite2",
+        );
+      done();
+    });
+  });
+
+  it("should keep the root suite waiting when a child suite never calls run", async function () {
+    var fixture = path.join("options", "delay-never-run");
+    var result = invokeMochaAsync(
+      [resolveFixturePath(fixture), "--delay", "--reporter", "json"],
+      { stdio: "pipe" },
+    );
+    var mochaProcess = result[0];
+    var resultPromise = result[1];
+
+    await sleep(200);
+    expect(mochaProcess.exitCode, "to be", null);
+
+    mochaProcess.kill("SIGINT");
+    var res = await resultPromise;
+
+    expect(res.code, "to be", 130);
+    expect(res.output, "not to contain", "suite3 should never run");
   });
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3007 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This pull request updates delayed execution behavior so delayed runs can be coordinated by registering each file by an identifier, not just by a single suite callback. It also adds tests for delayed execution with grep filtering.

### Changes:
- Replaced the previous delayed run helper with a shared delayed run coordinator that:
  - Registers pending identifiers.
  - Marks identifiers ready when run is called.
  - Starts the root suite only after all registered delayed identifiers are ready.
- Added an ```enableDelay``` to the global context when running with ```--delay``` to register delayed files.
  - ```enableDelay``` is called with a string identifier to register with the run coordinator.
  - A matching ```run``` is called with the same identifier to mark the file as ready. 
  - When all calls to ```enableDelay``` have a matching call to ```run```, the test suite runs. 
- Updated BDD, TDD, and QUnit interface contexts to expose ```run``` and ```enableDelay```.
- Added tests for new delay behavior.


Existing ```run``` usage with ```--delay``` remains compatible. If ```run``` is called without prior ```enableDelay``` calls, execution starts as before because there are no pending identifiers to wait on. Using ```enableDelay``` is only necessary to perform asynchronous operations in multiple files before running the test suite. 