### PR TITLE
fix: handle errors in stringifyDiffObjs to prevent silent exit code 0

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -277,8 +277,18 @@ var showDiff = (exports.showDiff = function (err) {
 
 function stringifyDiffObjs(err) {
   if (!utils.isString(err.actual) || !utils.isString(err.expected)) {
-    err.actual = utils.stringify(err.actual);
-    err.expected = utils.stringify(err.expected);
+    // Stringify each side independently so a failure in one does not
+    // discard a successfully stringified value from the other (#5507).
+    try {
+      err.actual = utils.stringify(err.actual);
+    } catch {
+      err.actual = "[unable to stringify]";
+    }
+    try {
+      err.expected = utils.stringify(err.expected);
+    } catch {
+      err.expected = "[unable to stringify]";
+    }
   }
 }
 

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -367,6 +367,29 @@ describe("Base reporter", function () {
     expect(errOut, "to match", /\+ expected/);
   });
 
+  it("should not throw when diff stringify fails (#5507)", function () {
+    var utils = require("../../lib/utils");
+    var originalStringify = utils.stringify;
+    utils.stringify = function () {
+      throw new TypeError("Converting circular structure to JSON");
+    };
+    try {
+      var err = new Error("test");
+      err.actual = { a: 1 };
+      err.expected = { b: 2 };
+      err.showDiff = true;
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n");
+      expect(errOut, "to match", /test/);
+      expect(errOut, "to match", /test title/);
+    } finally {
+      utils.stringify = originalStringify;
+    }
+  });
+
   it("should handle error messages that are not strings", function () {
     try {
       assert(false, true);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5507
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When `utils.stringify()` throws during diff generation (e.g. for cyclic objects with custom `Symbol.toStringTag`), the unhandled error propagates out of the `EVENT_TEST_FAIL` handler and kills the mocha process with exit code 0 instead of reporting the test failure.

**Failing scenario:** Any assertion error where `err.actual` or `err.expected` causes `utils.stringify()` to throw (cyclic objects with custom `Symbol.toStringTag`, objects with throwing getters, etc.)

**Before:** Process silently exits with code 0 — CI pipelines falsely report success.

**After:** Test failure is reported normally with exit code 1. Diff display degrades gracefully with a `[unable to stringify]` placeholder.

**Fix:** Wrap each `utils.stringify()` call in `stringifyDiffObjs` independently in try/catch, so:
- A failure in one side does not discard a successfully stringified value from the other
- On error, a fallback string is used instead of crashing

Regression test stubs `utils.stringify` to throw and verifies `Base.list()` completes without error.

**Reproduction:**
```js
it("t", async function() {
  const a = {}; a.self = a; a[Symbol.toStringTag] = "Custom";
  const b = {}; b.self = b; b[Symbol.toStringTag] = "Custom"; b.extra = 1;
  require("node:assert").deepStrictEqual(a, b);
});
```

**Validation:** `npm run test-node:reporters` (147 passing), `npm run test-node:unit` (1103 passing), `npm run test-smoke`, `npm run format:check`, eslint on changed files.