### PR TITLE
refactor: inline `escape-string-regexp` (single-regex utility)

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -6,7 +6,7 @@
  * MIT Licensed
  */
 
-var escapeRe = require("escape-string-regexp");
+var { escapeRegExp } = require("./utils/regexp.mjs");
 var path = require("node:path");
 var builtinReporters = require("./reporters");
 var utils = require("./utils");
@@ -513,7 +513,7 @@ Mocha.prototype.fgrep = function (str) {
   if (!str) {
     return this;
   }
-  return this.grep(new RegExp(escapeRe(str)));
+  return this.grep(new RegExp(escapeRegExp(str)));
 };
 
 /**

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -13,7 +13,7 @@
 
 var Base = require("./base");
 var utils = require("../utils");
-var escapeRe = require("escape-string-regexp");
+var { escapeRegExp } = require("../../lib/utils/regexp.mjs");
 var constants = require("../runner").constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
@@ -284,7 +284,7 @@ class HTML extends Base {
    * @param {Object} [suite]
    */
   suiteURL(suite) {
-    return makeUrl("^" + escapeRe(suite.fullTitle()) + " ");
+    return makeUrl("^" + escapeRegExp(suite.fullTitle()) + " ");
   }
 
   /**
@@ -293,7 +293,7 @@ class HTML extends Base {
    * @param {Object} [test]
    */
   testURL(test) {
-    return makeUrl("^" + escapeRe(test.fullTitle()) + "$");
+    return makeUrl("^" + escapeRegExp(test.fullTitle()) + "$");
   }
 
   /**

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -13,7 +13,7 @@
 
 var Base = require("./base");
 var utils = require("../utils");
-var { escapeRegExp } = require("../../lib/utils/regexp.mjs");
+var { escapeRegExp } = require("../utils/regexp.mjs");
 var constants = require("../runner").constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/lib/utils/regexp.mjs
+++ b/lib/utils/regexp.mjs
@@ -1,0 +1,14 @@
+// @ts-check
+
+/**
+ * Escapes special characters in a string to make it safe for use in regular expressions.
+ *
+ * @param {string} value - The string to escape
+ * @returns {string} The escaped string safe for use in regular expressions
+ */
+export function escapeRegExp (value) {
+  // TODO [engine:node@>=24]: Replace with built in RegExp.escape()
+  return value
+    .replaceAll(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+    .replaceAll('-', '\\x2d');
+}

--- a/lib/utils/regexp.mjs
+++ b/lib/utils/regexp.mjs
@@ -6,9 +6,9 @@
  * @param {string} value - The string to escape
  * @returns {string} The escaped string safe for use in regular expressions
  */
-export function escapeRegExp (value) {
+export function escapeRegExp(value) {
   // TODO [engine:node@>=24]: Replace with built in RegExp.escape()
   return value
-    .replaceAll(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-    .replaceAll('-', '\\x2d');
+    .replaceAll(/[|\\{}()[\]^$+*?.]/g, "\\$&")
+    .replaceAll("-", "\\x2d");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chokidar": "^5.0.0",
         "debug": "^4.3.5",
         "diff": "^8.0.3",
-        "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^13.0.0",
         "he": "^1.2.0",
@@ -4305,6 +4304,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "chokidar": "^5.0.0",
     "debug": "^4.3.5",
     "diff": "^8.0.3",
-    "escape-string-regexp": "^4.0.0",
     "find-up": "^5.0.0",
     "glob": "^13.0.0",
     "he": "^1.2.0",

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { version } = require("../package.json");
-const escapeRe = require("escape-string-regexp");
+const { escapeRegExp } = require("../lib/utils/regexp.mjs");
 
 module.exports = {
   name: "unexpected-mocha-internal",
@@ -330,7 +330,7 @@ module.exports = {
         "<RawResult|SummarizedResult> to contain [output] once <any>",
         (expect, result, output) => {
           if (typeof output === "string") {
-            output = escapeRe(output);
+            output = escapeRegExp(output);
           } else if (!(output instanceof RegExp)) {
             throw new TypeError("expected a string or regexp");
           }

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,12 +1,12 @@
 "use strict";
 
-const escapeRegExp = require("escape-string-regexp");
 const os = require("node:os");
 const fs = require("node:fs");
 const fsP = require("node:fs/promises");
 const { format } = require("node:util");
 const path = require("node:path");
 const Base = require("../../lib/reporters/base");
+const { escapeRegExp } = require("../../lib/utils/regexp.mjs");
 const debug = require("debug")("mocha:test:integration:helpers");
 const SIGNAL_OFFSET = 128;
 


### PR DESCRIPTION
The escape-string-regexp package is a single regex function. Inline it and remove the dependency.

Supersedes: #5772 #5773 

<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: #5357
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Contains an [expiring todo comment](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/expiring-todo-comments.md) that will be helpful when/if we add #5882 