### PR TITLE
fix symlink loop crash, markdown escaping, and symbol diffs

### DIFF
--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -69,6 +69,7 @@ module.exports = function lookupFiles(
   filepath,
   extensions = [],
   recursive = false,
+  _seen,
 ) {
   const files = [];
   let stat;
@@ -118,6 +119,22 @@ module.exports = function lookupFiles(
   }
 
   // Handle directory
+  // Track visited real paths to prevent symlink loops (GH-2330)
+  if (recursive) {
+    if (!_seen) {
+      _seen = new Set();
+    }
+    try {
+      var realPath = fs.realpathSync(filepath);
+      if (_seen.has(realPath)) {
+        return files;
+      }
+      _seen.add(realPath);
+    } catch {
+      return files;
+    }
+  }
+
   fs.readdirSync(filepath).forEach((dirent) => {
     const pathname = path.join(filepath, dirent);
     let stat;
@@ -126,7 +143,7 @@ module.exports = function lookupFiles(
       stat = fs.statSync(pathname);
       if (stat.isDirectory()) {
         if (recursive) {
-          files.push(...lookupFiles(pathname, extensions, recursive));
+          files.push(...lookupFiles(pathname, extensions, recursive, _seen));
         }
         return;
       }

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -83,6 +83,15 @@ class Base {
     });
 
     runner.on(EVENT_TEST_FAIL, function (test, err) {
+      // Stringify Symbol values so they can participate in diffs (GH-2183)
+      if (err) {
+        if (typeof err.actual === "symbol") {
+          err.actual = String(err.actual);
+        }
+        if (typeof err.expected === "symbol") {
+          err.expected = String(err.expected);
+        }
+      }
       if (showDiff(err)) {
         stringifyDiffObjs(err);
       }
@@ -410,6 +419,13 @@ exports.list = function (failures) {
     // uncaught
     if (err.uncaught) {
       msg = "Uncaught " + msg;
+    }
+    // Stringify Symbol values for display (GH-2183)
+    if (typeof err.actual === "symbol") {
+      err.actual = String(err.actual);
+    }
+    if (typeof err.expected === "symbol") {
+      err.expected = String(err.expected);
     }
     // explicitly show diff
     if (!exports.hideDiff && showDiff(err)) {

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -25,6 +25,17 @@ var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 
 var SUITE_PREFIX = "$";
 
+/**
+ * Escape markdown special characters in a string.
+ *
+ * @private
+ * @param {string} str
+ * @return {string}
+ */
+function escapeMarkdown(str) {
+  return str.replace(/[\\`*_{}[\]()#+\-.!|>~]/g, "\\$&");
+}
+
 class Markdown extends Base {
   static description = "GitHub Flavored Markdown";
 
@@ -44,7 +55,7 @@ class Markdown extends Base {
     var buf = "";
 
     function title(str) {
-      return Array(level).join("#") + " " + str;
+      return Array(level).join("#") + " " + escapeMarkdown(str);
     }
 
     function mapTOC(suite, obj) {
@@ -68,7 +79,7 @@ class Markdown extends Base {
           continue;
         }
         if (key !== SUITE_PREFIX) {
-          link = " - [" + key.substring(1) + "]";
+          link = " - [" + escapeMarkdown(key.substring(1)) + "]";
           link += "(#" + utils.slug(obj[key].suite.fullTitle()) + ")\n";
           buf += Array(level).join("  ") + link;
         }
@@ -97,7 +108,7 @@ class Markdown extends Base {
 
     runner.on(EVENT_TEST_PASS, function (test) {
       var code = utils.clean(test.body);
-      buf += test.title + ".\n";
+      buf += escapeMarkdown(test.title) + ".\n";
       buf += "\n```js\n";
       buf += code + "\n";
       buf += "```\n\n";

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -1,12 +1,7 @@
 "use strict";
 
 const lookupFiles = require("../../lib/cli/lookup-files");
-const {
-  existsSync,
-  symlinkSync,
-  renameSync,
-  mkdirSync,
-} = require("node:fs");
+const { existsSync, symlinkSync, renameSync, mkdirSync } = require("node:fs");
 const path = require("node:path");
 const { touchFile, createTempDir } = require("./helpers");
 

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -1,7 +1,12 @@
 "use strict";
 
 const lookupFiles = require("../../lib/cli/lookup-files");
-const { existsSync, symlinkSync, renameSync } = require("node:fs");
+const {
+  existsSync,
+  symlinkSync,
+  renameSync,
+  mkdirSync,
+} = require("node:fs");
 const path = require("node:path");
 const { touchFile, createTempDir } = require("./helpers");
 
@@ -45,6 +50,22 @@ describe("file utils", function () {
       renameSync(tmpFile("mocha-utils.js"), tmpFile("bob"));
       expect(existsSync(tmpFile("mocha-utils-link.js")), "to be", false);
       expect(lookupFiles(tmpDir, ["js"], false), "to equal", []);
+    });
+
+    it("should handle symlink loops without crashing", function () {
+      if (!SYMLINK_SUPPORT) {
+        return this.skip();
+      }
+
+      // Create a subdirectory with a symlink back to the parent
+      var subDir = path.join(tmpDir, "subdir");
+      mkdirSync(subDir);
+      touchFile(path.join(subDir, "test.js"));
+      symlinkSync(tmpDir, path.join(subDir, "loop-link"));
+
+      // Should not throw ENAMETOOLONG or cause infinite recursion
+      var files = lookupFiles(tmpDir, ["js"], true);
+      expect(files, "to contain", path.join(subDir, "test.js"));
     });
 
     it('should accept a glob "path" value', function () {

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -111,6 +111,54 @@ describe("Base reporter", function () {
       expect(errOut, "not to match", /- actual/);
       expect(errOut, "not to match", /\+ expected/);
     });
+
+    it("should show diffs when actual is a Symbol", function () {
+      var _err = new Error("test");
+      _err.actual = Symbol("actual-value");
+      _err.expected = "expected-value";
+      _err.showDiff = true;
+      var test = makeTest(_err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n");
+      expect(errOut, "to match", /Symbol\(actual-value\)/);
+      expect(errOut, "to match", /expected-value/);
+      expect(errOut, "to match", /- actual/);
+      expect(errOut, "to match", /\+ expected/);
+    });
+
+    it("should show diffs when expected is a Symbol", function () {
+      var _err = new Error("test");
+      _err.actual = "actual-value";
+      _err.expected = Symbol("expected-value");
+      _err.showDiff = true;
+      var test = makeTest(_err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n");
+      expect(errOut, "to match", /actual-value/);
+      expect(errOut, "to match", /Symbol\(expected-value\)/);
+      expect(errOut, "to match", /- actual/);
+      expect(errOut, "to match", /\+ expected/);
+    });
+
+    it("should show diffs when both actual and expected are Symbols", function () {
+      var _err = new Error("test");
+      _err.actual = Symbol("one");
+      _err.expected = Symbol("two");
+      _err.showDiff = true;
+      var test = makeTest(_err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n");
+      expect(errOut, "to match", /Symbol\(one\)/);
+      expect(errOut, "to match", /Symbol\(two\)/);
+      expect(errOut, "to match", /- actual/);
+      expect(errOut, "to match", /\+ expected/);
+    });
   });
 
   describe("getting two strings", function () {

--- a/test/reporters/markdown.spec.js
+++ b/test/reporters/markdown.spec.js
@@ -112,4 +112,89 @@ describe("Markdown reporter", function () {
       });
     });
   });
+
+  describe("escaping markdown special characters", function () {
+    it("should escape special characters in suite titles", async function () {
+      var specialSuite = {
+        title: "***bold***",
+        fullTitle: function () {
+          return "***bold***";
+        },
+        suites: [],
+      };
+      var runner = createMockRunner(
+        "suite suite end",
+        EVENT_SUITE_BEGIN,
+        EVENT_SUITE_END,
+        EVENT_RUN_END,
+        specialSuite,
+      );
+      runner.suite = specialSuite;
+      var options = {};
+      var { stdout } = await runReporter({}, runner, options);
+      var output = stdout.join("");
+
+      expect(output, "to contain", "\\*\\*\\*bold\\*\\*\\*");
+      expect(output, "not to match", /# \*\*\*bold\*\*\*/);
+    });
+
+    it("should escape special characters in TOC link text", async function () {
+      var specialSuite = {
+        title: "[link](url)",
+        fullTitle: function () {
+          return "[link](url)";
+        },
+        suites: [],
+      };
+      var runner = createMockRunner(
+        "suite suite end",
+        EVENT_SUITE_BEGIN,
+        EVENT_SUITE_END,
+        EVENT_RUN_END,
+        specialSuite,
+      );
+      runner.suite = specialSuite;
+      var options = {};
+      var { stdout } = await runReporter({}, runner, options);
+      var output = stdout.join("");
+
+      expect(output, "to contain", "\\[link\\]\\(url\\)");
+    });
+
+    it("should escape special characters in test titles", async function () {
+      var specialSuite = {
+        title: "suite",
+        fullTitle: function () {
+          return "suite";
+        },
+        suites: [],
+      };
+      var expectedBody = "some body";
+      var specialTest = {
+        title: ">>> should be escaped",
+        fullTitle: function () {
+          return "suite >>> should be escaped";
+        },
+        duration: 1000,
+        currentRetry: function () {
+          return 0;
+        },
+        slow: noop,
+        body: expectedBody,
+      };
+      var runner = createMockRunner(
+        "pass end",
+        EVENT_TEST_PASS,
+        EVENT_RUN_END,
+        null,
+        specialTest,
+      );
+      runner.suite = specialSuite;
+      var options = {};
+      var { stdout } = await runReporter({}, runner, options);
+      var output = stdout.join("");
+
+      expect(output, "to contain", "\\>\\>\\> should be escaped");
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2330, fixes #2306, fixes #2183
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Handful of fixes for some old open issues that have been bugging people.

**Symlink loops (#2330)** — `lookupFiles` would blow up with ENAMETOOLONG if you had a symlink pointing back to an ancestor. Now it keeps track of where it's been (via realpath) and just skips directories it already visited.

**Markdown reporter (#2306)** — if your describe/it titles had stuff like `***`, `[link](url)`, or `> whatever` in them, the `-R markdown` output came out mangled. Added a simple escape function that backslash-escapes the special chars before they hit headings/TOC/titles. Code blocks are left alone obviously.

**Symbol diffs (#2183)** — when `err.actual` or `err.expected` was a Symbol, mocha would silently swallow the diff because `sameType()` sees Symbol and String as different types. Now we just convert them to their string form (e.g. `Symbol(foo)`) before the diff check runs. Per @JoshuaKGoldberg's comment — treating this as a bug with Symbols in Error properties specifically.

Each fix is its own commit with tests.

Three commits:
1. `fix: prevent ENAMETOOLONG crash on symlink loops in lookupFiles`
2. `fix: escape markdown special characters in markdown reporter`
3. `fix: show diffs when err.actual or err.expected is a Symbol`

All existing tests pass, added new ones for each fix.