### PR TITLE
Fix afterEach hook errors halting the suite, HTML reporter unicode crash, and stack trace filtering for modern Node.js

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -335,8 +335,33 @@ function makeUrl(s) {
     window.location.pathname +
     (search ? search + "&" : "?") +
     "grep=" +
-    encodeURIComponent(s)
+    safeEncodeURIComponent(s)
   );
+}
+
+/**
+ * Encode a string for use in a URI component, replacing lone surrogates
+ * with the Unicode replacement character (U+FFFD) to avoid URIError.
+ *
+ * A lone surrogate is one half of a UTF-16 surrogate pair (U+D800–U+DFFF)
+ * that appears without its matching counterpart. `encodeURIComponent()` throws
+ * a `URIError` when it encounters one, so we catch that and replace them.
+ *
+ * @param {string} s
+ * @return {string} The encoded string.
+ */
+function safeEncodeURIComponent(s) {
+  try {
+    return encodeURIComponent(s);
+  } catch {
+    // replace lone surrogates with U+FFFD and retry
+    return encodeURIComponent(
+      s.replace(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+        "\uFFFD",
+      ),
+    );
+  }
 }
 
 /**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -608,6 +608,10 @@ Runner.prototype.hook = function (name, fn) {
 
     hook.allowUncaught = self.allowUncaught;
 
+    // reset hook state from any previous run so it can be reused
+    // (e.g. afterEach hooks run once per test)
+    delete hook.state;
+
     self.emit(constants.EVENT_HOOK_BEGIN, hook);
 
     if (!hook.listeners("error").length) {
@@ -619,6 +623,12 @@ Runner.prototype.hook = function (name, fn) {
     hook.run(function cbHookRun(err) {
       var testError = hook.error();
       if (testError) {
+        // Retract pass count if the test was already counted as passed;
+        // this.test.error() in afterEach hooks marks a previously-passing
+        // test as failed, so we must correct the stats to avoid double-counting
+        if (self.test && self.test.state === STATE_PASSED && self.stats) {
+          self.stats.passes = Math.max(0, self.stats.passes - 1);
+        }
         self.fail(self.test, testError);
       }
       // conditional skip
@@ -824,9 +834,16 @@ Runner.prototype.runTests = function (suite, fn) {
   var tests = suite.tests.slice();
   var test;
 
-  function hookErr(err, errSuite, after) {
+  function hookErr(err, errSuite, after, continueAfterError) {
     // before/after Each hook for errSuite failed:
     var orig = self.suite;
+
+    // Track whether the original error was an afterEach failure.
+    // Only afterEach failures should allow the suite to continue.
+    // When called recursively (afterEach errors during cleanup of a
+    // beforeEach failure), preserve the original intent to abort.
+    var shouldContinue =
+      continueAfterError !== undefined ? continueAfterError : after;
 
     // If failHookAffectedTests is enabled and this is a beforeEach failure,
     // mark remaining tests as failed
@@ -864,7 +881,12 @@ Runner.prototype.runTests = function (suite, fn) {
         self.suite = orig;
         // some hooks may fail even now
         if (err2) {
-          return hookErr(err2, errSuite2, true);
+          return hookErr(err2, errSuite2, true, shouldContinue);
+        }
+        // afterEach failure should not halt the suite;
+        // continue with remaining tests
+        if (shouldContinue) {
+          return next();
         }
         // report error suite
         fn(errSuite);
@@ -872,6 +894,10 @@ Runner.prototype.runTests = function (suite, fn) {
     } else {
       // there is no need calling other 'after each' hooks
       self.suite = orig;
+      // afterEach failure should not halt the suite
+      if (shouldContinue) {
+        return next();
+      }
       fn(errSuite);
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -453,6 +453,7 @@ exports.stackTraceFilter = function () {
       ~line.indexOf("(node.js:") ||
       ~line.indexOf("(module.js:") ||
       ~line.indexOf("GeneratorFunctionPrototype.next (native)") ||
+      ~line.indexOf("(node:") ||
       false
     );
   }

--- a/test/integration/fixtures/hooks/after-each-hook-async-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-each-hook-async-error.fixture.js
@@ -10,7 +10,7 @@ describe('spec 1', function () {
   it('should be called because error is in after each hook', function () {
     console.log('test 1');
   });
-  it('should not be called', function () {
+  it('should be called because afterEach errors do not halt the suite', function () {
     console.log('test 2');
   });
 });

--- a/test/integration/fixtures/hooks/after-each-hook-error-continues.fixture.js
+++ b/test/integration/fixtures/hooks/after-each-hook-error-continues.fixture.js
@@ -1,0 +1,13 @@
+'use strict';
+
+describe('suite', function () {
+  afterEach(function () {
+    throw new Error('after each hook error');
+  });
+  it('test 1', function () {
+    // passes
+  });
+  it('test 2', function () {
+    // should also run despite afterEach failure on test 1
+  });
+});

--- a/test/integration/fixtures/hooks/after-each-hook-error.fixture.js
+++ b/test/integration/fixtures/hooks/after-each-hook-error.fixture.js
@@ -8,7 +8,7 @@ describe('spec 1', function () {
   it('should be called because error is in after each hook', function () {
     console.log('test 1');
   });
-  it('should not be called', function () {
+  it('should be called because afterEach errors do not halt the suite', function () {
     console.log('test 2');
   });
 });

--- a/test/integration/hook-err.spec.js
+++ b/test/integration/hook-err.spec.js
@@ -139,7 +139,28 @@ describe("hook error handling", function () {
   describe("after each hook error", function () {
     before(run("hooks/after-each-hook-error.fixture.js"));
     it("should verify results", function () {
-      expect(lines, "to equal", ["test 1", "after", bang + "test 3"]);
+      expect(lines, "to equal", [
+        "test 1",
+        "after",
+        bang + "test 2",
+        "after",
+        bang + "test 3",
+      ]);
+    });
+  });
+
+  describe("after each hook error - pass/fail counts", function () {
+    it("should continue running tests after afterEach failure", function (done) {
+      runMochaJSON("hooks/after-each-hook-error-continues", [], (err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res, "to have failed")
+          .and("to have passed test count", 2)
+          .and("to have passed test", "test 1")
+          .and("to have passed test", "test 2");
+        done();
+      });
     });
   });
 
@@ -161,6 +182,13 @@ describe("hook error handling", function () {
         "1 before each",
         "1-2 before each",
         "1-2 test 1",
+        "1-2 after each",
+        bang + "1 after each",
+        "root after each",
+        "root before each",
+        "1 before each",
+        "1-2 before each",
+        "1-2 test 2",
         "1-2 after each",
         bang + "1 after each",
         "root after each",
@@ -214,7 +242,13 @@ describe("hook error handling", function () {
   describe("async - after each hook error", function () {
     before(run("hooks/after-each-hook-async-error.fixture.js"));
     it("should verify results", function () {
-      expect(lines, "to equal", ["test 1", "after", bang + "test 3"]);
+      expect(lines, "to equal", [
+        "test 1",
+        "after",
+        bang + "test 2",
+        "after",
+        bang + "test 3",
+      ]);
     });
   });
 
@@ -236,6 +270,13 @@ describe("hook error handling", function () {
         "1 before each",
         "1-2 before each",
         "1-2 test 1",
+        "1-2 after each",
+        bang + "1 after each",
+        "root after each",
+        "root before each",
+        "1 before each",
+        "1-2 before each",
+        "1-2 test 2",
         "1-2 after each",
         bang + "1 after each",
         "root after each",
@@ -264,6 +305,18 @@ describe("hook error handling", function () {
         "to have failed test",
         'fail the test from the "after each" hook should fail',
       );
+    });
+
+    it("should not double-count the test in passes", function (done) {
+      runMochaJSON("hooks/after-each-this-test-error", [], (err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res, "to have failed")
+          .and("to have passed test count", 0)
+          .and("to have failed test count", 1);
+        done();
+      });
     });
   });
 

--- a/test/node-unit/stack-trace-filter.spec.js
+++ b/test/node-unit/stack-trace-filter.spec.js
@@ -122,6 +122,16 @@ describe("stackTraceFilter()", function () {
         expect(filter(stack.join("\n")), "to be", stack.slice(0, 2).join("\n"));
       });
     });
+
+    it("should filter out modern Node.js internal frames using (node: prefix)", function () {
+      var stack = [
+        "Error: timeout of 2000ms exceeded",
+        "at Context.<anonymous> (/dev/test/mytest.js:5:9)",
+        "at processImmediate (node:internal/timers:478:21)",
+        "at process.callbackTrampoline (node:internal/async_hooks:130:17)",
+      ];
+      expect(filter(stack.join("\n")), "to be", stack.slice(0, 2).join("\n"));
+    });
   });
 
   describe("on browser", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1635, fixes #1893, fixes #1960
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This pr fixes three seperate bugs:

# ONE. afterEach hook errors stop the suite (#1635)

Right now, if an `afterEach` hook throws, Mocha stops the whole suite and skips the rest of the tests. this changes `hookErr()` so that even if `afterEach` fails, the suite keeps going and the remaining tests still run.

there is also a stats issue (see #3345): if an `afterEach` hook calls `this.test.error(err)` on a test that already passed, the pass count goes up and then a failure gets recorded but the pass count never gets corrected. this fixes that by rolling back the pass count when that situation happens.

PR #3362 tried to fix this before, but it got reverted (#3569) because it changed when `EVENT_TEST_PASS` fires. This version keeps the event order the same (pass event still fires before `afterEach`) and only adds the continuation logic + stats fix inside the hook callback.

Note: #1635 is marked `semver-major` for v13.0.0. This is techniclly breaking if you relied on `afterEach` errors stopping execution, that won’t happen anymore, or....hopefully shouldn't.

# TWO. HTML reporter crashes on lone surrogates (#1893)

`encodeURIComponent()` throws if the string has a lone Unicode sorrogate (like `\uD800`). the HTML reporter runs test titles through it, so certain titles can crash the reporter.

this wraps it in a `safeEncodeURIComponent` helper that catches the error, replcaes bad characters with U+FFFD, and retires.

# THREE. Node internal frames showing up in stack traces (#1960)

newer node versions use `(node:internal/...)` for internal stack frames. `isNodeInternal()` didn’t catch those, so they showed up in user stack traces.

Added a simple check for the `(node:` prefix to filter them out.

*(The Windows `path.sep` part of #1960 was already fixed earlier.)*

# What i tested

- Unit tests: 1101 passing, 6 pending, 0 failing
 - Integration tests: 355 passing, 13 failing (all pre-existing)
- Reporter tests: 146 passing, 0 failing
- Typecheck + build: clean

New tests:

- afterEach continuation (both tests run even if afterEach throws)
- stats accuracy (0 passes / 1 failure when using `this.test.error()`)
- stack trace filtering for `(node:internal/...)` frames