### PR TITLE
fix: --recursive with globs, watch cache invalidation, and watch exit on missing files

### DIFF
--- a/lib/cli/collect-files.js
+++ b/lib/cli/collect-files.js
@@ -98,8 +98,9 @@ module.exports = ({
             unmatchedSpecFiles[0].pattern,
           )}` // stringify to print escaped characters raw
         : "Error: No test files found";
-    console.error(pc.red(noneFoundMsg));
-    process.exit(1);
+    const err = new Error(noneFoundMsg);
+    err.code = NO_FILES_MATCH_PATTERN;
+    throw err;
   } else {
     // print messages as a warning
     unmatchedSpecFiles.forEach((warning) => {

--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -76,8 +76,17 @@ module.exports = function lookupFiles(
   if (!fs.existsSync(filepath)) {
     let pattern;
     if (glob.hasMagic(filepath, { windowsPathsNoEscape: true })) {
-      // Handle glob as is without extensions
-      pattern = filepath;
+      if (recursive && !filepath.includes("**")) {
+        // when --recursive is set, transform the glob to search subdirectories
+        // e.g './test/*.ts' becomes './test/**/*.ts'
+        const dir = path.dirname(filepath);
+        const base = path.basename(filepath);
+        pattern = path.join(dir, "**", base);
+        debug("recursive glob pattern: %s", pattern);
+      } else {
+        // Handle glob as is without extensions
+        pattern = filepath;
+      }
     } else {
       // glob pattern e.g. 'filepath+(.js|.ts)'
       const strExtensions = extensions

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -23,6 +23,7 @@ const collectFiles = require("./collect-files");
 const { format } = require("node:util");
 const { createInvalidLegacyPluginError } = require("../errors");
 const { requireOrImport } = require("../nodejs/esm-utils");
+const { NO_FILES_MATCH_PATTERN } = require("../error-constants.mjs").constants;
 const PluginLoader = require("../plugin-loader");
 
 /**
@@ -169,7 +170,16 @@ const singleRun = async (
   { exit, passOnFailingTestSuite },
   fileCollectParams,
 ) => {
-  const fileCollectionObj = collectFiles(fileCollectParams);
+  let fileCollectionObj;
+  try {
+    fileCollectionObj = collectFiles(fileCollectParams);
+  } catch (err) {
+    if (err.code === NO_FILES_MATCH_PATTERN) {
+      console.error(pc.red(err.message));
+      process.exit(1);
+    }
+    throw err;
+  }
 
   if (fileCollectionObj.unmatchedFiles.length > 0) {
     return handleUnmatchedFiles(mocha, fileCollectionObj.unmatchedFiles);
@@ -197,7 +207,16 @@ const singleRun = async (
  * @private
  */
 const parallelRun = async (mocha, options, fileCollectParams) => {
-  const fileCollectionObj = collectFiles(fileCollectParams);
+  let fileCollectionObj;
+  try {
+    fileCollectionObj = collectFiles(fileCollectParams);
+  } catch (err) {
+    if (err.code === NO_FILES_MATCH_PATTERN) {
+      console.error(pc.red(err.message));
+      process.exit(1);
+    }
+    throw err;
+  }
 
   if (fileCollectionObj.unmatchedFiles.length > 0) {
     return handleUnmatchedFiles(mocha, fileCollectionObj.unmatchedFiles);

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -12,6 +12,7 @@ const Context = require("../context.mjs").Context;
 const collectFiles = require("./collect-files");
 const runHelpers = require("./run-helpers");
 const { logSymbols } = require("../utils");
+const { NO_FILES_MATCH_PATTERN } = require("../error-constants.mjs").constants;
 
 /**
  * @typedef {import('chokidar').FSWatcher} FSWatcher
@@ -81,7 +82,18 @@ exports.watchParallelRun = (
       newMocha.suite.ctx = new Context();
 
       // reset the list of files
-      newMocha.files = collectFiles(fileCollectParams).files;
+      try {
+        newMocha.files = collectFiles(fileCollectParams).files;
+      } catch (err) {
+        if (err.code === NO_FILES_MATCH_PATTERN) {
+          console.error(
+            `${logSymbols.warning} [mocha] ${err.message}, waiting for changes...`,
+          );
+          newMocha.files = [];
+        } else {
+          throw err;
+        }
+      }
 
       // because we've swapped out the root suite (see the `run` inner function
       // in `createRerunner`), we need to call `mocha.ui()` again to set up the context/globals.
@@ -149,7 +161,18 @@ exports.watchRun = (mocha, { watchFiles, watchIgnore }, fileCollectParams) => {
       newMocha.suite.ctx = new Context();
 
       // reset the list of files
-      newMocha.files = collectFiles(fileCollectParams).files;
+      try {
+        newMocha.files = collectFiles(fileCollectParams).files;
+      } catch (err) {
+        if (err.code === NO_FILES_MATCH_PATTERN) {
+          console.error(
+            `${logSymbols.warning} [mocha] ${err.message}, waiting for changes...`,
+          );
+          newMocha.files = [];
+        } else {
+          throw err;
+        }
+      }
 
       // because we've swapped out the root suite (see the `run` inner function
       // in `createRerunner`), we need to call `mocha.ui()` again to set up the context/globals.
@@ -679,18 +702,48 @@ const eraseLine = () => {
 };
 
 /**
- * Blast all of the watched files out of `require.cache`
+ * Blast all of the watched files out of `require.cache`,
+ * plus any modules that transitively depend on them.
  * @param {PathMatcher} matcher - only delete keys allowed by this matcher
  * @ignore
  * @private
  */
 const blastCache = (matcher) => {
-  let deletedCount = 0;
+  const deletedKeys = new Set();
+
+  // First pass: delete all files matching the watcher
   for (const key in require.cache) {
     if (matcher.allow(key)) {
-      deletedCount++;
+      deletedKeys.add(key);
       delete require.cache[key];
     }
   }
-  debug("deleted %d file(s) from the require cache", deletedCount);
+
+  // Subsequent passes: also delete modules that depend on deleted modules.
+  // This ensures transitive dependents (e.g. an unwatched intermediary that
+  // requires a watched file) are also evicted so they pick up changes.
+  // Skip node_modules to avoid cascading into Mocha framework/library code
+  // (Mocha's own modules have test files as children via require()).
+  const nodeModulesSep = `${path.sep}node_modules${path.sep}`;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const key in require.cache) {
+      if (key.includes(nodeModulesSep)) {
+        continue;
+      }
+      const mod = require.cache[key];
+      if (
+        mod &&
+        mod.children &&
+        mod.children.some((child) => deletedKeys.has(child.filename))
+      ) {
+        deletedKeys.add(key);
+        delete require.cache[key];
+        changed = true;
+      }
+    }
+  }
+
+  debug("deleted %d file(s) from the require cache", deletedKeys.size);
 };

--- a/test/integration/file-utils.spec.js
+++ b/test/integration/file-utils.spec.js
@@ -253,6 +253,42 @@ describe("file utils", function () {
       });
     });
 
+    describe("when `recursive` option is true with a glob pattern", function () {
+      it("should find files in subdirectories", function () {
+        touchFile(tmpFile("sub/deep/nested.js"));
+        touchFile(tmpFile("sub/shallow.js"));
+
+        const res = lookupFiles(tmpFile("sub/*.js"), ["js"], true).map(
+          (foundFilepath) => path.normalize(foundFilepath),
+        );
+
+        expect(res, "to contain", tmpFile("sub/shallow.js"));
+        expect(res, "to contain", tmpFile("sub/deep/nested.js"));
+      });
+
+      it("should not inject ** when pattern already contains it", function () {
+        touchFile(tmpFile("sub/deep/nested.js"));
+
+        const res = lookupFiles(tmpFile("sub/**/*.js"), ["js"], true).map(
+          (foundFilepath) => path.normalize(foundFilepath),
+        );
+
+        expect(res, "to contain", tmpFile("sub/deep/nested.js"));
+      });
+
+      it("should not recurse when `recursive` is false", function () {
+        touchFile(tmpFile("sub/shallow.js"));
+        touchFile(tmpFile("sub/deep/nested.js"));
+
+        const res = lookupFiles(tmpFile("sub/*.js"), ["js"], false).map(
+          (foundFilepath) => path.normalize(foundFilepath),
+        );
+
+        expect(res, "to contain", tmpFile("sub/shallow.js"));
+        expect(res, "not to contain", tmpFile("sub/deep/nested.js"));
+      });
+    });
+
     describe("when no files match", function () {
       it("should throw an exception", function () {
         expect(() => lookupFiles(tmpFile("mocha-utils")), "to throw", {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4186, fixes #4016, fixes #4169
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This is basically three related fixes around how files are handled in the CLI and in watch mode.

First one, `--recursive` finally does what you’d expect when you use it with glob patterns. before, if you ran something like `mocha "./test/*.ts" --recursive`, it would just ignore the flag, because recursion only kicked in for plain directories. Now it just rewrites the glob a bit under the hood (adds a `**/` in the right spot), so it actually looks through subfolders too. If your glob already has `**`, it leaves it alone.

second fix is about watch mode being a bit “half-aware” of changes. say you got `test.js` requiring `lib-b`, and `lib-b` requires `lib-a`. If only `lib-a` is being watched and you change it, mocha would rerun but `lib-b` would still be cached with the old version of `lib-a`, so your change wouldn’t show up. pretty frustrating. now, when it clears the cache, it doesn’t just remove the directly watched files it also kicks out anything that depends on them (as long as it’s your code, not stuff in `node_modules`). That way the whole chain actually refreshes properly.

And the last one: watch mode used to just die if all your test files disappeared, like if you deleted the test folder while it was running. It was calling `process.exit(1)` straight away. Now it throws an error instead, the watcher catches it, logs a warning, and just keeps running, waiting for files to come back. If you’re not in watch mode, though, it still exits exactly like before, so no change there.

Testing wise, added a few new tests around the recursive glob behavior, and everything’s passing, unit tests, watch integration tests, the usual smoke tests, and TypeScript checks are all clean.