### PR TITLE
Run format check on all PRs and migrate some unit tests to chai

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,20 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    uses: ./.github/workflows/npm-script.yml
+    with:
+      npm-script: format:check

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -19,11 +19,6 @@ permissions:
   id-token: write # for Codecov OIDC
 
 jobs:
-  format:
-    uses: ./.github/workflows/npm-script.yml
-    with:
-      npm-script: format:check
-
   lint:
     uses: ./.github/workflows/npm-script.yml
     with:

--- a/test/node-unit/cli/mocha-flags.spec.js
+++ b/test/node-unit/cli/mocha-flags.spec.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var { expect } = require("chai");
 const {
   types,
   expectedTypeForFlag,
@@ -10,18 +11,18 @@ describe("mocha-flags", function () {
     Object.entries(types).forEach(([dataType, flags]) => {
       flags.forEach((flag) => {
         it(`returns expected ${flag}'s type as ${dataType}`, function () {
-          expect(expectedTypeForFlag(flag), "to equal", dataType);
+          expect(expectedTypeForFlag(flag)).to.equal(dataType);
         });
       });
     });
 
     it("returns undefined for node flags", function () {
-      expect(expectedTypeForFlag("--throw-deprecation"), "to equal", undefined);
-      expect(expectedTypeForFlag("throw-deprecation"), "to equal", undefined);
+      expect(expectedTypeForFlag("--throw-deprecation")).to.equal(undefined);
+      expect(expectedTypeForFlag("throw-deprecation")).to.equal(undefined);
     });
 
     it("returns undefined for unsupported flags", function () {
-      expect(expectedTypeForFlag("--foo"), "to equal", undefined);
+      expect(expectedTypeForFlag("--foo")).to.equal(undefined);
     });
   });
 });

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var { expect } = require("chai");
+
 describe("Context", function () {
   beforeEach(function () {
     this.calls = ["before"];
@@ -11,18 +13,18 @@ describe("Context", function () {
     });
 
     it("should work", function () {
-      expect(this.calls, "to equal", ["before", "before two"]);
+      expect(this.calls).to.deep.equal(["before", "before two"]);
       this.calls.push("test");
     });
 
     after(function () {
-      expect(this.calls, "to equal", ["before", "before two", "test"]);
+      expect(this.calls).to.deep.equal(["before", "before two", "test"]);
       this.calls.push("after two");
     });
   });
 
   after(function () {
-    expect(this.calls, "to equal", [
+    expect(this.calls).to.deep.equal([
       "before",
       "before two",
       "test",
@@ -43,7 +45,7 @@ describe("Context Siblings", function () {
     });
 
     it("should work", function () {
-      expect(this.hiddenFromSibling, "to equal", "This should be hidden");
+      expect(this.hiddenFromSibling).to.equal("This should be hidden");
     });
   });
 
@@ -53,25 +55,21 @@ describe("Context Siblings", function () {
     });
 
     it("should not have value set within a sibling describe", function () {
-      expect("This should be hidden", "not to equal", this.hiddenFromSibling);
+      expect("This should be hidden").to.not.equal(this.hiddenFromSibling);
       this.visibleFromTestSibling = "Visible from test sibling";
     });
 
     it("should allow test siblings to modify shared context", function () {
-      expect(
-        "Visible from test sibling",
-        "to equal",
-        this.visibleFromTestSibling,
-      );
+      expect("Visible from test sibling").to.equal(this.visibleFromTestSibling);
     });
 
     it("should have reset this.calls before describe", function () {
-      expect(this.calls, "to equal", ["before", "before sibling"]);
+      expect(this.calls).to.deep.equal(["before", "before sibling"]);
     });
   });
 
   after(function () {
-    expect(this.calls, "to equal", ["before", "before sibling"]);
+    expect(this.calls).to.deep.equal(["before", "before sibling"]);
   });
 });
 
@@ -80,19 +78,19 @@ describe("methods", function () {
     it("should return the timeout", function () {
       // set this explicitly because browser and node use diff settings
       this.timeout(1000);
-      expect(this.timeout(), "to be", 1000);
+      expect(this.timeout()).to.equal(1000);
     });
   });
 
   describe("slow()", function () {
     it("should return the slow", function () {
-      expect(this.slow(), "to be", 75);
+      expect(this.slow()).to.equal(75);
     });
   });
 
   describe("retries", function () {
     it("should return the number of retries", function () {
-      expect(this.retries(), "to be", -1);
+      expect(this.retries()).to.equal(-1);
     });
   });
 });

--- a/test/unit/grep.spec.js
+++ b/test/unit/grep.spec.js
@@ -1,24 +1,25 @@
 "use strict";
 
+var { expect } = require("chai");
 var Mocha = require("../../lib/mocha");
 
 describe("Mocha", function () {
   describe('"grep" option', function () {
     it("should add a RegExp to the mocha.options object", function () {
       var mocha = new Mocha({ grep: /foo.*/ });
-      expect(mocha.options.grep, "to equal", /foo.*/);
+      expect(mocha.options.grep).to.deep.equal(/foo.*/);
     });
 
     it("should convert string to a RegExp", function () {
       var mocha = new Mocha({ grep: "foo.*" });
-      expect(mocha.options.grep, "to equal", /foo.*/);
+      expect(mocha.options.grep).to.deep.equal(/foo.*/);
     });
   });
 
   describe('"fgrep" option', function () {
     it("should escape and convert string to a RegExp", function () {
       var mocha = new Mocha({ fgrep: "foo.*" });
-      expect(mocha.options.grep, "to equal", /foo\.\*/);
+      expect(mocha.options.grep).to.deep.equal(/foo\.\*/);
     });
   });
 
@@ -27,7 +28,7 @@ describe("Mocha", function () {
     function testGrep(mocha) {
       return function testGrep(grep, expected) {
         mocha.grep(grep);
-        expect(String(mocha.options.grep), "to be", expected);
+        expect(String(mocha.options.grep)).to.equal(expected);
       };
     }
 
@@ -54,14 +55,14 @@ describe("Mocha", function () {
 
     it("should return its parent Mocha object for chainability", function () {
       var mocha = new Mocha();
-      expect(mocha.grep(), "to be", mocha);
+      expect(mocha.grep()).to.equal(mocha);
     });
   });
 
   describe('"invert" option', function () {
     it("should add a Boolean to the mocha.options object", function () {
       var mocha = new Mocha({ invert: true });
-      expect(mocha.options.invert, "to be", true);
+      expect(mocha.options.invert).to.equal(true);
     });
   });
 });

--- a/test/unit/parse-query.spec.js
+++ b/test/unit/parse-query.spec.js
@@ -1,16 +1,17 @@
 "use strict";
 
+var { expect } = require("chai");
 var parseQuery = require("../../lib/browser/parse-query");
 
 describe("parseQuery()", function () {
   it("should get queryString and return key-value object", function () {
-    expect(parseQuery("?foo=1&bar=2&baz=3"), "to equal", {
+    expect(parseQuery("?foo=1&bar=2&baz=3")).to.deep.equal({
       foo: "1",
       bar: "2",
       baz: "3",
     });
 
-    expect(parseQuery("?r1=^@(?!.*\\)$)&r2=m{2}&r3=^co.*"), "to equal", {
+    expect(parseQuery("?r1=^@(?!.*\\)$)&r2=m{2}&r3=^co.*")).to.deep.equal({
       r1: "^@(?!.*\\)$)",
       r2: "m{2}",
       r3: "^co.*",
@@ -18,6 +19,6 @@ describe("parseQuery()", function () {
   });
 
   it('should parse "+" as a space', function () {
-    expect(parseQuery("?grep=foo+bar"), "to equal", { grep: "foo bar" });
+    expect(parseQuery("?grep=foo+bar")).to.deep.equal({ grep: "foo bar" });
   });
 });

--- a/test/unit/root.spec.js
+++ b/test/unit/root.spec.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var { expect } = require("chai");
 var calls = [];
 
 before(function () {
@@ -8,6 +9,6 @@ before(function () {
 
 describe("root", function () {
   it("should be a valid suite", function () {
-    expect(calls, "to equal", ["before"]);
+    expect(calls).to.deep.equal(["before"]);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5856, partial #5454
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

So this does two main things.

First, the formatting check actually runs everywhere now. Before, `format:check` was tucked inside `mocha.yml`, which had some path filters to skip things like docs or `.github` changes. Sounds nice in theory, but it also meant formatting just… wasn’t enforced on those PRs at all. Now it’s been moved into its own workflow (`format.yml`) with no filtering, so it runs on every push and PR to `main`. The old setup in `mocha.yml` is gone.

Second, started moving some unit tests from `unexpected` over to `chai`. This PR just does a small batch of the simpler ones to get things going stuff like `parse-query`, `grep`, `context`, and a few others.

While doing that, something kind of unexpetced showed up: a couple of assertions weren’t actually asserting anything. They were using this 3-argument `unexpected` syntax, and when that got translated to `chai`, it basically turned into a no-op, like it looked fine but didn’t check anything. Those have now been fixed so they’re real assertions.

Ran the full unit test suite (about 1100 tests), and everything passes. Linting, TypeScript checks, formatting, and smoke tests are all clean too.