### PR TITLE
ci: run format check on all PRs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,20 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    uses: ./.github/workflows/npm-script.yml
+    with:
+      npm-script: format:check

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -19,11 +19,6 @@ permissions:
   id-token: write # for Codecov OIDC
 
 jobs:
-  format:
-    uses: ./.github/workflows/npm-script.yml
-    with:
-      npm-script: format:check
-
   lint:
     uses: ./.github/workflows/npm-script.yml
     with:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5856
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The formatting check now runs on every PR and push to `main`, without exception.

Before this, `format:check` was a job inside `mocha.yml`, which had path filters that skipped runs for things like docs-only or `.github`-only changes. That meant formatting was simply not enforced on those PRs at all.

This moves `format:check` into its own dedicated workflow (`format.yml`) with no path filtering, so it always runs. The old job in `mocha.yml` is removed.