### PR TITLE
feat: add built-in github-actions reporter

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -36,8 +36,6 @@ jobs:
       npm-script: test-smoke
 
   test-node-lts:
-    # TODO: Restore "mocha-github-actions-reporter" style reporting without relying on third party module
-    # https://github.com/mochajs/mocha/issues/5183
     uses: ./.github/workflows/npm-script.yml
     needs: smoke
     strategy:
@@ -59,8 +57,6 @@ jobs:
     permissions:
       id-token: write # for Codecov OIDC
       contents: read # for Codecov OIDC
-    # TODO: Restore "mocha-github-actions-reporter" style reporting without relying on third party module
-    # https://github.com/mochajs/mocha/issues/5183
     uses: ./.github/workflows/npm-script.yml
     needs: test-node-lts
     strategy:

--- a/.github/workflows/npm-script.yml
+++ b/.github/workflows/npm-script.yml
@@ -71,6 +71,7 @@ jobs:
         env:
           BROWSER: ${{ matrix.browser }}
           COVERAGE: ${{ inputs.coverage && '1'}}
+          MOCHA_REPORTER: github-actions
           NODE_OPTIONS: "--trace-warnings"
       # Generate and upload coverage, even if tests fail
       - name: Generate coverage report

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -215,7 +215,7 @@ exports.builder = (yargs) =>
         group: GROUPS.FILES,
       },
       reporter: {
-        default: defaults.reporter,
+        default: process.env.MOCHA_REPORTER || defaults.reporter,
         description: "Specify reporter to use",
         group: GROUPS.OUTPUT,
         requiresArg: true,

--- a/lib/reporters/github-actions.js
+++ b/lib/reporters/github-actions.js
@@ -1,0 +1,155 @@
+"use strict";
+
+/**
+ * @typedef {import('../runner.js')} Runner
+ * @typedef {import('../test.js')} Test
+ */
+
+/**
+ * @module GithubActions
+ */
+/**
+ * Module dependencies.
+ */
+
+var fs = require("fs");
+var Spec = require("./spec");
+var ms = require("ms");
+var constants = require("../runner").constants;
+var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
+var EVENT_RUN_END = constants.EVENT_RUN_END;
+
+/**
+ * Extract file, line, and column from an error stack trace.
+ *
+ * @private
+ * @param {string} [stackTrace] - stack trace string
+ * @return {{ file?: string, line?: string, col?: string }}
+ */
+function extractLocation(stackTrace) {
+  if (!stackTrace) {
+    return {};
+  }
+  var matches =
+    /^\s*at Context.*\(([^()]+):([0-9]+):([0-9]+)\)/gm.exec(stackTrace) ||
+    /^\s*at.*\(([^()]+):([0-9]+):([0-9]+)\)/gm.exec(stackTrace);
+  if (matches === null) {
+    return {};
+  }
+  return {
+    file: matches[1],
+    line: matches[2],
+    col: matches[3],
+  };
+}
+
+/**
+ * Escape a value for use in a GitHub Actions workflow command.
+ *
+ * @private
+ * @param {string} value
+ * @return {string}
+ */
+function escapeWorkflowValue(value) {
+  return String(value)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+/**
+ * Escape a property value for use in a GitHub Actions workflow command.
+ *
+ * @private
+ * @param {string} value
+ * @return {string}
+ */
+function escapeWorkflowProperty(value) {
+  return String(value)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+}
+
+class GithubActions extends Spec {
+  static description =
+    "like spec, with GitHub Actions error annotations and job summary";
+
+  /**
+   * Constructs a new `GithubActions` reporter instance.
+   *
+   * @description
+   * Extends the Spec reporter to add GitHub Actions error annotations
+   * and Job Summary output when running in GitHub Actions CI.
+   *
+   * @public
+   * @memberof Mocha.reporters
+   * @extends Mocha.reporters.Spec
+   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Object} [options] - runner options
+   */
+  constructor(runner, options) {
+    super(runner, options);
+
+    var ciFailures = [];
+
+    runner.on(EVENT_TEST_FAIL, function (test) {
+      ciFailures.push(test);
+    });
+
+    runner.once(EVENT_RUN_END, () => {
+      if (ciFailures.length > 0) {
+        process.stdout.write("::group::Mocha Annotations\n");
+
+        for (var test of ciFailures) {
+          var location = extractLocation(test.err && test.err.stack);
+          var props = [];
+          if (location.file) {
+            props.push("file=" + escapeWorkflowProperty(location.file));
+          }
+          if (location.line) {
+            props.push("line=" + escapeWorkflowProperty(location.line));
+          }
+          if (location.col) {
+            props.push("col=" + escapeWorkflowProperty(location.col));
+          }
+
+          var message = test.err ? escapeWorkflowValue(test.err.message) : "";
+          process.stdout.write(
+            "::error " + props.join(",") + "::" + message + "\n",
+          );
+        }
+
+        process.stdout.write("::endgroup::\n");
+      }
+
+      // Write GitHub Job Summary if supported
+      var summaryFile = process.env.GITHUB_STEP_SUMMARY;
+      if (summaryFile) {
+        var lines = [];
+        lines.push(
+          ":white_check_mark: " +
+            (this.stats.passes || 0) +
+            " passing (" +
+            ms(this.stats.duration) +
+            ")",
+        );
+        if (this.stats.pending) {
+          lines.push(":pause_button: " + this.stats.pending + " pending");
+        }
+        if (this.stats.failures) {
+          lines.push(":x: " + this.stats.failures + " failing");
+        }
+        try {
+          fs.appendFileSync(summaryFile, lines.join("\n") + "\n");
+        } catch {
+          // Silently ignore summary write failures
+        }
+      }
+    });
+  }
+}
+
+exports = module.exports = GithubActions;

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -17,3 +17,4 @@ exports.Markdown = exports.markdown = require("./markdown");
 exports.Progress = exports.progress = require("./progress");
 exports.Landing = exports.landing = require("./landing");
 exports.JSONStream = exports["json-stream"] = require("./json-stream");
+exports.GithubActions = exports["github-actions"] = require("./github-actions");

--- a/test/reporters/github-actions.spec.js
+++ b/test/reporters/github-actions.spec.js
@@ -1,0 +1,206 @@
+"use strict";
+
+var sinon = require("sinon");
+var events = require("../../").Runner.constants;
+var helpers = require("./helpers");
+var reporters = require("../../").reporters;
+var createStatsCollector =
+  require("../../lib/stats-collector.mjs").createStatsCollector;
+
+var Base = reporters.Base;
+var GithubActions = reporters.GithubActions;
+var createMockRunner = helpers.createMockRunner;
+var makeRunReporter = helpers.createRunReporterFunction;
+
+var EVENT_TEST_FAIL = events.EVENT_TEST_FAIL;
+var EVENT_TEST_PASS = events.EVENT_TEST_PASS;
+var EVENT_RUN_END = events.EVENT_RUN_END;
+
+/**
+ * Creates a mock runner that fires EVENT_TEST_FAIL then EVENT_RUN_END
+ * with proper error argument (unlike "fail end pass" which passes {}).
+ */
+function createFailEndRunner(test, err) {
+  var handlers = {};
+  var fn = function (event, callback) {
+    if (!handlers[event]) {
+      handlers[event] = [];
+    }
+    handlers[event].push(callback);
+  };
+  var mockRunner = { on: fn, once: fn };
+  createStatsCollector(mockRunner);
+
+  // Fire events asynchronously (matching afterTick pattern)
+  Promise.resolve().then(function () {
+    (handlers[EVENT_TEST_FAIL] || []).forEach(function (cb) {
+      cb(test, err);
+    });
+    (handlers[EVENT_RUN_END] || []).forEach(function (cb) {
+      cb();
+    });
+  });
+
+  return mockRunner;
+}
+
+describe("GitHub Actions reporter", function () {
+  var runReporter = makeRunReporter(GithubActions);
+  var noop = function () {};
+
+  beforeEach(function () {
+    sinon.stub(Base, "useColors").value(false);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+    delete process.env.GITHUB_STEP_SUMMARY;
+  });
+
+  it("should be exported as 'github-actions'", function () {
+    expect(reporters["github-actions"], "to be", GithubActions);
+  });
+
+  it("should have a static description", function () {
+    expect(GithubActions.description, "to be a", "string");
+    expect(GithubActions.description, "not to be empty");
+  });
+
+  describe("event handlers", function () {
+    describe("on 'fail' and 'end' events", function () {
+      it("should emit ::error annotation for failures", async function () {
+        var err = new Error("expected true to be false");
+        err.stack =
+          "Error: expected true to be false\n    at Context.<anonymous> (test/example.js:10:5)";
+        var test = {
+          title: "failing test",
+          err: err,
+        };
+        var runner = createFailEndRunner(test, err);
+        var options = {};
+        var { stdout } = await runReporter({ epilogue: noop }, runner, options);
+        sinon.restore();
+
+        var output = stdout.join("");
+        expect(output, "to contain", "::group::Mocha Annotations");
+        expect(output, "to contain", "::error ");
+        expect(output, "to contain", "file=test/example.js");
+        expect(output, "to contain", "line=10");
+        expect(output, "to contain", "col=5");
+        expect(output, "to contain", "expected true to be false");
+        expect(output, "to contain", "::endgroup::");
+      });
+
+      it("should handle errors without stack trace", async function () {
+        var err = new Error("some error");
+        err.stack = undefined;
+        var test = {
+          title: "failing test",
+          err: err,
+        };
+        var runner = createFailEndRunner(test, err);
+        var options = {};
+        var { stdout } = await runReporter({ epilogue: noop }, runner, options);
+        sinon.restore();
+
+        var output = stdout.join("");
+        expect(output, "to contain", "::error ");
+        expect(output, "to contain", "some error");
+      });
+
+      it("should not emit annotations if no failures", async function () {
+        var test = {
+          title: "passing test",
+          duration: 1,
+          slow: function () {
+            return 75;
+          },
+        };
+        var runner = createMockRunner(
+          "pass end",
+          EVENT_TEST_PASS,
+          EVENT_RUN_END,
+          null,
+          test,
+        );
+        var options = {};
+        var { stdout } = await runReporter({ epilogue: noop }, runner, options);
+        sinon.restore();
+
+        var output = stdout.join("");
+        expect(output, "not to contain", "::group::");
+        expect(output, "not to contain", "::error");
+      });
+    });
+
+    describe("on 'end' event with GITHUB_STEP_SUMMARY", function () {
+      it("should write job summary when env var is set", async function () {
+        var fs = require("fs");
+        var tmpFile = require("path").join(
+          require("os").tmpdir(),
+          "mocha-test-summary-" + Date.now() + ".md",
+        );
+        process.env.GITHUB_STEP_SUMMARY = tmpFile;
+
+        var test = {
+          title: "passing test",
+          duration: 1,
+          slow: function () {
+            return 75;
+          },
+        };
+        var runner = createMockRunner(
+          "pass end",
+          EVENT_TEST_PASS,
+          EVENT_RUN_END,
+          null,
+          test,
+        );
+        runner.total = 1;
+        var options = {};
+        await runReporter(
+          {
+            epilogue: noop,
+            stats: { passes: 1, failures: 0, pending: 0, duration: 100 },
+          },
+          runner,
+          options,
+        );
+        sinon.restore();
+
+        try {
+          var content = fs.readFileSync(tmpFile, "utf8");
+          expect(content, "to contain", "passing");
+        } finally {
+          try {
+            fs.unlinkSync(tmpFile);
+          } catch {
+            // cleanup
+          }
+        }
+      });
+    });
+  });
+
+  describe("escaping", function () {
+    it("should escape newlines and percent signs in error messages", async function () {
+      var err = new Error("line1\nline2\n100% done");
+      err.stack =
+        "Error: line1\nline2\n    at Context.<anonymous> (test/file.js:1:1)";
+      var test = {
+        title: "failing test",
+        err: err,
+      };
+      var runner = createFailEndRunner(test, err);
+      var options = {};
+      var { stdout } = await runReporter({ epilogue: noop }, runner, options);
+      sinon.restore();
+
+      var output = stdout.join("");
+      // Newlines in the message should be escaped as %0A
+      expect(output, "to contain", "%0A");
+      // Percent signs should be escaped as %25
+      expect(output, "to contain", "%25");
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5183
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

this adds a built-in `github-actions` reporter, basically replacing the need for that external `mocha-github-actions-reporter` dependency in CI.

it’s built on top of the regular spec reporter, but adds a couple of nice extras when it detects it’s running inside GitHub Actions. For one, it creates error annotations, so if a test fails, you actually see it inline in the PR diff right where the problem is. super handy. It also writes a little summary (pass/fail/pending counts) to the job summary section in GitHub.

Another small but useful change: you can now set the reporter via a `MOCHA_REPORTER` env var. So in CI, you don’t even have to touch `.mocharc.yml` the workflow just sets `MOCHA_REPORTER=github-actions` and you’re good.

That cleans also up those old TODOs from when the external reporter got removed earlier, so now everything’s properly wired up without extra deps.