### PR TITLE
chore: fix format workflow permissions for npm-script.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # for Codecov OIDC (required by npm-script.yml)
 
 jobs:
   format:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5856
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixed the format workflow added in #5895, which failed at startup ([run #24606566620](https://github.com/mochajs/mocha/actions/runs/24606566620)) with:

> The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.

in #5895, what going wrong was that `format.yml` only declared `permissions: contents: read`. the reusable `npm-script.yml` it calls declares `id-token: write` (for Codecov OIDC). when a calling workflow specifies a `permissions` block, any permissions not listed default to `none` so `id-token` was `none`, but the called workflow needed `write`. GitHub Actions rejected the call.

i added `id-token: write` to `format.yml`'s permissions block, matching the pattern already used in `mocha.yml`.

`workflow_dispatch` was already present from #5895, so manual testing via "Run workflow" should work once this lands.