### PR TITLE
chore: convert dot, min, and list reporters to esm

### DIFF
--- a/lib/reporters/dot.mjs
+++ b/lib/reporters/dot.mjs
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * @typedef {import('../runner.js')} Runner
  */
@@ -8,11 +6,13 @@
  * @module Dot
  */
 /**
- * Module dependencies.
+ * module dependencies.
  */
 
-var Base = require("./base");
-var constants = require("../runner").constants;
+import Base from "./base.js";
+import Runner from "../runner.js";
+
+var { constants } = Runner;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
@@ -23,12 +23,12 @@ class Dot extends Base {
   static description = "dot matrix representation";
 
   /**
-   * Constructs a new `Dot` reporter instance.
+   * constructs a new `Dot` reporter instance.
    *
    * @public
    * @memberof Mocha.reporters
    * @extends Mocha.reporters.Base
-   * @param {Runner} runner - Instance triggers reporter actions.
+   * @param {Runner} runner - instance triggers reporter actions.
    * @param {Object} [options] - runner options
    */
   constructor(runner, options) {
@@ -74,4 +74,4 @@ class Dot extends Base {
   }
 }
 
-exports = module.exports = Dot;
+export { Dot };

--- a/lib/reporters/dot.mjs
+++ b/lib/reporters/dot.mjs
@@ -23,12 +23,12 @@ class Dot extends Base {
   static description = "dot matrix representation";
 
   /**
-   * constructs a new `Dot` reporter instance.
+   * Constructs a new `Dot` reporter instance.
    *
    * @public
    * @memberof Mocha.reporters
    * @extends Mocha.reporters.Base
-   * @param {Runner} runner - instance triggers reporter actions.
+   * @param {Runner} runner - Instance triggers reporter actions.
    * @param {Object} [options] - runner options
    */
   constructor(runner, options) {

--- a/lib/reporters/dot.mjs
+++ b/lib/reporters/dot.mjs
@@ -6,7 +6,7 @@
  * @module Dot
  */
 /**
- * module dependencies.
+ * Module dependencies.
  */
 
 import Base from "./base.js";

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -3,13 +3,16 @@
 // Alias exports to a their normalized format Mocha#reporter to prevent a need
 // for dynamic (try/catch) requires, which Browserify doesn't handle.
 exports.Base = exports.base = require("./base");
-exports.Dot = exports.dot = require("./dot");
+const { Dot } = require("./dot.mjs");
+exports.Dot = exports.dot = Dot;
 exports.Doc = exports.doc = require("./doc");
 exports.TAP = exports.tap = require("./tap");
 exports.JSON = exports.json = require("./json");
 exports.HTML = exports.html = require("./html");
-exports.List = exports.list = require("./list");
-exports.Min = exports.min = require("./min");
+const { List } = require("./list.mjs");
+exports.List = exports.list = List;
+const { Min } = require("./min.mjs");
+exports.Min = exports.min = Min;
 exports.Spec = exports.spec = require("./spec");
 exports.Nyan = exports.nyan = require("./nyan");
 exports.XUnit = exports.xunit = require("./xunit");

--- a/lib/reporters/list.mjs
+++ b/lib/reporters/list.mjs
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * @typedef {import('../runner.js')} Runner
  */
@@ -11,8 +9,10 @@
  * Module dependencies.
  */
 
-var Base = require("./base");
-var constants = require("../runner").constants;
+import Base from "./base.js";
+import Runner from "../runner.js";
+
+var { constants } = Runner;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_TEST_BEGIN = constants.EVENT_TEST_BEGIN;
@@ -70,4 +70,4 @@ class List extends Base {
   }
 }
 
-exports = module.exports = List;
+export { List };

--- a/lib/reporters/min.mjs
+++ b/lib/reporters/min.mjs
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * @typedef {import('../runner.js')} Runner
  */
@@ -11,8 +9,10 @@
  * Module dependencies.
  */
 
-var Base = require("./base");
-var constants = require("../runner").constants;
+import Base from "./base.js";
+import Runner from "../runner.js";
+
+var { constants } = Runner;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 
@@ -45,4 +45,4 @@ class Min extends Base {
   }
 }
 
-exports = module.exports = Min;
+export { Min };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: partial #5400
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Converts three reporter modules from CJS to ESM as part of #5400.

Changed files:
- `lib/reporters/dot.js` => dot.mjs
- `lib/reporters/min.js` => min.mjs
- `lib/reporters/list.js` => list.mjs
- index.js updated to `require()` the new `.mjs` files with named export destructuring

each file has four mechanical changes: remove `"use strict"`, replace `require` with `import`, replace `module.exports` with a named `export`, and add `.js` extensions to import paths. No logic, variable names, or class structure was changed.

This follows the same pattern used in #5853 and #5855. all three reporters are leaf modules (only depend on base.js and runner.js), so the scope is minimal and self-contained.

reporter tests (146 passing), smoke test, browser build, tsc, format check, lint.

<details>
  <summary>Info</summary>
   Done with the explicit blessing of @mark-wiemer , worth mentioning😊.
</details>
