### PR TITLE
chore: fix formatting in lib/cli/lookup-files.mjs

### DIFF
--- a/lib/cli/lookup-files.mjs
+++ b/lib/cli/lookup-files.mjs
@@ -7,10 +7,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import * as glob from "glob";
-import {  
-  createNoFilesMatchPatternError,  
-  createMissingArgumentError,  
-} from "../errors.js";  
+import {
+  createNoFilesMatchPatternError,
+  createMissingArgumentError,
+} from "../errors.js";
 import debugModule from "debug";
 const debug = debugModule("mocha:cli:lookup-files");
 


### PR DESCRIPTION
Formatting is failing on `main`. This fixes it.