### PR TITLE
fix: improve skipped test output

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -227,10 +227,16 @@ class HTML extends Base {
     });
 
     runner.on(EVENT_TEST_PENDING, function (test) {
+      var url = self.testURL(test);
       var el = fragment(
-        '<li class="test pass pending"><h2>%e</h2></li>',
+        '<li class="test pass pending"><h2>%e <a href="%s" class="replay">' +
+          playIcon +
+          "</a></h2></li>",
         test.title,
+        url,
       );
+
+      self.addCodeToggle(el, test.body);
       appendToStack(el);
       updateStats();
     });

--- a/mocha.css
+++ b/mocha.css
@@ -140,7 +140,7 @@ body {
 }
 
 #mocha .test.pending:hover h2::after {
-  content: "(pending)";
+  content: "(skipped)";
   font-family: arial, sans-serif;
 }
 

--- a/test/reporters/html.spec.js
+++ b/test/reporters/html.spec.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var fs = require("node:fs");
+var path = require("node:path");
+
+describe("HTML reporter", function () {
+  function fixture(file) {
+    return fs.readFileSync(path.join(__dirname, "../..", file), "utf8");
+  }
+
+  it("should label pending tests as skipped on hover", function () {
+    var css = fixture("mocha.css");
+
+    expect(css, "to contain", "#mocha .test.pending:hover h2::after");
+    expect(css, "to contain", 'content: "(skipped)"');
+    expect(css, "not to contain", 'content: "(pending)"');
+  });
+
+  it("should add replay link and code toggle for pending tests", function () {
+    var source = fixture("lib/reporters/html.js");
+    var pendingHandlerStart = source.indexOf("runner.on(EVENT_TEST_PENDING");
+    var pendingHandlerEnd = source.indexOf(
+      "updateStats();",
+      pendingHandlerStart,
+    );
+
+    expect(pendingHandlerStart, "not to be", -1);
+    expect(pendingHandlerEnd, "not to be", -1);
+
+    var pendingHandler = source.slice(pendingHandlerStart, pendingHandlerEnd);
+
+    expect(pendingHandler, "to contain", 'class="test pass pending"');
+    expect(pendingHandler, "to contain", "self.testURL(test)");
+    expect(pendingHandler, "to contain", "self.addCodeToggle(el, test.body)");
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: refs #5138
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR improves the HTML reporter output for skipped tests.

Skipped tests are reported through `EVENT_TEST_PENDING`, but the HTML reporter currently renders that path differently from passed and failed tests. Pending/skipped entries are rendered as plain items, so they do not expose the replay link or code toggle behavior available on other test entries.

This change updates the `EVENT_TEST_PENDING` rendering path to include the replay link and code toggle behavior.

It also changes the hover label from `(pending)` to `(skipped)` so skipped tests are easier to identify in the HTML reporter.

## Before / After

### Before

Skipped tests were shown with the `(pending)` hover label and did not expose the same code toggle behavior as passed/failed tests.

https://github.com/user-attachments/assets/c24cdc15-d40e-4c7d-a223-7fd82e35d829

### After

Skipped tests now show the `(skipped)` hover label and include replay link/code toggle behavior.

https://github.com/user-attachments/assets/71a6b445-a0f0-442a-9cf6-32c8aab543b1

## Tests

- [x] `npm run lint`
- [x] `npm run test-node:reporters`
- [x] `npm run test-node:integration -- --grep "posix-exit-codes"`

Refs #5138

Thanks to @JaeHyuckSa for discussing the issue and implementation direction.