### PR TITLE
ci: bump publish workflow to Node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       # If this step fails, it may be a transient issue, just run again


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5934
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The `npm install -g npm@latest` step in the publish workflow keeps hitting a bug in Node 22 (nodejs/node#62425). Switching to node version 24 avoids the problem and it already comes with npm 11.6.2+ anyway so OIDC works without any extra setup. Also lines up with what @mark-wiemer already confirmed in the issue.