### PR TITLE
ci: add workflow to block merging PRs with "status: blocked" label

### DIFF
--- a/.github/workflows/blocked-pr.yml
+++ b/.github/workflows/blocked-pr.yml
@@ -1,0 +1,24 @@
+name: Blocked PR Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  not-blocked:
+    name: not-blocked
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Verify "status: blocked" label is not applied'
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: "status: blocked"
+          message: "This PR has the 'status: blocked' label and cannot be merged until that label is removed."


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5924
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

A small "Blocked PR Check" workflow that just fails when a PR has the `status: blocked` label. It runs on normal PR events and when labels get added or removed, so it re-checks whenever someone toggles that state. to actually stop the kind of accidental merges that came up in #5409/#5881, it also needs to be set as a required status check in branch protection i think, that part ain’t handled in the repo itself it has to be configured at the admin level