### PR TITLE
ci: aggregate lint output so Knip failures are reported

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lint:knip-docs": "cd docs && npm run lint:knip",
     "lint:code": "eslint . --max-warnings 0",
     "prelint": "npm run clean",
-    "lint": "run-p lint:*",
+    "lint": "run-p --aggregate-output --continue-on-error lint:*",
     "prepublishOnly": "run-s clean build version",
     "test-browser-run": "cross-env NODE_PATH=. karma start ./karma.conf.js --single-run",
     "test-browser:reporters:bdd": "cross-env MOCHA_TEST=bdd npm run -s test-browser-run",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5920
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When one of the parallel `lint:*` tasks fails `run-p` kills the others halfway through, so their output gets cut off and mixed together. That's why the linked CI runs (mochajs/mocha#5920) showed knip messages without a clear "this failed because of that" summary.

with `--aggregate-output --continue-on-error` each script finish properly and keeps its output grouped together instead of interleaved. You still get a failing exit code if anything breaks but logs stay readable.

Ran `npm run lint` locally too,it  exits clean, and the output is nicely separated per step (installed-check then knip then knip-docs then code) instead of a messy stream.