### PR TITLE
docs: include the released version in the npm badge alt text

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -20,6 +20,8 @@
     { "type": "ci", "section": "🤖 Automation", "hidden": true }
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": ["README.md"]
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
 
-<a href="https://www.npmjs.com/package/mocha"><img src="https://img.shields.io/npm/v/mocha.svg" alt="NPM Version"></a>
+<a href="https://www.npmjs.com/package/mocha"><img src="https://img.shields.io/npm/v/mocha.svg" alt="npm version 12.0.0-beta-9.3"></a> <!-- x-release-please-version -->
 <a href="https://github.com/mochajs/mocha"><img src="https://img.shields.io/node/v/mocha.svg" alt="Node Version"></a>
 [![GitHub Actions Build Status](https://github.com/mochajs/mocha/actions/workflows/mocha.yml/badge.svg)](https://github.com/mochajs/mocha/actions/workflows/mocha.yml)
 <a href="https://codecov.io/gh/mochajs/mocha"><img src="https://codecov.io/gh/mochajs/mocha/branch/main/graph/badge.svg" alt="Codecov Coverage Status"></a>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5307
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

If the npm version svg fails to load, screen readers used to just show "NPM Version" with no actual version. The badge is dynamic (shields.io) but the README is static so the version can't be injected at render time.

using Josh's idea of handling it via code updates: release-please already opens a release PR so we let it also update the README. The alt text becomes `npm version <semver>` and an `<!-- x-release-please-version -->` marker tells the updater to replace that version on each release. With `extra-files: ["README.md"]` it's kept in sync with `package.json`.

There’s only one semver string in that line, so the update is unambiguous.