### PR TITLE
ci: comment on issues and PRs when their fix is released

### DIFF
--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -1,0 +1,21 @@
+name: Release Comment
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Comment on released issues and PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: apexskier/github-release-commenter@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            :tada: This was released in {release_link}. :tada:

--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           comment-template: |
-            :tada: This was released in {release_link}. :tada:
+            :brown_heart: This was released in {release_link}. :brown_heart:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5371
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a workflow that comments "this was released in vX.Y.Z" on every issue/PR included in a release, replacing the manual @73rhodes -style comments mentioned in #5371.

we use `apexskier/github-release-commenter` and run on `release: published` which already fires from `release-please-action` since releases ain't created as drafts. The `{release_link}` placeholder gets rendered as a markdown link automatically so the template stays short and simple.

One caveat tho: this can't really be dry run locally because it only triggers on an actual release publish. The first release after merge will effectively be the live test. If it gets noisy on dependency PRs later we can filter those out with a label + `skip-label`.