### PR TITLE
test: cover async resolve+load loader hooks for `--require`

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -12,6 +12,7 @@
     "test/integration/fixtures/options/watch/test-with-dependency.fixture.js",
   ],
   "ignoreDependencies": [
+    "@test/async-resolve-hook",
     "@test/esm-only-loader",
     "coffeescript",
     "fake",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-multi-entry": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
+        "@test/async-resolve-hook": "./test/compiler-fixtures/async-resolve-hook",
         "@test/esm-only-loader": "./test/compiler-fixtures/esm-only-loader",
         "@types/node": "^24.0.0",
         "@types/yargs": "^17.0.33",
@@ -2383,6 +2384,10 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@test/async-resolve-hook": {
+      "resolved": "test/compiler-fixtures/async-resolve-hook",
+      "link": true
     },
     "node_modules/@test/esm-only-loader": {
       "resolved": "test/compiler-fixtures/esm-only-loader",
@@ -11112,6 +11117,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "test/compiler-fixtures/async-resolve-hook": {
+      "name": "@test/async-resolve-hook",
+      "dev": true
     },
     "test/compiler-fixtures/esm-only-loader": {
       "name": "@test/esm-only-loader",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-multi-entry": "^7.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
+    "@test/async-resolve-hook": "./test/compiler-fixtures/async-resolve-hook",
     "@test/esm-only-loader": "./test/compiler-fixtures/esm-only-loader",
     "@types/node": "^24.0.0",
     "@types/yargs": "^17.0.33",

--- a/test/compiler-fixtures/async-resolve-hook/README.md
+++ b/test/compiler-fixtures/async-resolve-hook/README.md
@@ -1,0 +1,10 @@
+Test package that registers an async Node.js [customization hook][hooks] exposing both
+`resolve` and `load`. The `resolve` hook redirects bare specifiers prefixed with `virtual:`
+to a synthetic URL, and the `load` hook returns generated source for that URL.
+
+This exercises the `import()` fallback path in [`lib/nodejs/esm-utils.js`](../../../lib/nodejs/esm-utils.js)
+when `require()` cannot resolve a specifier on its own (regression coverage for the
+asynchronous-hook scenario described in
+[#5382](https://github.com/mochajs/mocha/issues/5382)).
+
+[hooks]: https://nodejs.org/docs/latest/api/module.html#customization-hooks

--- a/test/compiler-fixtures/async-resolve-hook/hook.fixture.mjs
+++ b/test/compiler-fixtures/async-resolve-hook/hook.fixture.mjs
@@ -1,0 +1,25 @@
+const VIRTUAL_PREFIX = "virtual:";
+const VIRTUAL_URL_PREFIX = "virtual-resolved:";
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith(VIRTUAL_PREFIX)) {
+    return {
+      url: VIRTUAL_URL_PREFIX + specifier.slice(VIRTUAL_PREFIX.length),
+      shortCircuit: true,
+      format: "module",
+    };
+  }
+  return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+  if (url.startsWith(VIRTUAL_URL_PREFIX)) {
+    const name = url.slice(VIRTUAL_URL_PREFIX.length);
+    return {
+      format: "module",
+      source: `export const value = ${JSON.stringify(name)};`,
+      shortCircuit: true,
+    };
+  }
+  return nextLoad(url, context);
+}

--- a/test/compiler-fixtures/async-resolve-hook/package.json
+++ b/test/compiler-fixtures/async-resolve-hook/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/async-resolve-hook",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./register.fixture.js"
+    }
+  }
+}

--- a/test/compiler-fixtures/async-resolve-hook/register.fixture.js
+++ b/test/compiler-fixtures/async-resolve-hook/register.fixture.js
@@ -1,0 +1,3 @@
+import Module from "node:module";
+
+Module.register(new URL("./hook.fixture.mjs", import.meta.url));

--- a/test/integration/compiler-async-resolve-hook.spec.js
+++ b/test/integration/compiler-async-resolve-hook.spec.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var exec = require("node:child_process").exec;
+var path = require("node:path");
+
+// Regression test for the asynchronous-hook scenario in
+// https://github.com/mochajs/mocha/issues/5382. Complements
+// compiler-esm-only-loader.spec.js, which only exercises a `load` hook;
+// here we exercise a hook that uses both `resolve` and `load`.
+describe("support async resolve+load hooks", function () {
+  it("loads test files that import from a virtual specifier", function (done) {
+    exec(
+      '"' +
+        process.execPath +
+        '" "' +
+        path.join("bin", "mocha") +
+        '" -R json --require "@test/async-resolve-hook" "test/integration/fixtures/async-resolve-hook/test.fixture.mjs"',
+      { cwd: path.join(__dirname, "..", "..") },
+      function (error, stdout) {
+        if (error && !stdout) {
+          return done(error);
+        }
+        var results = JSON.parse(stdout);
+        expect(results, "to have property", "tests");
+        expect(results.failures, "to be empty");
+        var titles = results.tests.map(function (test) {
+          return test.fullTitle;
+        });
+        expect(
+          titles,
+          "to contain",
+          "async resolve+load hook imports from a virtual specifier resolved by the hook",
+        ).and("to have length", 1);
+        done();
+      },
+    );
+  });
+});

--- a/test/integration/fixtures/async-resolve-hook/test.fixture.mjs
+++ b/test/integration/fixtures/async-resolve-hook/test.fixture.mjs
@@ -1,0 +1,7 @@
+import { value } from "virtual:greetings";
+
+describe("async resolve+load hook", function () {
+  it("imports from a virtual specifier resolved by the hook", function () {
+    expect(value, "to equal", "greetings");
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5382
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

#5382 mention three missing test cases from the "require(esm)" work in #5366. One of them ("ERR_PACKAGE_PATH_NOT_EXPORTED", including the swc-node-style case) was already covered by the fixture added in #5391. But the async-hook coverage only ever tested the "load" side of node's customization hooks not "resolve".

this adds a matching "@test/async-resolve-hook" fixture that handles both. Its "resolve" hook rewrites "virtual:<name>" imports to a synthetic URL and its "load" hook provides source code for that url. a new integration test runs "bin/mocha" with "--require @test/async-resolve-hook" against a .mjs file importing one of those virtual specifiers and veriifies it loads and runs correctly.

like "@test/esm-only-loader", the fixture only exposes "exports.import" so it also keeps coverage around the require=>import fallback path in "lib/nodejs/esm-utils.js"

wired into the workspace the same way as the existing fixture (package.json local dep + .knip.jsonc ignore entry) 