### PR TITLE
fix(watch): evict transitive dependents from require.cache upon rerun

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -612,15 +612,40 @@ const eraseLine = () => {
 };
 
 /**
- * Blast all of the watched files out of `require.cache`
+ * Blast all of the watched files out of `require.cache` as well as any modules that depend on them
  * @param {FSWatcher} watcher - Chokidar FSWatcher
  * @ignore
  * @private
  */
 const blastCache = (watcher) => {
-  const files = getWatchedFiles(watcher);
-  files.forEach((file) => {
-    delete require.cache[file];
+  const deletedKeys = new Set();
+  getWatchedFiles(watcher).forEach((file) => {
+    if (Object.prototype.hasOwnProperty.call(require.cache, file)) {
+      deletedKeys.add(file);
+      delete require.cache[file];
+    }
   });
-  debug("deleted %d file(s) from the require cache", files.length);
+
+  const nodeModulesSep = `${path.sep}node_modules${path.sep}`;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const key in require.cache) {
+      if (deletedKeys.has(key) || key.includes(nodeModulesSep)) {
+        continue;
+      }
+      const mod = require.cache[key];
+      if (
+        mod &&
+        mod.children &&
+        mod.children.some((child) => deletedKeys.has(child.filename))
+      ) {
+        deletedKeys.add(key);
+        delete require.cache[key];
+        changed = true;
+      }
+    }
+  }
+
+  debug("deleted %d file(s) from the require cache", deletedKeys.size);
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4016 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Splitting up #5889 per [Josh's instruction](https://github.com/mochajs/mocha/pull/5889#issuecomment-4467182307)