### PR TITLE
fix: recalculate runner.total after tests register in delay mode

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1223,6 +1223,7 @@ Runner.prototype.run = function (fn, opts = {}) {
     }
     this.state = constants.STATE_RUNNING;
     if (this._opts.delay) {
+      this.total = this.grepTotal(rootSuite);
       this.emit(constants.EVENT_DELAY_END);
       debug('run(): "delay" ended');
     }

--- a/test/unit/runner.spec.js
+++ b/test/unit/runner.spec.js
@@ -572,6 +572,23 @@ describe("Runner", function () {
         done();
       });
 
+      it("should update runner.total after tests are registered in delay mode", function (done) {
+        var delaySuite = new Suite("delay suite", "root");
+        var delayRunner = new Runner(delaySuite, { delay: true });
+
+        expect(delayRunner.total, "to be", 0);
+
+        delaySuite.addTest(new Test("test one", noop));
+        delaySuite.addTest(new Test("test two", noop));
+
+        delayRunner.run(function () {
+          expect(delayRunner.total, "to be", 2);
+          done();
+        });
+
+        delaySuite.emit(Suite.constants.EVENT_ROOT_SUITE_RUN);
+      });
+
       describe("stack traces", function () {
         var stack = [
           "AssertionError: foo bar",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2647
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When using `--delay`, tests get registered only after the `Runner` is already created. That means `runner.total` is set to early (in the constructor) and stays at 0 for the whole run. The html reporter uses that value for the progress bar so it always shows 0%.

the fix is to recompute `this.total = this.grepTotal(rootSuite)` inside `Runner.prototype.run`'s `prepare()` step right before the delayed execution starts. ny then, all tests are already registered so the total is accurate.