### PR TITLE
fix: warn when describe callback returns a promise instead of quitely ignoring it

### DIFF
--- a/lib/interfaces/common.mjs
+++ b/lib/interfaces/common.mjs
@@ -4,6 +4,9 @@ import {
   createUnsupportedError,
   createForbiddenExclusivityError,
 } from "../errors.mjs";
+import utils from "../utils.js";
+
+const { isPromise } = utils;
 
 /**
  * Functions common to more than one interface.
@@ -140,7 +143,12 @@ function createCommon(suites, context, mocha) {
           throw createUnsupportedError("Pending test forbidden");
         }
         if (typeof opts.fn === "function") {
-          opts.fn.call(suite);
+          const result = opts.fn.call(suite);
+          if (isPromise(result)) {
+            console.warn(
+              `Mocha: Suite ${suite.fullTitle()} returned a promise from its callback. async describe() callbacks are not supported. use before() for async setup instead`,
+            );
+          }
           suites.shift();
         } else if (typeof opts.fn === "undefined" && !suite.pending) {
           throw createMissingArgumentError(

--- a/test/integration/fixtures/suite/suite-async-callback.fixture.js
+++ b/test/integration/fixtures/suite/suite-async-callback.fixture.js
@@ -1,0 +1,5 @@
+'use strict';
+
+describe('a suite with an async callback', async function () {
+  it('a test', function () {});
+});

--- a/test/integration/fixtures/suite/suite-returning-value.fixture.js
+++ b/test/integration/fixtures/suite/suite-returning-value.fixture.js
@@ -1,5 +1,6 @@
 'use strict';
 
-describe('a suite returning a value', function () {
-  return Promise.resolve();
+describe('a suite returning a plain value', function () {
+  it('passes', function () {});
+  return 42;
 });

--- a/test/integration/suite.spec.js
+++ b/test/integration/suite.spec.js
@@ -56,8 +56,8 @@ describe("skipped suite w/ callback", function () {
   });
 });
 
-describe("suite returning a value", function () {
-  it("should not give a deprecation warning for suite callback returning a value", function (done) {
+describe("suite returning a plain value", function () {
+  it("should not warn when suite callback returns a non-promise value", function (done) {
     run(
       "suite/suite-returning-value.fixture.js",
       args,
@@ -65,7 +65,24 @@ describe("suite returning a value", function () {
         if (err) {
           return done(err);
         }
-        expect(res, "not to contain output", /Suites ignore return values/);
+        expect(res, "not to contain output", /returned a promise/);
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
+});
+
+describe("suite with async callback", function () {
+  it("should warn when suite callback returns a promise", function (done) {
+    run(
+      "suite/suite-async-callback.fixture.js",
+      args,
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res, "to contain output", /returned a promise/);
         done();
       },
       { stdio: "pipe" },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2116 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The fix to #2116  is to check what the suite callback returns using the `utils.isPromise()` helper that is already there and log a warning if its a thenable. normal return values (like CoffeeScript's implicit returns are left untouched on purpose since earlier attempts at warning there caused too many false positives and got reverted.