### PR TITLE
feat: add --exit-timeout to warn and force-quit should the process linger after test run

### DIFF
--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -28,16 +28,34 @@ const { PluginLoader } = require("../plugin-loader.mjs");
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
  * @param {number} clampedCode - Exit code; typically # of failures
+ * @param {number} [exitTimeout] - ms to wait before force-exiting. 0 means disabled
  * @ignore
  * @private
  */
-const exitMochaLater = (clampedCode) => {
+const exitMochaLater = (clampedCode, exitTimeout = 0) => {
+  const usePosixExitCodes = process.argv.includes("--posix-exit-codes");
+  let timedOut = false;
+
   process.on("exit", () => {
-    process.exitCode = Math.min(
-      clampedCode,
-      process.argv.includes("--posix-exit-codes") ? 1 : 255,
-    );
+    if (!timedOut) {
+      process.exitCode = Math.min(clampedCode, usePosixExitCodes ? 1 : 255);
+    }
   });
+
+  if (exitTimeout > 0) {
+    const timer = setTimeout(() => {
+      timedOut = true;
+      process.exitCode = Math.min(
+        clampedCode || 1,
+        usePosixExitCodes ? 1 : 255,
+      );
+      console.error(
+        `\nTimeout of ${exitTimeout}ms exseeded after test run. the process did not exit likely due to async resources still being open. Use --exit to force-exit or identify and close the resource leaks.`,
+      );
+      process.exit();
+    }, exitTimeout);
+    timer.unref();
+  }
 };
 
 /**
@@ -158,7 +176,7 @@ const handleUnmatchedFiles = (mocha, unmatchedFiles) => {
  */
 const singleRun = async (
   mocha,
-  { exit, passOnFailingTestSuite },
+  { exit, passOnFailingTestSuite, exitTimeout = 0 },
   fileCollectParams,
 ) => {
   const fileCollectionObj = collectFiles(fileCollectParams);
@@ -172,7 +190,9 @@ const singleRun = async (
 
   // handles ESM modules
   await mocha.loadFilesAsync();
-  return mocha.run(createExitHandler({ exit, passOnFailingTestSuite }));
+  return mocha.run(
+    createExitHandler({ exit, passOnFailingTestSuite, exitTimeout }),
+  );
 };
 
 /**
@@ -299,10 +319,16 @@ exports.validateLegacyPlugin = (opts, pluginType, map = {}) => {
   }
 };
 
-const createExitHandler = ({ exit, passOnFailingTestSuite }) => {
+const createExitHandler = ({
+  exit,
+  passOnFailingTestSuite,
+  exitTimeout = 0,
+}) => {
   return (code) => {
     const clampedCode = passOnFailingTestSuite ? 0 : Math.min(code, 255);
 
-    return exit ? exitMocha(clampedCode) : exitMochaLater(clampedCode);
+    return exit
+      ? exitMocha(clampedCode)
+      : exitMochaLater(clampedCode, exitTimeout);
   };
 };

--- a/lib/cli/run-option-metadata.mjs
+++ b/lib/cli/run-option-metadata.mjs
@@ -50,7 +50,7 @@ const types = {
     "sort",
     "watch",
   ],
-  number: ["retries", "jobs"],
+  number: ["exit-timeout", "retries", "jobs"],
   string: [
     "config",
     "fgrep",

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -91,6 +91,13 @@ exports.builder = (yargs) =>
         description: "Force Mocha to quit after tests complete",
         group: GROUPS.RULES,
       },
+      "exit-timeout": {
+        description:
+          "Fail and force-exit if process does not exit within this many ms after test run finishes (0 means disabled)",
+        group: GROUPS.RULES,
+        requiresArg: true,
+        default: 0,
+      },
       extension: {
         default: defaults.extension,
         description: "File extension(s) to load",

--- a/test/integration/options/exit.spec.js
+++ b/test/integration/options/exit.spec.js
@@ -78,3 +78,58 @@ describe("--exit", function () {
     );
   });
 });
+
+describe("--exit-timeout", function () {
+  var mocha;
+
+  function killSubprocess() {
+    if (mocha) mocha.kill("SIGKILL");
+  }
+
+  before(function () {
+    process.on("SIGINT", killSubprocess);
+  });
+
+  after(function () {
+    process.removeListener("SIGINT", killSubprocess);
+  });
+
+  it("should force-exit and report an error should the process not exit within the timeout", function (done) {
+    this.timeout(10000);
+    this.slow(Infinity);
+
+    mocha = runMocha(
+      "exit.fixture.js",
+      ["--exit-timeout", "500"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(
+          result.output,
+          "to match",
+          /Timeout of 500ms elapsed after test run/,
+        );
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
+
+  it("should not affect normal exit when process exits before exit", function (done) {
+    this.timeout(10000);
+    this.slow(Infinity);
+
+    mocha = runMocha(
+      "passing.fixture.js",
+      ["--exit-timeout", "5000"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have passed");
+        done();
+      },
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1855
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Sometimes a test suite finishes but the process still hangs because some async stuff didnt get cleaned up, `--exit` just force-kills everything which hides the real issue and without it there's no built in cut off.

`--exit-timeout <ms>` sets up an unref'd timer so it doesnt keep the process alive but if something else is still hanging the timer kicks in and prints a message about likely leaked resources and then exits with force.

if i am not mixing this up with the previos PR, i think i saw a bug [and fixed it] where the `process.on('exit')` handler overwrote the exit code after the timeout already sat it.