### PR TITLE
chore: remove "status: waiting for author" label on review request

### DIFF
--- a/.github/workflows/remove-waiting-label.yml
+++ b/.github/workflows/remove-waiting-label.yml
@@ -1,0 +1,38 @@
+name: Remove "waiting for author" label on review request
+
+on:
+  pull_request_target:
+    types: [review_requested]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  remove-label:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Remove "status: waiting for author" label'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'status: waiting for author';
+
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+
+            if (!labels.includes(label)) {
+              core.info(`Label "${label}" not present`);
+              return;
+            }
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: label,
+            });
+
+            core.info(`Removed label "${label}"`);

--- a/.github/workflows/remove-waiting-label.yml
+++ b/.github/workflows/remove-waiting-label.yml
@@ -16,23 +16,6 @@ jobs:
 
     steps:
       - name: 'Remove "status: waiting for author" label'
-        uses: actions/github-script@v7
+        uses: actions-ecosystem/action-remove-labels@v1
         with:
-          script: |
-            const label = 'status: waiting for author';
-
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-
-            if (!labels.includes(label)) {
-              core.info(`Label "${label}" not present`);
-              return;
-            }
-
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              name: label,
-            });
-
-            core.info(`Removed label "${label}"`);
+          labels: 'status: waiting for author'


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5978
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Adds a GitHub Actions workflow that removes the `status: waiting for author` label when a review is requested or re-requested on a pull request.

The workflow listens for the `pull_request_target` `review_requested` event and removes the label if it exists.

I also tested the workflow behavior in my fork to verify that the event fires correctly on review re-request.