### PR TITLE
feat: expose globalThis.mocha with runner name and version

### DIFF
--- a/lib/context.mjs
+++ b/lib/context.mjs
@@ -1,3 +1,28 @@
+import debugModule from "debug";
+import packageJson from "../package.json" with { type: "json" };
+
+const debug = debugModule("mocha:context");
+
+/**
+ * Defines a read-only `globalThis.mochaVar` so external tooling can
+ * statically identify Mocha as the active test runner. Guarded because
+ * sandboxed runtimes (SES/Endo, ShadowRealm) can disallow globalThis
+ * mutation, in those environments the marker is simply absent.
+ *
+ * @example
+ * globalThis.mochaVar; // { name: "mocha", version: "X.Y.Z" }
+ */
+try {
+  Object.defineProperty(globalThis, "mochaVar", {
+    get: () => ({
+      name: packageJson.name,
+      version: packageJson.version,
+    }),
+  });
+} catch (err) /* istanbul ignore next */ {
+  debug("unable to define globalThis.mochaVar", err);
+}
+
 /**
  * @typedef {import('./runnable.mjs')} Runnable
  */

--- a/test/integration/global-variable.spec.js
+++ b/test/integration/global-variable.spec.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const mochaPackageJson = require("../../package.json");
+
+describe('global "mochaVar" object', function () {
+  it("exposes the runner name and version", function () {
+    expect(globalThis.mochaVar, "to be an object");
+    expect(globalThis.mochaVar.name, "to equal", mochaPackageJson.name);
+    expect(globalThis.mochaVar.version, "to equal", mochaPackageJson.version);
+  });
+
+  it("returns a fresh object on each access (read-only getter)", function () {
+    const a = globalThis.mochaVar;
+    const b = globalThis.mochaVar;
+    expect(a, "not to be", b);
+    expect(a, "to equal", b);
+  });
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5084 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Picks up the work from #5089 (thanks @CheadleCheadle) and addresses the outstanding review feedback so it can land.

Adds a non-enumerable read-only `globalThis.mochaVar` getter exposing `{ name, version }` from `package.json`. 
