### PR TITLE
chore: enable eslint-plugin-promise (#5064)

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -10,7 +10,7 @@
     "test{,-*}.{js,cjs,mjs,ts}",
     "**/*{.,-}test.{js,cjs,mjs,ts}",
     "**/__tests__/**",
-    "**/{karma,rollup,webpack}.config.js",
+    "**/{eslint,karma,rollup,webpack}.config.js",
     "**/{babel.config,.eslintrc,.mocharc}.{js,cjs}",
     "lib/browser/**",
     "package-scripts.js",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
 const js = require("@eslint/js");
 const { defineConfig, globalIgnores } = require("eslint/config");
 const { default: n } = require("eslint-plugin-n");
+const promise = require("eslint-plugin-promise");
 const globals = require("globals");
 const { default: markdown } = require("@eslint/markdown");
 
@@ -14,7 +15,11 @@ const messages = {
 module.exports = defineConfig(
   {
     files: ["**/*.{cjs,js,mjs}"],
-    extends: [n.configs["flat/recommended-script"], js.configs.recommended],
+    extends: [
+      n.configs["flat/recommended-script"],
+      js.configs.recommended,
+      promise.configs["flat/recommended"],
+    ],
     languageOptions: {
       ecmaVersion: 2022,
       globals: {

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1047,6 +1047,7 @@ Mocha.prototype.run = function (fn) {
   // by the `process` event listeners.
   // also: returning anything other than `runner` would be a breaking
   // change
+  // eslint-disable-next-line promise/catch-or-return, promise/no-callback-in-promise
   runAsync(runner).then(done);
 
   return runner;

--- a/lib/runnable.mjs
+++ b/lib/runnable.mjs
@@ -360,6 +360,10 @@ class Runnable extends EventEmitter {
       var result = fn.call(ctx);
       if (result && typeof result.then === "function") {
         self.resetTimeout();
+        // Bridges a returned Promise to Mocha's `done`-style callback; both
+        // fulfillment and rejection paths invoke `done`, so a chained
+        // `.catch()` would itself need a no-op handler.
+        /* eslint-disable promise/catch-or-return, promise/no-callback-in-promise */
         result.then(
           function () {
             done();
@@ -373,6 +377,7 @@ class Runnable extends EventEmitter {
             );
           },
         );
+        /* eslint-enable promise/catch-or-return, promise/no-callback-in-promise */
       } else {
         if (self.asyncOnly) {
           return done(

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "cross-env": "^10.0.0",
         "eslint": "^10.0.0",
         "eslint-plugin-n": "^18.0.0",
+        "eslint-plugin-promise": "^7.3.0",
         "globals": "^17.0.0",
         "installed-check": "^10.0.0",
         "karma": "^6.4.2",
@@ -1135,9 +1136,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1155,9 +1153,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,9 +1170,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,9 +1187,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1215,9 +1204,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1235,9 +1221,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1238,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1275,9 +1255,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +2015,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2055,9 +2029,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2072,9 +2043,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,9 +2057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,9 +2071,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,9 +2085,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,9 +2099,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,9 +2113,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,9 +2127,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,9 +2141,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,9 +2155,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,9 +2169,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2242,9 +2183,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4400,6 +4338,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "cross-env": "^10.0.0",
     "eslint": "^10.0.0",
     "eslint-plugin-n": "^18.0.0",
+    "eslint-plugin-promise": "^7.3.0",
     "globals": "^17.0.0",
     "installed-check": "^10.0.0",
     "karma": "^6.4.2",

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -43,7 +43,7 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync([testFile], tempDir, () => {
         touchFile(testFile);
       }).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -56,7 +56,7 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync([testFile], tempDir, () => {
         replaceFileContents(testFile, "done((;", "done();");
       }).then((results) => {
-        expect(results, "to have length", 1);
+        return expect(results, "to have length", 1);
       });
     });
 
@@ -68,7 +68,7 @@ describe("--watch", function () {
         return runMochaWatchJSONAsync(["--parallel", testFile], tempDir, () => {
           touchFile(testFile);
         }).then((results) => {
-          expect(results, "to have length", 2);
+          return expect(results, "to have length", 2);
         });
       });
 
@@ -81,7 +81,7 @@ describe("--watch", function () {
         return runMochaWatchJSONAsync([testFile], tempDir, () => {
           replaceFileContents(testFile, "done((;", "done();");
         }).then((results) => {
-          expect(results, "to have length", 1);
+          return expect(results, "to have length", 1);
         });
       });
     });
@@ -100,7 +100,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results.length, "to equal", 2);
+        return expect(results.length, "to equal", 2);
       });
     });
 
@@ -116,7 +116,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -142,7 +142,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 4);
+        return expect(results, "to have length", 4);
       });
     });
 
@@ -160,7 +160,7 @@ describe("--watch", function () {
           fs.rmSync(watchedFile, { recursive: true, force: true });
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -178,7 +178,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -196,7 +196,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -214,7 +214,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -232,7 +232,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -250,7 +250,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -274,7 +274,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -292,7 +292,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results.length, "to equal", 1);
+        return expect(results.length, "to equal", 1);
       });
     });
 
@@ -310,7 +310,7 @@ describe("--watch", function () {
       ).then((results) => {
         expect(results, "to have length", 2);
         expect(results[0].passes, "to have length", 1);
-        expect(results[1].passes, "to have length", 3);
+        return expect(results[1].passes, "to have length", 3);
       });
     });
 
@@ -328,7 +328,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -339,7 +339,7 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync([testFile], tempDir, (mochaProcess) => {
         mochaProcess.stdin.write("rs\n");
       }).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -357,7 +357,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 2);
+        return expect(results, "to have length", 2);
       });
     });
 
@@ -379,7 +379,7 @@ describe("--watch", function () {
           touchFile(nodeModulesFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 1);
+        return expect(results, "to have length", 1);
       });
     });
 
@@ -403,7 +403,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results.length, "to equal", 1);
+        return expect(results.length, "to equal", 1);
       });
     });
 
@@ -422,7 +422,7 @@ describe("--watch", function () {
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results.length, "to equal", 1);
+        return expect(results.length, "to equal", 1);
       });
     });
 
@@ -445,7 +445,7 @@ describe("--watch", function () {
         expect(results[0].passes, "to have length", 0);
         expect(results[0].failures, "to have length", 1);
         expect(results[1].passes, "to have length", 1);
-        expect(results[1].failures, "to have length", 0);
+        return expect(results[1].failures, "to have length", 0);
       });
     });
 
@@ -471,7 +471,7 @@ describe("--watch", function () {
         expect(results[0].passes, "to have length", 1);
         expect(results[0].failures, "to have length", 0);
         expect(results[1].passes, "to have length", 0);
-        expect(results[1].failures, "to have length", 1);
+        return expect(results[1].failures, "to have length", 1);
       });
     });
 
@@ -520,7 +520,7 @@ describe("--watch", function () {
           ).then((results) => {
             expect(results.length, "to equal", 2);
             expect(results[0].failures, "to have length", 1);
-            expect(results[1].failures, "to have length", 1);
+            return expect(results[1].failures, "to have length", 1);
           });
         };
       }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5064
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`eslint-plugin-promise` was already listed as a `devDependency` historically but was pruned in #5060 because it was unused. This PR re-adds it and wires up its recommended preset, as suggested in #5064.

### Changes

- **`package.json` / `package-lock.json`** — add `eslint-plugin-promise@^7.3.0` as a `devDependency`.
- **`eslint.config.js`** — extend the JS-files config block with `promise.configs[\"flat/recommended\"]` alongside the existing `n` and `js` presets.
- **`lib/mocha.js`** — add an inline `eslint-disable-next-line` for the `runAsync(runner).then(done)` line, where the surrounding comment already documents that the missing `catch` is intentional and that returning anything other than `runner` would be a breaking change.
- **`lib/runnable.mjs`** — wrap the Promise-to-`done` bridge inside `callFn` with a block disable for `promise/catch-or-return` and `promise/no-callback-in-promise`. Both fulfillment and rejection paths invoke `done`, so a chained `.catch()` would itself need a no-op handler.
- **`test/integration/options/watch.spec.js`** — satisfy `promise/always-return` by returning the trailing `expect(...)` of each `.then((results) => { … })` arrow body. No assertions changed; only one position of `return` per `.then` block.

### Validation

- `npx eslint . --max-warnings 0` — clean
- `npm run format:check`, `npm run tsc`, `npm run lint:knip` — clean
- `npm run clean && npm run build` — bundle built
- `npm run test-smoke` — 1/1 passing
- `npm run test-node:integration:watch` — 30/30 passing
- `npm run test-node:unit -- --grep \"Runnable\"` — 74/74 passing

Closes #5064