### PR TITLE
fix: --reporter-option on CLI overrides values from config (#5532)

### DIFF
--- a/lib/cli/options.mjs
+++ b/lib/cli/options.mjs
@@ -283,6 +283,16 @@ export const loadPkgRc = (args = {}) => {
  * @alias module:lib/cli.loadOptions
  * @returns {external:yargsParser.Arguments} Parsed args from everything
  */
+// Reads `reporter-option` from a config source under any of its known
+// aliases. Keeps `loadOptions` agnostic of how each source was authored.
+const readReporterOption = (source) =>
+  source &&
+  (source["reporter-option"] ??
+    source["reporter-options"] ??
+    source.reporterOption ??
+    source.reporterOptions ??
+    source.O);
+
 export const loadOptions = (argv = []) => {
   let args = parse(argv);
   // short-circuit: look for a flag that would abort loading of options
@@ -298,6 +308,15 @@ export const loadOptions = (argv = []) => {
   const envConfig = parse(process.env.MOCHA_OPTIONS || "");
   const rcConfig = loadRc(args);
   const pkgConfig = loadPkgRc(args);
+
+  // Capture per-source `reporter-option` before yargs-parser's `combine-arrays`
+  // flattens them and loses provenance. See the re-merge step below for why.
+  const reporterOptionSources = {
+    pkg: readReporterOption(pkgConfig),
+    rc: readReporterOption(rcConfig),
+    env: readReporterOption(envConfig),
+    cli: readReporterOption(args),
+  };
 
   if (rcConfig) {
     args.config = false;
@@ -316,6 +335,20 @@ export const loadOptions = (argv = []) => {
     rcConfig || {},
     pkgConfig || {},
   );
+
+  // `combine-arrays` concatenates `reporter-option` from every source in
+  // high→low priority order. The downstream coerce in `lib/cli/run.js` reduces
+  // it left-to-right with last-writer-wins, which inverts the intended
+  // precedence. Re-emit lowest→highest priority so CLI overrides config.
+  const orderedReporterOption = [
+    reporterOptionSources.pkg,
+    reporterOptionSources.rc,
+    reporterOptionSources.env,
+    reporterOptionSources.cli,
+  ].reduce((acc, src) => (src ? acc.concat(list(src)) : acc), []);
+  if (orderedReporterOption.length) {
+    args["reporter-option"] = orderedReporterOption;
+  }
 
   // recombine positional arguments and "spec"
   if (args.spec) {

--- a/test/integration/fixtures/options/reporter-option-mocharc.yml
+++ b/test/integration/fixtures/options/reporter-option-mocharc.yml
@@ -1,0 +1,3 @@
+reporter-options:
+  - foo=fromConfig
+  - extra=keepMe

--- a/test/integration/options/reporter-option.spec.js
+++ b/test/integration/options/reporter-option.spec.js
@@ -83,4 +83,46 @@ describe("--reporter-option", function () {
       );
     });
   });
+
+  describe("when given options on the CLI and in a config file", function () {
+    var reporterFixture = path.join(
+      __dirname,
+      "..",
+      "fixtures",
+      "options",
+      "reporter-with-options.fixture.js",
+    );
+    var configFixture = path.join(
+      __dirname,
+      "..",
+      "fixtures",
+      "options",
+      "reporter-option-mocharc.yml",
+    );
+
+    it("should allow the CLI to override clashing keys from the config", function (done) {
+      runMocha(
+        "passing.fixture.js",
+        [
+          "--config",
+          configFixture,
+          "--reporter",
+          reporterFixture,
+          "--reporter-option",
+          "foo=fromCli",
+        ],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have passed").and(
+            "to contain output",
+            /{"foo":"fromCli","extra":"keepMe"}/,
+          );
+          done();
+        },
+        "pipe",
+      );
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5532
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--reporter-option` (`--reporter-options`, `-O`) given on the CLI did not override the same key declared in `.mocharc.*` or `package.json`. The config-file value won instead. Regression observed since v8.3.0, still present in v11.7.5+. The maintainer comment on the issue narrowed it to "Mocha not recognizing the clashing options as 'clashing'".

### Root cause

In `lib/cli/options.mjs`, the second call to `parse(...)` passes CLI args, env, RC, and `package.json` as `configObjects` in priority-HIGH→LOW order. `yargs-parser`'s `combine-arrays: true` concatenates the `reporter-option` array from every source in that order: `[CLI, env, rc, pkg]`. The downstream coerce in `lib/cli/run.js` (around L223-L243) then reduces this array left-to-right with last-writer-wins — so the **lowest-priority** source ends up taking precedence, which is the inverse of the intended priority order.

### Fix

After the second parse, re-emit `reporter-option` in priority-LOW→HIGH order (`pkg, rc, env, CLI`). The coerce's existing last-writer-wins reduction now yields the correct result: CLI overrides env overrides rc overrides pkg. Per-key merge semantics are preserved — CLI overrides only the clashing keys; non-clashing keys from the config still flow through.

A small helper (`readReporterOption`) reads the value under any of the supported source-side aliases (`reporter-option`, `reporter-options`, `reporterOption`, `reporterOptions`, `O`) so config files written with either casing/spelling are respected.

### Behavior matrix (verified locally)

| Scenario | Result |
|---|---|
| CLI `output=cli.xml`, config `output=config.xml` | CLI wins → `cli.xml` |
| CLI `output=cli.xml`, config `output=config.xml`, `suiteName=FromConfig` | `{output: 'cli.xml', suiteName: 'FromConfig'}` |
| CLI repeats `foo=bar foo=baz`, no config | `{foo: 'baz'}` (last wins, unchanged) |
| Env `foo=fromEnv`, config `foo=fromConfig` | Env wins |

### Tests

- New integration test in `test/integration/options/reporter-option.spec.js`: "should allow the CLI to override clashing keys from the config", driving Mocha via `--config <fixture-yaml>` + `--reporter-option foo=fromCli` and asserting the custom reporter prints `{"foo":"fromCli","extra":"keepMe"}`.
- New fixture: `test/integration/fixtures/options/reporter-option-mocharc.yml`.

### Validation

- `npm run format:check`, `npm run tsc` — clean
- `npm run test-smoke` — 1/1 passing
- `npm run -s test-node-run -- "test/integration/options/reporter-option.spec.js"` — 4/4 passing (3 pre-existing + 1 new)
- `npm run -s test-node-run -- "test/integration/options/*.spec.js"` — 158/158 passing
- `npm run test-node:unit` — 1008 passing, 3 pending

Closes #5532