### PR TITLE
fix: no re-emit unhandledRejection for non-Mocha registred listener 

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -222,20 +222,28 @@ class Runner extends EventEmitter {
           reason,
         );
         this.uncaught(reason);
-      } else {
+        return;
+      }
+
+      const hasOtherListener = process
+        .listeners("unhandledRejection")
+        .some((listener) => listener !== this.unhandled);
+
+      if (hasOtherListener) {
         debug(
-          "trapped unhandled rejection from (probably) user code; re-emitting on process",
+          "trapped unhandled rejection from, probably, user code. Another listener is registered and therefore not re-emitting",
         );
-        this._removeEventListener(
-          process,
-          "unhandledRejection",
-          this.unhandled,
-        );
-        try {
-          process.emit("unhandledRejection", reason, promise);
-        } finally {
-          this._addEventListener(process, "unhandledRejection", this.unhandled);
-        }
+        return;
+      }
+
+      debug(
+        "trapped unhandled rejection from, probably, user code, re-emitting on process",
+      );
+      this._removeEventListener(process, "unhandledRejection", this.unhandled);
+      try {
+        process.emit("unhandledRejection", reason, promise);
+      } finally {
+        this._addEventListener(process, "unhandledRejection", this.unhandled);
       }
     };
   }

--- a/test/integration/fixtures/uncaught/unhandled-with-user-listener.fixture.js
+++ b/test/integration/fixtures/uncaught/unhandled-with-user-listener.fixture.js
@@ -1,0 +1,16 @@
+"use strict";
+
+let count = 0;
+process.on("unhandledRejection", function () {
+  count++;
+  console.error("USER_LISTENER_CALLED " + count);
+});
+
+it("should emit an unhandled rejection", function (done) {
+  setTimeout(function () {
+    Promise.resolve().then(function () {
+      throw new Error("yikes");
+    });
+    setTimeout(done, 50);
+  });
+});

--- a/test/integration/uncaught.spec.js
+++ b/test/integration/uncaught.spec.js
@@ -215,4 +215,19 @@ describe("uncaught exceptions", function () {
       });
     });
   });
+
+  describe("user unhandledRejection listener should be invoked only once", function () {
+    it("should invoke a user-registered process listener exactly once", async function () {
+      const [, promise] = invokeMochaAsync(
+        [
+          resolveFixturePath("uncaught/unhandled-with-user-listener"),
+          "--unhandled-rejections=warn",
+        ],
+        { stdio: "pipe" },
+      );
+      const res = await promise;
+      const matches = res.output.match(/USER_LISTENER_CALLED \d+/g) || [];
+      expect(matches, "to equal", ["USER_LISTENER_CALLED 1"]);
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4743
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Current unhandledRejection handler used to remove itself and re-emit the event so node could apply its default behavior but this made user listeners to run twice when present.
this change skips the re-emit if any other unhandledRejection listener is registered thus preventing duplicates and in the same time keeping the existing no-listener behavior unchanged.

An integration test ensures user listeners are called exactly once.