### PR TITLE
Synchronise integration tests on IPC run-finished signal instead of sleeps

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -1,9 +1,7 @@
 "use strict";
 
 const debug = require("debug")("mocha:cli:watch");
-const fs = require("node:fs");
 const path = require("node:path");
-const timersPromises = require("node:timers/promises");
 const chokidar = require("chokidar");
 const glob = require("glob");
 const isPathInside = require("is-path-inside");
@@ -237,20 +235,6 @@ function createPathFilter(globPaths, basePath) {
     res.dir.paths.add(cleanPath);
     res.dir.globs.add(path.resolve(cleanPath, "**", "*"));
 
-    // If cleanPath doesnt exist yet we also start watching the closest existing parent folder.
-    // Chokidar version 5 does set up that parent watch eventually but it does it async after the ready event. and on slower filesystems (like Linux CI that github actions is running on/has) that can be a bit too late cuz stuff created right after mocha starts can slip through.
-    // so we just hook the parent early to make sure the watcher's already in place before user code runs so we dont miss any early events.
-    if (!fs.existsSync(cleanPath)) {
-      let ancestor = path.dirname(cleanPath);
-      while (ancestor !== path.dirname(ancestor)) {
-        if (fs.existsSync(ancestor)) {
-          res.dir.paths.add(ancestor);
-          break;
-        }
-        ancestor = path.dirname(ancestor);
-      }
-    }
-
     // match `absPath` and all of its contents
     const absPath = path.resolve(basePath, pattern.globString());
     debug("absolute path: %s", absPath);
@@ -444,92 +428,18 @@ const createWatcher = (
   const ignored = createPathFilter(watchIgnore, basePath);
   const matcher = createPathMatcher(allowed, ignored, basePath);
 
-  const _t0 = process.hrtime.bigint();
-  const _trace = (...a) => {
-    const elapsedMs = Number(process.hrtime.bigint() - _t0) / 1e6;
-    process.stderr.write(
-      `[TRACE-watch pid=${process.pid} +${elapsedMs.toFixed(1)}ms] ${a
-        .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
-        .join(" ")}\n`,
-    );
-  };
-  _trace("createWatcher: basePath=", basePath);
-  _trace("createWatcher: watchFiles=", watchFiles);
-  _trace("createWatcher: watchIgnore=", watchIgnore || []);
-  _trace("createWatcher: allowed.dir.paths=", Array.from(allowed.dir.paths));
-  _trace(
-    "createWatcher: allowed.match.paths=",
-    Array.from(allowed.match.paths),
-  );
-  _trace(
-    "createWatcher: allowed.match.globs=",
-    Array.from(allowed.match.globs),
-  );
-  _trace("createWatcher: ignored.dir.paths=", Array.from(ignored.dir.paths));
-  _trace(
-    "createWatcher: ignored.match.paths=",
-    Array.from(ignored.match.paths),
-  );
-  _trace(
-    "createWatcher: ignored.match.globs=",
-    Array.from(ignored.match.globs),
-  );
-
   // Chokidar has to watch the directory paths in case new files are created
   const watcher = chokidar.watch(Array.from(allowed.dir.paths), {
     ignoreInitial: true,
     ignored: matcher.ignore,
   });
-  _trace(
-    "chokidar.watch() returned; watching paths=",
-    Array.from(allowed.dir.paths),
-  );
 
   const rerunner = createRerunner(mocha, watcher, {
     beforeRun,
-    _trace,
   });
 
-  const requestedDirPaths = Array.from(allowed.dir.paths);
-  const isCovered = (p) => {
-    const watched = watcher.getWatched();
-    let cur = p;
-    while (cur) {
-      if (Object.prototype.hasOwnProperty.call(watched, cur)) return true;
-      const parent = path.dirname(cur);
-      if (parent === cur) return false;
-      cur = parent;
-    }
-    return false;
-  };
-
-  let readyFireCount = 0;
-  let started = false;
   watcher.on("ready", async () => {
-    readyFireCount += 1;
-    const watched = watcher.getWatched();
-    const coverage = requestedDirPaths.map((p) => ({
-      p,
-      covered: isCovered(p),
-    }));
-    _trace(
-      `'ready' fired #${readyFireCount}; started=${started} getWatched=`,
-      watched,
-      "coverage=",
-      coverage,
-    );
-    if (started) return;
-    if (!requestedDirPaths.every(isCovered)) {
-      _trace(
-        `'ready' #${readyFireCount}: not all requested paths covered yet, deferring start`,
-      );
-      return;
-    }
-    started = true;
     debug("watcher ready");
-    _trace(
-      `'ready' #${readyFireCount}: starting; triggering global setup + rerunner.run()`,
-    );
     if (!globalFixtureContext) {
       debug("triggering global setup");
       globalFixtureContext = await mocha.runGlobalSetup();
@@ -537,32 +447,11 @@ const createWatcher = (
     rerunner.run();
   });
 
-  watcher.on("error", (err) => {
-    _trace("'error':", err && (err.stack || err.message || String(err)));
-  });
-
-  watcher.on("raw", (event, p, details) => {
-    _trace(`'raw' event=${event} path=${p} details=`, details || {});
-  });
-
-  watcher.on("all", async (_event, filePath) => {
-    const allow = matcher.allow(filePath);
-    _trace(
-      `'all' event=${_event} path=${filePath} allow=${allow} started=${started} getWatched=`,
-      watcher.getWatched(),
-    );
-    if (!allow) return;
-    if (_event === "addDir") {
-      _trace(
-        `'all' addDir: yielding to Check phase before scheduleRun for ${filePath}`,
-      );
-      await timersPromises.setImmediate();
-      _trace(
-        `'all' addDir: resumed for ${filePath}; getWatched=`,
-        watcher.getWatched(),
-      );
+  watcher.on("all", (_event, filePath) => {
+    // only allow file paths that match the allowed patterns
+    if (matcher.allow(filePath)) {
+      rerunner.scheduleRun();
     }
-    rerunner.scheduleRun();
   });
 
   hideCursor();
@@ -626,7 +515,7 @@ const createWatcher = (
  * @ignore
  * @private
  */
-const createRerunner = (mocha, watcher, { beforeRun, _trace } = {}) => {
+const createRerunner = (mocha, watcher, { beforeRun } = {}) => {
   // Set to a `Runner` when mocha is running. Set to `null` when mocha is not
   // running.
   let runner = null;
@@ -634,88 +523,49 @@ const createRerunner = (mocha, watcher, { beforeRun, _trace } = {}) => {
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
-  const trace = _trace || (() => {});
-  let runCount = 0;
-
   const run = () => {
-    runCount += 1;
-    const thisRun = runCount;
-    trace(
-      `rerunner.run() #${thisRun} entry; rerunScheduled=${rerunScheduled} runner=${runner ? "set" : "null"}`,
-    );
     try {
       mocha = beforeRun ? beforeRun({ mocha, watcher }) || mocha : mocha;
-      trace(`rerunner.run() #${thisRun}: calling mocha.run()`);
       runner = mocha.run(() => {
         debug("finished watch run");
         const finishedRunner = runner;
         runner = null;
-        trace(
-          `rerunner: mocha.run() callback #${thisRun}; failures=${finishedRunner ? finishedRunner.failures : "n/a"} rerunScheduled=${rerunScheduled}`,
-        );
         blastCache(watcher);
         if (typeof process.send === "function" && process.connected) {
           try {
-            const payload = {
+            process.send({
               type: "mocha:watch:runFinished",
               failures: finishedRunner ? finishedRunner.failures : 0,
-            };
-            const sendResult = process.send(payload);
-            trace(
-              `rerunner: process.send() #${thisRun} returned`,
-              sendResult,
-              "payload=",
-              payload,
-            );
-          } catch (e) {
-            trace(
-              `rerunner: process.send() #${thisRun} THREW:`,
-              e && (e.stack || e.message || String(e)),
-            );
+            });
+          } catch {
             // parent disconnects are unrelated to this Mocha child itself
           }
-        } else {
-          trace(
-            `rerunner: process.send NOT available #${thisRun}; typeof process.send=${typeof process.send} process.connected=${process.connected}`,
-          );
         }
         if (rerunScheduled) {
-          trace(
-            `rerunner: #${thisRun} done; rerunScheduled=true, calling rerun()`,
-          );
           rerun();
         } else {
-          trace(`rerunner: #${thisRun} done; waiting for changes...`);
           console.error(`${logSymbols.info} [mocha] waiting for changes...`);
         }
       });
     } catch (err) {
-      trace(`rerunner.run() #${thisRun} THREW:`, err && err.stack);
       console.error(err.stack);
     }
   };
 
   const scheduleRun = () => {
-    trace(
-      `scheduleRun() entry; rerunScheduled=${rerunScheduled} runner=${runner ? "set" : "null"}`,
-    );
     if (rerunScheduled) {
-      trace("scheduleRun: already scheduled, ignoring");
       return;
     }
 
     rerunScheduled = true;
     if (runner) {
-      trace("scheduleRun: runner active, calling runner.abort()");
       runner.abort();
     } else {
-      trace("scheduleRun: no active runner, calling rerun() immediately");
       rerun();
     }
   };
 
   const rerun = () => {
-    trace("rerun() entry");
     rerunScheduled = false;
     eraseLine();
     run();

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -453,11 +453,27 @@ const createWatcher = (
     beforeRun,
   });
 
+  const _trace = (...a) =>
+    console.error(`[TRACE-watch ${Date.now()}]`, ...a);
+  _trace(
+    "createWatcher: dir.paths=",
+    JSON.stringify(Array.from(allowed.dir.paths)),
+    "allowed.match.paths=",
+    JSON.stringify(Array.from(allowed.match.paths)),
+    "allowed.match.globs=",
+    JSON.stringify(Array.from(allowed.match.globs)),
+  );
+  watcher.on("ready", () =>
+    _trace("'ready' fired; getWatched=", JSON.stringify(watcher.getWatched())),
+  );
+  watcher.on("error", (err) => _trace("'error':", err && err.message));
+
   // Chokidar version 5 can actually emit ready event more than once when you've got a mix of a non-existent path + an existing one.
   // basically the internal add(parent, basename) call bumps _readyCount again and triggers another ready event once the parent watcher is sat up.
   // so we just use "once" here to make sure the initial setup ONLY kicks off a single time instead of doing multiples.
   watcher.once("ready", async () => {
     debug("watcher ready");
+    _trace("once('ready'): runGlobalSetup + rerunner.run()");
     if (!globalFixtureContext) {
       debug("triggering global setup");
       globalFixtureContext = await mocha.runGlobalSetup();
@@ -466,8 +482,11 @@ const createWatcher = (
   });
 
   watcher.on("all", (_event, filePath) => {
-    // only allow file paths that match the allowed patterns
-    if (matcher.allow(filePath)) {
+    const allow = matcher.allow(filePath);
+    _trace(
+      `'all': event=${_event} path=${filePath} allow=${allow} getWatched=${JSON.stringify(watcher.getWatched())}`,
+    );
+    if (allow) {
       rerunner.scheduleRun();
     }
   });

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const debug = require("debug")("mocha:cli:watch");
+const fs = require("node:fs");
 const path = require("node:path");
 const chokidar = require("chokidar");
 const glob = require("glob");
@@ -235,6 +236,20 @@ function createPathFilter(globPaths, basePath) {
     res.dir.paths.add(cleanPath);
     res.dir.globs.add(path.resolve(cleanPath, "**", "*"));
 
+    // If cleanPath doesnt exist yet we also start watching the closest existing parent folder.
+    // Chokidar version 5 does set up that parent watch eventually but it does it async after the ready event. and on slower filesystems (like Linux CI that github actions is running on/has) that can be a bit too late cuz stuff created right after mocha starts can slip through.
+    // so we just hook the parent early to make sure the watcher's already in place before user code runs so we dont miss any early events.
+    if (!fs.existsSync(cleanPath)) {
+      let ancestor = path.dirname(cleanPath);
+      while (ancestor !== path.dirname(ancestor)) {
+        if (fs.existsSync(ancestor)) {
+          res.dir.paths.add(ancestor);
+          break;
+        }
+        ancestor = path.dirname(ancestor);
+      }
+    }
+
     // match `absPath` and all of its contents
     const absPath = path.resolve(basePath, pattern.globString());
     debug("absolute path: %s", absPath);
@@ -438,7 +453,10 @@ const createWatcher = (
     beforeRun,
   });
 
-  watcher.on("ready", async () => {
+  // Chokidar version 5 can actually emit ready event more than once when you've got a mix of a non-existent path + an existing one.
+  // basically the internal add(parent, basename) call bumps _readyCount again and triggers another ready event once the parent watcher is sat up.
+  // so we just use "once" here to make sure the initial setup ONLY kicks off a single time instead of doing multiples.
+  watcher.once("ready", async () => {
     debug("watcher ready");
     if (!globalFixtureContext) {
       debug("triggering global setup");
@@ -528,8 +546,19 @@ const createRerunner = (mocha, watcher, { beforeRun } = {}) => {
       mocha = beforeRun ? beforeRun({ mocha, watcher }) || mocha : mocha;
       runner = mocha.run(() => {
         debug("finished watch run");
+        const finishedRunner = runner;
         runner = null;
         blastCache(watcher);
+        if (typeof process.send === "function" && process.connected) {
+          try {
+            process.send({
+              type: "mocha:watch:runFinished",
+              failures: finishedRunner ? finishedRunner.failures : 0,
+            });
+          } catch {
+            // parent disconnects are unrelated to this Mocha child itself
+          }
+        }
         if (rerunScheduled) {
           rerun();
         } else {

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -544,15 +544,24 @@ const createWatcher = (
     _trace(`'raw' event=${event} path=${p} details=`, details || {});
   });
 
-  watcher.on("all", (_event, filePath) => {
+  watcher.on("all", async (_event, filePath) => {
     const allow = matcher.allow(filePath);
     _trace(
       `'all' event=${_event} path=${filePath} allow=${allow} started=${started} getWatched=`,
       watcher.getWatched(),
     );
-    if (allow) {
-      rerunner.scheduleRun();
+    if (!allow) return;
+    if (_event === "addDir") {
+      _trace(
+        `'all' addDir: yielding to setImmediate before scheduleRun for ${filePath}`,
+      );
+      await new Promise((resolve) => setImmediate(resolve));
+      _trace(
+        `'all' addDir: setImmediate resumed for ${filePath}; getWatched=`,
+        watcher.getWatched(),
+      );
     }
+    rerunner.scheduleRun();
   });
 
   hideCursor();

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -3,6 +3,7 @@
 const debug = require("debug")("mocha:cli:watch");
 const fs = require("node:fs");
 const path = require("node:path");
+const timersPromises = require("node:timers/promises");
 const chokidar = require("chokidar");
 const glob = require("glob");
 const isPathInside = require("is-path-inside");
@@ -553,11 +554,11 @@ const createWatcher = (
     if (!allow) return;
     if (_event === "addDir") {
       _trace(
-        `'all' addDir: yielding to setImmediate before scheduleRun for ${filePath}`,
+        `'all' addDir: yielding to Check phase before scheduleRun for ${filePath}`,
       );
-      await new Promise((resolve) => setImmediate(resolve));
+      await timersPromises.setImmediate();
       _trace(
-        `'all' addDir: setImmediate resumed for ${filePath}; getWatched=`,
+        `'all' addDir: resumed for ${filePath}; getWatched=`,
         watcher.getWatched(),
       );
     }

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -453,8 +453,7 @@ const createWatcher = (
     beforeRun,
   });
 
-  const _trace = (...a) =>
-    console.error(`[TRACE-watch ${Date.now()}]`, ...a);
+  const _trace = (...a) => console.error(`[TRACE-watch ${Date.now()}]`, ...a);
   _trace(
     "createWatcher: dir.paths=",
     JSON.stringify(Array.from(allowed.dir.paths)),

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -443,14 +443,50 @@ const createWatcher = (
   const ignored = createPathFilter(watchIgnore, basePath);
   const matcher = createPathMatcher(allowed, ignored, basePath);
 
+  const _t0 = process.hrtime.bigint();
+  const _trace = (...a) => {
+    const elapsedMs = Number(process.hrtime.bigint() - _t0) / 1e6;
+    process.stderr.write(
+      `[TRACE-watch pid=${process.pid} +${elapsedMs.toFixed(1)}ms] ${a
+        .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
+        .join(" ")}\n`,
+    );
+  };
+  _trace("createWatcher: basePath=", basePath);
+  _trace("createWatcher: watchFiles=", watchFiles);
+  _trace("createWatcher: watchIgnore=", watchIgnore || []);
+  _trace("createWatcher: allowed.dir.paths=", Array.from(allowed.dir.paths));
+  _trace(
+    "createWatcher: allowed.match.paths=",
+    Array.from(allowed.match.paths),
+  );
+  _trace(
+    "createWatcher: allowed.match.globs=",
+    Array.from(allowed.match.globs),
+  );
+  _trace("createWatcher: ignored.dir.paths=", Array.from(ignored.dir.paths));
+  _trace(
+    "createWatcher: ignored.match.paths=",
+    Array.from(ignored.match.paths),
+  );
+  _trace(
+    "createWatcher: ignored.match.globs=",
+    Array.from(ignored.match.globs),
+  );
+
   // Chokidar has to watch the directory paths in case new files are created
   const watcher = chokidar.watch(Array.from(allowed.dir.paths), {
     ignoreInitial: true,
     ignored: matcher.ignore,
   });
+  _trace(
+    "chokidar.watch() returned; watching paths=",
+    Array.from(allowed.dir.paths),
+  );
 
   const rerunner = createRerunner(mocha, watcher, {
     beforeRun,
+    _trace,
   });
 
   const requestedDirPaths = Array.from(allowed.dir.paths);
@@ -465,12 +501,34 @@ const createWatcher = (
     }
     return false;
   };
+
+  let readyFireCount = 0;
   let started = false;
   watcher.on("ready", async () => {
+    readyFireCount += 1;
+    const watched = watcher.getWatched();
+    const coverage = requestedDirPaths.map((p) => ({
+      p,
+      covered: isCovered(p),
+    }));
+    _trace(
+      `'ready' fired #${readyFireCount}; started=${started} getWatched=`,
+      watched,
+      "coverage=",
+      coverage,
+    );
     if (started) return;
-    if (!requestedDirPaths.every(isCovered)) return;
+    if (!requestedDirPaths.every(isCovered)) {
+      _trace(
+        `'ready' #${readyFireCount}: not all requested paths covered yet, deferring start`,
+      );
+      return;
+    }
     started = true;
     debug("watcher ready");
+    _trace(
+      `'ready' #${readyFireCount}: starting; triggering global setup + rerunner.run()`,
+    );
     if (!globalFixtureContext) {
       debug("triggering global setup");
       globalFixtureContext = await mocha.runGlobalSetup();
@@ -478,8 +536,21 @@ const createWatcher = (
     rerunner.run();
   });
 
+  watcher.on("error", (err) => {
+    _trace("'error':", err && (err.stack || err.message || String(err)));
+  });
+
+  watcher.on("raw", (event, p, details) => {
+    _trace(`'raw' event=${event} path=${p} details=`, details || {});
+  });
+
   watcher.on("all", (_event, filePath) => {
-    if (matcher.allow(filePath)) {
+    const allow = matcher.allow(filePath);
+    _trace(
+      `'all' event=${_event} path=${filePath} allow=${allow} started=${started} getWatched=`,
+      watcher.getWatched(),
+    );
+    if (allow) {
       rerunner.scheduleRun();
     }
   });
@@ -545,7 +616,7 @@ const createWatcher = (
  * @ignore
  * @private
  */
-const createRerunner = (mocha, watcher, { beforeRun } = {}) => {
+const createRerunner = (mocha, watcher, { beforeRun, _trace } = {}) => {
   // Set to a `Runner` when mocha is running. Set to `null` when mocha is not
   // running.
   let runner = null;
@@ -553,49 +624,88 @@ const createRerunner = (mocha, watcher, { beforeRun } = {}) => {
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
+  const trace = _trace || (() => {});
+  let runCount = 0;
+
   const run = () => {
+    runCount += 1;
+    const thisRun = runCount;
+    trace(
+      `rerunner.run() #${thisRun} entry; rerunScheduled=${rerunScheduled} runner=${runner ? "set" : "null"}`,
+    );
     try {
       mocha = beforeRun ? beforeRun({ mocha, watcher }) || mocha : mocha;
+      trace(`rerunner.run() #${thisRun}: calling mocha.run()`);
       runner = mocha.run(() => {
         debug("finished watch run");
         const finishedRunner = runner;
         runner = null;
+        trace(
+          `rerunner: mocha.run() callback #${thisRun}; failures=${finishedRunner ? finishedRunner.failures : "n/a"} rerunScheduled=${rerunScheduled}`,
+        );
         blastCache(watcher);
         if (typeof process.send === "function" && process.connected) {
           try {
-            process.send({
+            const payload = {
               type: "mocha:watch:runFinished",
               failures: finishedRunner ? finishedRunner.failures : 0,
-            });
-          } catch {
+            };
+            const sendResult = process.send(payload);
+            trace(
+              `rerunner: process.send() #${thisRun} returned`,
+              sendResult,
+              "payload=",
+              payload,
+            );
+          } catch (e) {
+            trace(
+              `rerunner: process.send() #${thisRun} THREW:`,
+              e && (e.stack || e.message || String(e)),
+            );
             // parent disconnects are unrelated to this Mocha child itself
           }
+        } else {
+          trace(
+            `rerunner: process.send NOT available #${thisRun}; typeof process.send=${typeof process.send} process.connected=${process.connected}`,
+          );
         }
         if (rerunScheduled) {
+          trace(
+            `rerunner: #${thisRun} done; rerunScheduled=true, calling rerun()`,
+          );
           rerun();
         } else {
+          trace(`rerunner: #${thisRun} done; waiting for changes...`);
           console.error(`${logSymbols.info} [mocha] waiting for changes...`);
         }
       });
     } catch (err) {
+      trace(`rerunner.run() #${thisRun} THREW:`, err && err.stack);
       console.error(err.stack);
     }
   };
 
   const scheduleRun = () => {
+    trace(
+      `scheduleRun() entry; rerunScheduled=${rerunScheduled} runner=${runner ? "set" : "null"}`,
+    );
     if (rerunScheduled) {
+      trace("scheduleRun: already scheduled, ignoring");
       return;
     }
 
     rerunScheduled = true;
     if (runner) {
+      trace("scheduleRun: runner active, calling runner.abort()");
       runner.abort();
     } else {
+      trace("scheduleRun: no active runner, calling rerun() immediately");
       rerun();
     }
   };
 
   const rerun = () => {
+    trace("rerun() entry");
     rerunScheduled = false;
     eraseLine();
     run();

--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -453,26 +453,24 @@ const createWatcher = (
     beforeRun,
   });
 
-  const _trace = (...a) => console.error(`[TRACE-watch ${Date.now()}]`, ...a);
-  _trace(
-    "createWatcher: dir.paths=",
-    JSON.stringify(Array.from(allowed.dir.paths)),
-    "allowed.match.paths=",
-    JSON.stringify(Array.from(allowed.match.paths)),
-    "allowed.match.globs=",
-    JSON.stringify(Array.from(allowed.match.globs)),
-  );
-  watcher.on("ready", () =>
-    _trace("'ready' fired; getWatched=", JSON.stringify(watcher.getWatched())),
-  );
-  watcher.on("error", (err) => _trace("'error':", err && err.message));
-
-  // Chokidar version 5 can actually emit ready event more than once when you've got a mix of a non-existent path + an existing one.
-  // basically the internal add(parent, basename) call bumps _readyCount again and triggers another ready event once the parent watcher is sat up.
-  // so we just use "once" here to make sure the initial setup ONLY kicks off a single time instead of doing multiples.
-  watcher.once("ready", async () => {
+  const requestedDirPaths = Array.from(allowed.dir.paths);
+  const isCovered = (p) => {
+    const watched = watcher.getWatched();
+    let cur = p;
+    while (cur) {
+      if (Object.prototype.hasOwnProperty.call(watched, cur)) return true;
+      const parent = path.dirname(cur);
+      if (parent === cur) return false;
+      cur = parent;
+    }
+    return false;
+  };
+  let started = false;
+  watcher.on("ready", async () => {
+    if (started) return;
+    if (!requestedDirPaths.every(isCovered)) return;
+    started = true;
     debug("watcher ready");
-    _trace("once('ready'): runGlobalSetup + rerunner.run()");
     if (!globalFixtureContext) {
       debug("triggering global setup");
       globalFixtureContext = await mocha.runGlobalSetup();
@@ -481,11 +479,7 @@ const createWatcher = (
   });
 
   watcher.on("all", (_event, filePath) => {
-    const allow = matcher.allow(filePath);
-    _trace(
-      `'all': event=${_event} path=${filePath} allow=${allow} getWatched=${JSON.stringify(watcher.getWatched())}`,
-    );
-    if (allow) {
+    if (matcher.allow(filePath)) {
       rerunner.scheduleRun();
     }
   });

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -442,49 +442,17 @@ async function runMochaWatchAsync(args, opts, change) {
 
   const useIpc = typeof change === "function" && change.length >= 2;
 
-  const _t0 = process.hrtime.bigint();
-  const _trace = (...a) => {
-    const elapsedMs = Number(process.hrtime.bigint() - _t0) / 1e6;
-    process.stderr.write(
-      `[TRACE-helper +${elapsedMs.toFixed(1)}ms] ${a
-        .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
-        .join(" ")}\n`,
-    );
-  };
-  _trace(
-    "runMochaWatchAsync start; useIpc=",
-    useIpc,
-    "sleepMs=",
-    opts.sleepMs,
-    "args=",
-    args,
-  );
-
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
   );
-  _trace("invokeMochaAsync returned; child pid=", mochaProcess.pid);
-  mochaProcess.on("exit", (code, signal) =>
-    _trace(`child 'exit' code=${code} signal=${signal}`),
-  );
-  mochaProcess.on("close", (code, signal) =>
-    _trace(`child 'close' code=${code} signal=${signal}`),
-  );
-  mochaProcess.on("disconnect", () => _trace(`child 'disconnect'`));
 
   let cleanup = () => {};
   let waitForRunFinished;
   if (useIpc) {
     const pending = [];
     const waiters = [];
-    let msgCount = 0;
     const onMessage = (msg) => {
-      msgCount += 1;
-      _trace(
-        `child IPC message #${msgCount}; pending=${pending.length} waiters=${waiters.length} msg=`,
-        msg,
-      );
       if (
         !msg ||
         typeof msg !== "object" ||
@@ -495,15 +463,9 @@ async function runMochaWatchAsync(args, opts, change) {
       const waiter = waiters.shift();
       if (waiter) {
         clearTimeout(waiter.timer);
-        _trace(
-          `child IPC message #${msgCount}: handed to waiter; waiters left=${waiters.length}`,
-        );
         waiter.resolve();
       } else {
         pending.push(msg);
-        _trace(
-          `child IPC message #${msgCount}: queued in pending; pending=${pending.length}`,
-        );
       }
     };
     mochaProcess.on("message", onMessage);
@@ -513,34 +475,17 @@ async function runMochaWatchAsync(args, opts, change) {
       for (const w of waiters) clearTimeout(w.timer);
     };
 
-    let waitCount = 0;
     waitForRunFinished = () => {
-      waitCount += 1;
-      const thisWait = waitCount;
-      _trace(
-        `waitForRunFinished #${thisWait} entry; pending=${pending.length} waiters=${waiters.length}`,
-      );
       if (pending.length > 0) {
         pending.shift();
-        _trace(
-          `waitForRunFinished #${thisWait}: consumed pending immediately; pending left=${pending.length}`,
-        );
         return Promise.resolve();
       }
       const timeoutMs = opts.sleepMs * 3;
       return new Promise((resolve, reject) => {
-        const waiter = {
-          resolve: () => {
-            _trace(`waitForRunFinished #${thisWait}: resolved by message`);
-            resolve();
-          },
-        };
+        const waiter = { resolve };
         waiter.timer = setTimeout(() => {
           const idx = waiters.indexOf(waiter);
           if (idx >= 0) waiters.splice(idx, 1);
-          _trace(
-            `waitForRunFinished #${thisWait}: TIMED OUT after ${timeoutMs}ms; pending=${pending.length} waiters=${waiters.length}`,
-          );
           reject(
             new Error(
               `runMochaWatchAsync: timed out after ${timeoutMs}ms waiting for watch run to finish`,
@@ -548,9 +493,6 @@ async function runMochaWatchAsync(args, opts, change) {
           );
         }, timeoutMs);
         waiters.push(waiter);
-        _trace(
-          `waitForRunFinished #${thisWait}: queued waiter; timeoutMs=${timeoutMs}`,
-        );
       });
     };
   }

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -434,30 +434,95 @@ async function runMochaWatchAsync(args, opts, change) {
     sleepMs: 2000,
     stdio: ["pipe", "pipe", "inherit"],
     ...opts,
-    fork: process.platform === "win32",
+    fork: true,
   };
+  if (typeof opts.stdio === "string") {
+    opts.stdio = [opts.stdio, opts.stdio, opts.stdio];
+  }
+
+  const useIpc = typeof change === "function" && change.length >= 2;
+
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
   );
-  await sleep(opts.sleepMs);
-  await change(mochaProcess);
-  await sleep(opts.sleepMs);
 
-  if (
-    !(mochaProcess.connected
-      ? mochaProcess.send("SIGINT")
-      : mochaProcess.kill("SIGINT"))
-  ) {
-    throw new Error("failed to send signal to subprocess");
+  let cleanup = () => {};
+  let waitForRunFinished;
+  if (useIpc) {
+    const pending = [];
+    const waiters = [];
+    const onMessage = (msg) => {
+      if (
+        !msg ||
+        typeof msg !== "object" ||
+        msg.type !== "mocha:watch:runFinished"
+      ) {
+        return;
+      }
+      const waiter = waiters.shift();
+      if (waiter) {
+        clearTimeout(waiter.timer);
+        waiter.resolve();
+      } else {
+        pending.push(msg);
+      }
+    };
+    mochaProcess.on("message", onMessage);
+
+    cleanup = () => {
+      mochaProcess.removeListener("message", onMessage);
+      for (const w of waiters) clearTimeout(w.timer);
+    };
+
+    waitForRunFinished = () => {
+      if (pending.length > 0) {
+        pending.shift();
+        return Promise.resolve();
+      }
+      const timeoutMs = opts.sleepMs * 3;
+      return new Promise((resolve, reject) => {
+        const waiter = { resolve };
+        waiter.timer = setTimeout(() => {
+          const idx = waiters.indexOf(waiter);
+          if (idx >= 0) waiters.splice(idx, 1);
+          reject(
+            new Error(
+              `runMochaWatchAsync: timed out after ${timeoutMs}ms waiting for watch run to finish`,
+            ),
+          );
+        }, timeoutMs);
+        waiters.push(waiter);
+      });
+    };
   }
 
-  const res = await resultPromise;
+  try {
+    if (useIpc) {
+      await change(mochaProcess, { waitForRunFinished });
+    } else {
+      await sleep(opts.sleepMs);
+      await change(mochaProcess);
+      await sleep(opts.sleepMs);
+    }
 
-  // we kill the process with `SIGINT`, so it will always appear as "failed" to our
-  // custom assertions (a non-zero exit code 130). just change it to 0.
-  res.code = 0;
-  return res;
+    if (
+      !(mochaProcess.connected
+        ? mochaProcess.send("SIGINT")
+        : mochaProcess.kill("SIGINT"))
+    ) {
+      throw new Error("failed to send signal to subprocess");
+    }
+
+    const res = await resultPromise;
+
+    // we kill the process with `SIGINT`, so it will always appear as "failed" to our
+    // custom assertions (a non-zero exit code 130). just change it to 0.
+    res.code = 0;
+    return res;
+  } finally {
+    cleanup();
+  }
 }
 
 /**

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -442,6 +442,16 @@ async function runMochaWatchAsync(args, opts, change) {
 
   const useIpc = typeof change === "function" && change.length >= 2;
 
+  const _t0 = Date.now();
+  const _ttrace = (...a) =>
+    console.error(`[TRACE-helper +${Date.now() - _t0}ms]`, ...a);
+  _ttrace(
+    "runMochaWatchAsync start; useIpc=",
+    useIpc,
+    "args=",
+    JSON.stringify(args),
+  );
+
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
@@ -453,6 +463,7 @@ async function runMochaWatchAsync(args, opts, change) {
     const pending = [];
     const waiters = [];
     const onMessage = (msg) => {
+      _ttrace("on('message'):", JSON.stringify(msg));
       if (
         !msg ||
         typeof msg !== "object" ||
@@ -476,16 +487,24 @@ async function runMochaWatchAsync(args, opts, change) {
     };
 
     waitForRunFinished = () => {
+      _ttrace("waitForRunFinished() called; pending=", pending.length);
       if (pending.length > 0) {
         pending.shift();
+        _ttrace("waitForRunFinished: consumed pending immediately");
         return Promise.resolve();
       }
       const timeoutMs = opts.sleepMs * 3;
       return new Promise((resolve, reject) => {
-        const waiter = { resolve };
+        const waiter = {
+          resolve: () => {
+            _ttrace("waitForRunFinished: resolved by message");
+            resolve();
+          },
+        };
         waiter.timer = setTimeout(() => {
           const idx = waiters.indexOf(waiter);
           if (idx >= 0) waiters.splice(idx, 1);
+          _ttrace("waitForRunFinished: TIMED OUT");
           reject(
             new Error(
               `runMochaWatchAsync: timed out after ${timeoutMs}ms waiting for watch run to finish`,

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -442,16 +442,6 @@ async function runMochaWatchAsync(args, opts, change) {
 
   const useIpc = typeof change === "function" && change.length >= 2;
 
-  const _t0 = Date.now();
-  const _ttrace = (...a) =>
-    console.error(`[TRACE-helper +${Date.now() - _t0}ms]`, ...a);
-  _ttrace(
-    "runMochaWatchAsync start; useIpc=",
-    useIpc,
-    "args=",
-    JSON.stringify(args),
-  );
-
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
@@ -463,7 +453,6 @@ async function runMochaWatchAsync(args, opts, change) {
     const pending = [];
     const waiters = [];
     const onMessage = (msg) => {
-      _ttrace("on('message'):", JSON.stringify(msg));
       if (
         !msg ||
         typeof msg !== "object" ||
@@ -487,24 +476,16 @@ async function runMochaWatchAsync(args, opts, change) {
     };
 
     waitForRunFinished = () => {
-      _ttrace("waitForRunFinished() called; pending=", pending.length);
       if (pending.length > 0) {
         pending.shift();
-        _ttrace("waitForRunFinished: consumed pending immediately");
         return Promise.resolve();
       }
       const timeoutMs = opts.sleepMs * 3;
       return new Promise((resolve, reject) => {
-        const waiter = {
-          resolve: () => {
-            _ttrace("waitForRunFinished: resolved by message");
-            resolve();
-          },
-        };
+        const waiter = { resolve };
         waiter.timer = setTimeout(() => {
           const idx = waiters.indexOf(waiter);
           if (idx >= 0) waiters.splice(idx, 1);
-          _ttrace("waitForRunFinished: TIMED OUT");
           reject(
             new Error(
               `runMochaWatchAsync: timed out after ${timeoutMs}ms waiting for watch run to finish`,

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -442,17 +442,49 @@ async function runMochaWatchAsync(args, opts, change) {
 
   const useIpc = typeof change === "function" && change.length >= 2;
 
+  const _t0 = process.hrtime.bigint();
+  const _trace = (...a) => {
+    const elapsedMs = Number(process.hrtime.bigint() - _t0) / 1e6;
+    process.stderr.write(
+      `[TRACE-helper +${elapsedMs.toFixed(1)}ms] ${a
+        .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
+        .join(" ")}\n`,
+    );
+  };
+  _trace(
+    "runMochaWatchAsync start; useIpc=",
+    useIpc,
+    "sleepMs=",
+    opts.sleepMs,
+    "args=",
+    args,
+  );
+
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
   );
+  _trace("invokeMochaAsync returned; child pid=", mochaProcess.pid);
+  mochaProcess.on("exit", (code, signal) =>
+    _trace(`child 'exit' code=${code} signal=${signal}`),
+  );
+  mochaProcess.on("close", (code, signal) =>
+    _trace(`child 'close' code=${code} signal=${signal}`),
+  );
+  mochaProcess.on("disconnect", () => _trace(`child 'disconnect'`));
 
   let cleanup = () => {};
   let waitForRunFinished;
   if (useIpc) {
     const pending = [];
     const waiters = [];
+    let msgCount = 0;
     const onMessage = (msg) => {
+      msgCount += 1;
+      _trace(
+        `child IPC message #${msgCount}; pending=${pending.length} waiters=${waiters.length} msg=`,
+        msg,
+      );
       if (
         !msg ||
         typeof msg !== "object" ||
@@ -463,9 +495,15 @@ async function runMochaWatchAsync(args, opts, change) {
       const waiter = waiters.shift();
       if (waiter) {
         clearTimeout(waiter.timer);
+        _trace(
+          `child IPC message #${msgCount}: handed to waiter; waiters left=${waiters.length}`,
+        );
         waiter.resolve();
       } else {
         pending.push(msg);
+        _trace(
+          `child IPC message #${msgCount}: queued in pending; pending=${pending.length}`,
+        );
       }
     };
     mochaProcess.on("message", onMessage);
@@ -475,17 +513,34 @@ async function runMochaWatchAsync(args, opts, change) {
       for (const w of waiters) clearTimeout(w.timer);
     };
 
+    let waitCount = 0;
     waitForRunFinished = () => {
+      waitCount += 1;
+      const thisWait = waitCount;
+      _trace(
+        `waitForRunFinished #${thisWait} entry; pending=${pending.length} waiters=${waiters.length}`,
+      );
       if (pending.length > 0) {
         pending.shift();
+        _trace(
+          `waitForRunFinished #${thisWait}: consumed pending immediately; pending left=${pending.length}`,
+        );
         return Promise.resolve();
       }
       const timeoutMs = opts.sleepMs * 3;
       return new Promise((resolve, reject) => {
-        const waiter = { resolve };
+        const waiter = {
+          resolve: () => {
+            _trace(`waitForRunFinished #${thisWait}: resolved by message`);
+            resolve();
+          },
+        };
         waiter.timer = setTimeout(() => {
           const idx = waiters.indexOf(waiter);
           if (idx >= 0) waiters.splice(idx, 1);
+          _trace(
+            `waitForRunFinished #${thisWait}: TIMED OUT after ${timeoutMs}ms; pending=${pending.length} waiters=${waiters.length}`,
+          );
           reject(
             new Error(
               `runMochaWatchAsync: timed out after ${timeoutMs}ms waiting for watch run to finish`,
@@ -493,6 +548,9 @@ async function runMochaWatchAsync(args, opts, change) {
           );
         }, timeoutMs);
         waiters.push(waiter);
+        _trace(
+          `waitForRunFinished #${thisWait}: queued waiter; timeoutMs=${timeoutMs}`,
+        );
       });
     };
   }

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -145,31 +145,19 @@ describe("--watch", function () {
       const dirPath = path.join(libPath, "dir");
       const watchedFile = path.join(dirPath, "file.xyz");
 
-      const _t = (...a) => console.error("[TRACE-test]", ...a);
-      _t("tempDir=", tempDir, "libPath=", libPath);
-
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         tempDir,
         async (_mochaProcess, { waitForRunFinished }) => {
-          _t("awaiting initial run");
           await waitForRunFinished();
-          _t("initial run done; mkdir libPath");
           fs.mkdirSync(libPath);
-          _t("awaiting rerun after mkdir libPath");
           await waitForRunFinished();
-          _t("rerun 1 done; mkdir dirPath");
           fs.mkdirSync(dirPath);
-          _t("awaiting rerun after mkdir dirPath");
           await waitForRunFinished();
-          _t("rerun 2 done; touchFile watchedFile");
           touchFile(watchedFile);
-          _t("awaiting rerun after touchFile");
           await waitForRunFinished();
-          _t("rerun 3 done; change callback complete");
         },
       ).then((results) => {
-        _t("results.length=", results.length);
         expect(results, "to have length", 4);
       });
     });

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -145,19 +145,31 @@ describe("--watch", function () {
       const dirPath = path.join(libPath, "dir");
       const watchedFile = path.join(dirPath, "file.xyz");
 
+      const _t = (...a) => console.error("[TRACE-test]", ...a);
+      _t("tempDir=", tempDir, "libPath=", libPath);
+
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         tempDir,
         async (_mochaProcess, { waitForRunFinished }) => {
+          _t("awaiting initial run");
           await waitForRunFinished();
+          _t("initial run done; mkdir libPath");
           fs.mkdirSync(libPath);
+          _t("awaiting rerun after mkdir libPath");
           await waitForRunFinished();
+          _t("rerun 1 done; mkdir dirPath");
           fs.mkdirSync(dirPath);
+          _t("awaiting rerun after mkdir dirPath");
           await waitForRunFinished();
+          _t("rerun 2 done; touchFile watchedFile");
           touchFile(watchedFile);
+          _t("awaiting rerun after touchFile");
           await waitForRunFinished();
+          _t("rerun 3 done; change callback complete");
         },
       ).then((results) => {
+        _t("results.length=", results.length);
         expect(results, "to have length", 4);
       });
     });

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -13,6 +13,12 @@ const {
   DEFAULT_FIXTURE,
 } = require("../helpers");
 
+// For documentation:
+// Chokidar can take a moment to attach an inotify watch to a newly-created directory on Linux.
+// Since there's no signal for when the watch is ready we wait briefly before creating anything inside it.
+// 1000ms has been reliable in practice, 500ms is what mark suggested in PR 5988.
+const WATCH_INSTALL_SETTLE_MS = 1000;
+
 describe("--watch", function () {
   describe("when enabled", function () {
     /**
@@ -152,8 +158,13 @@ describe("--watch", function () {
           await waitForRunFinished();
           fs.mkdirSync(libPath);
           await waitForRunFinished();
+          // Chokidar can take a moment to attach an inotify watch to a newly-created directory on Linux.
+          // If we create something inside it immediately, the event may be missed (see chokidar/chokidar#1422).
+          // We add a short delay to avoid racing the watcher.
+          await sleep(WATCH_INSTALL_SETTLE_MS);
           fs.mkdirSync(dirPath);
           await waitForRunFinished();
+          await sleep(WATCH_INSTALL_SETTLE_MS);
           touchFile(watchedFile);
           await waitForRunFinished();
         },

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -145,19 +145,53 @@ describe("--watch", function () {
       const dirPath = path.join(libPath, "dir");
       const watchedFile = path.join(dirPath, "file.xyz");
 
+      const _t0 = process.hrtime.bigint();
+      const _trace = (...a) => {
+        const elapsedMs = Number(process.hrtime.bigint() - _t0) / 1e6;
+        process.stderr.write(
+          `[TRACE-spec +${elapsedMs.toFixed(1)}ms] ${a
+            .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
+            .join(" ")}\n`,
+        );
+      };
+      _trace(
+        "test start; platform=",
+        process.platform,
+        "node=",
+        process.version,
+      );
+      _trace("tempDir=", tempDir);
+      _trace("testFile=", testFile);
+      _trace("libPath=", libPath);
+      _trace("dirPath=", dirPath);
+      _trace("watchedFile=", watchedFile);
+
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         tempDir,
         async (_mochaProcess, { waitForRunFinished }) => {
+          _trace("step 1: awaiting initial run");
           await waitForRunFinished();
+          _trace("step 1 done: initial run finished; about to mkdir libPath");
           fs.mkdirSync(libPath);
+          _trace("step 2: mkdir libPath done; awaiting rerun");
           await waitForRunFinished();
+          _trace(
+            "step 2 done: rerun after mkdir libPath; about to mkdir dirPath",
+          );
           fs.mkdirSync(dirPath);
+          _trace("step 3: mkdir dirPath done; awaiting rerun");
           await waitForRunFinished();
+          _trace(
+            "step 3 done: rerun after mkdir dirPath; about to touch watchedFile",
+          );
           touchFile(watchedFile);
+          _trace("step 4: touchFile done; awaiting rerun");
           await waitForRunFinished();
+          _trace("step 4 done: all reruns observed; change callback complete");
         },
       ).then((results) => {
+        _trace("results.length=", results.length);
         expect(results, "to have length", 4);
       });
     });

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -40,9 +40,15 @@ describe("--watch", function () {
       const testFile = path.join(tempDir, "test.js");
       copyFixture(DEFAULT_FIXTURE, testFile);
 
-      return runMochaWatchJSONAsync([testFile], tempDir, () => {
-        touchFile(testFile);
-      }).then((results) => {
+      return runMochaWatchJSONAsync(
+        [testFile],
+        tempDir,
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
+          touchFile(testFile);
+          await waitForRunFinished();
+        },
+      ).then((results) => {
         expect(results, "to have length", 2);
       });
     });
@@ -65,9 +71,15 @@ describe("--watch", function () {
         const testFile = path.join(tempDir, "test.js");
         copyFixture(DEFAULT_FIXTURE, testFile);
 
-        return runMochaWatchJSONAsync(["--parallel", testFile], tempDir, () => {
-          touchFile(testFile);
-        }).then((results) => {
+        return runMochaWatchJSONAsync(
+          ["--parallel", testFile],
+          tempDir,
+          async (_mochaProcess, { waitForRunFinished }) => {
+            await waitForRunFinished();
+            touchFile(testFile);
+            await waitForRunFinished();
+          },
+        ).then((results) => {
           expect(results, "to have length", 2);
         });
       });
@@ -96,8 +108,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "dir/*.xyz"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results.length, "to equal", 2);
@@ -112,8 +126,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "**/*.xyz"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -132,14 +148,14 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         tempDir,
-        async () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           fs.mkdirSync(libPath);
-          await sleep(1000);
-
+          await waitForRunFinished();
           fs.mkdirSync(dirPath);
-          await sleep(1000);
-
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 4);
@@ -156,8 +172,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib/**/*.xyz"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           fs.rmSync(watchedFile, { recursive: true, force: true });
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -174,8 +192,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib/file.xyz"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -192,8 +212,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -210,8 +232,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "**/lib"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -228,8 +252,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib/**/*"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -246,8 +272,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib/**/dir"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -270,8 +298,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", watchFilePattern],
         tempCwd,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -303,9 +333,11 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         ["test/**/*.js", "--watch-files", "test/**/*.js"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           const addedTestFile = path.join(tempDir, "test/b.js");
           copyFixture("passing", addedTestFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -324,8 +356,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--extension", "xyz,js"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -336,9 +370,15 @@ describe("--watch", function () {
       const testFile = path.join(tempDir, "test.js");
       copyFixture(DEFAULT_FIXTURE, testFile);
 
-      return runMochaWatchJSONAsync([testFile], tempDir, (mochaProcess) => {
-        mochaProcess.stdin.write("rs\n");
-      }).then((results) => {
+      return runMochaWatchJSONAsync(
+        [testFile],
+        tempDir,
+        async (mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
+          mochaProcess.stdin.write("rs\n");
+          await waitForRunFinished();
+        },
+      ).then((results) => {
         expect(results, "to have length", 2);
       });
     });
@@ -353,8 +393,10 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--extension", "xyz,js"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           touchFile(watchedFile);
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -433,12 +475,14 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "**/*.js"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           replaceFileContents(
             testFile,
             "testShouldFail = true",
             "testShouldFail = false",
           );
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -459,12 +503,14 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib/**/*.js"],
         tempDir,
-        () => {
+        async (_mochaProcess, { waitForRunFinished }) => {
+          await waitForRunFinished();
           replaceFileContents(
             dependency,
             "module.exports.testShouldFail = false",
             "module.exports.testShouldFail = true",
           );
+          await waitForRunFinished();
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -481,9 +527,15 @@ describe("--watch", function () {
       copyFixture("options/grep", testFile);
 
       return expect(
-        runMochaWatchJSONAsync([testFile, "--fgrep", "match"], tempDir, () => {
-          touchFile(testFile);
-        }),
+        runMochaWatchJSONAsync(
+          [testFile, "--fgrep", "match"],
+          tempDir,
+          async (_mochaProcess, { waitForRunFinished }) => {
+            await waitForRunFinished();
+            touchFile(testFile);
+            await waitForRunFinished();
+          },
+        ),
         "when fulfilled",
         "to satisfy",
         {
@@ -514,8 +566,10 @@ describe("--watch", function () {
           return runMochaWatchJSONAsync(
             [testFile, "--require", hookFile],
             tempDir,
-            () => {
+            async (_mochaProcess, { waitForRunFinished }) => {
+              await waitForRunFinished();
               touchFile(testFile);
+              await waitForRunFinished();
             },
           ).then((results) => {
             expect(results.length, "to equal", 2);
@@ -541,8 +595,6 @@ describe("--watch", function () {
           [testFile],
           { cwd: tempDir, stdio: "pipe" },
           async () => {
-            // we want to cause _n + 1_ reruns, which should cause the warning
-            // to occur if the listeners aren't properly destroyed
             const iterations = new Array(process.getMaxListeners() + 1);
             // eslint-disable-next-line no-unused-vars
             for await (const _ of iterations) {

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -145,53 +145,19 @@ describe("--watch", function () {
       const dirPath = path.join(libPath, "dir");
       const watchedFile = path.join(dirPath, "file.xyz");
 
-      const _t0 = process.hrtime.bigint();
-      const _trace = (...a) => {
-        const elapsedMs = Number(process.hrtime.bigint() - _t0) / 1e6;
-        process.stderr.write(
-          `[TRACE-spec +${elapsedMs.toFixed(1)}ms] ${a
-            .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
-            .join(" ")}\n`,
-        );
-      };
-      _trace(
-        "test start; platform=",
-        process.platform,
-        "node=",
-        process.version,
-      );
-      _trace("tempDir=", tempDir);
-      _trace("testFile=", testFile);
-      _trace("libPath=", libPath);
-      _trace("dirPath=", dirPath);
-      _trace("watchedFile=", watchedFile);
-
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         tempDir,
         async (_mochaProcess, { waitForRunFinished }) => {
-          _trace("step 1: awaiting initial run");
           await waitForRunFinished();
-          _trace("step 1 done: initial run finished; about to mkdir libPath");
           fs.mkdirSync(libPath);
-          _trace("step 2: mkdir libPath done; awaiting rerun");
           await waitForRunFinished();
-          _trace(
-            "step 2 done: rerun after mkdir libPath; about to mkdir dirPath",
-          );
           fs.mkdirSync(dirPath);
-          _trace("step 3: mkdir dirPath done; awaiting rerun");
           await waitForRunFinished();
-          _trace(
-            "step 3 done: rerun after mkdir dirPath; about to touch watchedFile",
-          );
           touchFile(watchedFile);
-          _trace("step 4: touchFile done; awaiting rerun");
           await waitForRunFinished();
-          _trace("step 4 done: all reruns observed; change callback complete");
         },
       ).then((results) => {
-        _trace("results.length=", results.length);
         expect(results, "to have length", 4);
       });
     });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5714 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

runMochaWatchAsync used fixed 2 seconds delays between each "change" which was slow in CI.
Replace with an IPC `mocha:watch:runFinished` event to let tests to wait for completion instead of sleeping. Helper now always forks and exposes waitForRunFinished. 