### PR TITLE
fix: report test error when afterEach also fails on retry

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -979,7 +979,13 @@ Runner.prototype.runTests = function (suite, fn) {
 
             // Early return + hook trigger so that it doesn't
             // increment the count wrong
-            return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+            return self.hookUp(HOOK_TYPE_AFTER_EACH, function (hookErr, hookErrSuite) {
+              if (hookErr) {
+                self.fail(test, err);
+                self.emit(constants.EVENT_TEST_END, test);
+              }
+              next(hookErr, hookErrSuite);
+            });
           } else {
             self.fail(test, err);
           }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -979,13 +979,16 @@ Runner.prototype.runTests = function (suite, fn) {
 
             // Early return + hook trigger so that it doesn't
             // increment the count wrong
-            return self.hookUp(HOOK_TYPE_AFTER_EACH, function (hookErr, hookErrSuite) {
-              if (hookErr) {
-                self.fail(test, err);
-                self.emit(constants.EVENT_TEST_END, test);
-              }
-              next(hookErr, hookErrSuite);
-            });
+            return self.hookUp(
+              HOOK_TYPE_AFTER_EACH,
+              function (hookErr, hookErrSuite) {
+                if (hookErr) {
+                  self.fail(test, err);
+                  self.emit(constants.EVENT_TEST_END, test);
+                }
+                next(hookErr, hookErrSuite);
+              },
+            );
           } else {
             self.fail(test, err);
           }

--- a/test/integration/fixtures/retries/after-each-error.fixture.js
+++ b/test/integration/fixtures/retries/after-each-error.fixture.js
@@ -1,0 +1,11 @@
+'use strict';
+
+describe('afterEach error with retries', function () {
+  afterEach(function () {
+    throw new Error('Error from after each');
+  });
+
+  it('test one', function () {
+    throw new Error('Error from test');
+  });
+});

--- a/test/integration/retries.spec.js
+++ b/test/integration/retries.spec.js
@@ -89,6 +89,39 @@ describe("retries", function () {
     });
   });
 
+  it("should report both the test error and the afterEach hook error when retries > 0 (#5007)", function (done) {
+    runJSON(
+      "retries/after-each-error.fixture.js",
+      ["--retries", "1"],
+      function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.strictEqual(res.stats.passes, 0);
+        assert.strictEqual(res.stats.failures, 2);
+
+        var failureMessages = res.failures.map(function (f) {
+          return f.err.message;
+        });
+        assert.ok(
+          failureMessages.indexOf("Error from test") !== -1,
+          "expected the original test error to be reported, got: " +
+            JSON.stringify(failureMessages),
+        );
+        assert.ok(
+          failureMessages.indexOf("Error from after each") !== -1,
+          "expected the afterEach hook error to be reported, got: " +
+            JSON.stringify(failureMessages),
+        );
+
+        assert.strictEqual(res.code, 2);
+        done();
+      },
+    );
+  });
+
   it("should not hang w/ async test", function (done) {
     helpers.runMocha(
       "retries/async.fixture.js",

--- a/test/integration/retries.spec.js
+++ b/test/integration/retries.spec.js
@@ -89,7 +89,7 @@ describe("retries", function () {
     });
   });
 
-  it("should report both the test error and the afterEach hook error when retries > 0 (#5007)", function (done) {
+  it("should report both the test error and the afterEach hook error when retries > 0", function (done) {
     runJSON(
       "retries/after-each-error.fixture.js",
       ["--retries", "1"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5007
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The fix wraps the retry-branch hookUp(AFTER_EACH, ...) callback so that if afterEach fails the original test error is still surfaced via `self.fail(test, err)` before forwarding the hook error to `next`.

I did not touch the normal retry flow: if afterEach succeeds, execution continues exactly as before.

Change is minimal and isolated to the retry path in `lib/runner.js` and does not affect: `--retries 0` or successful retries or `EVENT_TEST_RETRY` ordering or non-retry `EVENT_TEST_PASS` behavior.