### PR TITLE
fix: report sync error thrown after done() in async tests 

### DIFF
--- a/lib/runnable.mjs
+++ b/lib/runnable.mjs
@@ -332,12 +332,16 @@ class Runnable extends EventEmitter {
         callFnAsync(this.fn);
       } catch (err) {
         // handles async runnables which actually run synchronously
-        errorWasHandled = true;
         if (err instanceof PendingError) {
+          errorWasHandled = true;
           return; // done() is already called in this.skip()
         } else if (this.allowUncaught) {
           throw err;
         }
+        if (finished) {
+          return multiple(Runnable.toValueOrError(err));
+        }
+        errorWasHandled = true;
         done(Runnable.toValueOrError(err));
       }
       return;

--- a/test/integration/fixtures/sync-error-after-done.fixture.js
+++ b/test/integration/fixtures/sync-error-after-done.fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var assert = require('assert');
+
+it('should fail in a test-case', function (done) {
+  done();
+  assert.strictEqual(true, false);
+});

--- a/test/integration/multiple-done.spec.js
+++ b/test/integration/multiple-done.spec.js
@@ -139,6 +139,30 @@ describe("multiple calls to done()", function () {
     });
   });
 
+  describe("when test body synchronously throws after done()", function () {
+    before(function (done) {
+      runMochaJSON("sync-error-after-done", function (err, result) {
+        res = result;
+        done(err);
+      });
+    });
+
+    it("results in failure (GH-4202)", function () {
+      expect(res, "to have failed test count", 1)
+        .and("to have passed test count", 1)
+        .and("to have pending test count", 0)
+        .and("to have failed");
+    });
+
+    it("throws a descriptive error", function () {
+      expect(res, "to have failed with error", {
+        message:
+          /done\(\) called multiple times in test <should fail in a test-case> \(of root suite\) of file.+sync-error-after-done\.fixture\.js; in addition, done\(\) received error: AssertionError/,
+        code: MULTIPLE_DONE,
+      });
+    });
+  });
+
   describe("when done() called asynchronously", function () {
     before(function (done) {
       // we can't be sure that mocha won't fail with an uncaught exception here, which would cause any JSON


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4202
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Tests using done() could incorrectly pass if they called it synchronosly and then immediately threw an error afterward. Caused by the post-done() throw being treated as already handled that silently swallowed the error ( excuse me for the unprofessional way of describing ).

this fix detects throws that happen after done() completes and routes them through mocha’s existing multiple-done error handling causing the test to fail correctly and inntegration tests were added to verify the failure behavior and error message.