### PR TITLE
--fail-zero respects --delay test registration

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1223,6 +1223,7 @@ Runner.prototype.run = function (fn, opts = {}) {
     }
     this.state = constants.STATE_RUNNING;
     if (this._opts.delay) {
+      this.total = this.grepTotal(this.suite);
       this.emit(constants.EVENT_DELAY_END);
       debug('run(): "delay" ended');
     }

--- a/test/integration/options/failZero.spec.js
+++ b/test/integration/options/failZero.spec.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var path = require("node:path").posix;
 var helpers = require("../helpers");
 var runMochaJSON = helpers.runMochaJSON;
 
@@ -17,6 +18,24 @@ describe("--fail-zero", function () {
         .and("to have test count", 0)
         .and("to have exit code", 1);
       done();
+    });
+  });
+
+  describe("with --delay", function () {
+    it("should pass when delayed tests are registered (GH-4950)", function (done) {
+      var fixture = path.join("options", "delay");
+      runMochaJSON(
+        fixture,
+        ["--fail-zero", "--delay", "--no-forbid-only"],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res, "to have passed").and("to have passed test count", 1);
+          done();
+        },
+      );
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4950
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

So --fail-zero + --delay was incorrectly failing runs with exit code 1 even when tests actually executed fine.

the issue was that Runner captures this.total in the constructor but with --delay the tests dont exist yet at that point and they're only registered later when the user's deferred callback runs. so the runner thinks there are 0 tests the whole time.
then --fail-zero kicks in at the end and says “no tests ran => fail the run” even though tests actually did run.

i chose to, instead of trusting the constructor value, we recompute this.total in prepare() right after the delayed setup has finished and just before execution starts. that way it reflects the real suite (including --grep / --invert filtering).

So basically: we just move the "count the tests" moment to when the tests actually exist.
