### PR TITLE
--timeout 0 cant be reenabled by inner this.timeout(N)

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -734,6 +734,7 @@ Mocha.prototype.diff = function (diff) {
  */
 Mocha.prototype.timeout = function (msecs) {
   this.suite.timeout(msecs);
+  this.suite._userDisabledTimeouts = this.suite.timeout() === 0;
   return this;
 };
 

--- a/lib/runnable.mjs
+++ b/lib/runnable.mjs
@@ -22,6 +22,16 @@ var toString = Object.prototype.toString;
 
 var MAX_TIMEOUT = Math.pow(2, 31) - 1;
 
+/**
+ * Walk up to the root from node and report whether the root has been flagged as having timeouts disabled by the user (via Mocha.prototype.timeout(0) / CLI --timeout 0).
+ * inlined here, rather than imported from suite.mjs, to avoid a circular import, for example: suite.mjs and then to hook.mjs and then to runnable.mjs.
+ * @private
+ */
+function rootTimeoutsDisabled(node) {
+  while (node && node.parent) node = node.parent;
+  return Boolean(node && node._userDisabledTimeouts);
+}
+
 class Runnable extends EventEmitter {
   // "Additional properties" doc comment added for hosted docs (mochajs.org/api)
   /**
@@ -100,6 +110,10 @@ class Runnable extends EventEmitter {
     if (ms === range[0] || ms === range[1]) {
       this._timeout = 0;
     } else {
+      if (rootTimeoutsDisabled(this)) {
+        debug("timeout %d ignored: root timeouts disabled by user", ms);
+        return this;
+      }
       this._timeout = ms;
     }
     debug("timeout %d", this._timeout);

--- a/lib/suite.mjs
+++ b/lib/suite.mjs
@@ -217,6 +217,10 @@ class Suite extends EventEmitter {
     var INT_MAX = Math.pow(2, 31) - 1;
     var range = [0, INT_MAX];
     ms = clamp(ms, range);
+    if (ms !== 0 && !this.root && _rootTimeoutsDisabled(this)) {
+      debug("timeout %d ignored: root timeouts disabled by user", ms);
+      return this;
+    }
 
     debug("timeout %d", ms);
     this._timeout = parseInt(ms, 10);
@@ -667,4 +671,10 @@ class Suite extends EventEmitter {
   }
 }
 
-export { Suite };
+function _rootTimeoutsDisabled(runnableOrSuite) {
+  var node = runnableOrSuite;
+  while (node && node.parent) node = node.parent;
+  return Boolean(node && node._userDisabledTimeouts);
+}
+
+export { Suite, _rootTimeoutsDisabled };

--- a/test/integration/fixtures/options/timeout-zero-sticky.fixture.js
+++ b/test/integration/fixtures/options/timeout-zero-sticky.fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+
+describe('inner suite overrides', function () {
+  this.timeout(50);
+  it('should NOT time out when --timeout 0 was set globally', function (done) {
+    setTimeout(done, 200);
+  });
+});

--- a/test/integration/options/timeout.spec.js
+++ b/test/integration/options/timeout.spec.js
@@ -98,4 +98,19 @@ describe("--timeout", function () {
       },
     );
   });
+
+  it("should not be re-enabled by an inner `this.timeout(N)` (GH-4834)", function (done) {
+    runMochaJSON(
+      "options/timeout-zero-sticky",
+      ["--timeout", "0"],
+      function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, "to have passed").and("to have passed test count", 1);
+        done();
+      },
+    );
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4834 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR needs a bit more attention from maintainers because i had to look up a lot of stuff for this one, not a lot of code but a lot of searching and cross referencing was done instead and i think another PR introduced some issues that, i guess, maintainers did not see during review.
It turns out this.timeout(........) can accidentally override --timeout 0 which is supposed to fully disable timeouts.

After PR #4260, mocha only tracks the latest timeout value. so even if timeouts were disabled globally a later this.timeout(...) inside a test could turn them back on breaking expected behavior

A "timeouts disabled" flag at the root fixes. once --timeout 0 or mocha.timeout(0) is set decendant this.timeout(N > 0) calls are ignored. timeouts can still be re-enabled only from the toplevel API.

To keep it short: if you disable timeouts globally they stay disabled.