### PR TITLE
fix: surface global setup/teardown errors with a non-zero exit code

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1060,7 +1060,7 @@ Mocha.prototype.run = function (fn) {
 
   // Errors coming out of Runner#run itself remain uncaught/unhandled and are picked up by the `process` event listeners.
   // Only global fixture errors are intercepted above so they surface to the user instead of being silently "swallowed".
-// Also: returning anything other than `runner` would be a breaking change.
+  // Also: returning anything other than `runner` would be a breaking change.
   runAsync(runner).then(done);
 
   return runner;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1027,24 +1027,39 @@ Mocha.prototype.run = function (fn) {
     }
   };
 
+  const reportFixtureError = (phase, err) => {
+    process.stderr.write(
+      `\n[mocha] global ${phase} failed:\n${err && err.stack ? err.stack : err}\n`,
+    );
+  };
+
   const runAsync = async (runner) => {
-    const context =
-      this.options.enableGlobalSetup && this.hasGlobalSetupFixtures()
-        ? await this.runGlobalSetup(runner)
-        : {};
+    let context = {};
+    if (this.options.enableGlobalSetup && this.hasGlobalSetupFixtures()) {
+      try {
+        context = await this.runGlobalSetup(runner);
+      } catch (err) {
+        reportFixtureError("setup", err);
+        return 1;
+      }
+    }
     const failureCount = await runner.runAsync({
       files: this.files,
       options,
     });
     if (this.options.enableGlobalTeardown && this.hasGlobalTeardownFixtures()) {
-      await this.runGlobalTeardown(runner, { context });
+      try {
+        await this.runGlobalTeardown(runner, { context });
+      } catch (err) {
+        reportFixtureError("teardown", err);
+        return failureCount + 1;
+      }
     }
     return failureCount;
   };
 
-  // no "catch" here is intentional. errors coming out of
-  // Runner#run are considered uncaught/unhandled and caught
-  // by the `process` event listeners.
+  // errors coming out of Runner#run itself remain uncaught/unhandled and are picked up by the `process` event listeners.
+  // Only global fixture errors are intercepted above so they surface to the user instead of being silently "swallowed".
   // also: returning anything other than `runner` would be a breaking
   // change
   runAsync(runner).then(done);

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1058,10 +1058,9 @@ Mocha.prototype.run = function (fn) {
     return failureCount;
   };
 
-  // errors coming out of Runner#run itself remain uncaught/unhandled and are picked up by the `process` event listeners.
+  // Errors coming out of Runner#run itself remain uncaught/unhandled and are picked up by the `process` event listeners.
   // Only global fixture errors are intercepted above so they surface to the user instead of being silently "swallowed".
-  // also: returning anything other than `runner` would be a breaking
-  // change
+// Also: returning anything other than `runner` would be a breaking change.
   runAsync(runner).then(done);
 
   return runner;

--- a/test/integration/fixtures/plugins/global-fixtures/global-setup-throws.fixture.js
+++ b/test/integration/fixtures/plugins/global-fixtures/global-setup-throws.fixture.js
@@ -1,0 +1,9 @@
+"use strict";
+
+exports.mochaGlobalSetup = async function () {
+  throw new Error("setup kaboom");
+};
+
+exports.mochaGlobalTeardown = async function () {
+  console.log("teardown should not run");
+};

--- a/test/integration/fixtures/plugins/global-fixtures/global-teardown-throws.fixture.js
+++ b/test/integration/fixtures/plugins/global-fixtures/global-teardown-throws.fixture.js
@@ -1,0 +1,9 @@
+"use strict";
+
+exports.mochaGlobalSetup = async function () {
+  console.log("setup ran");
+};
+
+exports.mochaGlobalTeardown = async function () {
+  throw new Error("teardown kaboom");
+};

--- a/test/integration/plugins/global-fixtures.spec.js
+++ b/test/integration/plugins/global-fixtures.spec.js
@@ -81,7 +81,7 @@ describe("global setup/teardown", function () {
       });
     });
 
-    describe("when a global fixture throws (issue #5208)", function () {
+    describe("when a global fixture throws", function () {
       async function runWithFixture(fixturePath, extraArgs = []) {
         const [, promise] = invokeMochaAsync(
           [

--- a/test/integration/plugins/global-fixtures.spec.js
+++ b/test/integration/plugins/global-fixtures.spec.js
@@ -95,7 +95,7 @@ describe("global setup/teardown", function () {
         return promise;
       }
 
-      it("should exit non-zero and surface a teardown error", async function () {
+      it("should handle when global teardown throws", async function () {
         const res = await runWithFixture(
           "plugins/global-fixtures/global-teardown-throws",
         );
@@ -104,17 +104,11 @@ describe("global setup/teardown", function () {
           "to have failed with output",
           /\[mocha\] global teardown failed[\s\S]*teardown kaboom/,
         );
-      });
-
-      it("should preserve test results when teardown throws", async function () {
-        const res = await runWithFixture(
-          "plugins/global-fixtures/global-teardown-throws",
-        );
         expect(res.output, "to match", /setup ran/);
         expect(res.output, "to match", /1 passing/);
       });
 
-      it("should exit non-zero and surface a setup error", async function () {
+      it("should handle when global setup throws", async function () {
         const res = await runWithFixture(
           "plugins/global-fixtures/global-setup-throws",
         );
@@ -122,12 +116,6 @@ describe("global setup/teardown", function () {
           res,
           "to have failed with output",
           /\[mocha\] global setup failed[\s\S]*setup kaboom/,
-        );
-      });
-
-      it("should skip tests and teardown when setup throws", async function () {
-        const res = await runWithFixture(
-          "plugins/global-fixtures/global-setup-throws",
         );
         expect(res.output, "not to match", /teardown should not run/);
         expect(res.output, "not to match", /passing/);

--- a/test/integration/plugins/global-fixtures.spec.js
+++ b/test/integration/plugins/global-fixtures.spec.js
@@ -7,6 +7,7 @@ const {
   runMochaWatchAsync,
   copyFixture,
   DEFAULT_FIXTURE,
+  invokeMochaAsync,
   resolveFixturePath,
   createTempDir,
 } = require("../helpers");
@@ -77,6 +78,59 @@ describe("global setup/teardown", function () {
           "to contain once",
           /teardown: this.foo = 3/,
         );
+      });
+    });
+
+    describe("when a global fixture throws (issue #5208)", function () {
+      async function runWithFixture(fixturePath, extraArgs = []) {
+        const [, promise] = invokeMochaAsync(
+          [
+            "--require",
+            resolveFixturePath(fixturePath),
+            resolveFixturePath(DEFAULT_FIXTURE),
+            ...extraArgs,
+          ],
+          { stdio: "pipe" },
+        );
+        return promise;
+      }
+
+      it("should exit non-zero and surface a teardown error", async function () {
+        const res = await runWithFixture(
+          "plugins/global-fixtures/global-teardown-throws",
+        );
+        expect(
+          res,
+          "to have failed with output",
+          /\[mocha\] global teardown failed[\s\S]*teardown kaboom/,
+        );
+      });
+
+      it("should preserve test results when teardown throws", async function () {
+        const res = await runWithFixture(
+          "plugins/global-fixtures/global-teardown-throws",
+        );
+        expect(res.output, "to match", /setup ran/);
+        expect(res.output, "to match", /1 passing/);
+      });
+
+      it("should exit non-zero and surface a setup error", async function () {
+        const res = await runWithFixture(
+          "plugins/global-fixtures/global-setup-throws",
+        );
+        expect(
+          res,
+          "to have failed with output",
+          /\[mocha\] global setup failed[\s\S]*setup kaboom/,
+        );
+      });
+
+      it("should skip tests and teardown when setup throws", async function () {
+        const res = await runWithFixture(
+          "plugins/global-fixtures/global-setup-throws",
+        );
+        expect(res.output, "not to match", /teardown should not run/);
+        expect(res.output, "not to match", /passing/);
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5208
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When mochaGlobalSetup or mochaGlobalTeardown threw, the error escaped the runAsync(runner) promise chain and became an unhandled rejection. since there was no catch, "done" never ran, the failure never reached the runner, and mocha exited with code 0 while silently swallowing the error.

we now catch errors only at the runAsync boundary.
Normal runner errors are unchanged as before, only global fixture errors are handled here.