### PR TITLE
fix: split err.stack so embedded stacks in err message render once

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -402,36 +402,63 @@ var getFullErrorStack = function (err, seen) {
   }
 
   var message;
+  var usedInspect = false;
 
   if (typeof err.inspect === "function") {
     message = err.inspect() + "";
+    usedInspect = true;
   } else if (err.message && typeof err.message.toString === "function") {
     message = err.message + "";
   } else {
     message = "";
   }
 
-  var msg;
-  var stack = err.stack || message;
-  var index = message ? stack.indexOf(message) : -1;
-
-  if (index === -1) {
-    msg = message;
-  } else {
-    index += message.length;
-    msg = stack.slice(0, index);
-    // remove msg from stack
-    stack = stack.slice(index + 1);
-
-    if (err.cause) {
-      seen = seen || new Set();
-      seen.add(err);
-      const causeStack = getFullErrorStack(err.cause, seen);
-      stack +=
-        "\n   Caused by: " +
-        causeStack.msg +
-        (causeStack.stack ? "\n" + causeStack.stack : "");
+  var rawStack = err.stack || message;
+  var lines = rawStack.split("\n");
+  var lastLine = lines.length - 1;
+  while (lastLine >= 0 && lines[lastLine] === "") {
+    lastLine--;
+  }
+  var frameStart = lastLine + 1;
+  for (var i = lastLine; i >= 0; i--) {
+    if (/^\s+at\s/.test(lines[i])) {
+      frameStart = i;
+    } else {
+      break;
     }
+  }
+
+  var msg;
+  var stack;
+  var splitSucceeded = false;
+  if (frameStart <= lastLine) {
+    stack = lines.slice(frameStart, lastLine + 1).join("\n");
+    msg =
+      usedInspect || frameStart === 0
+        ? message
+        : lines.slice(0, frameStart).join("\n");
+    splitSucceeded = true;
+  } else {
+    var index = message ? rawStack.indexOf(message) : -1;
+    if (index === -1) {
+      msg = message;
+      stack = rawStack;
+    } else {
+      index += message.length;
+      msg = rawStack.slice(0, index);
+      stack = rawStack.slice(index + 1);
+      splitSucceeded = true;
+    }
+  }
+
+  if (splitSucceeded && err.cause) {
+    seen = seen || new Set();
+    seen.add(err);
+    const causeStack = getFullErrorStack(err.cause, seen);
+    stack +=
+      "\n   Caused by: " +
+      causeStack.msg +
+      (causeStack.stack ? "\n" + causeStack.stack : "");
   }
 
   return {

--- a/test/reporters/base.spec.cjs
+++ b/test/reporters/base.spec.cjs
@@ -491,6 +491,66 @@ describe("Base reporter", function () {
     expect(errOut, "to be", "1) test title:\n     Error\n  foo\n  bar");
   });
 
+  describe("message and stack splitting", function () {
+    it("should render the message and frames when the stack is only frames", function () {
+      var err = {
+        message: "Error",
+        stack: "    at foo (foo.js:1:1)\n    at bar (bar.js:2:2)",
+        showDiff: false,
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error\n      at foo (foo.js:1:1)\n      at bar (bar.js:2:2)",
+      );
+    });
+
+    it("should not duplicate an embedded stack when the message's frames are rewritten in the stack", function () {
+      var embeddedMessage =
+        "An error occured with following trace:\n\nError\n    at inner (/original/foo.js:1:1)";
+      var rewritten = embeddedMessage.replace(/\/original\//g, "/filtered/");
+      var err = {
+        message: embeddedMessage,
+        stack: "Error: " + rewritten + "\n    at runTest (lib/runner.js:1:1)",
+        showDiff: false,
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error: An error occured with following trace:\n\nError\n      at inner (/filtered/foo.js:1:1)\n      at runTest (lib/runner.js:1:1)",
+      );
+    });
+
+    it("should split identically when the rewritten stack has a trailing newline", function () {
+      var embeddedMessage =
+        "An error occured with following trace:\n\nError\n    at inner (/original/foo.js:1:1)";
+      var rewritten = embeddedMessage.replace(/\/original\//g, "/filtered/");
+      var err = {
+        message: embeddedMessage,
+        stack: "Error: " + rewritten + "\n    at runTest (lib/runner.js:1:1)\n",
+        showDiff: false,
+      };
+      var test = makeTest(err);
+      list([test]);
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error: An error occured with following trace:\n\nError\n      at inner (/filtered/foo.js:1:1)\n      at runTest (lib/runner.js:1:1)",
+      );
+    });
+  });
+
   describe("error causes", function () {
     it("should append any error cause trail to stack traces", function () {
       var err = {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3992
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

getFullErrorStack used to split err.stack by searching for err.message in it. that breaks when mocha filters stack traces and rewrites file paths, message stays unchanged but the stack changes so indexOf fails and the error gets printed twice (message + full stack).

What we do now is instead of matching the message string we now parse the stack the V8 way: treat the trailing "at ......." lines as the stack frames and everything above as the message. If the stack doesn't match V8 format we fall back to the old behavior.
We also keep err.inspect() overrides and err.cause chaining working as before. 