### PR TITLE
fix: handle EPERM symlink error on Windows non-admin sessions

### DIFF
--- a/test/integration/config.spec.js
+++ b/test/integration/config.spec.js
@@ -89,6 +89,8 @@ describe("config", function () {
           if (err.code === "EEXIST") {
             console.log("setup:", 'package already exists in "node_modules"');
             installedLocally = true;
+          } else if (err.code === "EPERM" && process.platform === "win32") {
+            console.log("setup:", "symlinks not available (non-admin Windows); skipping");
           } else {
             console.error("setup failed:", err);
           }


### PR DESCRIPTION
Fixes #5989

Why
On Windows accounts without "SeCreateSymbolicLinkPrivilege" (standard users without admin or Developer Mode), `fs.symlinkSync()` throws EPERM instead of EEXIST. The test setup only caught EEXIST, causing the error to fall through to a misleading console.error stack trace that looks like a real test failure.

Changes
Added an `EPERM && process.platform === "win32"` guard that gracefully logs that symlinks are unavailable and skips the dependent test, matching the existing pattern in `test/integration/file-utils.spec.js`.

Updated component: `test/integration/config.spec.js`

Testing
On Windows non-admin sessions, the before hook no longer emits a scary stack trace. The test continues without the symlinked config, exactly as intended.

Surface area
- Integration tests
- Bug fix
- Windows-specific