### PR TITLE
docs: modernize spies example, drop should.js

### DIFF
--- a/docs/src/content/docs/explainers/spies.mdx
+++ b/docs/src/content/docs/explainers/spies.mdx
@@ -3,7 +3,7 @@ description: How to use spies with Mocha for testing callbacks and function call
 title: Spies
 ---
 
-Mocha does not come equipped with spies, though libraries like [Sinon](https://github.com/sinonjs/sinon) provide this behaviour if desired. The following is an example of Mocha utilizing Sinon and [Should.js](https://github.com/shouldjs/should.js) to test an EventEmitter:
+Mocha does not come equipped with spies, though libraries like [Sinon](https://github.com/sinonjs/sinon) provide this behaviour if desired. The following is an example of Mocha utilizing Sinon to test an EventEmitter:
 
 ```javascript
 import sinon from "sinon";
@@ -17,7 +17,7 @@ describe("EventEmitter", function () {
 
       emitter.on("foo", spy);
       emitter.emit("foo");
-      spy.called.should.equal.true;
+      sinon.assert.calledOnce(spy);
     });
 
     it("should pass arguments to the callbacks", function () {
@@ -36,6 +36,9 @@ describe("EventEmitter", function () {
 The following is the same test, performed without any special spy library, utilizing the Mocha `done([err])` callback as a means to assert that the callback has occurred, otherwise resulting in a timeout. Note that Mocha only allows `done()` to be invoked once, and will otherwise error.
 
 ```javascript
+import { strict as assert } from "node:assert";
+import { EventEmitter } from "node:events";
+
 describe("EventEmitter", function () {
   describe("#emit()", function () {
     it("should invoke the callback", function (done) {
@@ -49,8 +52,8 @@ describe("EventEmitter", function () {
       const emitter = new EventEmitter();
 
       emitter.on("foo", function (a, b) {
-        a.should.equal("bar");
-        b.should.equal("baz");
+        assert.equal(a, "bar");
+        assert.equal(b, "baz");
         done();
       });
       emitter.emit("foo", "bar", "baz");


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: works on #5445
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The Spies explainer was flagged in #5445 as recommending should.js,
which has been deprecated since 2020. On a closer read the page also
contained syntactically broken examples:

- `spy.called.should.equal.true;` is a no-op (reads a property and
  drops the value); the correct should.js form would be
  `spy.called.should.be.true` or `spy.called.should.equal(true)`.
- The "without any special spy library" example claimed to use no
  library yet relied on `.should.equal(...)` from should.js.

This PR:

- Switches the first example to use sinon-only assertions
  (`sinon.assert.calledOnce`, `sinon.assert.calledWith`); the page
  already uses these on the second test in the same block.
- Switches the "no library" example to `node:assert`, matching the
  rest of the docs site (e.g. `getting-started.mdx` uses `node:assert`).
- Drops the should.js mention and link from the prose.

The broader audit of should.js mentions across other docs pages
remains tracked under #5445; this PR is intentionally scoped to the
spies explainer to keep the change focused.

No library code or workflow changes.

Note: #5445 is a meta-tracking issue per the maintainer's comment,
so this PR uses `fixes` to satisfy the PR template format but does
not aim to fully close the broader audit.
