### PR TITLE
fix: handle EPERM symlink error on Windows non-admin sessions

### DIFF
--- a/test/integration/config.spec.js
+++ b/test/integration/config.spec.js
@@ -89,6 +89,8 @@ describe("config", function () {
           if (err.code === "EEXIST") {
             console.log("setup:", 'package already exists in "node_modules"');
             installedLocally = true;
+          } else if (err.code === "EPERM" && process.platform === "win32") {
+            console.log("setup:", "symlinks not available (non-admin Windows); skipping");
           } else {
             console.error("setup failed:", err);
           }


### PR DESCRIPTION
Fixes #5989

On Windows systems without Administrator privileges or Developer Mode enabled, `fs.symlinkSync()` throws `EPERM` (errno: -4048) instead of the already-handled `EEXIST`. This causes a misleading "setup failed:" console.error message even though the dependent test is correctly skipped.

This fix adds an `EPERM` check for Windows, matching the pattern already used in `test/integration/file-utils.spec.js`.

---

- [x] Addresses an existing open issue: fixes #5989
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken
