### PR TITLE
chore: convert lib/nodejs/file-unloader.js to ESM

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -464,7 +464,8 @@ Mocha.unloadFile = function (file) {
       "unloadFile() is only supported in a Node.js environment",
     );
   }
-  return require("./nodejs/file-unloader").unloadFile(file);
+  const {unloadFile} = require("./nodejs/file-unloader.mjs");
+  return unloadFile(file);
 };
 
 /**

--- a/lib/nodejs/file-unloader.mjs
+++ b/lib/nodejs/file-unloader.mjs
@@ -1,15 +1,17 @@
-"use strict";
-
 /**
  * This module should not be in the browser bundle, so it's here.
  * @private
  * @module
  */
 
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+
 /**
  * Deletes a file from the `require` cache.
  * @param {string} file - File
  */
-exports.unloadFile = (file) => {
+export function unloadFile(file) {
   delete require.cache[require.resolve(file)];
-};
+}

--- a/package.json
+++ b/package.json
@@ -176,12 +176,12 @@
     "supports-color": false,
     "./lib/nodejs/buffered-worker-pool.js": false,
     "./lib/nodejs/esm-utils.js": false,
-    "./lib/nodejs/file-unloader.js": false,
     "./lib/nodejs/parallel-buffered-runner.js": false,
     "./lib/nodejs/serializer.js": false,
     "./lib/nodejs/worker.js": false,
     "./lib/nodejs/reporters/parallel-buffered.js": false,
-    "./lib/cli/index.js": false
+    "./lib/cli/index.js": false,
+    "./lib/nodejs/file-unloader.mjs": false
   },
   "overrides": {
     "@types/eslint": "^9.6.1",


### PR DESCRIPTION
Closes #6010.

Converts `lib/nodejs/file-unloader.js` from CommonJS to ESM, following the conventions in AGENTS.md.

**Changes:**
- Renamed `lib/nodejs/file-unloader.js` → `lib/nodejs/file-unloader.mjs`
- Converted `exports.unloadFile` to `export function unloadFile`
- Used `import {createRequire} from 'node:module'` for `require.cache` / `require.resolve` interop
- Updated `lib/mocha.js` call site to use destructured named import from `.mjs`
- Updated `package.json` browser field reference

Note: `require.cache` is used internally to manage test file module cache. In ESM, we use `createRequire` to obtain a compatible `require` function for this purpose, which is the standard Node.js approach for incremental CJS-to-ESM migration.