### PR TITLE
docs: clarify supported mocha version for ESM configuration 

### DIFF
--- a/docs/src/content/docs/running/configuring.mdx
+++ b/docs/src/content/docs/running/configuring.mdx
@@ -13,6 +13,7 @@ or the `.mjs` file extension.
 :::
 
 Mocha supports configuration files, typical of modern command-line tools, in several formats:
+
 - **JavaScript**: Create a `.mocharc.js` (or `.mocharc.cjs` when using [`"type"="module"`](#nodejs-native-esm-support) in your `package.json`)
 - **YAML**: Create a `.mocharc.yaml` (or `.mocharc.yml`) in your project's root directory.
 - **JSON**: Create a `.mocharc.json` (or `.mocharc.jsonc`) in your project's root directory.

--- a/docs/src/content/docs/running/configuring.mdx
+++ b/docs/src/content/docs/running/configuring.mdx
@@ -3,14 +3,17 @@ description: Configuration options and files across several formats.
 title: Configuring Mocha (Node.js)
 ---
 
+:::note[New in v12.0.0]
+:::
+
+Mocha added support for ESM configuration files (`export default  {/* ... */}`) when using [`"type"="module"`](#nodejs-native-esm-support) in your `package.json`
+or the `.mjs` file extension.
+
 :::note[New in v6.0.0]
 :::
 
 Mocha supports configuration files, typical of modern command-line tools, in several formats:
-
-- **JavaScript**: Create a `.mocharc.js` (or `.mocharc.cjs` when using [`"type"="module"`](/explainers/nodejs-native-esm-support) in your `package.json`)
-  in your project's root directory, and export an object (`module.exports = {/* ... */}`) containing your configuration. For native ESM and using `type="module"`
-  or using `.mjs`, use a default export (`export default  {/* ... */}`).
+- **JavaScript**: Create a `.mocharc.js` (or `.mocharc.cjs` when using [`"type"="module"`](#nodejs-native-esm-support) in your `package.json`)
 - **YAML**: Create a `.mocharc.yaml` (or `.mocharc.yml`) in your project's root directory.
 - **JSON**: Create a `.mocharc.json` (or `.mocharc.jsonc`) in your project's root directory.
   Comments--while not valid JSON--are allowed in this file, and will be ignored by Mocha.


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5049 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per https://github.com/mochajs/mocha/pull/5397/changes#r3316100857, it did seem a bit misleading around Mocha's support for ESM configuration files.  To help address this:
1. Restore previous v6.0.0 contents
1. Added a new _"New in v12.0.0"_ section specifically for ESM config support

<img width="839" height="511" alt="new config docs preview" src="https://github.com/user-attachments/assets/1475067b-e5de-41c2-9219-16528269d3cd" />