### PR TITLE
fix: surface ts-node compile errors

### DIFF
--- a/lib/nodejs/esm-utils.js
+++ b/lib/nodejs/esm-utils.js
@@ -98,6 +98,9 @@ const requireModule = async (file, esmDecorator) => {
     return require(file);
   } catch (requireErr) {
     debug("requireModule caught err: %O", requireErr.message);
+    if (requireErr.name === "TSError") {
+      throw requireErr;
+    }
     try {
       return dealWithExports(await formattedImport(file, esmDecorator));
     } catch (importErr) {

--- a/test/node-unit/esm-utils.spec.js
+++ b/test/node-unit/esm-utils.spec.js
@@ -34,6 +34,20 @@ describe("esm-utils", function () {
         },
       );
     });
+
+    it("should surface the ts-node TSError error rather than falling back to `import(...)`", async function () {
+      return expect(
+        () =>
+          esmUtils.requireOrImport(
+            "../../test/node-unit/fixtures/mock-ts-node-compile-err.ts",
+          ),
+        "to be rejected with error satisfying",
+        {
+          name: "TSError",
+          message: /A TS compilation error/,
+        },
+      );
+    });
   });
 
   describe("loadFilesAsync()", function () {

--- a/test/node-unit/fixtures/mock-ts-node-compile-err.ts
+++ b/test/node-unit/fixtures/mock-ts-node-compile-err.ts
@@ -1,0 +1,13 @@
+/*
+ Stripped down version of this error from ts-node:
+ https://github.com/TypeStrong/ts-node/blob/ddb05ef23be92a90c3ecac5a0220435c65ebbd2a/src/index.ts#L435
+ It's thrown when ts-node hits a compilation error.
+ */
+class TSError extends Error {
+  constructor(...args) {
+    super(...args);
+
+    this.name = "TSError";
+  }
+}
+throw new TSError("A TS compilation error");


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->


## PR Checklist

- [x] Addresses an existing open issue: fixes #6029
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Backport of #5572 to the `v11.x` line, addressing #6029 where a `.ts` module containing a compile error surfaces a misleading "Cannot find module" message instead of the real ts-node `TSError`.