### PR TITLE
fix: require serializer.mjs in parallel worker pool files

### DIFF
--- a/lib/nodejs/buffered-worker-pool.js
+++ b/lib/nodejs/buffered-worker-pool.js
@@ -15,7 +15,7 @@
 
 const serializeJavascript = require("serialize-javascript");
 const workerpool = require("workerpool");
-const { deserialize } = require("./serializer");
+const { deserialize } = require("./serializer.mjs");
 const debug = require("debug")("mocha:parallel:buffered-worker-pool");
 const { createInvalidArgumentTypeError } = require("../errors.mjs");
 

--- a/lib/nodejs/reporters/parallel-buffered.js
+++ b/lib/nodejs/reporters/parallel-buffered.js
@@ -33,7 +33,7 @@ const {
 const {
   SerializableEvent,
   SerializableWorkerResult,
-} = require("../serializer");
+} = require("../serializer.mjs");
 const debug = require("debug")("mocha:reporters:buffered");
 const { Base } = require("../../reporters/base.mjs");
 

--- a/test/node-unit/serializer.spec.js
+++ b/test/node-unit/serializer.spec.js
@@ -6,7 +6,7 @@ const {
   deserialize,
   SerializableEvent,
   SerializableWorkerResult,
-} = require("../../lib/nodejs/serializer");
+} = require("../../lib/nodejs/serializer.mjs");
 
 describe("serializer", function () {
   afterEach(function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6054
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

#6011 renamed lib/nodejs/serializer.js to serializer.mjs and updated one of its three consumers (lib/nodejs/worker.js), but the other two still require the module without an extension. CommonJS resolution never tries .mjs, so both requires fail unconditionally, and as of 12.0.0-beta-9.5 any --parallel run crashes at startup with Cannot find module './serializer' (see #6054 for a minimal reproduction).

This PR updates the three remaining stale requires to reference ./serializer.mjs explicitly, mirroring what worker.js already does:

- lib/nodejs/buffered-worker-pool.js — loaded in the main process via Mocha.parallelMode(); this is the startup crash.
- lib/nodejs/reporters/parallel-buffered.js — loaded in the worker processes; masked by the first failure until that one is fixed.
- test/node-unit/serializer.spec.js — the serializer spec itself cannot currently load on main for the same reason (its sibling worker.spec.js was already updated in #6011).

require() of a synchronous ESM graph is supported at Mocha's engines floor (^20.19.0 || >=22.12.0), so no loader changes are needed. Verified by applying the two lib/ changes to the published 12.0.0-beta-9.5 package: --parallel goes from the startup crash to passing, and serial runs are unaffected.

No new test is added: the fix makes the existing serializer spec loadable again, and any parallel-mode integration test exercises the repaired path by construction. #5969 (converting the worker-pool files themselves to ESM) will subsume these requires eventually; this is the minimal interim fix so the next beta doesn't ship with parallel mode unusable.
