### PR TITLE
fix: serialize parallel test results without mutating user objects

### DIFF
--- a/lib/nodejs/serializer.js
+++ b/lib/nodejs/serializer.js
@@ -11,14 +11,294 @@
  * @typedef {import('../types.d.ts').SerializedWorkerResult} SerializedWorkerResult
  */
 
-const { type, breakCircularDeps } = require("../utils");
+const { type, getMochaID, uniqueID } = require("../utils");
 const { createInvalidArgumentTypeError } = require("../errors");
 // this is not named `mocha:parallel:serializer` because it's noisy and it's
 // helpful to be able to write `DEBUG=mocha:parallel*` and get everything else.
 const debug = require("debug")("mocha:serializer");
 
 const SERIALIZABLE_RESULT_NAME = "SerializableWorkerResult";
-const SERIALIZABLE_TYPES = new Set(["object", "array", "function", "error"]);
+
+/**
+ * Placeholder written into the serialized output where the input contains a
+ * reference back to one of its own ancestors (a true cycle).
+ */
+const CIRCULAR = "[Circular]";
+
+/**
+ * Placeholder written into the serialized output where copying stopped
+ * because the input graph exceeded {@link MAX_NODES} or {@link MAX_DEPTH}.
+ */
+const TRUNCATED = "[Truncated]";
+
+/**
+ * Maximum number of objects/arrays/errors copied per event. Bounds total work
+ * on pathological graphs (e.g., accessors which mint fresh objects on every
+ * read, defeating identity-based cycle detection).
+ */
+const MAX_NODES = 10000;
+
+/**
+ * Maximum nesting depth copied per event. The IPC channel JSON-stringifies
+ * the result, which overflows the call stack at a few thousand levels; this
+ * keeps the output well clear of that limit on all supported platforms.
+ */
+const MAX_DEPTH = 256;
+
+/**
+ * Returns `parent[key]`, or `fallback` if reading the property throws
+ * (e.g., a throwing getter or a revoked `Proxy`).
+ * @ignore
+ */
+function safeRead(parent, key, fallback) {
+  try {
+    return parent[key];
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Returns `true` if `key` is an own enumerable property of `obj`.
+ * @ignore
+ */
+function isOwnEnumerable(obj, key) {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+    return Boolean(descriptor && descriptor.enumerable);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Used internally by {@link copySerializableData}; routes a child value
+ * either directly into the output slot or onto the stack for copying.
+ * Creates the output slot immediately so that key order (and thus the wire
+ * format) matches the input's own-key order.
+ * @ignore
+ */
+function copyChild(outParent, key, value, stack, depth) {
+  const valueType = type(value);
+  if (valueType === "function") {
+    // we _may_ want to dig in to functions for some assertion libraries
+    // that might put a usable property on a function.
+    // for now, just omit it.
+    return;
+  }
+  if (valueType === "bigint") {
+    // a BigInt anywhere in the result makes the IPC channel's
+    // `JSON.stringify` throw, losing the entire result batch
+    outParent[key] = String(value);
+    return;
+  }
+  if (
+    valueType === "object" ||
+    valueType === "array" ||
+    valueType === "error"
+  ) {
+    if (depth > MAX_DEPTH) {
+      outParent[key] = TRUNCATED;
+      return;
+    }
+    outParent[key] = undefined; // reserve the slot to fix key order
+    stack.push({ parent: outParent, key, value, depth });
+  } else {
+    outParent[key] = value;
+  }
+}
+
+/**
+ * Builds a fresh, JSON-safe deep copy of `input` without ever mutating
+ * `input` nor anything reachable from it.
+ *
+ * This is recursion in loop form (depth-first, using an explicit stack of
+ * "frames"); a frame describes a slot (`parent[key]`) in the *output* tree
+ * and the *input* value whose transformed copy belongs in that slot.
+ * @ignore
+ * @param {*} input - Value to copy
+ * @param {{nodes: number}} budget - Shared object/array/error count, capped
+ * at {@link MAX_NODES}
+ */
+function copySerializableData(input, budget) {
+  const root = { out: undefined };
+  // `path` contains input objects on the current depth-first path; a
+  // back-reference to any of them is a true cycle and becomes '[Circular]'.
+  const path = new Set();
+  const stack = [{ parent: root, key: "out", value: input, depth: 0 }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+
+    if (frame.exit) {
+      // finished copying everything beneath this input object
+      path.delete(frame.value);
+      continue;
+    }
+
+    let value = frame.value;
+    let valueType = type(value);
+
+    if (valueType === "object" && !frame.skipToJSON) {
+      // an object exposing a `serialize` method knows how to make itself
+      // JSON-safe; trust its output verbatim (mocha's `Runnable`s do this)
+      if (type(safeRead(value, "serialize")) === "function") {
+        frame.parent[frame.key] = value.serialize();
+        continue;
+      }
+      // otherwise mimic what `JSON.stringify` (used by the IPC channel)
+      // would have done with a `toJSON` method, then copy its output.
+      // an own enumerable `toJSON` is just a function-valued prop, which the
+      // walk omits before the IPC channel could ever call it; only inherited
+      // or non-enumerable implementations (e.g. `Date`, `Buffer`) are honored
+      if (
+        type(safeRead(value, "toJSON")) === "function" &&
+        !isOwnEnumerable(value, "toJSON")
+      ) {
+        try {
+          value = value.toJSON(String(frame.key));
+        } catch {
+          continue; // omit, rather than abort the whole batch
+        }
+        stack.push({
+          parent: frame.parent,
+          key: frame.key,
+          value,
+          depth: frame.depth,
+          skipToJSON: true, // `JSON.stringify` does not re-apply `toJSON`
+        });
+        continue;
+      }
+    }
+
+    if (valueType === "error") {
+      if (path.has(value)) {
+        frame.parent[frame.key] = CIRCULAR;
+        continue;
+      }
+      budget.nodes += 1;
+      if (budget.nodes > MAX_NODES) {
+        frame.parent[frame.key] = TRUNCATED;
+        continue;
+      }
+      // we need to reference the `stack` prop b/c it's lazily-loaded.
+      // `__type` is necessary for deserialization to create an `Error` later.
+      // `message` is not enumerable, so we must handle it specifically.
+      const out = Object.create(null);
+      frame.parent[frame.key] = out;
+      path.add(value);
+      stack.push({ exit: true, value });
+      // own enumerable props first, then stack/message/__type --
+      // matches the previous `Object.assign()`-based key order on the wire
+      for (const key of Object.keys(value)) {
+        copyChild(out, key, safeRead(value, key), stack, frame.depth + 1);
+      }
+      out.stack = safeRead(value, "stack");
+      out.message = safeRead(value, "message");
+      out.__type = "Error";
+      // `cause` is an own non-enumerable prop when set via the `Error`
+      // constructor; reporters render cause chains, so carry it explicitly
+      if (
+        !isOwnEnumerable(value, "cause") &&
+        Object.getOwnPropertyDescriptor(value, "cause")
+      ) {
+        copyChild(
+          out,
+          "cause",
+          safeRead(value, "cause"),
+          stack,
+          frame.depth + 1,
+        );
+      }
+    } else if (valueType === "object") {
+      if (path.has(value)) {
+        frame.parent[frame.key] = CIRCULAR;
+        continue;
+      }
+      budget.nodes += 1;
+      if (budget.nodes > MAX_NODES) {
+        frame.parent[frame.key] = TRUNCATED;
+        continue;
+      }
+      const out = Object.create(null);
+      frame.parent[frame.key] = out;
+      path.add(value);
+      stack.push({ exit: true, value });
+      let keys;
+      try {
+        keys = Object.keys(value);
+      } catch {
+        keys = []; // e.g., a revoked Proxy
+      }
+      for (const key of keys) {
+        copyChild(out, key, safeRead(value, key), stack, frame.depth + 1);
+      }
+    } else if (valueType === "array") {
+      if (path.has(value)) {
+        frame.parent[frame.key] = CIRCULAR;
+        continue;
+      }
+      budget.nodes += 1;
+      if (budget.nodes > MAX_NODES) {
+        frame.parent[frame.key] = TRUNCATED;
+        continue;
+      }
+      const out = [];
+      frame.parent[frame.key] = out;
+      path.add(value);
+      stack.push({ exit: true, value });
+      for (let idx = 0; idx < value.length; idx++) {
+        const item = safeRead(value, idx, null);
+        if (type(item) === "function") {
+          // `JSON.stringify` (the IPC channel) used to turn leaked array
+          // members of type function into `null`; keep the wire identical
+          out[idx] = null;
+        } else {
+          copyChild(out, idx, item, stack, frame.depth + 1);
+        }
+      }
+      out.length = value.length; // preserve trailing holes
+    } else if (valueType === "function") {
+      // a bare function (only reachable here as the root value); omit it
+      delete frame.parent[frame.key];
+    } else if (valueType === "bigint") {
+      frame.parent[frame.key] = String(value);
+    } else {
+      // primitives are handed to the IPC channel as-is, exactly as before
+      frame.parent[frame.key] = value;
+    }
+  }
+
+  return root.out;
+}
+
+/**
+ * Builds a stand-in for an event which could not be serialized, so that a
+ * single pathological event cannot cause every event of the test file run to
+ * be lost. The stand-in has the same `eventName` (so suite bookkeeping in the
+ * main process stays balanced) and explains the failure via its `error`.
+ * @ignore
+ */
+function createFallbackEvent(event, err) {
+  const data = Object.assign(Object.create(null), {
+    title: safeRead(safeRead(event, "originalValue", {}) || {}, "title"),
+    __mocha_id__: getMochaID(safeRead(event, "originalValue")) || uniqueID(),
+  });
+  const error = Object.assign(Object.create(null), {
+    message: `Mocha was unable to serialize an event ("${
+      event.eventName
+    }") emitted by a worker process: ${err && err.message}`,
+    stack: err && err.stack,
+    __type: "Error",
+  });
+  return Object.freeze(
+    Object.assign(Object.create(null), {
+      eventName: event.eventName,
+      data,
+      error,
+    }),
+  );
+}
 
 /**
  * The serializable result of a test file run from a worker.
@@ -70,11 +350,19 @@ class SerializableWorkerResult {
   /**
    * Serializes each {@link SerializableEvent} in our `events` prop;
    * makes this object read-only.
+   *
+   * An event which cannot be serialized is replaced by a stand-in describing
+   * the problem, rather than losing every event of the file's run.
    * @returns {Readonly<SerializableWorkerResult>}
    */
   serialize() {
-    this.events.forEach((event) => {
-      event.serialize();
+    this.events = this.events.map((event) => {
+      try {
+        return event.serialize();
+      } catch (err) {
+        debug("failed to serialize a %s event: %O", event.eventName, err);
+        return createFallbackEvent(event, err);
+      }
     });
     return Object.freeze(this);
   }
@@ -188,100 +476,26 @@ class SerializableEvent {
   }
 
   /**
-   * Used internally by {@link SerializableEvent#serialize}.
-   * @ignore
-   * @param {Array<object|string>} pairs - List of parent/key tuples to process; modified in-place. This JSDoc type is an approximation
-   * @param {object} parent - Some parent object
-   * @param {string} key - Key to inspect
-   */
-  static _serialize(pairs, parent, key) {
-    let value = parent[key];
-    let _type = type(value);
-    if (_type === "error") {
-      // we need to reference the stack prop b/c it's lazily-loaded.
-      // `__type` is necessary for deserialization to create an `Error` later.
-      // `message` is apparently not enumerable, so we must handle it specifically.
-      value = Object.assign(Object.create(null), value, {
-        stack: value.stack,
-        message: value.message,
-        __type: "Error",
-      });
-      parent[key] = value;
-      // after this, set the result of type(value) to be `object`, and we'll throw
-      // whatever other junk is in the original error into the new `value`.
-      _type = "object";
-    }
-    switch (_type) {
-      case "object":
-        if (type(value.serialize) === "function") {
-          parent[key] = value.serialize();
-        } else {
-          // by adding props to the `pairs` array, we will process it further
-          pairs.push(
-            ...Object.keys(value)
-              .filter((key) => SERIALIZABLE_TYPES.has(type(value[key])))
-              .map((key) => [value, key]),
-          );
-        }
-        break;
-      case "function":
-        // we _may_ want to dig in to functions for some assertion libraries
-        // that might put a usable property on a function.
-        // for now, just zap it.
-        delete parent[key];
-        break;
-      case "array":
-        pairs.push(
-          ...value
-            .filter((value) => SERIALIZABLE_TYPES.has(type(value)))
-            .map((value, index) => [value, index]),
-        );
-        break;
-    }
-  }
-
-  /**
-   * Modifies this object *in place* (for theoretical memory consumption &
-   * performance reasons); serializes `SerializableEvent#originalValue` (placing
-   * the result in `SerializableEvent#data`) and `SerializableEvent#error`.
-   * Freezes this object. The result is an object that can be transmitted over
-   * IPC.
-   * If this quickly becomes unmaintainable, we will want to move towards immutable
-   * objects post-haste.
+   * Computes JSON-safe copies of `SerializableEvent#originalValue` (placing
+   * the result in `SerializableEvent#data`) and
+   * `SerializableEvent#originalError` (placing the result in
+   * `SerializableEvent#error`), then freezes this object. The result is an
+   * object that can be transmitted over IPC.
+   *
+   * Unlike previous implementations, this _never modifies_ `originalValue`
+   * nor `originalError`, nor anything reachable from them.
    */
   serialize() {
-    // given a parent object and a key, inspect the value and decide whether
-    // to replace it, remove it, or add it to our `pairs` array to further process.
-    // this is recursion in loop form.
+    const budget = { nodes: 0 };
     const originalValue = this.originalValue;
-    const result = Object.assign(Object.create(null), {
-      data:
-        type(originalValue) === "object" &&
-        type(originalValue.serialize) === "function"
-          ? originalValue.serialize()
-          : originalValue,
-      error: this.originalError,
-    });
-
-    // mutates the object
-    breakCircularDeps(result.error);
-
-    const pairs = Object.keys(result).map((key) => [result, key]);
-    const seenPairs = new Set();
-    let pair;
-
-    while ((pair = pairs.shift())) {
-      if (seenPairs.has(pair[1])) {
-        continue;
-      }
-
-      seenPairs.add(pair[1]);
-      SerializableEvent._serialize(pairs, ...pair);
-    }
-
-    this.data = result.data;
-    this.error = result.error;
-
+    this.data = copySerializableData(
+      type(originalValue) === "object" &&
+        type(safeRead(originalValue, "serialize")) === "function"
+        ? originalValue.serialize()
+        : originalValue,
+      budget,
+    );
+    this.error = copySerializableData(this.originalError, budget);
     return Object.freeze(this);
   }
 

--- a/test/node-unit/serializer.spec.js
+++ b/test/node-unit/serializer.spec.js
@@ -106,7 +106,7 @@ describe("serializer", function () {
 
     describe("instance method", function () {
       describe("serialize", function () {
-        it("should mutate the instance in-place", function () {
+        it("should return the same instance", function () {
           const evt = SerializableEvent.create("foo");
           expect(evt.serialize(), "to be", evt);
         });
@@ -142,7 +142,7 @@ describe("serializer", function () {
         });
 
         describe("when passed an object containing a non-`serialize` method", function () {
-          it("should remove the method", function () {
+          it("should omit the method from the serialized data", function () {
             const obj = {
               func: () => {},
             };
@@ -537,6 +537,343 @@ describe("serializer", function () {
           "to have readonly property",
           "__type",
         );
+      });
+    });
+  });
+
+  describe("non-mutating serialization", function () {
+    describe("SerializableEvent", function () {
+      it("should not mutate objects reachable from the error", function () {
+        const lib = { fn: () => {}, constant: 42 };
+        Object.defineProperty(lib, "locked", {
+          get: () => () => {},
+          enumerable: true,
+          configurable: false,
+        });
+        const err = new Error("boom");
+        err.appState = { lib };
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(typeof lib.fn, "to be", "function");
+        expect(
+          Object.getOwnPropertyDescriptor(lib, "locked").get,
+          "to be a",
+          "function",
+        );
+        expect(evt.error.appState.lib.constant, "to be", 42);
+        expect(evt.error.appState.lib, "not to have property", "fn");
+        expect(evt.error.appState.lib, "not to have property", "locked");
+      });
+
+      it("should not mutate the real crypto module", function () {
+        const crypto = require("node:crypto");
+        const propCountBefore = Object.getOwnPropertyNames(crypto).length;
+        const err = new Error("boom");
+        err.lib = crypto;
+
+        expect(
+          () => SerializableEvent.create("fail", {}, err).serialize(),
+          "not to throw",
+        );
+
+        expect(typeof crypto.randomBytes, "to be", "function");
+        expect(typeof crypto.createHash, "to be", "function");
+        expect(typeof crypto.getRandomValues, "to be", "function");
+        expect(
+          Object.getOwnPropertyNames(crypto).length,
+          "to be",
+          propCountBefore,
+        );
+      });
+
+      it("should not throw when the data contains frozen objects with function props", function () {
+        const data = { frozen: Object.freeze({ fn: () => {}, keep: "me" }) };
+
+        const evt = SerializableEvent.create("event", data).serialize();
+
+        expect(evt.data.frozen.keep, "to be", "me");
+        expect(evt.data.frozen, "not to have property", "fn");
+        expect(typeof data.frozen.fn, "to be", "function");
+      });
+
+      it("should not break on ESM module namespace objects", async function () {
+        const namespace = await import("node:crypto");
+        const err = new Error("boom");
+        err.deep = { mod: namespace };
+
+        expect(
+          () => SerializableEvent.create("fail", {}, err).serialize(),
+          "not to throw",
+        );
+
+        expect(typeof namespace.randomBytes, "to be", "function");
+      });
+
+      it('should replace cycles with "[Circular]" without mutating the original', function () {
+        const node = { name: "a" };
+        node.self = node;
+        const err = new Error("boom");
+        err.node = node;
+        const data = { items: [] };
+        data.items.push(data);
+
+        const evt = SerializableEvent.create("fail", data, err).serialize();
+
+        expect(evt.error.node.self, "to be", "[Circular]");
+        expect(evt.data.items[0], "to be", "[Circular]");
+        expect(node.self, "to be", node);
+        expect(data.items[0], "to be", data);
+        expect(() => JSON.stringify(evt.data), "not to throw");
+      });
+
+      it("should serialize same-named properties on sibling objects", function () {
+        const value = {
+          one: { mistake: new Error("first") },
+          two: { mistake: new Error("second") },
+          nested: { data: { marker: 1 }, error: { marker: 2 } },
+        };
+
+        const evt = SerializableEvent.create("event", value).serialize();
+
+        expect(evt.data.one.mistake.__type, "to be", "Error");
+        expect(evt.data.two.mistake.__type, "to be", "Error");
+        expect(evt.data.two.mistake.message, "to be", "second");
+        expect(evt.data.nested.data.marker, "to be", 1);
+        expect(evt.data.nested.error.marker, "to be", 2);
+      });
+
+      it("should serialize array contents", function () {
+        const err = new Error("boom");
+        err.multiple = [
+          new Error("second"),
+          () => {},
+          { fn: () => {}, keep: 1 },
+        ];
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(evt.error.multiple[0].__type, "to be", "Error");
+        expect(evt.error.multiple[0].message, "to be", "second");
+        expect(evt.error.multiple[1], "to be", null);
+        expect(evt.error.multiple[2].keep, "to be", 1);
+        expect(evt.error.multiple[2], "not to have property", "fn");
+        expect(err.multiple[0], "to be an", Error);
+        expect(typeof err.multiple[2].fn, "to be", "function");
+      });
+
+      it("should normalize BigInt values", function () {
+        const err = new Error("boom");
+        err.big = BigInt(10);
+        err.nested = { big: BigInt(20) };
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(evt.error.big, "to be", "10");
+        expect(evt.error.nested.big, "to be", "20");
+        expect(() => JSON.stringify(evt.error), "not to throw");
+      });
+
+      it("should omit properties whose getters throw", function () {
+        const obj = { keep: "me" };
+        Object.defineProperty(obj, "bad", {
+          get: () => {
+            throw new Error("nope");
+          },
+          enumerable: true,
+          configurable: true,
+        });
+        const err = new Error("boom");
+        err.obj = obj;
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(evt.error.obj.keep, "to be", "me");
+        expect(evt.error.obj, "not to have property", "bad");
+      });
+
+      it("should invoke getters exactly once", function () {
+        const get = sinon.stub().returns("value");
+        const obj = {};
+        Object.defineProperty(obj, "prop", {
+          get,
+          enumerable: true,
+          configurable: true,
+        });
+
+        SerializableEvent.create("event", { obj }).serialize();
+
+        expect(get, "was called once");
+      });
+
+      it("should honor inherited toJSON but not own enumerable toJSON", function () {
+        const when = new Date(0);
+        const own = { toJSON: () => "custom", keep: 1 };
+
+        const evt = SerializableEvent.create("event", {
+          when,
+          own,
+        }).serialize();
+
+        expect(evt.data.when, "to be", "1970-01-01T00:00:00.000Z");
+        expect(evt.data.own.keep, "to be", 1);
+        expect(evt.data.own, "not to have property", "toJSON");
+      });
+
+      it("should carry a constructor-form error cause", function () {
+        const cause = new Error("root cause");
+        const err = new Error("top", { cause });
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(evt.error.cause.__type, "to be", "Error");
+        expect(evt.error.cause.message, "to be", "root cause");
+        expect(err.cause, "to be", cause);
+      });
+
+      it('should serialize a self-referential cause as "[Circular]"', function () {
+        const err = new Error("top");
+        Object.defineProperty(err, "cause", {
+          value: err,
+          enumerable: false,
+          configurable: true,
+        });
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(evt.error.cause, "to be", "[Circular]");
+      });
+
+      it("should keep message and stack of an AggregateError and drop its errors", function () {
+        const err = new AggregateError([new Error("inner")], "agg");
+
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+
+        expect(evt.error.message, "to be", "agg");
+        expect(evt.error.__type, "to be", "Error");
+        expect(evt.error, "not to have property", "errors");
+      });
+
+      it("should truncate beyond the depth cap", function () {
+        const root = {};
+        let current = root;
+        for (let i = 0; i < 300; i++) {
+          current.next = {};
+          current = current.next;
+        }
+        current.tip = "end";
+
+        const evt = SerializableEvent.create("event", {
+          chain: root,
+        }).serialize();
+
+        expect(JSON.stringify(evt.data), "to contain", '"[Truncated]"');
+      });
+
+      it("should terminate on lazily-infinite getter chains", function () {
+        const lazyNode = () => {
+          const obj = {};
+          Object.defineProperty(obj, "next", {
+            get: () => lazyNode(),
+            enumerable: true,
+            configurable: true,
+          });
+          return obj;
+        };
+
+        const evt = SerializableEvent.create("event", {
+          chain: lazyNode(),
+        }).serialize();
+
+        expect(JSON.stringify(evt.data), "to contain", '"[Truncated]"');
+      });
+
+      it("should bound work on self-expanding object graphs", function () {
+        const mintProxy = () =>
+          new Proxy(
+            {},
+            {
+              ownKeys: () => ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+              getOwnPropertyDescriptor: () => ({
+                enumerable: true,
+                configurable: true,
+              }),
+              get: (target, key) =>
+                key === "serialize" || key === "toJSON"
+                  ? undefined
+                  : mintProxy(),
+            },
+          );
+
+        const evt = SerializableEvent.create("event", {
+          graph: mintProxy(),
+        }).serialize();
+
+        expect(() => JSON.stringify(evt.data), "not to throw");
+      });
+    });
+
+    describe("SerializableWorkerResult", function () {
+      it("should substitute a fallback event when one event cannot be serialized", function () {
+        const good = SerializableEvent.create("pass", { title: "ok" });
+        const bad = SerializableEvent.create("fail", {
+          nested: {
+            serialize: () => {
+              throw new Error("cannot");
+            },
+          },
+        });
+
+        const result = SerializableWorkerResult.create(
+          [good, bad],
+          1,
+        ).serialize();
+
+        expect(result.events.length, "to be", 2);
+        expect(result.events[0].data.title, "to be", "ok");
+        expect(result.events[1].eventName, "to be", "fail");
+        expect(
+          result.events[1].error.message,
+          "to contain",
+          "unable to serialize",
+        );
+        expect(() => JSON.stringify(result), "not to throw");
+      });
+
+      it("should serialize the same error attached to two events consistently", function () {
+        const lib = { fn: () => {} };
+        const err = new Error("boom");
+        err.lib = lib;
+        const eventOne = SerializableEvent.create("fail", { title: "t" }, err);
+        const eventTwo = SerializableEvent.create(
+          "test end",
+          { title: "t" },
+          err,
+        );
+
+        const result = SerializableWorkerResult.create(
+          [eventOne, eventTwo],
+          1,
+        ).serialize();
+
+        expect(typeof lib.fn, "to be", "function");
+        expect(result.events[0].error.message, "to be", "boom");
+        expect(result.events[1].error.message, "to be", "boom");
+      });
+    });
+
+    describe("deserialization parity", function () {
+      it("should leave nested __type markers under the error as plain objects", function () {
+        const err = new Error("boom");
+        err.multiple = [new Error("second")];
+        const evt = SerializableEvent.create("fail", {}, err).serialize();
+        const wire = JSON.parse(JSON.stringify(evt));
+
+        const deserialized = SerializableEvent.deserialize(wire);
+
+        expect(deserialized.error, "to be an", Error);
+        expect(deserialized.error.multiple[0], "not to be an", Error);
+        expect(deserialized.error.multiple[0].message, "to be", "second");
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: #6053 (v11.x backport of #6056)
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Backport of #6056 to v11.x, the current stable line. The serializer here (`lib/nodejs/serializer.js`) is identical to `main`'s `serializer.mjs` apart from the CJS/ESM module wrappers, so the change transposes one-to-one — see #6056 for the full description of the bug and the fix.

On this branch the full node-unit suite passes (598 tests, including the 20 new serializer regression tests), as do the parallel integration specs (circular-reference and getter fixtures) and an end-to-end run of the #6053 repro: the original failure is reported, and `require('crypto')` keeps its functions in the reused worker.
