### PR TITLE
chore: synchronize watch integration tests on observed runs instead of sleeps

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -21,7 +21,7 @@ The `helpers.js` module contains many functions to handle the common cases of sp
 
 ### Return Types
 
-- `RawResult`: an object containing props `args`, `code`, `output` and `command`
+- `RawResult`: an object containing props `args`, `code`, `output`, `command`, and `stderr`
 - `SummarizedResult`: a `RawResult` + props `passing`, `failing` and `pending`
 - `JSONResult`: a `RawResult` + parsed output of `json` reporter
 

--- a/test/integration/constants.mjs
+++ b/test/integration/constants.mjs
@@ -1,3 +1,5 @@
+// Shared constants to avoid circular dependencies
+
 /**
  * Shared deadline for everything a single `runMochaWatchAsync` call waits
  * on.

--- a/test/integration/constants.mjs
+++ b/test/integration/constants.mjs
@@ -1,0 +1,9 @@
+/**
+ * Shared deadline for everything a single `runMochaWatchAsync` call waits
+ * on.
+ * 
+ * Suites using the watch helpers must keep their test timeouts above
+ * this, so that the helper's diagnostic error wins the race against Mocha's
+ * own timeout.
+ */
+export const DEFAULT_WATCH_BUDGET_MS = 50000;

--- a/test/integration/constants.mjs
+++ b/test/integration/constants.mjs
@@ -3,7 +3,7 @@
 /**
  * Shared deadline for everything a single `runMochaWatchAsync` call waits
  * on.
- * 
+ *
  * Suites using the watch helpers must keep their test timeouts above
  * this, so that the helper's diagnostic error wins the race against Mocha's
  * own timeout.

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -301,10 +301,12 @@ function invokeNode(args, done, opts = {}) {
  * @param {RawResultCallback} done - Callback
  * @param {Object|string} [opts] - Options to `child_process` or 'pipe' for shortcut to `{stdio: pipe}`
  * @param {boolean} [opts.fork] - If `true`, use `child_process.fork` instead
+ * @param {boolean} [opts.separateStderr] - If `true`, accumulate piped `STDERR` into the result's `stderr` field instead of merging it into `output`
  * @returns {import('child_process').ChildProcess}
  */
 function createSubprocess(args, done, opts = {}) {
   let output = "";
+  let stderrOutput = "";
 
   if (opts === "pipe") {
     opts = { stdio: ["inherit", "pipe", "pipe"] };
@@ -347,13 +349,20 @@ function createSubprocess(args, done, opts = {}) {
 
   mocha.stdout.on("data", listener);
   if (mocha.stderr) {
-    mocha.stderr.on("data", listener);
+    if (opts.separateStderr) {
+      mocha.stderr.on("data", (data) => {
+        stderrOutput += data;
+      });
+    } else {
+      mocha.stderr.on("data", listener);
+    }
   }
   mocha.on("error", done);
 
   mocha.on("close", (code) => {
     done(null, {
       output,
+      stderr: stderrOutput,
       code,
       args,
       command: args.join(" "),
@@ -410,46 +419,260 @@ function getSummary(res) {
 }
 
 /**
- * Runs the mocha executable in watch mode calls `change` and returns the
+ * Marker printed to `STDERR` by mocha's watch mode (`lib/cli/watch-run.js`)
+ * after every completed test run which did not already have a rerun
+ * scheduled, including the very first run.
+ */
+const WATCH_RUN_MARKER = "[mocha] waiting for changes";
+
+/**
+ * Shared deadline for everything a single `runMochaWatchAsync` call waits
+ * on. Suites using the watch helpers must keep their test timeouts above
+ * this, so that the helper's diagnostic error wins the race against mocha's
+ * own opaque timeout.
+ */
+const DEFAULT_WATCH_BUDGET_MS = 50000;
+
+/**
+ * Bounded window observed by "no rerun expected" tests between the change
+ * and `SIGINT`: long enough for an erroneous rerun to begin, mirroring the
+ * fixed sleep these helpers used historically.
+ */
+const WATCH_NO_RERUN_GRACE_MS = 2000;
+
+/**
+ * How long to wait for the watch child to exit after `SIGINT` before
+ * escalating to `SIGKILL`.
+ */
+const WATCH_EXIT_TIMEOUT_MS = 10000;
+
+/**
+ * Parses the output of a `mocha --watch --reporter json` child into one
+ * object per **completed** test run, ignoring a trailing segment which has
+ * not fully arrived yet. Watch mode erases the line (writes `\u001b[2K` to
+ * `STDOUT`) immediately before every rerun, which delimits the segments.
+ *
+ * @param {string} output - Raw `STDOUT` of the watch child
+ * @returns {object[]} One parsed JSON result per completed run
+ */
+function parseWatchJSONOutput(output) {
+  return (
+    output
+      // eslint-disable-next-line no-control-regex
+      .replace(/\[\?25./g, "")
+      .split("[2K")
+      .filter(Boolean)
+      .map((segment) => {
+        try {
+          return JSON.parse(segment);
+        } catch {
+          // an incomplete segment still crossing the pipe
+          return null;
+        }
+      })
+      .filter((parsed) => parsed !== null)
+  );
+}
+
+/**
+ * Observes a `mocha --watch` child's output, letting callers wait until a
+ * given number of test runs have verifiably completed instead of sleeping
+ * and hoping (fixed sleeps lose the race on slow CI runners: a file change
+ * made before the watcher is ready is ignored entirely, and killing the
+ * child too early discards the final run).
+ *
+ * Two detectors are available:
+ * - `json` counts fully parseable `--reporter json` payloads on `STDOUT`. A
+ *   successful parse proves the run completed AND its output completely
+ *   crossed the pipe, making it safe to `SIGINT` the child afterwards
+ *   (killing the child can discard output it has not flushed yet).
+ * - `marker` counts watch mode's "waiting for changes" `STDERR` messages,
+ *   for tests using reporters other than `json`.
+ *
+ * @param {import('child_process').ChildProcess} mochaProcess - Watch child with piped stdio
+ * @param {Object} opts - Options
+ * @param {'json'|'marker'} opts.runDetector - How to count completed runs
+ * @param {number} opts.budgetMs - Shared deadline for all waits of one helper call
+ */
+function createWatchRunObserver(mochaProcess, { runDetector, budgetMs }) {
+  const deadlineAt = Date.now() + budgetMs;
+  let stdout = "";
+  let stderr = "";
+  const waiters = new Set();
+
+  const runCount = () =>
+    runDetector === "json"
+      ? parseWatchJSONOutput(stdout).length
+      : stderr.split(WATCH_RUN_MARKER).length - 1;
+
+  const evaluate = () => {
+    for (const waiter of waiters) {
+      if (waiter.isSatisfied()) {
+        waiters.delete(waiter);
+        clearTimeout(waiter.timer);
+        waiter.resolve();
+      }
+    }
+  };
+
+  mochaProcess.stdout.on("data", (chunk) => {
+    stdout += chunk;
+    evaluate();
+  });
+  mochaProcess.stderr.on("data", (chunk) => {
+    stderr += chunk;
+    evaluate();
+  });
+
+  const waitFor = (isSatisfied, description) => {
+    if (isSatisfied()) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = { isSatisfied, resolve };
+      waiter.timer = setTimeout(
+        () => {
+          waiters.delete(waiter);
+          reject(
+            new Error(
+              `runMochaWatchAsync: timed out waiting for ${description}; ` +
+                `${runCount()} run(s) completed so far\n` +
+                `=== watch child STDOUT ===\n${stdout}\n` +
+                `=== watch child STDERR ===\n${stderr}`,
+            ),
+          );
+        },
+        Math.max(deadlineAt - Date.now(), 1),
+      );
+      waiters.add(waiter);
+    });
+  };
+
+  return {
+    runCount,
+    waitForRuns: (n) =>
+      waitFor(() => runCount() >= n, `watch run #${n} to complete`),
+    waitForStderr: (pattern, description) =>
+      waitFor(() => pattern.test(stderr), description),
+  };
+}
+
+/**
+ * Shuts a watch child down with `SIGINT` (sent as an IPC message when the
+ * child was forked, as on Windows), escalating to `SIGKILL` if it has not
+ * exited within {@link WATCH_EXIT_TIMEOUT_MS}.
+ *
+ * @param {import('child_process').ChildProcess} mochaProcess - Watch child
+ * @param {Promise<void>} closed - Resolves once the child has closed
+ */
+async function shutdownWatchChild(mochaProcess, closed) {
+  if (mochaProcess.exitCode === null && mochaProcess.signalCode === null) {
+    try {
+      if (mochaProcess.connected) {
+        mochaProcess.send("SIGINT");
+      } else {
+        mochaProcess.kill("SIGINT");
+      }
+    } catch {
+      // the child exited in between; the bounded wait below settles it
+    }
+  }
+  const killTimer = setTimeout(() => {
+    try {
+      mochaProcess.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }, WATCH_EXIT_TIMEOUT_MS);
+  await closed;
+  clearTimeout(killTimer);
+}
+
+/**
+ * Runs the mocha executable in watch mode, calls `change` and returns the
  * raw result.
  *
- * The function starts mocha with the given arguments and `--watch` and
- * waits until the first test run has completed. Then it calls `change`
- * and waits until the second test run has been completed. Mocha is
- * killed and the result is returned.
+ * The function starts mocha with the given arguments and `--watch`, waits
+ * until the first test run has verifiably completed (which also proves the
+ * file watcher is ready), calls `change`, and waits until
+ * `opts.expectedRuns` runs have completed in total. Mocha is then killed
+ * and the result is returned.
  *
  * On Windows, this will call `child_process.fork()` instead of `spawn()`.
  *
  * **Exit code will always be 0**
  * @param {string[]} args - Array of argument strings
- * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process`
- * @param {Function} change - A potentially `Promise`-returning callback to execute which will change a watched file
+ * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process` plus the watch options below
+ * @param {number} [opts.expectedRuns] - Total completed runs (including the first) to wait for before killing mocha; defaults to `2`
+ * @param {boolean} [opts.noRerun] - If `true`, expect NO rerun: observe a bounded grace period after `change` instead of waiting for a second run
+ * @param {boolean} [opts.firstRunCrashes] - If `true`, the first run fails to load: it prints only an error stack, so there is no countable run output to wait for
+ * @param {'json'|'marker'} [opts.runDetector] - How completed runs are counted; `runMochaWatchJSONAsync` sets `json`
+ * @param {number} [opts.budgetMs] - Shared deadline for everything this call waits on; must stay below the test's timeout
+ * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns, runCount}`
  * @returns {Promise<RawResult>}
  */
 async function runMochaWatchAsync(args, opts, change) {
   if (typeof opts === "string") {
     opts = { cwd: opts };
   }
+  const {
+    expectedRuns = 2,
+    noRerun = false,
+    firstRunCrashes = false,
+    runDetector = "marker",
+    budgetMs = DEFAULT_WATCH_BUDGET_MS,
+    ...spawnOpts
+  } = opts;
   opts = {
-    sleepMs: 2000,
-    stdio: ["pipe", "pipe", "inherit"],
-    ...opts,
+    stdio: ["pipe", "pipe", "pipe"],
+    separateStderr: true,
+    ...spawnOpts,
     fork: process.platform === "win32",
   };
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
   );
-  await sleep(opts.sleepMs);
-  await change(mochaProcess);
-  await sleep(opts.sleepMs);
+  // avoid an unhandled rejection when a wait below throws first
+  resultPromise.catch(() => {});
+  const closed = new Promise((resolve) => {
+    mochaProcess.once("close", resolve);
+  });
+  const observer = createWatchRunObserver(mochaProcess, {
+    runDetector,
+    budgetMs,
+  });
 
-  if (
-    !(mochaProcess.connected
-      ? mochaProcess.send("SIGINT")
-      : mochaProcess.kill("SIGINT"))
-  ) {
-    throw new Error("failed to send signal to subprocess");
+  try {
+    // The first watch run only starts inside chokidar's `ready` handler, and
+    // file events from before then are ignored (`ignoreInitial` in
+    // lib/cli/watch-run.js) -- so a completed first run proves the watcher
+    // is armed and `change` cannot be lost. If watch mode ever starts the
+    // first run before the watcher is ready (e.g. mochajs/mocha#5409), this
+    // gate needs an explicit watcher-ready signal instead.
+    if (firstRunCrashes) {
+      await observer.waitForStderr(
+        /SyntaxError/,
+        "the first (crashing) watch run to print its error",
+      );
+    } else {
+      await observer.waitForRuns(1);
+    }
+
+    await change(mochaProcess, {
+      waitForRuns: observer.waitForRuns,
+      runCount: observer.runCount,
+    });
+
+    if (noRerun) {
+      // the absence of a rerun cannot be awaited; give an erroneous rerun a
+      // bounded window to show up, like the fixed sleep used historically
+      await sleep(WATCH_NO_RERUN_GRACE_MS);
+    } else {
+      await observer.waitForRuns(expectedRuns);
+    }
+  } finally {
+    await shutdownWatchChild(mochaProcess, closed);
   }
 
   const res = await resultPromise;
@@ -461,53 +684,55 @@ async function runMochaWatchAsync(args, opts, change) {
 }
 
 /**
- * Runs the mocha executable in watch mode calls `change` and returns the
- * JSON result.
+ * Runs the mocha executable in watch mode, calls `change` and returns the
+ * JSON result of every completed test run.
  *
- * The function starts mocha with the given arguments and `--watch` and
- * waits until the first test run has completed. Then it calls `change`
- * and waits until the second test run has been completed. Mocha is
- * killed and the result is returned.
- *
- * On Windows, this will call `child_process.fork()` instead of `spawn()`.
+ * See {@link runMochaWatchAsync} for the synchronization behavior and
+ * options; completed runs are counted by parsing the json reporter's
+ * output.
  *
  * **Exit code will always be 0**
  * @param {string[]} args - Array of argument strings
- * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process`
+ * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for {@link runMochaWatchAsync}
  * @param {Function} change - A potentially `Promise`-returning callback to execute which will change a watched file
  * @returns {Promise<JSONResult>}
  */
 async function runMochaWatchJSONAsync(args, opts, change) {
+  if (typeof opts === "string") {
+    opts = { cwd: opts };
+  }
   const res = await runMochaWatchAsync(
     [...args, "--reporter", "json"],
-    opts,
+    { runDetector: "json", ...opts },
     change,
   );
-  return (
-    res.output
-      // eslint-disable-next-line no-control-regex
-      .replace(/\u001b\[\?25./g, "")
-      .split("\u001b[2K")
-      .filter((x) => x)
-      .map((x) => JSON.parse(x))
-  );
+  return parseWatchJSONOutput(res.output);
 }
 
-const touchRef = new Date();
+let lastTouchedTime = Date.now();
 
 /**
- * Synchronously touch a file. Creates
- * the file and all its parent directories if necessary.
+ * Synchronously touch a file with a fresh, strictly-increasing mtime.
+ * Creates the file and all its parent directories if necessary.
+ *
+ * Every touch gets its own mtime so that each one registers as a change on
+ * every file-watcher backend; repeatedly setting an identical mtime is
+ * invisible to polling watchers. Note that watchers may still coalesce
+ * repeated touches of the same file made in very quick succession --
+ * space them out in time.
  *
  * @param {string} filepath - Path to file
  */
 function touchFile(filepath) {
   fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  lastTouchedTime = Math.max(lastTouchedTime + 1000, Date.now());
+  const touchTime = new Date(lastTouchedTime);
   try {
-    fs.utimesSync(filepath, touchRef, touchRef);
+    fs.utimesSync(filepath, touchTime, touchTime);
   } catch {
     const fd = fs.openSync(filepath, "a");
     fs.closeSync(fd);
+    fs.utimesSync(filepath, touchTime, touchTime);
   }
 }
 

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -487,7 +487,7 @@ function getUnparsedSegments(output) {
 /**
  * Returns the split JSON for each run in the `output` session.
  * @param {string} output stdout from a `mocha --watch --reporter json` session
- * @returns {string[]} truthy strings, test run CLI output. 
+ * @returns {string[]} truthy strings, test run CLI output.
  */
 function getJsonSegments(output) {
   /** Pattern for CLI output hiding or showing the cursor */

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -605,7 +605,7 @@ async function shutdownWatchChild(mochaProcess, closed) {
  * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process` plus the watch options below
  * @param {number} [opts.expectedRuns] - Total completed runs (including the first) to wait for before killing mocha; defaults to `2`
  * @param {boolean} [opts.noRerun] - If `true`, expect NO rerun: observe a bounded grace period after `change` instead of waiting for a second run
- * @param {boolean} [opts.firstRunCrashes] - If `true`, the first run fails to load: it prints only an error stack, so there is no countable run output to wait for
+ * @param {RegExp} [opts.firstRunCrashPattern] - If set, expect the first run to fail to load, printing only an error stack (no stdout) with a message matching this pattern. No countable run output to wait for.
  * @param {'json'|'marker'} [opts.runDetector] - How completed runs are counted; `runMochaWatchJSONAsync` sets `json`
  * @param {number} [opts.budgetMs] - Shared deadline for everything this call waits on; must stay below the test's timeout
  * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns, runCount}`
@@ -618,7 +618,7 @@ async function runMochaWatchAsync(args, opts, change) {
   const {
     expectedRuns = 2,
     noRerun = false,
-    firstRunCrashes = false,
+    firstRunCrashPattern = null,
     runDetector = "marker",
     budgetMs = DEFAULT_WATCH_BUDGET_MS,
     ...spawnOpts
@@ -650,9 +650,9 @@ async function runMochaWatchAsync(args, opts, change) {
     // is armed and `change` cannot be lost. If watch mode ever starts the
     // first run before the watcher is ready (e.g. mochajs/mocha#5409), this
     // gate needs an explicit watcher-ready signal instead.
-    if (firstRunCrashes) {
+    if (firstRunCrashPattern) {
       await observer.waitForStderr(
-        /SyntaxError/,
+        firstRunCrashPattern,
         "the first (crashing) watch run to print its error",
       );
     } else {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -625,8 +625,7 @@ async function shutdownWatchChild(mochaProcess, closed) {
 }
 
 /**
- * Runs the mocha executable in watch mode, calls `change` and returns the
- * raw result.
+ * Runs the mocha executable in watch mode, calls `change`, returns the raw result.
  *
  * The function starts mocha with the given arguments and `--watch`, waits
  * until the first test run has verifiably completed (which also proves the

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -643,7 +643,7 @@ async function shutdownWatchChild(mochaProcess, closed) {
  * @param {RegExp} [opts.firstRunCrashPattern] - If set, expect the first run to fail to load, printing only an error stack (no stdout) with a message matching this pattern. No countable run output to wait for.
  * @param {'json'|'marker'} [opts.runDetector] - How completed runs are counted; `runMochaWatchJSONAsync` sets `json`
  * @param {number} [opts.budgetMs] - Shared deadline for everything this call waits on; must stay below the test's timeout
- * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns, runCount}`
+ * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns}`
  * @returns {Promise<RawResult>}
  */
 async function runMochaWatchAsync(args, opts, change) {
@@ -701,7 +701,6 @@ async function runMochaWatchAsync(args, opts, change) {
 
     await change(mochaProcess, {
       waitForRuns: observer.waitForRuns,
-      runCount: observer.runCount,
     });
 
     if (noRerun) {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -456,28 +456,22 @@ const WATCH_KILL_GRACE_MS = 2000;
  * Parses the output of a `mocha --watch --reporter json` child into one
  * object per **completed** test run, ignoring a trailing segment which has
  * not fully arrived yet. Watch mode erases the line immediately before every rerun,
- * which delimiting the segments.
+ * which delimits the segments.
  *
  * @param {string} output - Raw `STDOUT` of the watch child
  * @returns {object[]} One parsed JSON result per completed run
  */
 function parseWatchJSONOutput(output) {
-  return (
-    output
-      // eslint-disable-next-line no-control-regex
-      .replace(/\u001b\[\?25./g, "") // strip "hide cursor" and "show cursor" outputs
-      .split("\u001b[2K") // split on line erasure
-      .filter(Boolean) // remove empty strings
-      .map((segment) => {
-        try {
-          return JSON.parse(segment);
-        } catch {
-          // an incomplete segment still crossing the pipe
-          return null;
-        }
-      })
-      .filter((parsed) => parsed !== null)
-  );
+  return getJsonSegments(output)
+    .map((segment) => {
+      try {
+        return JSON.parse(segment);
+      } catch {
+        // an incomplete segment still crossing the pipe
+        return null;
+      }
+    })
+    .filter((parsed) => parsed !== null);
 }
 
 /**
@@ -489,21 +483,26 @@ function parseWatchJSONOutput(output) {
  * @returns {string[]} Segments that failed JSON.parse
  */
 function getUnparsedSegments(output) {
-  return (
-    output
-      // eslint-disable-next-line no-control-regex
-      .replace(/\[\?25./g, "")
-      .split("[2K")
-      .filter(Boolean)
-      .filter((segment) => {
-        try {
-          JSON.parse(segment);
-          return false;
-        } catch {
-          return true;
-        }
-      })
-  );
+  return getJsonSegments(output).filter((segment) => {
+    try {
+      JSON.parse(segment);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
+
+function getJsonSegments(output) {
+  /** Pattern for CLI output hiding or showing the cursor */
+  // eslint-disable-next-line no-control-regex
+  const hideOrShowCursorRegex = /\u001b\[\?25./g;
+  /** CLI output for erasing the current line */
+  const lineErasureCliOutput = "\u001b[2K";
+  return output
+    .replace(hideOrShowCursorRegex, "")
+    .split(lineErasureCliOutput)
+    .filter(Boolean);
 }
 
 /**

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -619,7 +619,10 @@ async function shutdownWatchChild(mochaProcess, closed) {
       // already gone
     }
   }, WATCH_EXIT_TIMEOUT_MS);
-  await Promise.race([closed, sleep(WATCH_EXIT_TIMEOUT_MS + WATCH_KILL_GRACE_MS)]);
+  await Promise.race([
+    closed,
+    sleep(WATCH_EXIT_TIMEOUT_MS + WATCH_KILL_GRACE_MS),
+  ]);
   clearTimeout(killTimer);
 }
 
@@ -660,7 +663,7 @@ async function runMochaWatchAsync(args, opts, change) {
   } = opts;
   if (noRerun && opts.expectedRuns !== undefined) {
     throw new Error(
-      "runMochaWatchAsync: `noRerun` and `expectedRuns` are mutually exclusive"
+      "runMochaWatchAsync: `noRerun` and `expectedRuns` are mutually exclusive",
     );
   }
   opts = {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -9,6 +9,7 @@ const { Base } = require("../../lib/reporters/base.mjs");
 const { escapeRegExp } = require("../../lib/utils/regexp.mjs");
 const debug = require("debug")("mocha:test:integration:helpers");
 const SIGNAL_OFFSET = 128;
+const { DEFAULT_WATCH_BUDGET_MS } = require("./constants.mjs");
 
 /**
  * Path to `mocha` executable
@@ -424,14 +425,6 @@ function getSummary(res) {
  * scheduled, including the very first run.
  */
 const WATCH_RUN_MARKER = "[mocha] waiting for changes";
-
-/**
- * Shared deadline for everything a single `runMochaWatchAsync` call waits
- * on. Suites using the watch helpers must keep their test timeouts above
- * this, so that the helper's diagnostic error wins the race against mocha's
- * own opaque timeout.
- */
-const DEFAULT_WATCH_BUDGET_MS = 50000;
 
 /**
  * Bounded window observed by "no rerun expected" tests between the change

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -526,7 +526,8 @@ function createWatchRunObserver(mochaProcess, { runDetector, budgetMs }) {
 
   const runCount = () =>
     runDetector === "json"
-      ? parseWatchJSONOutput(stdout).length
+      ? // wait for JSON payload to flush for future assertions
+        parseWatchJSONOutput(stdout).length
       : stderr.split(WATCH_RUN_MARKER).length - 1;
 
   const evaluate = () => {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -427,8 +427,7 @@ function getSummary(res) {
 const WATCH_RUN_MARKER = "[mocha] waiting for changes";
 
 /**
- * Bounded window observed by "no rerun expected" tests between the change
- * and `SIGINT`: long enough for an erroneous rerun to begin
+ * Time to wait for an erroneous rerun to begin after run finishes
  */
 const WATCH_NO_RERUN_GRACE_MS = 2000;
 
@@ -448,8 +447,7 @@ const WATCH_KILL_GRACE_MS = 2000;
 /**
  * Parses the output of a `mocha --watch --reporter json` child into one
  * object per **completed** test run, ignoring a trailing segment which has
- * not fully arrived yet. Watch mode erases the line immediately before every rerun,
- * which delimits the segments.
+ * not fully arrived yet.
  *
  * @param {string} output - Raw `STDOUT` of the watch child
  * @returns {object[]} One parsed JSON result per completed run
@@ -486,6 +484,11 @@ function getUnparsedSegments(output) {
   });
 }
 
+/**
+ * Returns the split JSON for each run in the `output` session.
+ * @param {string} output stdout from a `mocha --watch --reporter json` session
+ * @returns {string[]} truthy strings, test run CLI output. 
+ */
 function getJsonSegments(output) {
   /** Pattern for CLI output hiding or showing the cursor */
   // eslint-disable-next-line no-control-regex
@@ -500,10 +503,7 @@ function getJsonSegments(output) {
 
 /**
  * Observes a `mocha --watch` child's output, letting callers wait until a
- * given number of test runs have verifiably completed instead of sleeping
- * and hoping (fixed sleeps lose the race on slow CI runners: a file change
- * made before the watcher is ready is ignored entirely, and killing the
- * child too early discards the final run).
+ * given number of test runs have verifiably completed.
  *
  * Two detectors are available:
  * - `json` counts fully parseable `--reporter json` payloads on `STDOUT`. A
@@ -576,7 +576,7 @@ function createWatchRunObserver(mochaProcess, { runDetector, budgetMs }) {
   return {
     runCount,
     waitForRuns: (n) =>
-      waitFor(() => runCount() >= n, `watch run #${n} to complete`),
+      waitFor(() => runCount() >= n, `${n} run(s) to complete`),
     waitForStderr: (pattern, description) =>
       waitFor(() => pattern.test(stderr), description),
   };

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -649,6 +649,11 @@ async function runMochaWatchAsync(args, opts, change) {
     budgetMs = DEFAULT_WATCH_BUDGET_MS,
     ...spawnOpts
   } = opts;
+  if (noRerun && opts.expectedRuns !== undefined) {
+    throw new Error(
+      "runMochaWatchAsync: `noRerun` and `expectedRuns` are mutually exclusive"
+    );
+  }
   opts = {
     stdio: ["pipe", "pipe", "pipe"],
     separateStderr: true,

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -866,6 +866,7 @@ module.exports = {
  * @property {number?} code - Exit code or `null` in some circumstances
  * @property {string[]} args - Array of program arguments
  * @property {string} command - Complete command executed
+ * @property {string} stderr - Process stderr output
  */
 
 /**

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -435,8 +435,7 @@ const DEFAULT_WATCH_BUDGET_MS = 50000;
 
 /**
  * Bounded window observed by "no rerun expected" tests between the change
- * and `SIGINT`: long enough for an erroneous rerun to begin, mirroring the
- * fixed sleep these helpers used historically.
+ * and `SIGINT`: long enough for an erroneous rerun to begin
  */
 const WATCH_NO_RERUN_GRACE_MS = 2000;
 
@@ -456,8 +455,8 @@ const WATCH_KILL_GRACE_MS = 2000;
 /**
  * Parses the output of a `mocha --watch --reporter json` child into one
  * object per **completed** test run, ignoring a trailing segment which has
- * not fully arrived yet. Watch mode erases the line (writes `\u001b[2K` to
- * `STDOUT`) immediately before every rerun, which delimits the segments.
+ * not fully arrived yet. Watch mode erases the line immediately before every rerun,
+ * which delimiting the segments.
  *
  * @param {string} output - Raw `STDOUT` of the watch child
  * @returns {object[]} One parsed JSON result per completed run
@@ -466,9 +465,9 @@ function parseWatchJSONOutput(output) {
   return (
     output
       // eslint-disable-next-line no-control-regex
-      .replace(/\u001b\[\?25./g, "")
-      .split("\u001b[2K")
-      .filter(Boolean)
+      .replace(/\u001b\[\?25./g, "") // strip "hide cursor" and "show cursor" outputs
+      .split("\u001b[2K") // split on line erasure
+      .filter(Boolean) // remove empty strings
       .map((segment) => {
         try {
           return JSON.parse(segment);

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -447,6 +447,13 @@ const WATCH_NO_RERUN_GRACE_MS = 2000;
 const WATCH_EXIT_TIMEOUT_MS = 10000;
 
 /**
+ * How long to wait for the `close` event after `SIGKILL` is sent.  SIGKILL is
+ * unignorable, so the OS delivers it almost instantly; this is just a safety
+ * cap so {@link shutdownWatchChild} has a finite deadline.
+ */
+const WATCH_KILL_GRACE_MS = 2000;
+
+/**
  * Parses the output of a `mocha --watch --reporter json` child into one
  * object per **completed** test run, ignoring a trailing segment which has
  * not fully arrived yet. Watch mode erases the line (writes `\u001b[2K` to
@@ -586,7 +593,9 @@ function createWatchRunObserver(mochaProcess, { runDetector, budgetMs }) {
 /**
  * Shuts a watch child down with `SIGINT` (sent as an IPC message when the
  * child was forked, as on Windows), escalating to `SIGKILL` if it has not
- * exited within {@link WATCH_EXIT_TIMEOUT_MS}.
+ * exited within {@link WATCH_EXIT_TIMEOUT_MS}, then waits for the `close`
+ * event with a {@link WATCH_KILL_GRACE_MS} grace period so the total deadline
+ * is always finite.
  *
  * @param {import('child_process').ChildProcess} mochaProcess - Watch child
  * @param {Promise<void>} closed - Resolves once the child has closed
@@ -610,7 +619,7 @@ async function shutdownWatchChild(mochaProcess, closed) {
       // already gone
     }
   }, WATCH_EXIT_TIMEOUT_MS);
-  await closed;
+  await Promise.race([closed, sleep(WATCH_EXIT_TIMEOUT_MS + WATCH_KILL_GRACE_MS)]);
   clearTimeout(killTimer);
 }
 

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -698,8 +698,7 @@ async function runMochaWatchAsync(args, opts, change) {
     });
 
     if (noRerun) {
-      // the absence of a rerun cannot be awaited; give an erroneous rerun a
-      // bounded window to show up, like the fixed sleep used historically
+      // Give an erroneous rerun time to show up
       await sleep(WATCH_NO_RERUN_GRACE_MS);
     } else {
       await observer.waitForRuns(expectedRuns);

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -459,8 +459,8 @@ function parseWatchJSONOutput(output) {
   return (
     output
       // eslint-disable-next-line no-control-regex
-      .replace(/\[\?25./g, "")
-      .split("[2K")
+      .replace(/\u001b\[\?25./g, "")
+      .split("\u001b[2K")
       .filter(Boolean)
       .map((segment) => {
         try {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -475,6 +475,32 @@ function parseWatchJSONOutput(output) {
 }
 
 /**
+ * Returns non-empty segments from the watch child's `STDOUT` that cannot be
+ * parsed as JSON. A non-empty unparseable segment means a run started but its
+ * output was truncated (e.g. the child was killed mid-flush).
+ *
+ * @param {string} output - Raw `STDOUT` of the watch child
+ * @returns {string[]} Segments that failed JSON.parse
+ */
+function getUnparsedSegments(output) {
+  return (
+    output
+      // eslint-disable-next-line no-control-regex
+      .replace(/\[\?25./g, "")
+      .split("[2K")
+      .filter(Boolean)
+      .filter((segment) => {
+        try {
+          JSON.parse(segment);
+          return false;
+        } catch {
+          return true;
+        }
+      })
+  );
+}
+
+/**
  * Observes a `mocha --watch` child's output, letting callers wait until a
  * given number of test runs have verifiably completed instead of sleeping
  * and hoping (fixed sleeps lose the race on slow CI runners: a file change
@@ -676,6 +702,17 @@ async function runMochaWatchAsync(args, opts, change) {
   }
 
   const res = await resultPromise;
+
+  if (noRerun && runDetector === "json" && !firstRunCrashPattern) {
+    const unparsed = getUnparsedSegments(res.output);
+    if (unparsed.length > 0) {
+      throw new Error(
+        `noRerun: ${unparsed.length} non-empty unparseable JSON segment(s) found ` +
+          `after the grace period — an erroneous rerun was killed mid-flush\n` +
+          `=== watch child STDOUT ===\n${res.output}`,
+      );
+    }
+  }
 
   // we kill the process with `SIGINT`, so it will always appear as "failed" to our
   // custom assertions (a non-zero exit code 130). just change it to 0.

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -58,7 +58,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile],
-        { cwd: tempDir, firstRunCrashes: true, expectedRuns: 1 },
+        { cwd: tempDir, firstRunCrashPattern: /SyntaxError/, expectedRuns: 1 },
         () => {
           replaceFileContents(testFile, "done((;", "done();");
         },
@@ -89,7 +89,11 @@ describe("--watch", function () {
 
         return runMochaWatchJSONAsync(
           [testFile],
-          { cwd: tempDir, firstRunCrashes: true, expectedRuns: 1 },
+          {
+            cwd: tempDir,
+            firstRunCrashPattern: /SyntaxError/,
+            expectedRuns: 1,
+          },
           () => {
             replaceFileContents(testFile, "done((;", "done();");
           },

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -530,7 +530,7 @@ describe("--watch", function () {
       const testFile = path.join(tempDir, "test.js");
       copyFixture(DEFAULT_FIXTURE, testFile);
 
-      // we want to cause _n + 1_ reruns, which should cause the warning
+      // we want to cause _n + 1_ reruns (n + 2 total runs), which should cause the warning
       // to occur if the listeners aren't properly destroyed
       const totalRuns = process.getMaxListeners() + 2;
 

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -567,12 +567,13 @@ describe("--watch", function () {
           [testFile],
           { cwd: tempDir, expectedRuns: totalRuns },
           async (mochaProcess, { waitForRuns }) => {
+            // 1-based indexing, starting with second run
             for (let run = 2; run <= totalRuns; run++) {
               touchFile(testFile);
               await waitForRuns(run);
               // watchers coalesce same-file touches made in very quick
               // succession; space them out so every touch causes a rerun
-              await sleep(250);
+              if (run < totalRuns) await sleep(250);
             }
           },
         ),

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -124,7 +124,7 @@ describe("--watch", function () {
       const watchedFile = path.join(dirPath, "file.xyz");
       // 1 first run + 3 creations = 4
       const expectedRunCount = 4;
-      const graceMs = 100; // buffer time for watcher
+      const graceMs = 1_000; // buffer time for watcher
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -122,19 +122,21 @@ describe("--watch", function () {
       const libPath = path.join(tempDir, "lib");
       const dirPath = path.join(libPath, "dir");
       const watchedFile = path.join(dirPath, "file.xyz");
+      // 1 first run + 3 creations = 4
+      const expectedRunCount = 4;
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
-        { cwd: tempDir, expectedRuns: 4 },
+        { cwd: tempDir, expectedRuns: expectedRunCount },
         async (mochaProcess, { waitForRuns }) => {
           fs.mkdirSync(libPath);
-          await waitForRuns(2);
+          await waitForRuns(2); // wait for second run
           fs.mkdirSync(dirPath);
-          await waitForRuns(3);
+          await waitForRuns(3); // wait for third run
           touchFile(watchedFile);
         },
       ).then((results) => {
-        expect(results, "to have length", 4);
+        expect(results, "to have length", expectedRunCount);
       });
     });
 

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -124,6 +124,7 @@ describe("--watch", function () {
       const watchedFile = path.join(dirPath, "file.xyz");
       // 1 first run + 3 creations = 4
       const expectedRunCount = 4;
+      const graceMs = 100; // buffer time for watcher
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
@@ -131,8 +132,10 @@ describe("--watch", function () {
         async (mochaProcess, { waitForRuns }) => {
           fs.mkdirSync(libPath);
           await waitForRuns(2); // wait for second run
+          await sleep(graceMs); // grace
           fs.mkdirSync(dirPath);
           await waitForRuns(3); // wait for third run
+          await sleep(graceMs);
           touchFile(watchedFile);
         },
       ).then((results) => {

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -129,15 +129,8 @@ describe("--watch", function () {
         async (mochaProcess, { waitForRuns }) => {
           fs.mkdirSync(libPath);
           await waitForRuns(2);
-          // the watcher installs its watch on a newly created directory
-          // asynchronously; an event inside it before that is lost entirely
-          // (chokidar#1112), so give the installation a moment
-          await sleep(1000);
-
           fs.mkdirSync(dirPath);
           await waitForRuns(3);
-          await sleep(1000);
-
           touchFile(watchedFile);
         },
       ).then((results) => {

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -12,6 +12,7 @@ const {
   createTempDir,
   DEFAULT_FIXTURE,
 } = require("../helpers");
+const { DEFAULT_WATCH_BUDGET_MS } = require("../constants.mjs");
 
 describe("--watch", function () {
   describe("when enabled", function () {
@@ -25,9 +26,8 @@ describe("--watch", function () {
     let cleanup;
 
     this.slow(5000);
-    // tests wait on observed runs, bounded by the helpers' shared 50s budget
-    // with diagnostic output; keep mocha's own timeout above that budget
-    this.timeout(60000);
+    // with diagnostic output; keep Mocha's own timeout above that budget
+    this.timeout(DEFAULT_WATCH_BUDGET_MS + 10_000);
 
     beforeEach(async function () {
       const { dirpath, removeTempDir } = await createTempDir();

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -25,6 +25,9 @@ describe("--watch", function () {
     let cleanup;
 
     this.slow(5000);
+    // tests wait on observed runs, bounded by the helpers' shared 50s budget
+    // with diagnostic output; keep mocha's own timeout above that budget
+    this.timeout(60000);
 
     beforeEach(async function () {
       const { dirpath, removeTempDir } = await createTempDir();
@@ -53,9 +56,13 @@ describe("--watch", function () {
 
       replaceFileContents(testFile, "done();", "done((;");
 
-      return runMochaWatchJSONAsync([testFile], tempDir, () => {
-        replaceFileContents(testFile, "done((;", "done();");
-      }).then((results) => {
+      return runMochaWatchJSONAsync(
+        [testFile],
+        { cwd: tempDir, firstRunCrashes: true, expectedRuns: 1 },
+        () => {
+          replaceFileContents(testFile, "done((;", "done();");
+        },
+      ).then((results) => {
         expect(results, "to have length", 1);
       });
     });
@@ -72,15 +79,21 @@ describe("--watch", function () {
         });
       });
 
+      // TODO: this test never passes `--parallel`, so it duplicates the
+      // non-parallel crash test above; kept as-is in this stabilization change
       it("reruns test when watched test file is crashed", function () {
         const testFile = path.join(tempDir, "test.js");
         copyFixture(DEFAULT_FIXTURE, testFile);
 
         replaceFileContents(testFile, "done();", "done((;");
 
-        return runMochaWatchJSONAsync([testFile], tempDir, () => {
-          replaceFileContents(testFile, "done((;", "done();");
-        }).then((results) => {
+        return runMochaWatchJSONAsync(
+          [testFile],
+          { cwd: tempDir, firstRunCrashes: true, expectedRuns: 1 },
+          () => {
+            replaceFileContents(testFile, "done((;", "done();");
+          },
+        ).then((results) => {
           expect(results, "to have length", 1);
         });
       });
@@ -131,12 +144,17 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
-        tempDir,
-        async () => {
+        { cwd: tempDir, expectedRuns: 4 },
+        async (mochaProcess, { waitForRuns }) => {
           fs.mkdirSync(libPath);
+          await waitForRuns(2);
+          // the watcher installs its watch on a newly created directory
+          // asynchronously; an event inside it before that is lost entirely
+          // (chokidar#1112), so give the installation a moment
           await sleep(1000);
 
           fs.mkdirSync(dirPath);
+          await waitForRuns(3);
           await sleep(1000);
 
           touchFile(watchedFile);
@@ -287,7 +305,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "dir/*.xyz"],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(watchedFile);
         },
@@ -373,7 +391,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--extension", "xyz,js"],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(gitFile);
           touchFile(nodeModulesFile);
@@ -398,7 +416,7 @@ describe("--watch", function () {
           "--watch-ignore",
           "dir/*ignore*",
         ],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(watchedFile);
         },
@@ -417,7 +435,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "dir/[ab].js"],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(watchedFile);
         },
@@ -536,25 +554,28 @@ describe("--watch", function () {
       const testFile = path.join(tempDir, "test.js");
       copyFixture(DEFAULT_FIXTURE, testFile);
 
+      // we want to cause _n + 1_ reruns, which should cause the warning
+      // to occur if the listeners aren't properly destroyed
+      const totalRuns = process.getMaxListeners() + 2;
+
       return expect(
         runMochaWatchAsync(
           [testFile],
-          { cwd: tempDir, stdio: "pipe" },
-          async () => {
-            // we want to cause _n + 1_ reruns, which should cause the warning
-            // to occur if the listeners aren't properly destroyed
-            const iterations = new Array(process.getMaxListeners() + 1);
-            // eslint-disable-next-line no-unused-vars
-            for await (const _ of iterations) {
+          { cwd: tempDir, expectedRuns: totalRuns },
+          async (mochaProcess, { waitForRuns }) => {
+            for (let run = 2; run <= totalRuns; run++) {
               touchFile(testFile);
-              await sleep(1000);
+              await waitForRuns(run);
+              // watchers coalesce same-file touches made in very quick
+              // succession; space them out so every touch causes a rerun
+              await sleep(250);
             }
           },
         ),
         "when fulfilled",
         "to satisfy",
         {
-          output: expect.it("not to match", /MaxListenersExceededWarning/),
+          stderr: expect.it("not to match", /MaxListenersExceededWarning/),
         },
       );
     });

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -78,29 +78,6 @@ describe("--watch", function () {
           expect(results, "to have length", 2);
         });
       });
-
-      // TODO: this test never passes `--parallel`, so it duplicates the
-      // non-parallel crash test above; kept as-is in this stabilization change
-      it("reruns test when watched test file is crashed", function () {
-        const testFile = path.join(tempDir, "test.js");
-        copyFixture(DEFAULT_FIXTURE, testFile);
-
-        replaceFileContents(testFile, "done();", "done((;");
-
-        return runMochaWatchJSONAsync(
-          [testFile],
-          {
-            cwd: tempDir,
-            firstRunCrashPattern: /SyntaxError/,
-            expectedRuns: 1,
-          },
-          () => {
-            replaceFileContents(testFile, "done((;", "done();");
-          },
-        ).then((results) => {
-          expect(results, "to have length", 1);
-        });
-      });
     });
 
     it("reruns test when file matching --watch-files changes", function () {

--- a/test/integration/plugins/global-fixtures.spec.js
+++ b/test/integration/plugins/global-fixtures.spec.js
@@ -13,6 +13,8 @@ const {
 } = require("../helpers");
 
 describe("global setup/teardown", function () {
+  const watchBudgetMs = 8500;
+
   describe("when mocha run in serial mode", function () {
     it("should execute global setup and teardown", async function () {
       return expect(
@@ -151,7 +153,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            { cwd: tempDir, budgetMs: 8500 },
+            { cwd: tempDir, budgetMs: watchBudgetMs },
             () => {
               touchFile(testFile);
             },
@@ -170,7 +172,7 @@ describe("global setup/teardown", function () {
                 resolveFixturePath("plugins/global-fixtures/global-teardown"),
                 testFile,
               ],
-              { cwd: tempDir, budgetMs: 8500 },
+              { cwd: tempDir, budgetMs: watchBudgetMs },
               () => {
                 touchFile(testFile);
               },
@@ -191,7 +193,7 @@ describe("global setup/teardown", function () {
                 resolveFixturePath("plugins/global-fixtures/global-setup"),
                 testFile,
               ],
-              { cwd: tempDir, budgetMs: 8500 },
+              { cwd: tempDir, budgetMs: watchBudgetMs },
               () => {
                 touchFile(testFile);
               },
@@ -213,7 +215,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            { cwd: tempDir, budgetMs: 8500 },
+            { cwd: tempDir, budgetMs: watchBudgetMs },
             () => {
               touchFile(testFile);
             },
@@ -299,7 +301,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            { cwd: tempDir, budgetMs: 8500 },
+            { cwd: tempDir, budgetMs: watchBudgetMs },
             () => {
               touchFile(testFile);
             },
@@ -320,7 +322,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            { cwd: tempDir, budgetMs: 8500 },
+            { cwd: tempDir, budgetMs: watchBudgetMs },
             () => {
               touchFile(testFile);
             },

--- a/test/integration/plugins/global-fixtures.spec.js
+++ b/test/integration/plugins/global-fixtures.spec.js
@@ -151,7 +151,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },
@@ -170,7 +170,7 @@ describe("global setup/teardown", function () {
                 resolveFixturePath("plugins/global-fixtures/global-teardown"),
                 testFile,
               ],
-              tempDir,
+              { cwd: tempDir, budgetMs: 8500 },
               () => {
                 touchFile(testFile);
               },
@@ -191,7 +191,7 @@ describe("global setup/teardown", function () {
                 resolveFixturePath("plugins/global-fixtures/global-setup"),
                 testFile,
               ],
-              tempDir,
+              { cwd: tempDir, budgetMs: 8500 },
               () => {
                 touchFile(testFile);
               },
@@ -213,7 +213,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },
@@ -299,7 +299,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },
@@ -320,7 +320,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6037
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Replaces sleeps with a CLI output observer.

`runMochaWatchAsync` now waits until the first run has verifiably completed before calling `change`, then waits for `expectedRuns` completed runs before `SIGINT`. Completed runs are counted from the child's own output: a fully parseable `--reporter json` payload on `stdout` or watch mode's "waiting for changes" `stderr` marker for other reporters.

A few tests opt out. Those expecting no rerun observe for an erroneous rerun for at most 2 seconds. Those whose first run crashes print only a stack: since there is no run output to count, they gate on the error output instead.

Every wait draws on a bounded per-Mocha-session budget and fails with the child's full output attached.

The suite also gets much faster: the 30 watch tests drop from a hard 4s-of-sleep floor each (~2 minutes total) to ~20s under nyc locally (ref #5714)
