### PR TITLE
test: synchronize watch integration tests on observed runs instead of sleeps

### DIFF
--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -300,10 +300,12 @@ function invokeNode(args, done, opts = {}) {
  * @param {RawResultCallback} done - Callback
  * @param {Object|string} [opts] - Options to `child_process` or 'pipe' for shortcut to `{stdio: pipe}`
  * @param {boolean} [opts.fork] - If `true`, use `child_process.fork` instead
+ * @param {boolean} [opts.separateStderr] - If `true`, accumulate piped `STDERR` into the result's `stderr` field instead of merging it into `output`
  * @returns {import('child_process').ChildProcess}
  */
 function createSubprocess(args, done, opts = {}) {
   let output = "";
+  let stderrOutput = "";
 
   if (opts === "pipe") {
     opts = { stdio: ["inherit", "pipe", "pipe"] };
@@ -346,13 +348,20 @@ function createSubprocess(args, done, opts = {}) {
 
   mocha.stdout.on("data", listener);
   if (mocha.stderr) {
-    mocha.stderr.on("data", listener);
+    if (opts.separateStderr) {
+      mocha.stderr.on("data", (data) => {
+        stderrOutput += data;
+      });
+    } else {
+      mocha.stderr.on("data", listener);
+    }
   }
   mocha.on("error", done);
 
   mocha.on("close", (code) => {
     done(null, {
       output,
+      stderr: stderrOutput,
       code,
       args,
       command: args.join(" "),
@@ -409,46 +418,260 @@ function getSummary(res) {
 }
 
 /**
- * Runs the mocha executable in watch mode calls `change` and returns the
+ * Marker printed to `STDERR` by mocha's watch mode (`lib/cli/watch-run.js`)
+ * after every completed test run which did not already have a rerun
+ * scheduled, including the very first run.
+ */
+const WATCH_RUN_MARKER = "[mocha] waiting for changes";
+
+/**
+ * Shared deadline for everything a single `runMochaWatchAsync` call waits
+ * on. Suites using the watch helpers must keep their test timeouts above
+ * this, so that the helper's diagnostic error wins the race against mocha's
+ * own opaque timeout.
+ */
+const DEFAULT_WATCH_BUDGET_MS = 50000;
+
+/**
+ * Bounded window observed by "no rerun expected" tests between the change
+ * and `SIGINT`: long enough for an erroneous rerun to begin, mirroring the
+ * fixed sleep these helpers used historically.
+ */
+const WATCH_NO_RERUN_GRACE_MS = 2000;
+
+/**
+ * How long to wait for the watch child to exit after `SIGINT` before
+ * escalating to `SIGKILL`.
+ */
+const WATCH_EXIT_TIMEOUT_MS = 10000;
+
+/**
+ * Parses the output of a `mocha --watch --reporter json` child into one
+ * object per **completed** test run, ignoring a trailing segment which has
+ * not fully arrived yet. Watch mode erases the line (writes `\u001b[2K` to
+ * `STDOUT`) immediately before every rerun, which delimits the segments.
+ *
+ * @param {string} output - Raw `STDOUT` of the watch child
+ * @returns {object[]} One parsed JSON result per completed run
+ */
+function parseWatchJSONOutput(output) {
+  return (
+    output
+      // eslint-disable-next-line no-control-regex
+      .replace(/\[\?25./g, "")
+      .split("[2K")
+      .filter(Boolean)
+      .map((segment) => {
+        try {
+          return JSON.parse(segment);
+        } catch {
+          // an incomplete segment still crossing the pipe
+          return null;
+        }
+      })
+      .filter((parsed) => parsed !== null)
+  );
+}
+
+/**
+ * Observes a `mocha --watch` child's output, letting callers wait until a
+ * given number of test runs have verifiably completed instead of sleeping
+ * and hoping (fixed sleeps lose the race on slow CI runners: a file change
+ * made before the watcher is ready is ignored entirely, and killing the
+ * child too early discards the final run).
+ *
+ * Two detectors are available:
+ * - `json` counts fully parseable `--reporter json` payloads on `STDOUT`. A
+ *   successful parse proves the run completed AND its output completely
+ *   crossed the pipe, making it safe to `SIGINT` the child afterwards
+ *   (killing the child can discard output it has not flushed yet).
+ * - `marker` counts watch mode's "waiting for changes" `STDERR` messages,
+ *   for tests using reporters other than `json`.
+ *
+ * @param {import('child_process').ChildProcess} mochaProcess - Watch child with piped stdio
+ * @param {Object} opts - Options
+ * @param {'json'|'marker'} opts.runDetector - How to count completed runs
+ * @param {number} opts.budgetMs - Shared deadline for all waits of one helper call
+ */
+function createWatchRunObserver(mochaProcess, { runDetector, budgetMs }) {
+  const deadlineAt = Date.now() + budgetMs;
+  let stdout = "";
+  let stderr = "";
+  const waiters = new Set();
+
+  const runCount = () =>
+    runDetector === "json"
+      ? parseWatchJSONOutput(stdout).length
+      : stderr.split(WATCH_RUN_MARKER).length - 1;
+
+  const evaluate = () => {
+    for (const waiter of waiters) {
+      if (waiter.isSatisfied()) {
+        waiters.delete(waiter);
+        clearTimeout(waiter.timer);
+        waiter.resolve();
+      }
+    }
+  };
+
+  mochaProcess.stdout.on("data", (chunk) => {
+    stdout += chunk;
+    evaluate();
+  });
+  mochaProcess.stderr.on("data", (chunk) => {
+    stderr += chunk;
+    evaluate();
+  });
+
+  const waitFor = (isSatisfied, description) => {
+    if (isSatisfied()) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = { isSatisfied, resolve };
+      waiter.timer = setTimeout(
+        () => {
+          waiters.delete(waiter);
+          reject(
+            new Error(
+              `runMochaWatchAsync: timed out waiting for ${description}; ` +
+                `${runCount()} run(s) completed so far\n` +
+                `=== watch child STDOUT ===\n${stdout}\n` +
+                `=== watch child STDERR ===\n${stderr}`,
+            ),
+          );
+        },
+        Math.max(deadlineAt - Date.now(), 1),
+      );
+      waiters.add(waiter);
+    });
+  };
+
+  return {
+    runCount,
+    waitForRuns: (n) =>
+      waitFor(() => runCount() >= n, `watch run #${n} to complete`),
+    waitForStderr: (pattern, description) =>
+      waitFor(() => pattern.test(stderr), description),
+  };
+}
+
+/**
+ * Shuts a watch child down with `SIGINT` (sent as an IPC message when the
+ * child was forked, as on Windows), escalating to `SIGKILL` if it has not
+ * exited within {@link WATCH_EXIT_TIMEOUT_MS}.
+ *
+ * @param {import('child_process').ChildProcess} mochaProcess - Watch child
+ * @param {Promise<void>} closed - Resolves once the child has closed
+ */
+async function shutdownWatchChild(mochaProcess, closed) {
+  if (mochaProcess.exitCode === null && mochaProcess.signalCode === null) {
+    try {
+      if (mochaProcess.connected) {
+        mochaProcess.send("SIGINT");
+      } else {
+        mochaProcess.kill("SIGINT");
+      }
+    } catch {
+      // the child exited in between; the bounded wait below settles it
+    }
+  }
+  const killTimer = setTimeout(() => {
+    try {
+      mochaProcess.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }, WATCH_EXIT_TIMEOUT_MS);
+  await closed;
+  clearTimeout(killTimer);
+}
+
+/**
+ * Runs the mocha executable in watch mode, calls `change` and returns the
  * raw result.
  *
- * The function starts mocha with the given arguments and `--watch` and
- * waits until the first test run has completed. Then it calls `change`
- * and waits until the second test run has been completed. Mocha is
- * killed and the result is returned.
+ * The function starts mocha with the given arguments and `--watch`, waits
+ * until the first test run has verifiably completed (which also proves the
+ * file watcher is ready), calls `change`, and waits until
+ * `opts.expectedRuns` runs have completed in total. Mocha is then killed
+ * and the result is returned.
  *
  * On Windows, this will call `child_process.fork()` instead of `spawn()`.
  *
  * **Exit code will always be 0**
  * @param {string[]} args - Array of argument strings
- * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process`
- * @param {Function} change - A potentially `Promise`-returning callback to execute which will change a watched file
+ * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process` plus the watch options below
+ * @param {number} [opts.expectedRuns] - Total completed runs (including the first) to wait for before killing mocha; defaults to `2`
+ * @param {boolean} [opts.noRerun] - If `true`, expect NO rerun: observe a bounded grace period after `change` instead of waiting for a second run
+ * @param {boolean} [opts.firstRunCrashes] - If `true`, the first run fails to load: it prints only an error stack, so there is no countable run output to wait for
+ * @param {'json'|'marker'} [opts.runDetector] - How completed runs are counted; `runMochaWatchJSONAsync` sets `json`
+ * @param {number} [opts.budgetMs] - Shared deadline for everything this call waits on; must stay below the test's timeout
+ * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns, runCount}`
  * @returns {Promise<RawResult>}
  */
 async function runMochaWatchAsync(args, opts, change) {
   if (typeof opts === "string") {
     opts = { cwd: opts };
   }
+  const {
+    expectedRuns = 2,
+    noRerun = false,
+    firstRunCrashes = false,
+    runDetector = "marker",
+    budgetMs = DEFAULT_WATCH_BUDGET_MS,
+    ...spawnOpts
+  } = opts;
   opts = {
-    sleepMs: 2000,
-    stdio: ["pipe", "pipe", "inherit"],
-    ...opts,
+    stdio: ["pipe", "pipe", "pipe"],
+    separateStderr: true,
+    ...spawnOpts,
     fork: process.platform === "win32",
   };
   const [mochaProcess, resultPromise] = invokeMochaAsync(
     [...args, "--watch"],
     opts,
   );
-  await sleep(opts.sleepMs);
-  await change(mochaProcess);
-  await sleep(opts.sleepMs);
+  // avoid an unhandled rejection when a wait below throws first
+  resultPromise.catch(() => {});
+  const closed = new Promise((resolve) => {
+    mochaProcess.once("close", resolve);
+  });
+  const observer = createWatchRunObserver(mochaProcess, {
+    runDetector,
+    budgetMs,
+  });
 
-  if (
-    !(mochaProcess.connected
-      ? mochaProcess.send("SIGINT")
-      : mochaProcess.kill("SIGINT"))
-  ) {
-    throw new Error("failed to send signal to subprocess");
+  try {
+    // The first watch run only starts inside chokidar's `ready` handler, and
+    // file events from before then are ignored (`ignoreInitial` in
+    // lib/cli/watch-run.js) -- so a completed first run proves the watcher
+    // is armed and `change` cannot be lost. If watch mode ever starts the
+    // first run before the watcher is ready (e.g. mochajs/mocha#5409), this
+    // gate needs an explicit watcher-ready signal instead.
+    if (firstRunCrashes) {
+      await observer.waitForStderr(
+        /SyntaxError/,
+        "the first (crashing) watch run to print its error",
+      );
+    } else {
+      await observer.waitForRuns(1);
+    }
+
+    await change(mochaProcess, {
+      waitForRuns: observer.waitForRuns,
+      runCount: observer.runCount,
+    });
+
+    if (noRerun) {
+      // the absence of a rerun cannot be awaited; give an erroneous rerun a
+      // bounded window to show up, like the fixed sleep used historically
+      await sleep(WATCH_NO_RERUN_GRACE_MS);
+    } else {
+      await observer.waitForRuns(expectedRuns);
+    }
+  } finally {
+    await shutdownWatchChild(mochaProcess, closed);
   }
 
   const res = await resultPromise;
@@ -460,53 +683,55 @@ async function runMochaWatchAsync(args, opts, change) {
 }
 
 /**
- * Runs the mocha executable in watch mode calls `change` and returns the
- * JSON result.
+ * Runs the mocha executable in watch mode, calls `change` and returns the
+ * JSON result of every completed test run.
  *
- * The function starts mocha with the given arguments and `--watch` and
- * waits until the first test run has completed. Then it calls `change`
- * and waits until the second test run has been completed. Mocha is
- * killed and the result is returned.
- *
- * On Windows, this will call `child_process.fork()` instead of `spawn()`.
+ * See {@link runMochaWatchAsync} for the synchronization behavior and
+ * options; completed runs are counted by parsing the json reporter's
+ * output.
  *
  * **Exit code will always be 0**
  * @param {string[]} args - Array of argument strings
- * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for `child_process`
+ * @param {object|string} opts - If a `string`, then `cwd`, otherwise options for {@link runMochaWatchAsync}
  * @param {Function} change - A potentially `Promise`-returning callback to execute which will change a watched file
  * @returns {Promise<JSONResult>}
  */
 async function runMochaWatchJSONAsync(args, opts, change) {
+  if (typeof opts === "string") {
+    opts = { cwd: opts };
+  }
   const res = await runMochaWatchAsync(
     [...args, "--reporter", "json"],
-    opts,
+    { runDetector: "json", ...opts },
     change,
   );
-  return (
-    res.output
-      // eslint-disable-next-line no-control-regex
-      .replace(/\u001b\[\?25./g, "")
-      .split("\u001b[2K")
-      .filter((x) => x)
-      .map((x) => JSON.parse(x))
-  );
+  return parseWatchJSONOutput(res.output);
 }
 
-const touchRef = new Date();
+let lastTouchedTime = Date.now();
 
 /**
- * Synchronously touch a file. Creates
- * the file and all its parent directories if necessary.
+ * Synchronously touch a file with a fresh, strictly-increasing mtime.
+ * Creates the file and all its parent directories if necessary.
+ *
+ * Every touch gets its own mtime so that each one registers as a change on
+ * every file-watcher backend; repeatedly setting an identical mtime is
+ * invisible to polling watchers. Note that watchers may still coalesce
+ * repeated touches of the same file made in very quick succession --
+ * space them out in time.
  *
  * @param {string} filepath - Path to file
  */
 function touchFile(filepath) {
   fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  lastTouchedTime = Math.max(lastTouchedTime + 1000, Date.now());
+  const touchTime = new Date(lastTouchedTime);
   try {
-    fs.utimesSync(filepath, touchRef, touchRef);
-  } catch (err) {
+    fs.utimesSync(filepath, touchTime, touchTime);
+  } catch {
     const fd = fs.openSync(filepath, "a");
     fs.closeSync(fd);
+    fs.utimesSync(filepath, touchTime, touchTime);
   }
 }
 

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -25,6 +25,9 @@ describe("--watch", function () {
     let cleanup;
 
     this.slow(5000);
+    // tests wait on observed runs, bounded by the helpers' shared 50s budget
+    // with diagnostic output; keep mocha's own timeout above that budget
+    this.timeout(60000);
 
     beforeEach(async function () {
       const { dirpath, removeTempDir } = await createTempDir();
@@ -53,9 +56,13 @@ describe("--watch", function () {
 
       replaceFileContents(testFile, "done();", "done((;");
 
-      return runMochaWatchJSONAsync([testFile], tempDir, () => {
-        replaceFileContents(testFile, "done((;", "done();");
-      }).then((results) => {
+      return runMochaWatchJSONAsync(
+        [testFile],
+        { cwd: tempDir, firstRunCrashes: true, expectedRuns: 1 },
+        () => {
+          replaceFileContents(testFile, "done((;", "done();");
+        },
+      ).then((results) => {
         expect(results, "to have length", 1);
       });
     });
@@ -72,15 +79,21 @@ describe("--watch", function () {
         });
       });
 
+      // TODO: this test never passes `--parallel`, so it duplicates the
+      // non-parallel crash test above; kept as-is in this stabilization change
       it("reruns test when watched test file is crashed", function () {
         const testFile = path.join(tempDir, "test.js");
         copyFixture(DEFAULT_FIXTURE, testFile);
 
         replaceFileContents(testFile, "done();", "done((;");
 
-        return runMochaWatchJSONAsync([testFile], tempDir, () => {
-          replaceFileContents(testFile, "done((;", "done();");
-        }).then((results) => {
+        return runMochaWatchJSONAsync(
+          [testFile],
+          { cwd: tempDir, firstRunCrashes: true, expectedRuns: 1 },
+          () => {
+            replaceFileContents(testFile, "done((;", "done();");
+          },
+        ).then((results) => {
           expect(results, "to have length", 1);
         });
       });
@@ -131,12 +144,17 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
-        tempDir,
-        async () => {
+        { cwd: tempDir, expectedRuns: 4 },
+        async (mochaProcess, { waitForRuns }) => {
           fs.mkdirSync(libPath);
+          await waitForRuns(2);
+          // the watcher installs its watch on a newly created directory
+          // asynchronously; an event inside it before that is lost entirely
+          // (chokidar#1112), so give the installation a moment
           await sleep(1000);
 
           fs.mkdirSync(dirPath);
+          await waitForRuns(3);
           await sleep(1000);
 
           touchFile(watchedFile);
@@ -287,7 +305,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "dir/*.xyz"],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(watchedFile);
         },
@@ -373,7 +391,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--extension", "xyz,js"],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(gitFile);
           touchFile(nodeModulesFile);
@@ -398,7 +416,7 @@ describe("--watch", function () {
           "--watch-ignore",
           "dir/*ignore*",
         ],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(watchedFile);
         },
@@ -417,7 +435,7 @@ describe("--watch", function () {
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "dir/[ab].js"],
-        tempDir,
+        { cwd: tempDir, noRerun: true },
         () => {
           touchFile(watchedFile);
         },
@@ -536,25 +554,28 @@ describe("--watch", function () {
       const testFile = path.join(tempDir, "test.js");
       copyFixture(DEFAULT_FIXTURE, testFile);
 
+      // we want to cause _n + 1_ reruns, which should cause the warning
+      // to occur if the listeners aren't properly destroyed
+      const totalRuns = process.getMaxListeners() + 2;
+
       return expect(
         runMochaWatchAsync(
           [testFile],
-          { cwd: tempDir, stdio: "pipe" },
-          async () => {
-            // we want to cause _n + 1_ reruns, which should cause the warning
-            // to occur if the listeners aren't properly destroyed
-            const iterations = new Array(process.getMaxListeners() + 1);
-            // eslint-disable-next-line no-unused-vars
-            for await (const _ of iterations) {
+          { cwd: tempDir, expectedRuns: totalRuns },
+          async (mochaProcess, { waitForRuns }) => {
+            for (let run = 2; run <= totalRuns; run++) {
               touchFile(testFile);
-              await sleep(1000);
+              await waitForRuns(run);
+              // watchers coalesce same-file touches made in very quick
+              // succession; space them out so every touch causes a rerun
+              await sleep(250);
             }
           },
         ),
         "when fulfilled",
         "to satisfy",
         {
-          output: expect.it("not to match", /MaxListenersExceededWarning/),
+          stderr: expect.it("not to match", /MaxListenersExceededWarning/),
         },
       );
     });

--- a/test/integration/plugins/global-fixtures.spec.js
+++ b/test/integration/plugins/global-fixtures.spec.js
@@ -109,7 +109,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },
@@ -128,7 +128,7 @@ describe("global setup/teardown", function () {
                 resolveFixturePath("plugins/global-fixtures/global-teardown"),
                 testFile,
               ],
-              tempDir,
+              { cwd: tempDir, budgetMs: 8500 },
               () => {
                 touchFile(testFile);
               },
@@ -149,7 +149,7 @@ describe("global setup/teardown", function () {
                 resolveFixturePath("plugins/global-fixtures/global-setup"),
                 testFile,
               ],
-              tempDir,
+              { cwd: tempDir, budgetMs: 8500 },
               () => {
                 touchFile(testFile);
               },
@@ -171,7 +171,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },
@@ -257,7 +257,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },
@@ -278,7 +278,7 @@ describe("global setup/teardown", function () {
               ),
               testFile,
             ],
-            tempDir,
+            { cwd: tempDir, budgetMs: 8500 },
             () => {
               touchFile(testFile);
             },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: #6037 (v11.x backport of #6058)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Backport of #6058 to v11.x. The watch implementation and tests are identical on this branch (the only difference was a `catch` binding style in `touchFile`), so the change transposes one-to-one — see #6058 for the full description of the races and the synchronization design.

On this branch the watch suite (30 tests) and the global-fixtures watch tests pass under nyc in ~20s and ~5s respectively, with no fixed sleeps left outside the documented bounded windows (no-rerun grace, directory-watch settle).
