### PR TITLE
chore: fix "remove 'waiting for author' " workflow

### DIFF
--- a/.github/workflows/remove-waiting-label.yml
+++ b/.github/workflows/remove-waiting-label.yml
@@ -3,7 +3,6 @@ name: Remove "waiting for author" label on review request
 on:
   pull_request_target:
     types: [review_requested]
-  workflow_dispatch:
 
 permissions:
   issues: write
@@ -16,6 +15,17 @@ jobs:
 
     steps:
       - name: 'Remove "status: waiting for author" label'
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions/github-script@v7
         with:
-          labels: "status: waiting for author"
+          # REST gives 404 if label isn't present
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'status: waiting for author',
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5978
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The action in the workflow wasn't trusted. This action definitely should be! My mistake for merging without testing. That's the second time I've done that, definitely learned my lesson now!

From https://github.com/mark-wiemer/mocha/pull/16:

1. Exits gracefully when label isn't present: https://github.com/mark-wiemer/mocha/actions/runs/27834974884?pr=16
2. Succeeds when label is present: https://github.com/mark-wiemer/mocha/actions/runs/27835168796?pr=16

<img width="913" height="584" alt="test PR convo history showing bot actually removed label after review was requested" src="https://github.com/user-attachments/assets/a772c915-1bc3-4032-81df-287618313651" />

Yippee :)