### PR TITLE
test: require exact fixture references in integration tests

### DIFF
--- a/test/integration/duplicate-arguments.spec.cjs
+++ b/test/integration/duplicate-arguments.spec.cjs
@@ -6,7 +6,7 @@ describe("when non-array argument is provided multiple times", function () {
   describe("when the same argument name is used", function () {
     it("should prefer the last value", function (done) {
       runMochaJSON(
-        "passing-sync",
+        "passing-sync.fixture.js",
         ["--no-async-only", "--async-only", "--no-async-only"],
         function (err, result) {
           if (err) {
@@ -22,7 +22,7 @@ describe("when non-array argument is provided multiple times", function () {
   describe("when a different argument name is used", function () {
     it("should prefer the last value", function (done) {
       runMochaJSON(
-        "passing-async",
+        "passing-async.fixture.js",
         ["--timeout", "100", "-t", "10"],
         function (err, result) {
           if (err) {

--- a/test/integration/helpers.cjs
+++ b/test/integration/helpers.cjs
@@ -24,7 +24,7 @@ const SPLIT_DOT_REPORTER_REGEXP = new RegExp("[\\n" + Base.symbols.dot + "]+");
 /**
  * Name of "default" fixture file.
  */
-const DEFAULT_FIXTURE = "__default__";
+const DEFAULT_FIXTURE = "__default__.fixture.js";
 
 /**
  * Path to "default" fixture file
@@ -386,9 +386,14 @@ function createSubprocess(args, done, opts = {}) {
 }
 
 /**
- * Given a fixture "name" (a relative path from `${__dirname}/fixtures`),
- * with or without extension, or an absolute path, resolve a fixture filepath
- * @param {string} fixture - Fixture name
+ * Given an exact fixture reference (a relative path from `${__dirname}/fixtures`,
+ * including its extension) or an absolute path, resolve a fixture filepath.
+ *
+ * Fixture references must be exact. Passing a bare name such as my-file and
+ * relying on my-file.fixture.js being found is no longer supported, pass the
+ * full file name (for example: my-file.fixture.js) instead.
+ *
+ * @param {string} fixture - Exact fixture reference
  * @returns {string} Resolved filepath
  */
 function resolveFixturePath(fixture) {
@@ -396,24 +401,14 @@ function resolveFixturePath(fixture) {
     return fixture;
   }
 
-  const supportedFixtureExtensions = [".cjs", ".js", ".ts"];
-
-  if (supportedFixtureExtensions.includes(path.extname(fixture))) {
-    return path.resolve(__dirname, "fixtures", fixture);
-  }
-
-  for (const extension of supportedFixtureExtensions) {
-    const resolved = path.resolve(
-      __dirname,
-      "fixtures",
-      `${fixture}.fixture${extension}`,
+  if (!path.extname(fixture)) {
+    throw new Error(
+      `Fixture "${fixture}" must be referenced by its exact file name, ` +
+        `e.g. "${fixture}.fixture.js".`,
     );
-    if (fs.existsSync(resolved)) {
-      return resolved;
-    }
   }
 
-  return path.resolve(__dirname, "fixtures", `${fixture}.fixture.js`);
+  return path.resolve(__dirname, "fixtures", fixture);
 }
 
 /**

--- a/test/integration/hook-err.spec.cjs
+++ b/test/integration/hook-err.spec.cjs
@@ -29,51 +29,63 @@ describe("hook error handling", function () {
 
   describe("before hook root error", function () {
     it("should verify results", function (done) {
-      runMochaJSON("hooks/before-hook-root-error", [], (err, res) => {
-        if (err) {
-          return done(err);
-        }
-        expect(res, "to have failed with error", "before hook root error")
-          .and("to have failed test", '"before all" hook in "{root}"')
-          .and("to have passed test count", 0);
-        done();
-      });
+      runMochaJSON(
+        "hooks/before-hook-root-error.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "before hook root error")
+            .and("to have failed test", '"before all" hook in "{root}"')
+            .and("to have passed test count", 0);
+          done();
+        },
+      );
     });
   });
 
   describe("before hook nested error", function () {
     it("should verify results", function (done) {
-      runMochaJSON("hooks/before-hook-nested-error", [], (err, res) => {
-        if (err) {
-          return done(err);
-        }
-        expect(res, "to have failed with error", "before hook nested error")
-          .and(
-            "to have failed test",
-            '"before all" hook for "it nested - this title should be used"',
-          )
-          .and("to have passed test count", 1)
-          .and("to have passed test", "should pass");
-        done();
-      });
+      runMochaJSON(
+        "hooks/before-hook-nested-error.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "before hook nested error")
+            .and(
+              "to have failed test",
+              '"before all" hook for "it nested - this title should be used"',
+            )
+            .and("to have passed test count", 1)
+            .and("to have passed test", "should pass");
+          done();
+        },
+      );
     });
   });
 
   describe("before hook deepnested error", function () {
     it("should verify results", function (done) {
-      runMochaJSON("hooks/before-hook-deepnested-error", [], (err, res) => {
-        if (err) {
-          return done(err);
-        }
-        expect(res, "to have failed with error", "before hook nested error")
-          .and(
-            "to have failed test",
-            '"before all" hook in "spec 2 nested - this title should be used"',
-          )
-          .and("to have passed test count", 1)
-          .and("to have passed test", "should pass");
-        done();
-      });
+      runMochaJSON(
+        "hooks/before-hook-deepnested-error.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "before hook nested error")
+            .and(
+              "to have failed test",
+              '"before all" hook in "spec 2 nested - this title should be used"',
+            )
+            .and("to have passed test count", 1)
+            .and("to have passed test", "should pass");
+          done();
+        },
+      );
     });
   });
 
@@ -93,46 +105,54 @@ describe("hook error handling", function () {
 
   describe("after hook nested error", function () {
     it("should verify results", function (done) {
-      runMochaJSON("hooks/after-hook-nested-error", [], (err, res) => {
-        if (err) {
-          return done(err);
-        }
-        expect(res, "to have failed with error", "after hook nested error")
-          .and(
-            "to have failed test",
-            '"after all" hook for "it nested - this title should be used"',
-          )
-          .and("to have passed test count", 3)
-          .and(
-            "to have passed test order",
-            "should pass",
-            "it nested - this title should be used",
-            "it nested - not this title",
-          );
-        done();
-      });
+      runMochaJSON(
+        "hooks/after-hook-nested-error.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "after hook nested error")
+            .and(
+              "to have failed test",
+              '"after all" hook for "it nested - this title should be used"',
+            )
+            .and("to have passed test count", 3)
+            .and(
+              "to have passed test order",
+              "should pass",
+              "it nested - this title should be used",
+              "it nested - not this title",
+            );
+          done();
+        },
+      );
     });
   });
 
   describe("after hook deepnested error", function () {
     it("should verify results", function (done) {
-      runMochaJSON("hooks/after-hook-deepnested-error", [], (err, res) => {
-        if (err) {
-          return done(err);
-        }
-        expect(res, "to have failed with error", "after hook nested error")
-          .and(
-            "to have failed test",
-            '"after all" hook in "spec 2 nested - this title should be used"',
-          )
-          .and("to have passed test count", 2)
-          .and(
-            "to have passed test order",
-            "should pass",
-            "it nested - this title should not be used",
-          );
-        done();
-      });
+      runMochaJSON(
+        "hooks/after-hook-deepnested-error.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "after hook nested error")
+            .and(
+              "to have failed test",
+              '"after all" hook in "spec 2 nested - this title should be used"',
+            )
+            .and("to have passed test count", 2)
+            .and(
+              "to have passed test order",
+              "should pass",
+              "it nested - this title should not be used",
+            );
+          done();
+        },
+      );
     });
   });
 
@@ -256,7 +276,7 @@ describe("hook error handling", function () {
   describe('"this.test.error()-style failure', function () {
     it("should fail the associated test", async function () {
       return expect(
-        runMochaJSONAsync("hooks/after-each-this-test-error"),
+        runMochaJSONAsync("hooks/after-each-this-test-error.fixture.js"),
         "when fulfilled",
         "to have failed",
       ).and(
@@ -271,7 +291,7 @@ describe("hook error handling", function () {
     describe("error in `before` hook", function () {
       it("should fail all affected tests", function (done) {
         runMochaJSON(
-          "hooks/before-hook-error-with-fail-affected",
+          "hooks/before-hook-error-with-fail-affected.fixture.js",
           ["--fail-hook-affected-tests"],
           (err, res) => {
             if (err) {
@@ -293,7 +313,7 @@ describe("hook error handling", function () {
     describe("error in `beforeEach` hook", function () {
       it("should fail all affected tests", function (done) {
         runMochaJSON(
-          "hooks/before-each-hook-error-with-fail-affected",
+          "hooks/before-each-hook-error-with-fail-affected.fixture.js",
           ["--fail-hook-affected-tests"],
           (err, res) => {
             if (err) {
@@ -315,7 +335,7 @@ describe("hook error handling", function () {
     describe("non-Error thrown in `before` hook", function () {
       it("should handle null, undefined, and other non-Error values", function (done) {
         runMochaJSON(
-          "hooks/before-hook-throw-non-error",
+          "hooks/before-hook-throw-non-error.fixture.js",
           ["--fail-hook-affected-tests"],
           (err, res) => {
             if (err) {
@@ -336,7 +356,7 @@ describe("hook error handling", function () {
     describe("non-Error thrown in `beforeEach` hook", function () {
       it("should handle null, undefined, and other non-Error values", function (done) {
         runMochaJSON(
-          "hooks/before-each-hook-throw-non-error",
+          "hooks/before-each-hook-throw-non-error.fixture.js",
           ["--fail-hook-affected-tests"],
           (err, res) => {
             if (err) {

--- a/test/integration/multiple-done.spec.cjs
+++ b/test/integration/multiple-done.spec.cjs
@@ -9,7 +9,7 @@ describe("multiple calls to done()", function () {
   var res;
   describe("from a spec", function () {
     before(function (done) {
-      runMochaJSON("multiple-done", function (err, result) {
+      runMochaJSON("multiple-done.fixture.js", function (err, result) {
         res = result;
         done(err);
       });
@@ -33,10 +33,13 @@ describe("multiple calls to done()", function () {
 
   describe("with error passed on second call", function () {
     before(function (done) {
-      runMochaJSON("multiple-done-with-error", function (err, result) {
-        res = result;
-        done(err);
-      });
+      runMochaJSON(
+        "multiple-done-with-error.fixture.js",
+        function (err, result) {
+          res = result;
+          done(err);
+        },
+      );
     });
 
     it("results in failure", function () {
@@ -57,7 +60,7 @@ describe("multiple calls to done()", function () {
 
   describe("with multiple specs", function () {
     before(function (done) {
-      runMochaJSON("multiple-done-specs", function (err, result) {
+      runMochaJSON("multiple-done-specs.fixture.js", function (err, result) {
         res = result;
         done(err);
       });
@@ -84,7 +87,7 @@ describe("multiple calls to done()", function () {
 
   describe("from a before hook", function () {
     before(function (done) {
-      runMochaJSON("multiple-done-before", function (err, result) {
+      runMochaJSON("multiple-done-before.fixture.js", function (err, result) {
         res = result;
         done(err);
       });
@@ -110,10 +113,13 @@ describe("multiple calls to done()", function () {
 
   describe('from a "before each" hook', function () {
     before(function (done) {
-      runMochaJSON("multiple-done-before-each", function (err, result) {
-        res = result;
-        done(err);
-      });
+      runMochaJSON(
+        "multiple-done-before-each.fixture.js",
+        function (err, result) {
+          res = result;
+          done(err);
+        },
+      );
     });
 
     it("results in a failure", function () {

--- a/test/integration/options/allowUncaught.spec.cjs
+++ b/test/integration/options/allowUncaught.spec.cjs
@@ -33,7 +33,11 @@ describe("--allow-uncaught", function () {
   });
 
   it("should run with conditional `this.skip()`", function (done) {
-    var fixture = path.join("options", "allow-uncaught", "this-skip-it");
+    var fixture = path.join(
+      "options",
+      "allow-uncaught",
+      "this-skip-it.fixture.js",
+    );
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);

--- a/test/integration/options/asyncOnly.spec.cjs
+++ b/test/integration/options/asyncOnly.spec.cjs
@@ -12,7 +12,7 @@ describe("--async-only", function () {
   });
 
   it("should fail synchronous specs", function (done) {
-    var fixture = path.join("options", "async-only-sync");
+    var fixture = path.join("options", "async-only-sync.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -24,7 +24,7 @@ describe("--async-only", function () {
   });
 
   it("should allow asynchronous specs", function (done) {
-    var fixture = path.join("options", "async-only-async");
+    var fixture = path.join("options", "async-only-async.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);

--- a/test/integration/options/bail.spec.cjs
+++ b/test/integration/options/bail.spec.cjs
@@ -12,7 +12,7 @@ describe("--bail", function () {
   });
 
   it("should stop after the first error", function (done) {
-    var fixture = path.join("options", "bail");
+    var fixture = path.join("options", "bail.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -28,7 +28,7 @@ describe("--bail", function () {
   });
 
   it("should stop after the first error - async", function (done) {
-    var fixture = path.join("options", "bail-async");
+    var fixture = path.join("options", "bail-async.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -44,7 +44,7 @@ describe("--bail", function () {
   });
 
   it('should stop all tests after failing "before" hook', function (done) {
-    var fixture = path.join("options", "bail-with-before");
+    var fixture = path.join("options", "bail-with-before.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -62,7 +62,7 @@ describe("--bail", function () {
   });
 
   it('should stop all tests after failing "beforeEach" hook', function (done) {
-    var fixture = path.join("options", "bail-with-beforeEach");
+    var fixture = path.join("options", "bail-with-beforeEach.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -80,7 +80,7 @@ describe("--bail", function () {
   });
 
   it("should stop all tests after failing test", function (done) {
-    var fixture = path.join("options", "bail-with-test");
+    var fixture = path.join("options", "bail-with-test.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -95,7 +95,7 @@ describe("--bail", function () {
   });
 
   it('should stop all tests after failing "after" hook', function (done) {
-    var fixture = path.join("options", "bail-with-after");
+    var fixture = path.join("options", "bail-with-after.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -114,7 +114,7 @@ describe("--bail", function () {
   });
 
   it('should stop all tests after failing "afterEach" hook', function (done) {
-    var fixture = path.join("options", "bail-with-afterEach");
+    var fixture = path.join("options", "bail-with-afterEach.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);

--- a/test/integration/options/delay.spec.cjs
+++ b/test/integration/options/delay.spec.cjs
@@ -8,7 +8,7 @@ describe("--delay", function () {
   var args = ["--delay", "--no-forbid-only"];
 
   it("should run the generated test suite", function (done) {
-    var fixture = path.join("options", "delay");
+    var fixture = path.join("options", "delay.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -20,7 +20,7 @@ describe("--delay", function () {
   });
 
   it("should execute exclusive tests only", function (done) {
-    var fixture = path.join("options", "delay-only");
+    var fixture = path.join("options", "delay-only.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -38,7 +38,7 @@ describe("--delay", function () {
   });
 
   it("should throw an error if the test suite failed to run", function (done) {
-    var fixture = path.join("options", "delay-fail");
+    var fixture = path.join("options", "delay-fail.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);

--- a/test/integration/options/dryRun.spec.cjs
+++ b/test/integration/options/dryRun.spec.cjs
@@ -8,7 +8,7 @@ describe("--dry-run", function () {
   var args = ["--dry-run", "--no-forbid-only"];
 
   it("should only report, but not execute any test", function (done) {
-    var fixture = path.join("options/dry-run", "dry-run");
+    var fixture = path.join("options/dry-run", "dry-run.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -29,7 +29,7 @@ describe("--dry-run", function () {
   });
 
   it('should pass without "RangeError: maximum call stack size exceeded"', function (done) {
-    var fixture = path.join("options/dry-run", "stack-size");
+    var fixture = path.join("options/dry-run", "stack-size.fixture.cjs");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);

--- a/test/integration/options/file.spec.cjs
+++ b/test/integration/options/file.spec.cjs
@@ -10,9 +10,9 @@ const {
 describe("--file", function () {
   var args = [];
   var fixtures = {
-    alpha: path.join("options", "file-alpha"),
-    beta: path.join("options", "file-beta"),
-    theta: path.join("options", "file-theta"),
+    alpha: path.join("options", "file-alpha.fixture.js"),
+    beta: path.join("options", "file-beta.fixture.js"),
+    theta: path.join("options", "file-theta.fixture.js"),
   };
 
   it("should run tests passed via file first", function (done) {

--- a/test/integration/options/forbidOnly.spec.cjs
+++ b/test/integration/options/forbidOnly.spec.cjs
@@ -14,7 +14,7 @@ describe("--forbid-only", function () {
   });
 
   it("should succeed if there are only passed tests", function (done) {
-    var fixture = path.join("options", "forbid-only", "passed");
+    var fixture = path.join("options", "forbid-only", "passed.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -25,7 +25,7 @@ describe("--forbid-only", function () {
   });
 
   it("should fail if there are tests marked only", function (done) {
-    var fixture = path.join("options", "forbid-only", "only");
+    var fixture = path.join("options", "forbid-only", "only.fixture.js");
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -42,7 +42,7 @@ describe("--forbid-only", function () {
   });
 
   it("should fail if there are tests in suites marked only", function (done) {
-    var fixture = path.join("options", "forbid-only", "only-suite");
+    var fixture = path.join("options", "forbid-only", "only-suite.fixture.js");
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -59,7 +59,11 @@ describe("--forbid-only", function () {
   });
 
   it("should fail if there is empty suite marked only", function (done) {
-    var fixture = path.join("options", "forbid-only", "only-empty-suite");
+    var fixture = path.join(
+      "options",
+      "forbid-only",
+      "only-empty-suite.fixture.js",
+    );
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -76,7 +80,7 @@ describe("--forbid-only", function () {
   });
 
   it("should fail if there is suite marked only which matches grep", function (done) {
-    var fixture = path.join("options", "forbid-only", "only-suite");
+    var fixture = path.join("options", "forbid-only", "only-suite.fixture.js");
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -93,7 +97,7 @@ describe("--forbid-only", function () {
   });
 
   it("should fail if suite marked only does not match grep", function (done) {
-    var fixture = path.join("options", "forbid-only", "only-suite");
+    var fixture = path.join("options", "forbid-only", "only-suite.fixture.js");
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -110,7 +114,7 @@ describe("--forbid-only", function () {
   });
 
   it("should fail if suite marked only does not match inverted grep", function (done) {
-    var fixture = path.join("options", "forbid-only", "only-suite");
+    var fixture = path.join("options", "forbid-only", "only-suite.fixture.js");
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -127,7 +131,7 @@ describe("--forbid-only", function () {
   });
 
   it('should fail even if before has "skip"', function (done) {
-    var fixture = path.join("options", "forbid-only", "only-before");
+    var fixture = path.join("options", "forbid-only", "only-before.fixture.js");
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -144,7 +148,11 @@ describe("--forbid-only", function () {
   });
 
   it('should fail even if beforeEach has "skip"', function (done) {
-    var fixture = path.join("options", "forbid-only", "only-before-each");
+    var fixture = path.join(
+      "options",
+      "forbid-only",
+      "only-before-each.fixture.js",
+    );
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,

--- a/test/integration/options/forbidPending.spec.cjs
+++ b/test/integration/options/forbidPending.spec.cjs
@@ -14,7 +14,7 @@ describe("--forbid-pending", function () {
   });
 
   it("should succeed if there are only passed tests", function (done) {
-    var fixture = path.join("options", "forbid-pending", "passed");
+    var fixture = path.join("options", "forbid-pending", "passed.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);
@@ -25,7 +25,11 @@ describe("--forbid-pending", function () {
   });
 
   it("should fail if there are tests in suites marked skip", function (done) {
-    var fixture = path.join("options", "forbid-pending", "skip-suite");
+    var fixture = path.join(
+      "options",
+      "forbid-pending",
+      "skip-suite.fixture.js",
+    );
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -45,7 +49,11 @@ describe("--forbid-pending", function () {
   });
 
   it("should fail if there is empty suite marked pending", function (done) {
-    var fixture = path.join("options", "forbid-pending", "skip-empty-suite");
+    var fixture = path.join(
+      "options",
+      "forbid-pending",
+      "skip-empty-suite.fixture.js",
+    );
     var spawnOpts = { stdio: "pipe" };
     runMocha(
       fixture,
@@ -65,11 +73,12 @@ describe("--forbid-pending", function () {
   });
 
   var forbidPendingFailureTests = {
-    "should fail if there are tests marked skip": "skip",
-    "should fail if there are pending tests": "pending",
-    "should fail if tests call `skip()`": "this-skip",
-    "should fail if beforeEach calls `skip()`": "beforeEach-this-skip",
-    "should fail if before calls `skip()`": "before-this-skip",
+    "should fail if there are tests marked skip": "skip.fixture.js",
+    "should fail if there are pending tests": "pending.fixture.js",
+    "should fail if tests call `skip()`": "this-skip.fixture.js",
+    "should fail if beforeEach calls `skip()`":
+      "beforeEach-this-skip.fixture.js",
+    "should fail if before calls `skip()`": "before-this-skip.fixture.js",
   };
 
   Object.keys(forbidPendingFailureTests).forEach(function (title) {

--- a/test/integration/options/grep.spec.cjs
+++ b/test/integration/options/grep.spec.cjs
@@ -4,7 +4,7 @@ var helpers = require("../helpers.cjs");
 var runMocha = helpers.runMocha;
 var runMochaJSON = helpers.runMochaJSON;
 
-var FIXTURE = "options/grep";
+var FIXTURE = "options/grep.fixture.js";
 
 describe("--grep", function () {
   it("should run specs matching a string", function (done) {

--- a/test/integration/options/ignore.spec.cjs
+++ b/test/integration/options/ignore.spec.cjs
@@ -27,12 +27,15 @@ describe("--ignore", function () {
   }
 
   it("should ignore specific files", function (done) {
-    var fixtures = path.join("options", "ignore", "*");
+    var fixtures = path.join("options", "ignore", "*.fixture.js");
     runMochaTest(
       fixtures,
       [
         "--ignore",
-        resolvePath(path.join("options", "ignore", "fail")).replace(/\\/g, "/"),
+        resolvePath(path.join("options", "ignore", "fail.fixture.js")).replace(
+          /\\/g,
+          "/",
+        ),
       ],
       function (res) {
         expect(res, "to have passed")
@@ -44,7 +47,7 @@ describe("--ignore", function () {
   });
 
   it("should ignore globbed files", function (done) {
-    var fixtures = path.join("options", "ignore", "**", "*");
+    var fixtures = path.join("options", "ignore", "**", "*.fixture.js");
     runMochaTest(
       fixtures,
       ["--ignore", "**/fail.fixture.js"],
@@ -58,17 +61,19 @@ describe("--ignore", function () {
   });
 
   it("should ignore multiple patterns", function (done) {
-    var fixtures = path.join("options", "ignore", "**", "*");
+    var fixtures = path.join("options", "ignore", "**", "*.fixture.js");
     runMochaTest(
       fixtures,
       [
         "--ignore",
-        resolvePath(path.join("options", "ignore", "fail")).replace(/\\/g, "/"),
-        "--ignore",
-        resolvePath(path.join("options", "ignore", "nested", "fail")).replace(
+        resolvePath(path.join("options", "ignore", "fail.fixture.js")).replace(
           /\\/g,
           "/",
         ),
+        "--ignore",
+        resolvePath(
+          path.join("options", "ignore", "nested", "fail.fixture.js"),
+        ).replace(/\\/g, "/"),
       ],
       function (res) {
         expect(res, "to have passed")

--- a/test/integration/options/invert.spec.cjs
+++ b/test/integration/options/invert.spec.cjs
@@ -6,7 +6,7 @@ describe("--invert", function () {
   describe("when used without --fgrep or --grep", function () {
     it("it should report an error", function (done) {
       runMocha(
-        "options/grep",
+        "options/grep.fixture.js",
         ["--invert"],
         function (err, res) {
           if (err) {

--- a/test/integration/options/jobs.spec.cjs
+++ b/test/integration/options/jobs.spec.cjs
@@ -8,7 +8,7 @@ describe("--jobs", function () {
     it("should run tests in serial", function () {
       return expect(
         runMochaAsync(
-          "options/jobs/fail-in-parallel",
+          "options/jobs/fail-in-parallel.fixture.cjs",
           ["--parallel", "--jobs", "1"],
           "pipe",
         ),
@@ -22,7 +22,7 @@ describe("--jobs", function () {
     it("should run tests in parallel", function () {
       return expect(
         runMochaAsync(
-          "options/jobs/fail-in-parallel",
+          "options/jobs/fail-in-parallel.fixture.cjs",
           ["--parallel", "--jobs", "2"],
           "pipe",
         ),

--- a/test/integration/options/parallel.spec.cjs
+++ b/test/integration/options/parallel.spec.cjs
@@ -8,7 +8,9 @@ const {
 } = require("../helpers.cjs");
 const psList = require("ps-list").default;
 
-const REPORTER_FIXTURE_PATH = resolveFixturePath("options/parallel/test-a");
+const REPORTER_FIXTURE_PATH = resolveFixturePath(
+  "options/parallel/test-a.fixture.js",
+);
 
 /**
  * Get child processes of a given PID using ps-list
@@ -97,7 +99,9 @@ describe("--parallel", function () {
     describe("when there is only a single test file", function () {
       it("should fail gracefully", async function () {
         return expect(
-          runMochaAsync("options/parallel/syntax-err", ["--parallel"]),
+          runMochaAsync("options/parallel/syntax-err.fixture.js", [
+            "--parallel",
+          ]),
           "when fulfilled",
           "to have failed with output",
           /SyntaxError/,
@@ -109,7 +113,10 @@ describe("--parallel", function () {
       it("should fail gracefully", async function () {
         return expect(
           invokeMochaAsync(
-            [resolveFixturePath("options/parallel/syntax-err"), "--parallel"],
+            [
+              resolveFixturePath("options/parallel/syntax-err.fixture.js"),
+              "--parallel",
+            ],
             "pipe",
           )[1],
           "when fulfilled",
@@ -121,11 +128,12 @@ describe("--parallel", function () {
 
   describe("when used with CJS tests", function () {
     it("should have the same result as with --no-parallel", async function () {
-      const expected = await runMochaAsync("options/parallel/test-*", [
-        "--no-parallel",
-      ]);
+      const expected = await runMochaAsync(
+        "options/parallel/test-*.fixture.js",
+        ["--no-parallel"],
+      );
       return expect(
-        runMochaAsync("options/parallel/test-*", ["--parallel"]),
+        runMochaAsync("options/parallel/test-*.fixture.js", ["--parallel"]),
         "to be fulfilled with value satisfying",
         {
           passing: expected.passing,
@@ -164,7 +172,7 @@ describe("--parallel", function () {
   describe("when used with --retries", function () {
     it("should retry tests appropriately", async function () {
       return expect(
-        runMochaAsync("options/parallel/retries-*", ["--parallel"]),
+        runMochaAsync("options/parallel/retries-*.fixture.js", ["--parallel"]),
         "when fulfilled",
         "to satisfy",
         expect
@@ -182,7 +190,7 @@ describe("--parallel", function () {
       return expect(
         invokeMochaAsync(
           [
-            resolveFixturePath("options/parallel/uncaught"),
+            resolveFixturePath("options/parallel/uncaught.fixture.js"),
             "--parallel",
             "--allow-uncaught",
           ],
@@ -203,7 +211,7 @@ describe("--parallel", function () {
         invokeMochaAsync(
           [
             "--file",
-            resolveFixturePath("options/parallel/test-a"),
+            resolveFixturePath("options/parallel/test-a.fixture.js"),
             "--parallel",
           ],
           "pipe",
@@ -221,7 +229,7 @@ describe("--parallel", function () {
         invokeMochaAsync(
           [
             "--sort",
-            resolveFixturePath("options/parallel/test-*"),
+            resolveFixturePath("options/parallel/test-*.fixture.js"),
             "--parallel",
           ],
           "pipe",
@@ -238,7 +246,7 @@ describe("--parallel", function () {
       return expect(
         invokeMochaAsync(
           [
-            resolveFixturePath("options/parallel/exclusive-test-*"),
+            resolveFixturePath("options/parallel/exclusive-test-*.fixture.js"),
             "--parallel",
           ],
           "pipe",
@@ -252,7 +260,7 @@ describe("--parallel", function () {
 
   describe("when used with --bail", function () {
     it("should skip some tests", async function () {
-      const result = await runMochaAsync("options/parallel/test-*", [
+      const result = await runMochaAsync("options/parallel/test-*.fixture.js", [
         "--parallel",
         "--bail",
       ]);
@@ -268,7 +276,10 @@ describe("--parallel", function () {
 
     it("should fail", async function () {
       return expect(
-        runMochaAsync("options/parallel/test-*", ["--parallel", "--bail"]),
+        runMochaAsync("options/parallel/test-*.fixture.js", [
+          "--parallel",
+          "--bail",
+        ]),
         "when fulfilled",
         "to have failed",
       );
@@ -277,7 +288,7 @@ describe("--parallel", function () {
 
   describe('when encountering a "bail" in context', function () {
     it("should skip some tests", async function () {
-      const result = await runMochaAsync("options/parallel/bail", [
+      const result = await runMochaAsync("options/parallel/bail.fixture.js", [
         "--parallel",
       ]);
       return expect(
@@ -289,7 +300,10 @@ describe("--parallel", function () {
 
     it("should fail", async function () {
       return expect(
-        runMochaAsync("options/parallel/bail", ["--parallel", "--bail"]),
+        runMochaAsync("options/parallel/bail.fixture.js", [
+          "--parallel",
+          "--bail",
+        ]),
         "when fulfilled",
         "to have failed",
       );
@@ -298,12 +312,12 @@ describe("--parallel", function () {
 
   describe('when used with "grep"', function () {
     it("should be equivalent to running in serial", async function () {
-      const expected = await runMochaAsync("options/parallel/test-*", [
-        "--no-parallel",
-        '--grep="suite d"',
-      ]);
+      const expected = await runMochaAsync(
+        "options/parallel/test-*.fixture.js",
+        ["--no-parallel", '--grep="suite d"'],
+      );
       return expect(
-        runMochaAsync("options/parallel/test-*", [
+        runMochaAsync("options/parallel/test-*.fixture.js", [
           "--parallel",
           '--grep="suite d"',
         ]),
@@ -329,13 +343,12 @@ describe("--parallel", function () {
           it("should have the same result as when run with --no-parallel", async function () {
             // note that the output may not be in the same order, as running file
             // order is non-deterministic in parallel mode
-            const expected = await runMochaAsync("options/parallel/test-*", [
-              "--reporter",
-              reporter,
-              "--no-parallel",
-            ]);
+            const expected = await runMochaAsync(
+              "options/parallel/test-*.fixture.js",
+              ["--reporter", reporter, "--no-parallel"],
+            );
             return expect(
-              runMochaAsync("options/parallel/test-*", [
+              runMochaAsync("options/parallel/test-*.fixture.js", [
                 "--reporter",
                 reporter,
                 "--parallel",
@@ -405,7 +418,7 @@ describe("--parallel", function () {
         return expect(
           invokeMochaAsync(
             [
-              resolveFixturePath("options/parallel/test-a"),
+              resolveFixturePath("options/parallel/test-a.fixture.js"),
               "--reporter=progress",
               "--parallel",
             ],
@@ -425,7 +438,7 @@ describe("--parallel", function () {
         return expect(
           invokeMochaAsync(
             [
-              resolveFixturePath("options/parallel/test-a"),
+              resolveFixturePath("options/parallel/test-a.fixture.js"),
               "--reporter=markdown",
               "--parallel",
             ],
@@ -445,7 +458,7 @@ describe("--parallel", function () {
         return expect(
           invokeMochaAsync(
             [
-              resolveFixturePath("options/parallel/test-a"),
+              resolveFixturePath("options/parallel/test-a.fixture.js"),
               "--reporter=json-stream",
               "--parallel",
             ],
@@ -515,7 +528,7 @@ describe("--parallel", function () {
     describe("during normal operation", function () {
       it("should not leave orphaned processes around", async function () {
         const [{ pid }, promise] = invokeMochaAsync([
-          resolveFixturePath("options/parallel/test-*"),
+          resolveFixturePath("options/parallel/test-*.fixture.js"),
           "--parallel",
         ]);
         const childPids = await waitForChildPids(pid);
@@ -536,7 +549,7 @@ describe("--parallel", function () {
     describe("during operation with --bail", function () {
       it("should not leave orphaned processes around", async function () {
         const [{ pid }, promise] = invokeMochaAsync([
-          resolveFixturePath("options/parallel/test-*"),
+          resolveFixturePath("options/parallel/test-*.fixture.js"),
           "--bail",
           "--parallel",
         ]);

--- a/test/integration/options/retries.spec.cjs
+++ b/test/integration/options/retries.spec.cjs
@@ -9,7 +9,7 @@ describe("--retries", function () {
 
   it("should retry test failures after a certain threshold", function (done) {
     args = ["--retries", "3"];
-    var fixture = path.join("options", "retries");
+    var fixture = path.join("options", "retries.fixture.js");
     runMochaJSON(fixture, args, function (err, res) {
       if (err) {
         return done(err);

--- a/test/integration/options/sort.spec.cjs
+++ b/test/integration/options/sort.spec.cjs
@@ -12,7 +12,7 @@ describe("--sort", function () {
   });
 
   it("should sort tests in alphabetical order", function (done) {
-    var fixtures = path.join("options", "sort*");
+    var fixtures = path.join("options", "sort*.fixture.js");
     runMochaJSON(fixtures, args, function (err, res) {
       if (err) {
         done(err);

--- a/test/integration/options/timeout.spec.cjs
+++ b/test/integration/options/timeout.spec.cjs
@@ -5,21 +5,25 @@ var runMochaJSON = helpers.runMochaJSON;
 
 describe("--timeout", function () {
   it("should allow human-readable string value", function (done) {
-    runMochaJSON("options/slow-test", ["--timeout", "1s"], function (err, res) {
-      if (err) {
-        done(err);
-        return;
-      }
-      expect(res, "to have failed")
-        .and("to have passed test count", 1)
-        .and("to have failed test count", 1);
-      done();
-    });
+    runMochaJSON(
+      "options/slow-test.fixture.js",
+      ["--timeout", "1s"],
+      function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, "to have failed")
+          .and("to have passed test count", 1)
+          .and("to have failed test count", 1);
+        done();
+      },
+    );
   });
 
   it("should allow numeric value", function (done) {
     runMochaJSON(
-      "options/slow-test",
+      "options/slow-test.fixture.js",
       ["--timeout", "1000"],
       function (err, res) {
         if (err) {
@@ -35,7 +39,7 @@ describe("--timeout", function () {
   });
 
   it("should allow multiple values", function (done) {
-    var fixture = "options/slow-test";
+    var fixture = "options/slow-test.fixture.js";
     runMochaJSON(
       fixture,
       ["--timeout", "2s", "--timeout", "1000"],
@@ -53,7 +57,7 @@ describe("--timeout", function () {
   });
 
   it('should disable timeout with "--inspect"', function (done) {
-    var fixture = "options/slow-test";
+    var fixture = "options/slow-test.fixture.js";
     runMochaJSON(
       fixture,
       ["--inspect", "--timeout", "200"],
@@ -69,7 +73,7 @@ describe("--timeout", function () {
   });
 
   it('should disable timeout with "-n inspect"', function (done) {
-    var fixture = "options/slow-test";
+    var fixture = "options/slow-test.fixture.js";
     runMochaJSON(
       fixture,
       ["-n", "inspect", "--timeout", "200"],
@@ -86,7 +90,7 @@ describe("--timeout", function () {
 
   it("should complete tests having unref'd async behavior", function (done) {
     runMochaJSON(
-      "options/timeout-unref",
+      "options/timeout-unref.fixture.js",
       ["--timeout", "0"],
       function (err, res) {
         if (err) {

--- a/test/integration/options/ui.spec.cjs
+++ b/test/integration/options/ui.spec.cjs
@@ -9,7 +9,7 @@ describe("--ui", function () {
 
   it("should load interface and run it", function (done) {
     runMochaJSON(
-      "test-for-simple-ui",
+      "test-for-simple-ui.fixture.js",
       ["--ui", simpleUiPath],
       function (err, res) {
         if (err) {
@@ -24,7 +24,7 @@ describe("--ui", function () {
 
   it("should work if required and name added to Mocha's `interfaces` prop", function (done) {
     runMochaJSON(
-      "test-for-simple-ui",
+      "test-for-simple-ui.fixture.js",
       ["--require", simpleUiPath, "--ui", "simple-ui"],
       function (err, res) {
         if (err) {
@@ -39,7 +39,7 @@ describe("--ui", function () {
 
   it("should work for ESM", function (done) {
     runMochaJSON(
-      "test-for-simple-ui",
+      "test-for-simple-ui.fixture.js",
       ["--require", simpleUiESMPath, "--ui", "simple-ui"],
       function (err, res) {
         if (err) {
@@ -54,7 +54,7 @@ describe("--ui", function () {
 
   it("should work for ESM when imported via path", function (done) {
     runMochaJSON(
-      "test-for-simple-ui",
+      "test-for-simple-ui.fixture.js",
       ["--ui", simpleUiESMPath],
       function (err, res) {
         if (err) {

--- a/test/integration/options/watch.spec.cjs
+++ b/test/integration/options/watch.spec.cjs
@@ -302,7 +302,7 @@ describe("--watch", function () {
         tempDir,
         () => {
           const addedTestFile = path.join(tempDir, "test/b.js");
-          copyFixture("passing", addedTestFile);
+          copyFixture("passing.fixture.cjs", addedTestFile);
         },
       ).then((results) => {
         expect(results, "to have length", 2);
@@ -425,7 +425,7 @@ describe("--watch", function () {
 
     it("reloads test files when they change", function () {
       const testFile = path.join(tempDir, "test.js");
-      copyFixture("options/watch/test-file-change", testFile);
+      copyFixture("options/watch/test-file-change.fixture.js", testFile);
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "**/*.js"],
@@ -448,10 +448,10 @@ describe("--watch", function () {
 
     it("reloads test dependencies when they change", function () {
       const testFile = path.join(tempDir, "test.js");
-      copyFixture("options/watch/test-with-dependency", testFile);
+      copyFixture("options/watch/test-with-dependency.fixture.cjs", testFile);
 
       const dependency = path.join(tempDir, "lib", "dependency.js");
-      copyFixture("options/watch/dependency", dependency);
+      copyFixture("options/watch/dependency.fixture.cjs", dependency);
 
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib/**/*.js"],
@@ -475,7 +475,7 @@ describe("--watch", function () {
     // Regression test for https://github.com/mochajs/mocha/issues/2027
     it("respects --fgrep on re-runs", async function () {
       const testFile = path.join(tempDir, "test.js");
-      copyFixture("options/grep", testFile);
+      copyFixture("options/grep.fixture.js", testFile);
 
       return expect(
         runMochaWatchJSONAsync([testFile, "--fgrep", "match"], tempDir, () => {
@@ -503,8 +503,8 @@ describe("--watch", function () {
           const testFile = path.join(tempDir, "test.js");
           const hookFile = path.join(tempDir, "hook.js");
 
-          copyFixture("__default__", testFile);
-          copyFixture("options/watch/hook", hookFile);
+          copyFixture("__default__.fixture.js", testFile);
+          copyFixture("options/watch/hook.fixture.cjs", hookFile);
 
           replaceFileContents(hookFile, "<hook>", hookName);
 

--- a/test/integration/uncaught.spec.cjs
+++ b/test/integration/uncaught.spec.cjs
@@ -11,7 +11,7 @@ var args = [];
 
 describe("uncaught exceptions", function () {
   it("handles uncaught exceptions from hooks", function (done) {
-    run("uncaught/hook", args, function (err, res) {
+    run("uncaught/hook.fixture.js", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -27,7 +27,7 @@ describe("uncaught exceptions", function () {
   });
 
   it("handles uncaught exceptions from async specs", function (done) {
-    run("uncaught/double", args, function (err, res) {
+    run("uncaught/double.fixture.js", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -47,7 +47,7 @@ describe("uncaught exceptions", function () {
   });
 
   it("handles uncaught exceptions from which Mocha cannot recover", function (done) {
-    run("uncaught/fatal", args, function (err, res) {
+    run("uncaught/fatal.fixture.js", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -64,7 +64,7 @@ describe("uncaught exceptions", function () {
   });
 
   it("handles uncaught exceptions within pending tests", function (done) {
-    run("uncaught/pending", args, function (err, res) {
+    run("uncaught/pending.fixture.js", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -87,7 +87,7 @@ describe("uncaught exceptions", function () {
   });
 
   it("handles uncaught exceptions within open tests", function (done) {
-    run("uncaught/recover", args, function (err, res) {
+    run("uncaught/recover.fixture.cjs", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -114,19 +114,22 @@ describe("uncaught exceptions", function () {
   });
 
   it("removes uncaught exceptions handlers correctly", function (done) {
-    invokeNode([resolveFixturePath("uncaught/listeners")], function (err, res) {
-      if (err) {
-        return done(err);
-      }
+    invokeNode(
+      [resolveFixturePath("uncaught/listeners.fixture.cjs")],
+      function (err, res) {
+        if (err) {
+          return done(err);
+        }
 
-      expect(res, "to have passed");
-      done();
-    });
+        expect(res, "to have passed");
+        done();
+      },
+    );
   });
 
   it("handles uncaught exceptions after runner's end", function (done) {
     runMocha(
-      "uncaught/after-runner",
+      "uncaught/after-runner.fixture.js",
       args,
       function (err, res) {
         if (err) {
@@ -147,7 +150,7 @@ describe("uncaught exceptions", function () {
   });
 
   it("issue-1327: should run the first test and then bail", function (done) {
-    run("uncaught/issue-1327", args, function (err, res) {
+    run("uncaught/issue-1327.fixture.js", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -161,7 +164,7 @@ describe("uncaught exceptions", function () {
   });
 
   it("issue-1417: uncaught exceptions from async specs", function (done) {
-    run("uncaught/issue-1417", args, function (err, res) {
+    run("uncaught/issue-1417.fixture.js", args, function (err, res) {
       if (err) {
         return done(err);
       }
@@ -182,7 +185,7 @@ describe("uncaught exceptions", function () {
       it("should warn", async function () {
         const [, promise] = invokeMochaAsync(
           [
-            resolveFixturePath("uncaught/unhandled"),
+            resolveFixturePath("uncaught/unhandled.fixture.js"),
             "--unhandled-rejections=warn",
           ],
           { stdio: "pipe" },
@@ -201,7 +204,7 @@ describe("uncaught exceptions", function () {
       it("should fail with an uncaught exception", async function () {
         const [, promise] = invokeMochaAsync(
           [
-            resolveFixturePath("uncaught/unhandled"),
+            resolveFixturePath("uncaught/unhandled.fixture.js"),
             "--unhandled-rejections=strict",
           ],
           { stdio: "pipe" },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6081 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

"resolveFixturePath" used to accept bare fixture names (for example "my-file") and guessed a extension by trying ".fixture.cjs", ".fixture.js", and ".fixture.ts". With both .cjs and .js fixtures now in use that behavior is ambiguous.

We now require fixture references to be explicit, resolveFixturePath no longer guesses extensions and throws if a reference has none. DEFAULT_FIXTURE is now __default__.fixture.js. All fixture references and glob patterns now include the full fixture filename (for example "test-*.fixture.js"), including paths used by the ignore tests.