### PR TITLE
perf!: replace glob package with node:fs glob

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -5,7 +5,7 @@ If you are having trouble, don't be afraid to [ask for help](./CONTRIBUTING.md#â
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/en/download) `^20.19.0 || >=22.12.0` (Node >=22 LTS recommended).
+- [Node.js](https://nodejs.org/en/download) `>=22.12.0` (Node >=22 LTS recommended).
   - If you're new to installing Node, a tool like [nvm](https://github.com/nvm-sh/nvm#install-script) can help you manage multiple version installations.
 - npm (do not use yarn or pnpm for this repository).
 - [Google Chrome](https://www.google.com/chrome) is required to run browser tests locally.

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -27,7 +27,7 @@ jobs:
   smoke:
     uses: ./.github/workflows/npm-script.yml
     with:
-      node-versions: "20,22,24"
+      node-versions: "22,24"
       npm-script: test-smoke
 
   test-node-lts:
@@ -76,7 +76,7 @@ jobs:
       os: "ubuntu-latest,windows-latest"
       # We pin exact versions here per https://github.com/mochajs/mocha/issues/5052
       # Ref https://nodejs.org/en/about/previous-releases
-      node-versions: "20.19.4,22.18.0,24.6.0"
+      node-versions: "22.18.0,24.6.0"
       npm-script: test-node:${{ matrix.test-part }}
       coverage: ${{ matrix.coverage }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Agent onboarding for the `mochajs/mocha` repository.
 
 ## Environment prerequisites
 
-- Node.js: `^20.19.0 || >=22.12.0` (prefer Node 22 locally)
+- Node.js: `>=22.12.0` (prefer Node 22 locally)
 - npm (do not use pnpm/yarn for this repo)
 - Google Chrome (required for browser tests)
 
@@ -98,7 +98,7 @@ CI partitions checks into separate jobs:
 
 - `format:check`
 - `lint`
-- `test-smoke` (Node 20/22/24)
+- `test-smoke` (Node 22/24)
 - `test-node:*` matrix (interfaces/unit/integration/jsapi/requires/reporters/only)
 - browser tests (`test-browser` with ChromeHeadless)
 - `tsc`

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -12,7 +12,7 @@ First, install the [`mocha` package](https://www.npmjs.com/package/mocha) as a d
 <PackageManagers dev type="add" pkg="mocha" />
 
 :::note
-As of v12.0.0, Mocha requires [Node.js](https://nodejs.org) `^20.19.0 || >=22.12.0`.
+As of v13.0.0, Mocha requires [Node.js](https://nodejs.org) `>=22.12.0`.
 :::
 
 ## 2. Test File

--- a/lib/cli/lookup-files.js
+++ b/lib/cli/lookup-files.js
@@ -6,7 +6,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import * as glob from "glob";
+import { Minimatch } from "minimatch";
 import {
   createNoFilesMatchPatternError,
   createMissingArgumentError,
@@ -72,7 +72,7 @@ export function lookupFiles(filepath, extensions = [], recursive = false) {
 
   if (!fs.existsSync(filepath)) {
     let pattern;
-    if (glob.hasMagic(filepath, { windowsPathsNoEscape: true })) {
+    if (new Minimatch(filepath, { windowsPathsNoEscape: true }).hasMagic()) {
       // Handle glob as is without extensions
       pattern = filepath;
     } else {
@@ -84,13 +84,12 @@ export function lookupFiles(filepath, extensions = [], recursive = false) {
       debug("looking for files using glob pattern: %s", pattern);
     }
     files.push(
-      ...glob
-        .sync(pattern, {
-          nodir: true,
-          windowsPathsNoEscape: true,
-        })
-        // glob@8 and earlier sorted results in en; glob@9 depends on OS sorting.
-        // This preserves the older glob behavior.
+      ...fs
+        .globSync(pattern, { withFileTypes: true })
+        .filter((dirent) => !dirent.isDirectory())
+        .map((dirent) => path.join(dirent.parentPath, dirent.name))
+        // glob@8 and earlier sorted results in en; node:fs and glob@9 depend
+        // on OS sorting. This preserves the older glob behavior.
         // https://github.com/mochajs/mocha/pull/5250/files#r1840469747
         .sort((a, b) => a.localeCompare(b, "en")),
     );

--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -3,18 +3,14 @@
 const debug = require("debug")("mocha:cli:watch");
 const path = require("node:path");
 const chokidar = require("chokidar");
-const glob = require("glob");
 const isPathInside = require("is-path-inside");
-const { minimatch } = require("minimatch");
+const { minimatch, Minimatch } = require("minimatch");
 const Context = require("../context.js").Context;
 const collectFiles = require("./collect-files.cjs");
 const { logSymbols } = require("../utils.cjs");
 
 /**
  * @typedef {import('chokidar').FSWatcher} FSWatcher
- * @typedef {import('glob').Glob['patterns'][number]} Pattern
- * The `Pattern` class is not exported by the `glob` package.
- * Ref [link](../../node_modules/glob/dist/commonjs/pattern.d.ts).
  * @typedef {import('../mocha.cjs')} Mocha
  * @typedef {import('../types.d.ts').BeforeWatchRun} BeforeWatchRun
  * @typedef {import('../types.d.ts').FileCollectionOptions} FileCollectionOptions
@@ -183,66 +179,40 @@ function createPathFilter(globPaths, basePath) {
   // for checking if a path ends with `/**/*`
   const globEnd = path.join(path.sep, "**", "*");
 
-  /**
-   * The current glob pattern to check.
-   * @type {Pattern[]}
-   */
   const patterns = globPaths.flatMap((globPath) => {
-    return new glob.Glob(globPath, {
+    const mm = new Minimatch(globPath, {
       dot: true,
-      magicalBraces: true,
       windowsPathsNoEscape: true,
-    }).patterns;
-  }, []);
+    });
+    return mm.set.map((parts, index) => ({
+      parts,
+      globString: mm.globSet[index],
+    }));
+  });
 
-  // each pattern will have its own path because of the `magicalBraces` option
-  for (const pattern of patterns) {
-    debug("processing glob pattern: %s", pattern.globString());
+  for (const { parts, globString } of patterns) {
+    debug("processing glob pattern: %s", globString);
 
-    /**
-     * Path segments before the glob pattern.
-     * @type {string[]}
-     */
-    const segments = [];
-
-    /**
-     * The current glob pattern to check.
-     * @type {Pattern | null}
-     */
-    let currentPattern = pattern;
-    let isGlob = false;
-
-    do {
-      // save string patterns until a non-string (glob or regexp) is matched
-      const entry = currentPattern.pattern();
-      const isString = typeof entry === "string";
-      debug(
-        "found %s pattern: %s",
-        isString ? "string" : "glob or regexp",
-        entry,
-      );
-      if (!isString) {
-        // if the entry is a glob
-        isGlob = true;
-        break;
-      }
-
-      segments.push(entry);
-
-      // go to next pattern
-    } while ((currentPattern = currentPattern.rest()));
+    let firstGlobIndex = parts.findIndex((part) => typeof part !== "string");
+    const isGlob = firstGlobIndex !== -1;
     if (!isGlob) {
-      debug("all subpatterns of %j processed", pattern.globString());
+      firstGlobIndex = parts.length;
+      debug("all subpatterns of %j processed", globString);
     }
 
-    // match `cleanPath` (path without the glob part) and its subdirectories
-    const cleanPath = path.resolve(basePath, ...segments);
+    // match `cleanPath` (path without the glob part) and its subdirectories.
+    // After lots of errors, it turned out that globString is "/"-separated and keeps the absolute root (for example the
+    // drive C:/ on Windows), so derive the static prefix from it.
+    const cleanPath = path.resolve(
+      basePath,
+      globString.split("/").slice(0, firstGlobIndex).join("/"),
+    );
     debug("clean path: %s", cleanPath);
     res.dir.paths.add(cleanPath);
     res.dir.globs.add(path.resolve(cleanPath, "**", "*"));
 
     // match `absPath` and all of its contents
-    const absPath = path.resolve(basePath, pattern.globString());
+    const absPath = path.resolve(basePath, globString);
     debug("absolute path: %s", absPath);
     (isGlob ? res.match.globs : res.match.paths).add(absPath);
 

--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -201,7 +201,7 @@ function createPathFilter(globPaths, basePath) {
     }
 
     // match `cleanPath` (path without the glob part) and its subdirectories.
-    // After lots of errors, it turned out that globString is "/"-separated and keeps the absolute root (for example the
+    // globString is "/"-separated and keeps the absolute root (e.g.
     // drive C:/ on Windows), so derive the static prefix from it.
     const cleanPath = path.resolve(
       basePath,

--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -3,18 +3,14 @@
 const debug = require("debug")("mocha:cli:watch");
 const path = require("node:path");
 const chokidar = require("chokidar");
-const glob = require("glob");
 const { default: isPathInside } = require("is-path-inside");
-const { minimatch } = require("minimatch");
+const { minimatch, Minimatch } = require("minimatch");
 const Context = require("../context.js").Context;
 const collectFiles = require("./collect-files.cjs");
 const { logSymbols } = require("../utils.cjs");
 
 /**
  * @typedef {import('chokidar').FSWatcher} FSWatcher
- * @typedef {import('glob').Glob['patterns'][number]} Pattern
- * The `Pattern` class is not exported by the `glob` package.
- * Ref [link](../../node_modules/glob/dist/commonjs/pattern.d.ts).
  * @typedef {import('../mocha.cjs')} Mocha
  * @typedef {import('../types.d.ts').BeforeWatchRun} BeforeWatchRun
  * @typedef {import('../types.d.ts').FileCollectionOptions} FileCollectionOptions
@@ -183,66 +179,40 @@ function createPathFilter(globPaths, basePath) {
   // for checking if a path ends with `/**/*`
   const globEnd = path.join(path.sep, "**", "*");
 
-  /**
-   * The current glob pattern to check.
-   * @type {Pattern[]}
-   */
   const patterns = globPaths.flatMap((globPath) => {
-    return new glob.Glob(globPath, {
+    const mm = new Minimatch(globPath, {
       dot: true,
-      magicalBraces: true,
       windowsPathsNoEscape: true,
-    }).patterns;
-  }, []);
+    });
+    return mm.set.map((parts, index) => ({
+      parts,
+      globString: mm.globSet[index],
+    }));
+  });
 
-  // each pattern will have its own path because of the `magicalBraces` option
-  for (const pattern of patterns) {
-    debug("processing glob pattern: %s", pattern.globString());
+  for (const { parts, globString } of patterns) {
+    debug("processing glob pattern: %s", globString);
 
-    /**
-     * Path segments before the glob pattern.
-     * @type {string[]}
-     */
-    const segments = [];
-
-    /**
-     * The current glob pattern to check.
-     * @type {Pattern | null}
-     */
-    let currentPattern = pattern;
-    let isGlob = false;
-
-    do {
-      // save string patterns until a non-string (glob or regexp) is matched
-      const entry = currentPattern.pattern();
-      const isString = typeof entry === "string";
-      debug(
-        "found %s pattern: %s",
-        isString ? "string" : "glob or regexp",
-        entry,
-      );
-      if (!isString) {
-        // if the entry is a glob
-        isGlob = true;
-        break;
-      }
-
-      segments.push(entry);
-
-      // go to next pattern
-    } while ((currentPattern = currentPattern.rest()));
+    let firstGlobIndex = parts.findIndex((part) => typeof part !== "string");
+    const isGlob = firstGlobIndex !== -1;
     if (!isGlob) {
-      debug("all subpatterns of %j processed", pattern.globString());
+      firstGlobIndex = parts.length;
+      debug("all subpatterns of %j processed", globString);
     }
 
-    // match `cleanPath` (path without the glob part) and its subdirectories
-    const cleanPath = path.resolve(basePath, ...segments);
+    // match `cleanPath` (path without the glob part) and its subdirectories.
+    // After lots of errors, it turned out that globString is "/"-separated and keeps the absolute root (for example the
+    // drive C:/ on Windows), so derive the static prefix from it.
+    const cleanPath = path.resolve(
+      basePath,
+      globString.split("/").slice(0, firstGlobIndex).join("/"),
+    );
     debug("clean path: %s", cleanPath);
     res.dir.paths.add(cleanPath);
     res.dir.globs.add(path.resolve(cleanPath, "**", "*"));
 
     // match `absPath` and all of its contents
-    const absPath = path.resolve(basePath, pattern.globString());
+    const absPath = path.resolve(basePath, globString);
     debug("absolute path: %s", absPath);
     (isGlob ? res.match.globs : res.match.paths).add(absPath);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "debug": "^4.3.5",
         "diff": "^9.0.0",
         "find-up": "^5.0.0",
-        "glob": "^13.0.0",
         "is-path-inside": "^3.0.3",
         "is-unicode-supported": "^0.1.0",
         "js-yaml": "^5.0.0",
@@ -75,7 +74,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4583,6 +4582,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -6705,6 +6705,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7368,6 +7369,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -7384,6 +7386,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "debug": "^4.3.5",
         "diff": "^9.0.0",
         "find-up": "^8.0.0",
-        "glob": "^13.0.0",
         "is-path-inside": "^4.0.0",
         "is-unicode-supported": "^0.1.0",
         "js-yaml": "^5.0.0",
@@ -69,7 +68,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4601,6 +4600,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -6714,6 +6714,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7379,6 +7380,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -7395,6 +7397,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "rollup -c ./rollup.config.js",
@@ -92,7 +92,6 @@
     "debug": "^4.3.5",
     "diff": "^9.0.0",
     "find-up": "^5.0.0",
-    "glob": "^13.0.0",
     "is-path-inside": "^3.0.3",
     "is-unicode-supported": "^0.1.0",
     "js-yaml": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "rollup -c ./rollup.config.js",
@@ -93,7 +93,6 @@
     "debug": "^4.3.5",
     "diff": "^9.0.0",
     "find-up": "^8.0.0",
-    "glob": "^13.0.0",
     "is-path-inside": "^4.0.0",
     "is-unicode-supported": "^0.1.0",
     "js-yaml": "^5.0.0",

--- a/test/node-unit/cli/run-helpers.spec.cjs
+++ b/test/node-unit/cli/run-helpers.spec.cjs
@@ -62,12 +62,14 @@ describe("helpers", function () {
       // this test name is referenced in a comment in `lib/mocha.cjs`
       // don't change here without also changing there
       it('should add the interface to "Mocha.interfaces"', function () {
-        // let's suppose that `glob` is an interface
-        const opts = { ui: "glob" };
+        // let's suppose that `minimatch` is an interface
+        const opts = { ui: "minimatch" };
         validateLegacyPlugin(opts, "ui", Mocha.interfaces);
-        expect(opts.ui, "to equal", "glob");
-        expect(Mocha.interfaces, "to satisfy", { glob: require("glob") });
-        delete Mocha.interfaces.glob;
+        expect(opts.ui, "to equal", "minimatch");
+        expect(Mocha.interfaces, "to satisfy", {
+          minimatch: require("minimatch"),
+        });
+        delete Mocha.interfaces.minimatch;
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5962 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Replace the "glob" dependency with Node's built-in node:fs glob plus "minimatch" (which Mocha already depends on, and which glob is itself built on). Removed glob from production dependencies, shrinking what users install.

IMPROTANT

**This is a breaking change (semver-major):** fs.globSync is only available on Node 22+ and so this drops support for Node.js 20. `engines` is now >=22.12.0, and the CI matrix and docs are updated to match.