### PR TITLE
test: widen --exit detection window to fix sporadic CI failures

### DIFF
--- a/test/integration/options/exit.spec.cjs
+++ b/test/integration/options/exit.spec.cjs
@@ -52,11 +52,13 @@ describe("--exit", function () {
         done();
       });
 
+      var waitForExitMs = shouldExit ? 30000 : timeout - 500;
+
       // If this callback happens, then Mocha didn't automatically exit.
       timeoutObj = setTimeout(function () {
         didExit = false;
         killSubprocess();
-      }, timeout - 500);
+      }, waitForExitMs);
     };
   };
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6060 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Increased the timeout for the "should exit" case to 30s. The extra time is only used if Mocha never exits, so successful runs are not slowed down. The no-exit tests keep their existing timeout, leaving overall suite runtime unchanged.