### PR TITLE
fix: propagate chained Suite#timeout() to already-registered hooks

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -224,11 +224,22 @@ class Suite extends EventEmitter {
     // Allow overriding inner/nested suites
     // See and test-cases with chain-called timeout argument.
     // https://github.com/mochajs/mocha/issues/5422
+    // https://github.com/mochajs/mocha/issues/6033
     for (const t of this.tests) {
       t.timeout(this._timeout);
     }
     for (const s of this.suites) {
       s.timeout(this._timeout);
+    }
+    for (const hooks of [
+      this._beforeAll,
+      this._beforeEach,
+      this._afterAll,
+      this._afterEach,
+    ]) {
+      for (const h of hooks) {
+        h.timeout(this._timeout);
+      }
     }
     return this;
   }

--- a/test/unit/suite.spec.cjs
+++ b/test/unit/suite.spec.cjs
@@ -105,6 +105,24 @@ describe("Suite", function () {
           const newSuite = suite.timeout(5000);
           expect(newSuite.timeout(), "to be", 5000);
         });
+
+        it("should propagate the timeout to already-registered hooks", function () {
+          // https://github.com/mochajs/mocha/issues/6033
+          // The chained `describe(...).timeout(N)` form creates hooks during the
+          // describe callback (with the suite's default timeout) and only calls
+          // the setter afterwards, so the new value must reach the hook arrays.
+          suite.beforeAll(function () {});
+          suite.beforeEach(function () {});
+          suite.afterAll(function () {});
+          suite.afterEach(function () {});
+
+          suite.timeout(5000);
+
+          expect(suite.getHooks("beforeAll")[0].timeout(), "to be", 5000);
+          expect(suite.getHooks("beforeEach")[0].timeout(), "to be", 5000);
+          expect(suite.getHooks("afterAll")[0].timeout(), "to be", 5000);
+          expect(suite.getHooks("afterEach")[0].timeout(), "to be", 5000);
+        });
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6033 (the change is also a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes) — a small loop mirroring the existing tests/suites propagation)
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — it is currently `status: in triage`; happy to wait for triage, opening early since the fix is small and self-contained
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`Suite#timeout(ms)` retroactively applies the new timeout to child tests and suites (added in #5612 for #5422), but it only iterates `this.tests` and `this.suites` — it skips the four hook arrays (`_beforeAll`, `_beforeEach`, `_afterAll`, `_afterEach`).

So the **chained** form does not raise the timeout for hooks:

```js
describe('foo', () => {
  before(async () => { /* slow setup > 2000ms */ });
  it('bar', () => {});
}).timeout(10000);
```

The hooks are created during the `describe` callback with the suite's timeout at that moment (the default), and the subsequent `.timeout(10000)` call never reaches them. The inner `it()` and the `function () { this.timeout(N); ... }` form both work, which makes the behaviour inconsistent (see the table in #6033).

### Fix

Iterate the hook arrays alongside `tests`/`suites` in the setter. Hooks are `Runnable` instances and already expose a `.timeout()` setter, so this mirrors the existing loops exactly:

```js
for (const hooks of [
  this._beforeAll,
  this._beforeEach,
  this._afterAll,
  this._afterEach,
]) {
  for (const h of hooks) {
    h.timeout(this._timeout);
  }
}
```

### Tests

Added a unit test in `test/unit/suite.spec.cjs` under `timeout() > when argument is passed` that registers one hook of each kind, calls `suite.timeout(5000)`, and asserts all four hooks report `5000`.

- Fails without the fix: `expected 2000 to be 5000`.
- Passes with the fix.
- Full node unit suite (1102 passing) and the chained-timeout self-test (`test/unit/timeout.spec.cjs`, 13 passing) remain green; `eslint` clean.
