### PR TITLE
Strip ANSI sequences from xunit output

### DIFF
--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -25,6 +25,10 @@ var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 var STATE_FAILED = Runnable.constants.STATE_FAILED;
 var escape = utils.escape;
+var ANSI_ESCAPE_SEQUENCE = new RegExp(
+  String.fromCharCode(27) + "\\[[0-?]*[ -/]*[@-~]",
+  "g",
+);
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -173,7 +177,10 @@ class XUnit extends Base {
             "failure",
             {},
             false,
-            escape(err.message) + escape(diff) + "\n" + escape(err.stack),
+            escapeXml(err.message) +
+              escapeXml(diff) +
+              "\n" +
+              escapeXml(err.stack),
           ),
         ),
       );
@@ -201,7 +208,7 @@ function tag(name, attrs, close, content) {
 
   for (var key in attrs) {
     if (Object.prototype.hasOwnProperty.call(attrs, key)) {
-      pairs.push(key + '="' + escape(attrs[key]) + '"');
+      pairs.push(key + '="' + escapeXml(attrs[key]) + '"');
     }
   }
 
@@ -210,6 +217,30 @@ function tag(name, attrs, close, content) {
     tag += content + "</" + name + end;
   }
   return tag;
+}
+
+function escapeXml(value) {
+  return escape(
+    stripInvalidXmlCharacters(String(value).replace(ANSI_ESCAPE_SEQUENCE, "")),
+  );
+}
+
+function stripInvalidXmlCharacters(value) {
+  var result = "";
+
+  for (var i = 0; i < value.length; i += 1) {
+    var charCode = value.charCodeAt(i);
+    if (
+      charCode === 0x09 ||
+      charCode === 0x0a ||
+      charCode === 0x0d ||
+      charCode >= 0x20
+    ) {
+      result += value[i];
+    }
+  }
+
+  return result;
 }
 
 function testFilePath(filepath, options) {

--- a/test/reporters/xunit.spec.cjs
+++ b/test/reporters/xunit.spec.cjs
@@ -429,6 +429,38 @@ describe("XUnit reporter", function () {
 
         expect(expectedWrite, "to contain", expectedDiff);
       });
+
+      it("should remove ANSI escape sequences and invalid XML control characters", function () {
+        var xunit = new XUnit(runner);
+        var expectedTest = {
+          state: STATE_FAILED,
+          title: "\x1b[32m" + expectedTitle + "\x1b[39m",
+          file: expectedFile,
+          parent: {
+            fullTitle: function () {
+              return expectedClassName;
+            },
+          },
+          duration: 1000,
+          err: {
+            actual: "foo",
+            expected: "bar",
+            message: "\x1b[31m" + expectedMessage + "\x1b[39m\u0007",
+            stack: "\x1b[31m" + expectedStack + "\x1b[39m\u0007",
+          },
+        };
+
+        xunit.test.call(fakeThis, expectedTest);
+        sinon.restore();
+
+        expect(expectedWrite, "to contain", 'name="' + expectedTitle + '"');
+        expect(expectedWrite, "to contain", "<failure>" + expectedMessage);
+        expect(expectedWrite, "to contain", expectedStack);
+        expect(expectedWrite, "not to contain", "&#x1B;");
+        expect(expectedWrite, "not to contain", "&#x7;");
+        expect(expectedWrite, "not to contain", "[31m");
+        expect(expectedWrite, "not to contain", "[39m");
+      });
     });
 
     describe("on test pending", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4526 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes #4526.

The xunit reporter was escaping failure text and attributes directly, so ANSI color sequences from assertion output survived as XML character references like `&#x1B;`. Those references still point at XML 1.0 control characters, which makes strict XML parsers reject the report.

This keeps the change local to the xunit reporter: it strips common ANSI CSI sequences, drops XML-invalid control characters, and then uses the existing escape helper for the final XML text. The same cleanup is applied to testcase attributes and failure contents so colored titles, messages, and stacks do not leak invalid XML into the report.

Validated with:

- `npm run -s test-node-run -- --grep "XUnit reporter" test/reporters/xunit.spec.cjs`
- `npm run -s test-node:reporters`
- `npm run -s test-smoke`
- `npx prettier --check lib/reporters/xunit.js test/reporters/xunit.spec.cjs`
- `npx eslint lib/reporters/xunit.js test/reporters/xunit.spec.cjs`
- direct xunit CLI repro with an ANSI-colored assertion failure

---

https://github.com/googleapis/release-please#how-can-i-fix-release-notes

BEGIN_COMMIT_OVERRIDE
fix: strip ANSI sequences from xunit output
END_COMMIT_OVERRIDE