### PR TITLE
docs: add sponsor logos to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,15 @@ Also, your company's logo will show [on GitHub](https://github.com/mochajs/mocha
 
 ### Supporters
 
-[![WallabyJS](https://img.shields.io/badge/WallabyJS-Provided%20license-blue)](https://wallabyjs.com)
-[![SauceLabs](https://img.shields.io/badge/SauceLabs-Upgraded%20service-blue)](https://saucelabs.com)
-[![JetBrains](https://img.shields.io/badge/JetBrains-WebStorm%20licenses-blue)](https://www.jetbrains.com/webstorm/)
+[![WallabyJS](https://wallabyjs.com/assets/img/logo.svg)](https://wallabyjs.com)
+[![SauceLabs](https://saucelabs.com/images/logo.svg)](https://saucelabs.com)
+[![JetBrains](https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg)](https://www.jetbrains.com/webstorm/)
 
-## Services
+### Services
 
-[![Travis CI](https://img.shields.io/badge/Travis%20CI-Continuous%20Integration-blue)](https://travis-ci.org)
-[![AppVeyor](https://img.shields.io/badge/AppVeyor-Windows%20CI-blue)](https://appveyor.com)
-[![Coveralls](https://img.shields.io/badge/Coveralls-Code%20Coverage-blue)](https://coveralls.io)
-[![Netlify](https://img.shields.io/badge/Netlify-Hosting-blue)](https://netlify.com)
+[![GitHub Actions](https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png)](https://github.com/features/actions)
+[![AppVeyor](https://www.appveyor.com/assets/img/appveyor-logo-256.png)](https://appveyor.com)
+[![Netlify](https://img.shields.io/badge/Netlify-Hosting-00C7B7?logo=netlify&logoColor=white)](https://netlify.com)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ Also, your company's logo will show [on GitHub](https://github.com/mochajs/mocha
 [![MochaJS Sponsor](https://opencollective.com/mochajs/tiers/sponsors/2/avatar)](https://opencollective.com/mochajs/tiers/sponsors/2/website)
 [![MochaJS Sponsor](https://opencollective.com/mochajs/tiers/sponsors/3/avatar)](https://opencollective.com/mochajs/tiers/sponsors/3/website)
 
+### Supporters
+
+[![WallabyJS](https://img.shields.io/badge/WallabyJS-Provided%20license-blue)](https://wallabyjs.com)
+[![SauceLabs](https://img.shields.io/badge/SauceLabs-Upgraded%20service-blue)](https://saucelabs.com)
+[![JetBrains](https://img.shields.io/badge/JetBrains-WebStorm%20licenses-blue)](https://www.jetbrains.com/webstorm/)
+
+## Services
+
+[![Travis CI](https://img.shields.io/badge/Travis%20CI-Continuous%20Integration-blue)](https://travis-ci.org)
+[![AppVeyor](https://img.shields.io/badge/AppVeyor-Windows%20CI-blue)](https://appveyor.com)
+[![Coveralls](https://img.shields.io/badge/Coveralls-Code%20Coverage-blue)](https://coveralls.io)
+[![Netlify](https://img.shields.io/badge/Netlify-Hosting-blue)](https://netlify.com)
+
 ## Development
 
 You might want to know that:


### PR DESCRIPTION
Fixes #3627

Adds logos and links for WallabyJS, SauceLabs, and JetBrains as supporters under the Sponsors section.

Also adds a Services section with badges for Travis CI, AppVeyor, Coveralls, and Netlify.

All badges use shields.io format for reliable image rendering.