### PR TITLE
chore: enforce devDependency engine ranges in installed-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "docs": "cd docs; npm run docs",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",
-    "lint:installed-check": "installed-check --engine-check --ignore-dev",
+    "lint:installed-check": "installed-check --engine-check --ignore \"@eslint/*\" --ignore eslint --ignore eslint-plugin-n --ignore installed-check",
     "lint:knip": "knip --cache",
     "lint:knip-docs": "cd docs && npm run lint:knip",
     "lint:code": "eslint . --max-warnings 0",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6039 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

drop --ignore-dev so devDeps are engine-checked against engines.node and explicitly ignores the ESLint 10 toolchain (eslint, @eslint/*, eslint-plugin-n, installed-check), which requires Node 22.13+ for development. Everything else including a future devDep that drops node 20 now fails the existing lint job.

i actually wanted to bump engines.node to 20.19.0 || 22.13.0 || >= 24.0.0 but the thing is that it would have contradicted the v12 announcement, although that is what installed-check recommends and is a simpler gate but the thing is that it drops 22.12.x + 23.x consumer support and also affects some docs i think so i kept engines.node as-is, 22.12.0 is the published v12 floor so the published support matrix should not be narrowed just to satisfy dev tooling.