### PR TITLE
test: raise timeout for node-unit Mocha spec to fix flaky hook

### DIFF
--- a/test/node-unit/mocha.spec.cjs
+++ b/test/node-unit/mocha.spec.cjs
@@ -10,6 +10,8 @@ const DUMBER_FIXTURE_PATH =
   require.resolve("./fixtures/dumber-module.fixture.js");
 
 describe("Mocha", function () {
+  this.timeout(5000);
+
   let stubs;
   let opts;
   let Mocha;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6063
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

node-unit/mocha.spec.cjs rebuilds the Mocha module graph in beforeEach using rewiremock.proxy. It's synchronous but sometimes slow enough that CI (especially Windows with coverage) hits the 1s timeout and makes the next test look like it failed in beforeEach.

Nothing is actually stuck it’s just setup time.

Bumping the suite timeout to 5s like we already do in a couple of other specs so this doesn't flake anymore. 