### PR TITLE
test: retry touch in dir-add watch test to reduce flakiness

### DIFF
--- a/test/integration/helpers.cjs
+++ b/test/integration/helpers.cjs
@@ -654,7 +654,7 @@ async function shutdownWatchChild(mochaProcess, closed) {
  * @param {RegExp} [opts.firstRunCrashPattern] - If set, expect the first run to fail to load, printing only an error stack (no stdout) with a message matching this pattern. No countable run output to wait for.
  * @param {'json'|'marker'} [opts.runDetector] - How completed runs are counted; `runMochaWatchJSONAsync` sets `json`
  * @param {number} [opts.budgetMs] - Shared deadline for everything this call waits on; must stay below the test's timeout
- * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns}`
+ * @param {Function} change - A potentially `Promise`-returning callback which changes a watched file; receives the child process and `{waitForRuns, runCount}` (`runCount()` reports completed runs observed so far)
  * @returns {Promise<RawResult>}
  */
 async function runMochaWatchAsync(args, opts, change) {
@@ -712,6 +712,7 @@ async function runMochaWatchAsync(args, opts, change) {
 
     await change(mochaProcess, {
       waitForRuns: observer.waitForRuns,
+      runCount: observer.runCount,
     });
 
     if (noRerun) {

--- a/test/integration/options/watch.spec.cjs
+++ b/test/integration/options/watch.spec.cjs
@@ -129,14 +129,17 @@ describe("--watch", function () {
       return runMochaWatchJSONAsync(
         [testFile, "--watch-files", "lib"],
         { cwd: tempDir, expectedRuns: expectedRunCount },
-        async (mochaProcess, { waitForRuns }) => {
+        async (mochaProcess, { waitForRuns, runCount }) => {
           fs.mkdirSync(libPath);
           await waitForRuns(2); // wait for second run
-          await sleep(graceMs); // grace
+          await sleep(graceMs); // let the watch on `lib` install
           fs.mkdirSync(dirPath);
           await waitForRuns(3); // wait for third run
-          await sleep(graceMs);
-          touchFile(watchedFile);
+          // re-touch until the new subdir's watch catches the change, only re-touches when idle (no rerun happened) so it can not abort a run
+          while (runCount() < expectedRunCount) {
+            touchFile(watchedFile);
+            await sleep(graceMs);
+          }
         },
       ).then((results) => {
         expect(results, "to have length", expectedRunCount);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6079
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The test that watches "--watch-files" sometimes flakes because it only touches lib/dir/file.xyz once after a 1s delay. If the watcher has not fully picked up the new lib/dir yet that touch gets missed and the expected 4th run never happens so the test times out.

fix is simple, instead of touching the file once and hoping for the best we keep re-touching it until we actually see the 4 runs. Each touch updates the timestamp so it will eventually get picked up once the watcher is ready.

we stop as soon as run #4 happens so it cant overshoot and we only retry when things are idle so it won't interrupt active runs.

Also added runCount to the helper callback so the test can track progress properly.

One thing worth noting is that i unfortunately couldn't reproduce it locally even under a very heavy stress-test (fancy processor?), but this should cover the slow watcher setup window that was causing the flake.