### PR TITLE
feat: print each error within AggregateErrors

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -389,7 +389,7 @@ Base.generateDiff = function (actual, expected) {
 };
 
 /**
- * Traverses err.cause and returns all stack traces
+ * Traverses err.cause and err.errors (AggregateError) and returns all stack traces
  *
  * @private
  * @param {Error} err
@@ -431,6 +431,22 @@ var getFullErrorStack = function (err, seen) {
         "\n   Caused by: " +
         causeStack.msg +
         (causeStack.stack ? "\n" + causeStack.stack : "");
+    }
+
+    if (Array.isArray(err.errors)) {
+      seen = seen || new Set();
+      seen.add(err);
+      err.errors.forEach(function (aggregateError) {
+        const normalized =
+          aggregateError && (aggregateError.stack || aggregateError.message)
+            ? aggregateError
+            : { message: String(aggregateError) };
+        const aggregateStack = getFullErrorStack(normalized, seen);
+        stack +=
+          "\n   Aggregated error: " +
+          aggregateStack.msg +
+          (aggregateStack.stack ? "\n" + aggregateStack.stack : "");
+      });
     }
   }
 

--- a/test/reporters/base.spec.cjs
+++ b/test/reporters/base.spec.cjs
@@ -593,6 +593,121 @@ describe("Base reporter", function () {
     });
   });
 
+  describe("aggregate errors", function () {
+    it("should append each aggregated error to the stack trace", function () {
+      var err = {
+        message: "Error",
+        stack: "Error\nfoo\nbar",
+        showDiff: false,
+        errors: [
+          { message: "Err1", stack: "Err1\na\nb", showDiff: false },
+          { message: "Err2", stack: "Err2\nc\nd", showDiff: false },
+        ],
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error\n  foo\n  bar\n     Aggregated error: Err1\n  a\n  b\n     Aggregated error: Err2\n  c\n  d",
+      );
+    });
+
+    it("should append a single aggregated error", function () {
+      var err = {
+        message: "Error",
+        stack: "Error\nfoo\nbar",
+        showDiff: false,
+        errors: [{ message: "Err1", stack: "Err1\na\nb", showDiff: false }],
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error\n  foo\n  bar\n     Aggregated error: Err1\n  a\n  b",
+      );
+    });
+
+    it("should render aggregated errors that are not Error instances", function () {
+      var err = {
+        message: "Error",
+        stack: "Error\nfoo\nbar",
+        showDiff: false,
+        errors: ["boom"],
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error\n  foo\n  bar\n     Aggregated error: boom",
+      );
+    });
+
+    it("should recurse into nested aggregated errors", function () {
+      var err = {
+        message: "Error",
+        stack: "Error\nfoo\nbar",
+        showDiff: false,
+        errors: [
+          {
+            message: "Err1",
+            stack: "Err1\na\nb",
+            showDiff: false,
+            errors: [
+              { message: "Nested", stack: "Nested\nx\ny", showDiff: false },
+            ],
+          },
+        ],
+      };
+      var test = makeTest(err);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error\n  foo\n  bar\n     Aggregated error: Err1\n  a\n  b\n     Aggregated error: Nested\n  x\n  y",
+      );
+    });
+
+    it("should not get stuck in a circular aggregated error trail", function () {
+      var err1 = {
+        message: "Error",
+        stack: "Error\nfoo\nbar",
+        showDiff: false,
+      };
+      var err2 = {
+        message: "Cause1",
+        stack: "Cause1\nbar\nfoo",
+        showDiff: false,
+        errors: [err1],
+      };
+      err1.errors = [err2];
+      var test = makeTest(err1);
+
+      list([test]);
+
+      var errOut = stdout.join("\n").trim();
+      expect(
+        errOut,
+        "to be",
+        "1) test title:\n     Error\n  foo\n  bar\n     Aggregated error: Cause1\n  bar\n  foo\n     Aggregated error: <circular>",
+      );
+    });
+  });
+
   it("should list multiple Errors per test", function () {
     var err = new Error("First Error");
     err.multiple = [new Error("Second Error - same test")];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4982
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When a test throws an `AggregateError`, reporters only printed the top-level message and stack; the individual errors in `error.errors` were dropped. This extends `getFullErrorStack` in `lib/reporters/base.js` to traverse `err.errors` and append each contained error (message + stack), reusing the same recursive formatting as the existing `err.cause` trail.

- Nested aggregates and `cause` chains inside aggregated errors render via the same recursion.
- Non-`Error` entries (an `AggregateError` may be constructed with any iterable) are stringified rather than crashing the reporter.
- Circular references are guarded by the existing `seen` set.

Output for an `AggregateError`:

```
  1) test:
     AggregateError: 2 things went wrong
      <stack>
     Aggregated error: Error: first failure
      <stack>
     Aggregated error: TypeError: second failure
      <stack>
```

Unit tests added in `test/reporters/base.spec.cjs` cover multiple/single/non-Error/nested/circular cases.