### PR TITLE
feat!: replace yargs-parser in CLI option loading

### DIFF
--- a/lib/cli/options.cjs
+++ b/lib/cli/options.cjs
@@ -9,38 +9,25 @@
 
 const { readFileSync } = require("node:fs");
 const pc = require("picocolors");
-const yargsParser = require("yargs-parser");
-const {
-  types,
-  aliases,
-  isMochaFlag,
-  expectedTypeForFlag,
-} = require("./run-option-metadata.cjs");
+const { parseMochaArgs } = require("./parse-args.js");
 const { ONE_AND_DONE_ARGS } = require("./one-and-dones.js");
 const mocharc = require("../mocharc.json");
-const { list } = require("./run-helpers.cjs");
 const { loadConfig, findConfig } = require("./config.cjs");
 const { sync } = require("find-up");
 const debugModule = require("debug");
-const { isNodeFlag } = require("./node-flags.cjs");
-const {
-  createUnparsableFileError,
-  createInvalidArgumentTypeError,
-  createUnsupportedError,
-} = require("../errors.js");
-const { isNumeric } = require("../utils.cjs");
+const { createUnparsableFileError, isMochaError } = require("../errors.js");
 
 const debug = debugModule("mocha:cli:options");
 
 /**
- * The `yargs-parser` namespace
- * @external yargsParser
- * @see {@link https://npm.im/yargs-parser}
+ * The `parseArgs` function
+ * @external parseArgs
+ * @see {@link https://nodejs.org/api/util.html#utilparseargsconfig}
  */
 
 /**
- * An object returned by a configured `yargs-parser` representing arguments
- * @memberof external:yargsParser
+ * An object representing arguments parsed from the CLI
+ * @memberof external:parseArgs
  * @interface Arguments
  */
 
@@ -56,152 +43,23 @@ const YARGS_PARSER_CONFIG = {
 };
 
 /**
- * This is the config pulled from the `yargs` property of Mocha's
- * `package.json`, but it also disables camel case expansion as to
- * avoid outputting non-canonical keynames, as we need to do some
- * lookups.
- * @private
- * @ignore
- */
-const configuration = Object.assign({}, YARGS_PARSER_CONFIG, {
-  "camel-case-expansion": false,
-});
-
-/**
- * This is a really fancy way to:
- * - `array`-type options: ensure unique values and evtl. split comma-delimited lists
- * - `boolean`/`number`/`string`- options: use last element when given multiple times
- * This is passed as the `coerce` option to `yargs-parser`
- * @private
- * @ignore
- */
-const globOptions = ["spec", "ignore"];
-const coerceOpts = Object.assign(
-  types.array.reduce(
-    (acc, arg) =>
-      Object.assign(acc, {
-        [arg]: (v) =>
-          Array.from(new Set(globOptions.includes(arg) ? v : list(v))),
-      }),
-    {},
-  ),
-  types.boolean
-    .concat(types.string, types.number)
-    .reduce(
-      (acc, arg) =>
-        Object.assign(acc, { [arg]: (v) => (Array.isArray(v) ? v.pop() : v) }),
-      {},
-    ),
-);
-
-/**
- * We do not have a case when multiple arguments are ever allowed after a flag
- * (e.g., `--foo bar baz quux`), so we fix the number of arguments to 1 across
- * the board of non-boolean options.
- * This is passed as the `narg` option to `yargs-parser`
- * @private
- * @ignore
- */
-const nargOpts = types.array
-  .concat(types.string, types.number)
-  .reduce((acc, arg) => Object.assign(acc, { [arg]: 1 }), {});
-
-/**
- * Throws either "UNSUPPORTED" error or "INVALID_ARG_TYPE" error for numeric positional arguments.
- * @param {string[]} allArgs - Stringified args passed to mocha cli
- * @param {number} numericArg - Numeric positional arg for which error must be thrown
- * @param {Object} parsedResult - Result from `yargs-parser`
- * @private
- * @ignore
- */
-const createErrorForNumericPositionalArg = (
-  numericArg,
-  allArgs,
-  parsedResult,
-) => {
-  // A flag for `numericArg` exists if:
-  // 1. A mocha flag immediately preceeded the numericArg in `allArgs` array and
-  // 2. `numericArg` value could not be assigned to this flag by `yargs-parser` because of incompatible datatype.
-  const flag = allArgs.find((arg, index) => {
-    const normalizedArg = arg.replace(/^--?/, "");
-    return (
-      isMochaFlag(arg) &&
-      allArgs[index + 1] === String(numericArg) &&
-      parsedResult[normalizedArg] !== String(numericArg)
-    );
-  });
-
-  if (flag) {
-    throw createInvalidArgumentTypeError(
-      `Mocha flag '${flag}' given invalid option: '${numericArg}'`,
-      numericArg,
-      expectedTypeForFlag(flag),
-    );
-  } else {
-    throw createUnsupportedError(
-      `Option ${numericArg} is unsupported by the mocha cli`,
-    );
-  }
-};
-
-/**
- * Wrapper around `yargs-parser` which applies our settings
+ * Wrapper around `parseArgs` which applies our settings
  * @param {string|string[]} args - Arguments to parse
  * @param {Object} defaultValues - Default values of mocharc.json
- * @param  {...Object} configObjects - `configObjects` for yargs-parser
+ * @param  {...Object} configObjects - Objects to merge into parsed arguments
  * @private
  * @ignore
  */
 const parse = (args = [], defaultValues = {}, ...configObjects) => {
-  // save node-specific args for special handling.
-  // 1. when these args have a "=" they should be considered to have values
-  // 2. if they don't, they are just boolean flags
-  // 3. to avoid explicitly defining the set of them, we tell yargs-parser they
-  //    are ALL boolean flags.
-  // 4. we can then reapply the values after yargs-parser is done.
-  const allArgs = Array.isArray(args) ? args : args.split(" ");
-  const nodeArgs = allArgs.reduce((acc, arg) => {
-    const pair = arg.split("=");
-    let flag = pair[0];
-    if (isNodeFlag(flag, false)) {
-      flag = flag.replace(/^--?/, "");
-      return acc.concat([[flag, arg.includes("=") ? pair[1] : true]]);
+  try {
+    return parseMochaArgs(args, defaultValues, ...configObjects);
+  } catch (err) {
+    if (isMochaError(err)) {
+      throw err;
     }
-    return acc;
-  }, []);
-
-  const result = yargsParser.detailed(args, {
-    configuration,
-    configObjects,
-    default: defaultValues,
-    coerce: coerceOpts,
-    narg: nargOpts,
-    alias: aliases,
-    string: types.string,
-    array: types.array,
-    number: types.number,
-    boolean: types.boolean.concat(nodeArgs.map((pair) => pair[0])),
-  });
-  if (result.error) {
-    console.error(pc.red(`Error: ${result.error.message}`));
+    console.error(pc.red(`Error: ${err.message}`));
     process.exit(1);
   }
-
-  const numericPositionalArg = result.argv._.find((arg) => isNumeric(arg));
-  if (numericPositionalArg) {
-    createErrorForNumericPositionalArg(
-      numericPositionalArg,
-      allArgs,
-      result.argv,
-    );
-  }
-
-  // reapply "=" arg values from above
-  nodeArgs.forEach(([key, value]) => {
-    result.argv[key] = value;
-  });
-
-  return result.argv;
 };
 
 /**

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -1,0 +1,325 @@
+import { parseArgs } from "node:util";
+import {
+  createInvalidArgumentTypeError,
+  createUnsupportedError,
+} from "../errors.js";
+import { isNumeric } from "../utils.cjs";
+import { list } from "./run-helpers.cjs";
+import {
+  aliases,
+  expectedTypeForFlag,
+  isMochaFlag,
+  types,
+} from "./run-option-metadata.cjs";
+import { isNodeFlag } from "./node-flags.cjs";
+
+const globOptions = ["spec", "ignore"];
+const aliasToCanonical = Object.entries(aliases).reduce(
+  (acc, [canonical, optionAliases]) => {
+    optionAliases.forEach((alias) => {
+      acc[alias] = canonical;
+    });
+    return acc;
+  },
+  {},
+);
+
+const canonicalOptionName = (name) => aliasToCanonical[name] || name;
+
+const optionTypeByName = Object.entries(types).reduce((acc, [type, names]) => {
+  names.forEach((name) => {
+    acc[name] = type;
+  });
+  return acc;
+}, {});
+
+const arrayOptions = new Set(types.array);
+const numberOptions = new Set(types.number);
+const scalarOptions = new Set(types.boolean.concat(types.string, types.number));
+
+const createParseArgsOptions = (nodeArgs) => {
+  const options = {};
+
+  Object.entries(optionTypeByName).forEach(([name, type]) => {
+    const short = (aliases[name] || []).find((alias) => alias.length === 1);
+    options[name] = {
+      type: type === "boolean" ? "boolean" : "string",
+      multiple: type !== "boolean",
+    };
+    if (short) {
+      options[name].short = short;
+    }
+  });
+
+  nodeArgs.forEach(([name]) => {
+    options[name] = { type: "boolean" };
+  });
+
+  return options;
+};
+
+const toArray = (value) => {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const coerceArrayOption = (name, value) => {
+  const values = toArray(value);
+  return Array.from(
+    new Set(globOptions.includes(name) ? values : list(values)),
+  );
+};
+
+const coerceScalarOption = (value) => {
+  return Array.isArray(value) ? value[value.length - 1] : value;
+};
+
+const coerceNumberOption = (value) => {
+  const scalar = coerceScalarOption(value);
+  return scalar === undefined ? scalar : Number(scalar);
+};
+
+const mergeValue = (existing, next) => {
+  if (existing === undefined) {
+    return next;
+  }
+  return toArray(existing).concat(toArray(next));
+};
+
+const mergeConfigObjects = (defaultValues, configObjects) => {
+  const defaultArrayOptions = new Set();
+
+  return [defaultValues]
+    .concat(configObjects.slice().reverse())
+    .reduce((merged, config) => {
+      if (!config) {
+        return merged;
+      }
+
+      Object.entries(config).forEach(([rawName, value]) => {
+        const name = canonicalOptionName(rawName);
+        if (name === "_") {
+          merged._ = mergeValue(value, merged._);
+        } else if (arrayOptions.has(name)) {
+          if (config === defaultValues) {
+            defaultArrayOptions.add(name);
+            merged[name] = value;
+          } else if (defaultArrayOptions.has(name)) {
+            defaultArrayOptions.delete(name);
+            merged[name] = value;
+          } else {
+            merged[name] = mergeValue(value, merged[name]);
+          }
+        } else {
+          merged[name] = value;
+        }
+      });
+
+      return merged;
+    }, {});
+};
+
+const isKnownOptionName = (name) => {
+  const normalizedName = name.replace(/^no-/, "");
+  return (
+    optionTypeByName[normalizedName] ||
+    aliasToCanonical[normalizedName] ||
+    isNodeFlag(`--${normalizedName}`, false)
+  );
+};
+
+const preprocessArgs = (allArgs) => {
+  return allArgs.reduce((processed, arg, index) => {
+    if (arg === "--") {
+      return processed;
+    }
+
+    const noPrefix = arg.replace(/^--?/, "");
+    const [name, ...rest] = noPrefix.split("=");
+    const canonical = canonicalOptionName(name.replace(/^no-/, ""));
+    const negated = name.startsWith("no-");
+    const prefix = arg.startsWith("--") ? "--" : arg.startsWith("-") ? "-" : "";
+
+    if (
+      prefix === "-" &&
+      name.length === 1 &&
+      !rest.length &&
+      !isKnownOptionName(name)
+    ) {
+      const next = allArgs[index + 1];
+      if (next !== undefined && next !== "--" && !next.startsWith("-")) {
+        processed.push(`--${name}=${next}`);
+      } else {
+        processed.push(`--${name}`);
+      }
+      return processed;
+    }
+
+    if (prefix === "--" && !rest.length && !isKnownOptionName(name)) {
+      const next = allArgs[index + 1];
+      if (next !== undefined && next !== "--" && !next.startsWith("-")) {
+        processed.push(`${arg}=${next}`);
+        return processed;
+      }
+    }
+
+    if (!prefix || name === canonical || name.length === 1) {
+      const previous = allArgs[index - 1];
+      if (
+        !prefix &&
+        previous &&
+        previous.startsWith("-") &&
+        !previous.includes("=") &&
+        !isKnownOptionName(previous.replace(/^--?/, ""))
+      ) {
+        return processed;
+      }
+      processed.push(arg);
+      return processed;
+    }
+
+    const normalizedName = negated ? `no-${canonical}` : canonical;
+    processed.push(
+      `${prefix}${normalizedName}${rest.length ? `=${rest.join("=")}` : ""}`,
+    );
+    return processed;
+  }, []);
+};
+
+const requiresValue = (name) => {
+  const canonical = canonicalOptionName(name);
+  return (
+    arrayOptions.has(canonical) ||
+    types.string.includes(canonical) ||
+    numberOptions.has(canonical)
+  );
+};
+
+const validateArgsBeforeParse = (allArgs) => {
+  allArgs.forEach((arg, index) => {
+    if (!arg.startsWith("-") || arg === "--" || arg.includes("=")) {
+      return;
+    }
+
+    const name = canonicalOptionName(arg.replace(/^--?/, ""));
+    const next = allArgs[index + 1];
+
+    if (requiresValue(name) && (next === undefined || next.startsWith("-"))) {
+      throw new Error(`Not enough arguments following: ${name}`);
+    }
+  });
+};
+
+const normalizeParsedValues = (values, positionals) => {
+  const normalized = Object.assign({ _: positionals }, values);
+
+  Object.keys(normalized).forEach((rawName) => {
+    if (rawName === "_") {
+      return;
+    }
+
+    const name = canonicalOptionName(rawName);
+    if (name !== rawName) {
+      normalized[name] = mergeValue(normalized[name], normalized[rawName]);
+      delete normalized[rawName];
+    }
+  });
+
+  arrayOptions.forEach((name) => {
+    if (normalized[name] !== undefined) {
+      normalized[name] = coerceArrayOption(name, normalized[name]);
+    }
+  });
+
+  scalarOptions.forEach((name) => {
+    if (normalized[name] !== undefined) {
+      normalized[name] = coerceScalarOption(normalized[name]);
+    }
+  });
+
+  numberOptions.forEach((name) => {
+    if (normalized[name] !== undefined) {
+      normalized[name] = coerceNumberOption(normalized[name]);
+    }
+  });
+
+  return normalized;
+};
+
+const createErrorForNumericPositionalArg = (
+  numericArg,
+  allArgs,
+  parsedResult,
+) => {
+  const flag = allArgs.find((arg, index) => {
+    const normalizedArg = arg.replace(/^--?/, "");
+    return (
+      isMochaFlag(arg) &&
+      allArgs[index + 1] === String(numericArg) &&
+      parsedResult[normalizedArg] !== String(numericArg)
+    );
+  });
+
+  if (flag) {
+    throw createInvalidArgumentTypeError(
+      `Mocha flag '${flag}' given invalid option: '${numericArg}'`,
+      numericArg,
+      expectedTypeForFlag(flag),
+    );
+  }
+
+  throw createUnsupportedError(
+    `Option ${numericArg} is unsupported by the mocha cli`,
+  );
+};
+
+export const parseMochaArgs = (
+  args = [],
+  defaultValues = {},
+  ...configObjects
+) => {
+  const allArgs = Array.isArray(args) ? args : args ? args.split(" ") : [];
+  const nodeArgs = allArgs.reduce((acc, arg) => {
+    const pair = arg.split("=");
+    let flag = pair[0];
+    if (isNodeFlag(flag, false)) {
+      flag = flag.replace(/^--?/, "");
+      return acc.concat([[flag, arg.includes("=") ? pair[1] : true]]);
+    }
+    return acc;
+  }, []);
+
+  validateArgsBeforeParse(allArgs);
+  const parsed = parseArgs({
+    args: preprocessArgs(allArgs),
+    options: createParseArgsOptions(nodeArgs),
+    allowNegative: true,
+    allowPositionals: true,
+    strict: false,
+  });
+
+  const result = normalizeParsedValues(
+    Object.assign(
+      mergeConfigObjects(defaultValues, configObjects),
+      parsed.values,
+    ),
+    parsed.positionals,
+  );
+
+  const numericPositionalArg = result._.find((arg) => isNumeric(arg));
+  if (numericPositionalArg) {
+    createErrorForNumericPositionalArg(
+      Number(numericPositionalArg),
+      allArgs,
+      result,
+    );
+  }
+
+  nodeArgs.forEach(([key, value]) => {
+    result[key] = value;
+  });
+
+  return result;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "supports-color": "^8.1.1",
         "workerpool": "^10.0.0",
         "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "supports-color": "^8.1.1",
     "workerpool": "^10.0.0",
     "yargs": "^17.7.2",
-    "yargs-parser": "^21.1.1",
     "yargs-unparser": "^2.0.0"
   },
   "devDependencies": {

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -1,0 +1,181 @@
+import { constants } from "../../../lib/error-constants.js";
+import { parseMochaArgs } from "../../../lib/cli/parse-args.js";
+
+const defaults = {
+  timeout: 1000,
+  extension: ["js"],
+};
+
+describe("parse-args", function () {
+  it("canonicalizes aliases and strips alias keys", function () {
+    const result = parseMochaArgs(
+      [
+        "-R",
+        "json",
+        "-t",
+        "123",
+        "-A",
+        "-b",
+        "-g",
+        "foo",
+        "-r",
+        "./x.js",
+        "-O",
+        "a=b",
+        "test/a.js",
+      ],
+      defaults,
+    );
+
+    expect(result, "to satisfy", {
+      _: ["test/a.js"],
+      reporter: "json",
+      timeout: "123",
+      "async-only": true,
+      bail: true,
+      grep: "foo",
+      require: ["./x.js"],
+      "reporter-option": ["a=b"],
+    });
+    ["R", "t", "A", "b", "g", "r", "O"].forEach((alias) => {
+      expect(result, "not to have property", alias);
+    });
+  });
+
+  it("uses the last value for repeated scalar options across aliases", function () {
+    expect(
+      parseMochaArgs(["--timeout", "100", "-t", "10"], defaults),
+      "to satisfy",
+      {
+        timeout: "10",
+      },
+    );
+  });
+
+  it("splits, deduplicates, and preserves order for repeated array options", function () {
+    expect(
+      parseMochaArgs(
+        [
+          "--require",
+          "a",
+          "--require",
+          "a,b",
+          "--extension",
+          "js,ts",
+          "--extension",
+          "ts",
+        ],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        require: ["a", "b"],
+        extension: ["js", "ts"],
+      },
+    );
+  });
+
+  it("preserves boolean negation including long alias negation", function () {
+    expect(
+      parseMochaArgs(
+        [
+          "--color",
+          "--no-color",
+          "--parallel",
+          "--no-parallel",
+          "--no-timeouts",
+        ],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        color: false,
+        parallel: false,
+        timeout: false,
+      },
+    );
+  });
+
+  it("keeps unknown options accepted and parsed", function () {
+    expect(parseMochaArgs(["--foo", "bar"], defaults), "to satisfy", {
+      _: [],
+      foo: "bar",
+    });
+  });
+
+  it("keeps unknown short options accepted with separated values", function () {
+    expect(parseMochaArgs(["-x", "bar"], defaults), "to satisfy", {
+      _: [],
+      x: "bar",
+    });
+  });
+
+  it("treats unknown short equals-form options as native grouped shorts", function () {
+    expect(parseMochaArgs(["-x=bar"], defaults), "to satisfy", {
+      _: [],
+      x: true,
+      "=": true,
+      bail: true,
+      a: true,
+      require: ["true"],
+    });
+  });
+
+  it("snapshots current option terminator behavior", function () {
+    expect(
+      parseMochaArgs(["--", "--not-an-option", "test.js"], defaults),
+      "to satisfy",
+      {
+        _: [],
+        "not-an-option": "test.js",
+      },
+    );
+  });
+
+  it("accepts dash-prefixed option values in equals form", function () {
+    expect(parseMochaArgs(["--grep=-foo"], defaults), "to satisfy", {
+      grep: "-foo",
+    });
+  });
+
+  it("rejects dash-prefixed option values in separated form", function () {
+    expect(
+      () => parseMochaArgs(["--grep", "-foo"], defaults),
+      "to throw",
+      /Not enough arguments following: grep/,
+    );
+  });
+
+  it("preserves directly-passed Node and V8 flags", function () {
+    expect(
+      parseMochaArgs(
+        ["--trace-warnings", "--max-old-space-size=4096", "--conditions=dev"],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        "trace-warnings": true,
+        "max-old-space-size": "4096",
+        conditions: "dev",
+      },
+    );
+  });
+
+  it("uses native short option grouping behavior", function () {
+    expect(parseMochaArgs(["-bc"], defaults), "to satisfy", {
+      _: [],
+      bail: true,
+      color: true,
+    });
+  });
+
+  it("preserves numeric positional argument errors", function () {
+    expect(() => parseMochaArgs(["--delay", "123"], defaults), "to throw", {
+      message: "Mocha flag '--delay' given invalid option: '123'",
+      code: constants.INVALID_ARG_TYPE,
+      argument: 123,
+      actual: "number",
+      expected: "boolean",
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: starts on #6122 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Part 1 of ~2-3 for #6122. This replaces the `yargs-parser` dependency and a lot of its wrapping logic with different local wrapping logic. The parser preserves config/env/package/default priority and `yargs`-y compatibility behavior, with a few low-impact simplifications captured in snapshots.

Internal line change amount is approximately +185 (+325 for parse-args.js, +15/-157 for options.cjs).

Note that this doesn't change `node_modules/` size, since `yargs` itself has a dependency on `yargs-parser`.
