### PR TITLE
fix!: replace `he` dependency with manual HTML encoding

### DIFF
--- a/lib/utils.cjs
+++ b/lib/utils.cjs
@@ -9,11 +9,36 @@
  * Module dependencies.
  */
 var path = require("node:path");
-var he = require("he");
 var pc = require("picocolors");
 var isUnicodeSupported = require("is-unicode-supported")();
 
 const MOCHA_ID_PROP_NAME = "__mocha_id__";
+
+function htmlCodePointEscape(codePoint) {
+  return "&#x" + codePoint.toString(16).toUpperCase() + ";";
+}
+
+function shouldEscapeHtmlChar(codePoint) {
+  return (
+    (codePoint >= 0x01 && codePoint <= 0x09) ||
+    codePoint === 0x0b ||
+    codePoint === 0x0c ||
+    (codePoint >= 0x0e && codePoint <= 0x1f) ||
+    codePoint === 0x22 ||
+    codePoint === 0x26 ||
+    codePoint === 0x27 ||
+    codePoint === 0x3c ||
+    codePoint === 0x3e ||
+    codePoint === 0x60 ||
+    codePoint === 0x7f ||
+    codePoint === 0x81 ||
+    codePoint === 0x8d ||
+    codePoint === 0x8f ||
+    codePoint === 0x90 ||
+    codePoint === 0x9d ||
+    codePoint >= 0xa0
+  );
+}
 
 /**
  * Escape special characters in the given string of html.
@@ -23,7 +48,35 @@ const MOCHA_ID_PROP_NAME = "__mocha_id__";
  * @return {string}
  */
 exports.escape = function (html) {
-  return he.encode(String(html), { useNamedReferences: false });
+  var string = String(html);
+  var escaped = "";
+
+  for (var index = 0; index < string.length; index++) {
+    var codePoint = string.charCodeAt(index);
+
+    if (
+      codePoint >= 0xd800 &&
+      codePoint <= 0xdbff &&
+      index + 1 < string.length
+    ) {
+      var low = string.charCodeAt(index + 1);
+
+      if (low >= 0xdc00 && low <= 0xdfff) {
+        // Decode a UTF-16 surrogate pair into a single Unicode code point.
+        // See https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+        codePoint = (codePoint - 0xd800) * 0x400 + low - 0xdc00 + 0x10000;
+        escaped += htmlCodePointEscape(codePoint);
+        index++;
+        continue;
+      }
+    }
+
+    escaped += shouldEscapeHtmlChar(codePoint)
+      ? htmlCodePointEscape(codePoint)
+      : string.charAt(index);
+  }
+
+  return escaped;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "diff": "^9.0.0",
         "find-up": "^5.0.0",
         "glob": "^13.0.0",
-        "he": "^1.2.0",
         "is-path-inside": "^3.0.3",
         "is-unicode-supported": "^0.1.0",
         "js-yaml": "^4.1.0",
@@ -4799,14 +4798,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "diff": "^9.0.0",
     "find-up": "^5.0.0",
     "glob": "^13.0.0",
-    "he": "^1.2.0",
     "is-path-inside": "^3.0.3",
     "is-unicode-supported": "^0.1.0",
     "js-yaml": "^4.1.0",

--- a/test/unit/utils.spec.cjs
+++ b/test/unit/utils.spec.cjs
@@ -2,6 +2,7 @@
 "use strict";
 
 var utils = require("../../lib/utils.cjs");
+var pkg = require("../../package.json");
 var sinon = require("sinon");
 
 describe("lib/utils", function () {
@@ -685,24 +686,170 @@ describe("lib/utils", function () {
   });
 
   describe("escape()", function () {
-    it("replaces the usual xml suspects", function () {
-      expect(utils.escape("<a<bc<d<"), "to be", "&#x3C;a&#x3C;bc&#x3C;d&#x3C;");
-      expect(utils.escape(">a>bc>d>"), "to be", "&#x3E;a&#x3E;bc&#x3E;d&#x3E;");
-      expect(utils.escape('"a"bc"d"'), "to be", "&#x22;a&#x22;bc&#x22;d&#x22;");
-      expect(utils.escape('<>"&'), "to be", "&#x3C;&#x3E;&#x22;&#x26;");
-
-      expect(utils.escape("&a&bc&d&"), "to be", "&#x26;a&#x26;bc&#x26;d&#x26;");
-      expect(utils.escape("&amp;&lt;"), "to be", "&#x26;amp;&#x26;lt;");
+    [
+      ["null", null, "null"],
+      ["undefined", undefined, "undefined"],
+      ["number", 42, "42"],
+      ["boolean", false, "false"],
+      ["object", { toString: () => "<tag>" }, "&#x3C;tag&#x3E;"],
+    ].forEach(function ([label, input, expected]) {
+      it(`coerces ${label} to a string before escaping`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
     });
 
-    it("replaces invalid xml characters", function () {
+    [
+      [
+        "alphanumeric",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+      ],
+      ["safe punctuation", " !#$%()*+,-./:;=?@[\\]^_{|}~"],
+    ].forEach(function ([label, input]) {
+      it(`leaves safe ascii ${label} unchanged`, function () {
+        expect(utils.escape(input), "to be", input);
+      });
+    });
+
+    [
+      ["less-than signs", "<a<bc<d<", "&#x3C;a&#x3C;bc&#x3C;d&#x3C;"],
+      ["greater-than signs", ">a>bc>d>", "&#x3E;a&#x3E;bc&#x3E;d&#x3E;"],
+      ["double quotes", '"a"bc"d"', "&#x22;a&#x22;bc&#x22;d&#x22;"],
+      ["ampersands", "&a&bc&d&", "&#x26;a&#x26;bc&#x26;d&#x26;"],
+      ["existing entities", "&amp;&lt;", "&#x26;amp;&#x26;lt;"],
+      [
+        "all sensitive punctuation",
+        "<>\"&'`",
+        "&#x3C;&#x3E;&#x22;&#x26;&#x27;&#x60;",
+      ],
+    ].forEach(function ([label, input, expected]) {
+      it(`replaces ${label} with uppercase hexadecimal references`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    [
+      ["nul", "\x00", "\x00"],
+      ["start of heading", "\x01", "&#x1;"],
+      ["start of text", "\x02", "&#x2;"],
+      ["end of text", "\x03", "&#x3;"],
+      ["end of transmission", "\x04", "&#x4;"],
+      ["enquiry", "\x05", "&#x5;"],
+      ["acknowledge", "\x06", "&#x6;"],
+      ["bell", "\x07", "&#x7;"],
+      ["backspace", "\x08", "&#x8;"],
+      ["tab", "\x09", "&#x9;"],
+      ["line feed", "\x0A", "\n"],
+      ["vertical tab", "\x0B", "&#xB;"],
+      ["form feed", "\x0C", "&#xC;"],
+      ["carriage return", "\x0D", "\r"],
+      ["shift out", "\x0E", "&#xE;"],
+      ["shift in", "\x0F", "&#xF;"],
+      ["data link escape", "\x10", "&#x10;"],
+      ["device control one", "\x11", "&#x11;"],
+      ["device control two", "\x12", "&#x12;"],
+      ["device control three", "\x13", "&#x13;"],
+      ["device control four", "\x14", "&#x14;"],
+      ["negative acknowledge", "\x15", "&#x15;"],
+      ["synchronous idle", "\x16", "&#x16;"],
+      ["end transmission block", "\x17", "&#x17;"],
+      ["cancel", "\x18", "&#x18;"],
+      ["end of medium", "\x19", "&#x19;"],
+      ["substitute", "\x1A", "&#x1A;"],
+      ["escape", "\x1B", "&#x1B;"],
+      ["file separator", "\x1C", "&#x1C;"],
+      ["group separator", "\x1D", "&#x1D;"],
+      ["record separator", "\x1E", "&#x1E;"],
+      ["unit separator", "\x1F", "&#x1F;"],
+    ].forEach(function ([label, input, expected]) {
+      it(`handles C0 control ${label}`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    [
+      ["delete", "\x7F", "&#x7F;"],
+      ["padding character", "\x80", "\x80"],
+      ["high octet preset", "\x81", "&#x81;"],
+      ["partial line backward", "\x8C", "\x8C"],
+      ["reverse line feed", "\x8D", "&#x8D;"],
+      ["single shift two", "\x8E", "\x8E"],
+      ["single shift three", "\x8F", "&#x8F;"],
+      ["device control string", "\x90", "&#x90;"],
+      ["private use one", "\x91", "\x91"],
+      ["string terminator", "\x9C", "\x9C"],
+      ["operating system command", "\x9D", "&#x9D;"],
+      ["privacy message", "\x9E", "\x9E"],
+      ["application program command", "\x9F", "\x9F"],
+    ].forEach(function ([label, input, expected]) {
+      it(`handles C1 control ${label}`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    [
+      ["copyright sign", "©", "&#xA9;"],
+      ["latin small e acute", "é", "&#xE9;"],
+      ["em dash", "—", "&#x2014;"],
+      ["CJK character", "中", "&#x4E2D;"],
+      ["replacement character", "\uFFFD", "&#xFFFD;"],
+      ["noncharacter FFFE", "\uFFFE", "&#xFFFE;"],
+      ["noncharacter FFFF", "\uFFFF", "&#xFFFF;"],
+    ].forEach(function ([label, input, expected]) {
+      it(`replaces non-ascii unicode ${label}`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    [
+      ["pile of poo", "💩", "&#x1F4A9;"],
+      ["grinning face", "😀", "&#x1F600;"],
+      ["tetragram", "𝌆", "&#x1D306;"],
+      ["CJK extension", "𠜎", "&#x2070E;"],
+    ].forEach(function ([label, input, expected]) {
+      it(`replaces astral unicode ${label} as one code point`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    [
+      ["lone high surrogate", "\uD800", "&#xD800;"],
+      ["lone low surrogate", "\uDC00", "&#xDC00;"],
+      ["high surrogate between ascii", "a\uD800b", "a&#xD800;b"],
+      ["low surrogate between ascii", "a\uDC00b", "a&#xDC00;b"],
+    ].forEach(function ([label, input, expected]) {
+      it(`replaces ${label}`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    it("does not rely on he as a runtime dependency", function () {
+      expect(pkg.dependencies, "not to have key", "he");
+    });
+
+    [
+      ["ansi color escapes", "\x1B[32mfoo\x1B[0m", "&#x1B;[32mfoo&#x1B;[0m"],
+      ["ascii whitespace controls", "\t\n\r", "&#x9;\n\r"],
+      ["mixed null and C1 controls", "\0\x7F\x80\x81", "\0&#x7F;\x80&#x81;"],
+    ].forEach(function ([label, input, expected]) {
+      it(`replaces ${label}`, function () {
+        expect(utils.escape(input), "to be", expected);
+      });
+    });
+
+    it("replaces unpaired surrogates without consuming neighboring characters", function () {
       expect(
-        utils.escape("\x1B[32mfoo\x1B[0m"),
+        utils.escape("\uD800\uD800\uDC00\uDC00"),
         "to be",
-        "&#x1B;[32mfoo&#x1B;[0m",
+        "&#xD800;&#x10000;&#xDC00;",
       );
-      // Ensure we can handle non-trivial unicode characters as well
-      expect(utils.escape("💩"), "to be", "&#x1F4A9;");
+    });
+
+    it("escapes mixed reporter content in order", function () {
+      expect(
+        utils.escape("Suite <root> failed: 💩 & \x1B[31mred\x1B[0m"),
+        "to be",
+        "Suite &#x3C;root&#x3E; failed: &#x1F4A9; &#x26; &#x1B;[31mred&#x1B;[0m",
+      );
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6122 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

Reopens #5490. I still don't love doing this tricky in our codebase when dependencies exist, but the package size is rather unpalatable for the very small amount of logic we actually need.

Just to be safe, I added a boatload of tests.

https://github.com/googleapis/release-please#how-can-i-fix-release-notes:

BEGIN_COMMIT_OVERRIDE
fix!: replace `he` dependency with manual HTML encoding (#6129)
END_COMMIT_OVERRIDE