### PR TITLE
fix: fail nested-suite tests affected by a failing beforeEach hook

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -851,6 +851,25 @@ Runner.prototype.runTests = function (suite, fn) {
           self.emit(constants.EVENT_TEST_END, t);
         }
       });
+      // Tests in descendant suites are skipped along with the remaining
+      // tests of this suite when a `before each` hook fails, so fail them too.
+      self.suite.suites.forEach(function failSubSuiteTests(s) {
+        s.tests.forEach(function (t) {
+          if (!t.state) {
+            var testError = createHookSkipError(
+              self._failedBeforeEachHook.title,
+              self._failedBeforeEachHook.error,
+            );
+
+            t.state = STATE_FAILED;
+            self.failures++;
+            self.emit(constants.EVENT_TEST_BEGIN, t);
+            self.emit(constants.EVENT_TEST_FAIL, t, testError);
+            self.emit(constants.EVENT_TEST_END, t);
+          }
+        });
+        s.suites.forEach(failSubSuiteTests);
+      });
       // Clear the stored hook info
       delete self._failedBeforeEachHook;
     }

--- a/test/integration/fixtures/hooks/before-each-hook-error-with-fail-affected-nested.fixture.js
+++ b/test/integration/fixtures/hooks/before-each-hook-error-with-fail-affected-nested.fixture.js
@@ -1,0 +1,23 @@
+'use strict';
+
+describe('fails `beforeEach` hook', function () {
+  beforeEach(function () {
+    throw new Error('error in `beforeEach` hook');
+  });
+  it('test 1', function () {
+    // This should be reported as failed due to beforeEach hook failure
+  });
+  describe('nested suite', function () {
+    it('test 2', function () {
+      // This should be reported as failed due to the parent beforeEach hook failure
+    });
+    it('test 3', function () {
+      // This should be reported as failed due to the parent beforeEach hook failure
+    });
+  });
+});
+describe('passes normally', function () {
+  it('test 4', function () {
+    // This should pass normally
+  });
+});

--- a/test/integration/hook-err.spec.cjs
+++ b/test/integration/hook-err.spec.cjs
@@ -332,6 +332,29 @@ describe("hook error handling", function () {
       });
     });
 
+    describe("error in `beforeEach` hook with nested suites", function () {
+      it("should fail affected tests in nested suites", function (done) {
+        runMochaJSON(
+          "hooks/before-each-hook-error-with-fail-affected-nested.fixture.js",
+          ["--fail-hook-affected-tests"],
+          (err, res) => {
+            if (err) {
+              return done(err);
+            }
+            expect(res, "to have failed")
+              .and("to have failed test count", 4)
+              .and("to have failed test", '"before each" hook for "test 1"')
+              .and("to have failed test", "test 1")
+              .and("to have failed test", "test 2")
+              .and("to have failed test", "test 3")
+              .and("to have passed test count", 1)
+              .and("to have passed test", "test 4");
+            done();
+          },
+        );
+      });
+    });
+
     describe("non-Error thrown in `before` hook", function () {
       it("should handle null, undefined, and other non-Error values", function (done) {
         runMochaJSON(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6132
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22). I filed #6132 for this; it needs a maintainer to triage and label it before I can check this box.
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--fail-hook-affected-tests` (added in v12) is documented to report tests as failed when they are affected by a hook failure, instead of silently skipping them. A failing `beforeEach` affects every test the hook would have run before, including tests in nested `describe` blocks. The option handles the `before` (beforeAll) case by recursing into sub-suites, but the `beforeEach` case only fails the remaining tests of the immediate suite and drops the tests in nested sub-suites. With the option on, those nested tests still vanish from the run, and the failure and total counts are under-reported in every reporter (spec, json, tap, xunit).

## Repro

A suite with a failing `beforeEach`, one direct test, and a nested `describe` with two tests. With `--fail-hook-affected-tests` the run reports 2 failures (the hook and the direct test) and drops the two nested tests. The same shape with `before` instead of `beforeEach` already reports all of them, which is the behavior this change brings to `beforeEach`.

## Fix

After failing the remaining tests of the current suite, recurse into `self.suite.suites` and fail their not-yet-run tests too, mirroring the existing `failAffectedTests` recursion used by the `before` path. The `!t.state` guard leaves already-run tests untouched.

Added a fixture and an integration test. The test fails before this change (2 failures) and passes after (4 failures, 1 pass); the hook, retries, pending and reporter suites stay green.

One point for review: like the existing `before`/beforeAll branch, this reports a statically `.skip()`ed test inside an affected sub-suite as failed rather than pending. That keeps the two branches consistent. If you would rather exempt pending tests, that is a separate change that should apply to both branches at once.

