### PR TITLE
feat: add --clear-screen option for watch mode

### DIFF
--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -59,6 +59,8 @@ Reporting & Output
                                                       [string] [default: "spec"]
   -O, --reporter-option,                    Reporter-specific options
   --reporter-options                        (<k=v,[k1=v1,..]>)           [array]
+      --clear-screen                        Clear the terminal before each run
+                                            in watch mode              [boolean]
 
 Configuration
       --config       Path to config file   [string] [default: (nearest rc file)]
@@ -77,8 +79,6 @@ File Handling
   -S, --sort               Sort test files                             [boolean]
   -w, --watch              Watch files in the current working directory for
                            changes                                     [boolean]
-      --clear-screen       Clear the terminal before each run in watch mode
-                                                                       [boolean]
       --watch-files        List of paths or globs to watch               [array]
       --watch-ignore       List of paths or globs to exclude from watching
                                       [array] [default: ["node_modules",".git"]]
@@ -356,6 +356,15 @@ Not all reporters accept options.
 
 Can be specified as a comma-delimited list.
 
+### `--clear-screen`
+
+:::note[New in v12.0.0]
+:::
+
+Clear the terminal before each run when `--watch` is set.
+
+This keeps only the latest run's output on screen, similar to the built-in behavior of the [`min` reporter](/reporters/min). It has no effect without `--watch`.
+
 ## Configuration
 
 ### `--config <path>`
@@ -483,15 +492,6 @@ Rerun tests on file changes.
 The `--watch-files` and `--watch-ignore` options can be used to control which files are watched for changes.
 
 Tests may be rerun manually by typing `rs` and pressing enter (same shortcut as `nodemon`).
-
-### `--clear-screen`
-
-:::note[New in v12.0.0]
-:::
-
-Clear the terminal before each run when `--watch` is set.
-
-This keeps only the latest run's output on screen, similar to the built-in behavior of the [`min` reporter](/reporters/min). It has no effect without `--watch`.
 
 ### `--watch-files <file|directory|glob>`
 

--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -77,6 +77,8 @@ File Handling
   -S, --sort               Sort test files                             [boolean]
   -w, --watch              Watch files in the current working directory for
                            changes                                     [boolean]
+      --clear-screen       Clear the terminal before each run in watch mode
+                                                                       [boolean]
       --watch-files        List of paths or globs to watch               [array]
       --watch-ignore       List of paths or globs to exclude from watching
                                       [array] [default: ["node_modules",".git"]]
@@ -481,6 +483,15 @@ Rerun tests on file changes.
 The `--watch-files` and `--watch-ignore` options can be used to control which files are watched for changes.
 
 Tests may be rerun manually by typing `rs` and pressing enter (same shortcut as `nodemon`).
+
+### `--clear-screen`
+
+:::note[New in v12.0.0]
+:::
+
+Clear the terminal before each run when `--watch` is set.
+
+This keeps only the latest run's output on screen, similar to the built-in behavior of the [`min` reporter](/reporters/min). It has no effect without `--watch`.
 
 ### `--watch-files <file|directory|glob>`
 

--- a/lib/cli/run-option-metadata.cjs
+++ b/lib/cli/run-option-metadata.cjs
@@ -30,6 +30,7 @@ const types = {
     "async-only",
     "bail",
     "check-leaks",
+    "clear-screen",
     "color",
     "delay",
     "diff",

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -277,7 +277,7 @@ exports.builder = (yargs) =>
       },
       "clear-screen": {
         description: "Clear the terminal before each run in watch mode",
-        group: GROUPS.FILES,
+        group: GROUPS.OUTPUT,
       },
       "watch-files": {
         description: "List of paths or globs to watch",

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -275,6 +275,10 @@ exports.builder = (yargs) =>
         description: "Watch files in the current working directory for changes",
         group: GROUPS.FILES,
       },
+      "clear-screen": {
+        description: "Clear the terminal before each run in watch mode",
+        group: GROUPS.FILES,
+      },
       "watch-files": {
         description: "List of paths or globs to watch",
         group: GROUPS.FILES,

--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -46,7 +46,7 @@ const { logSymbols } = require("../utils.cjs");
  */
 exports.watchParallelRun = (
   mocha,
-  { watchFiles, watchIgnore },
+  { watchFiles, watchIgnore, clearScreen },
   fileCollectParams,
 ) => {
   debug("creating parallel watcher");
@@ -54,6 +54,7 @@ exports.watchParallelRun = (
   return createWatcher(mocha, {
     watchFiles,
     watchIgnore,
+    clearScreen,
     beforeRun({ mocha }) {
       // I don't know why we're cloning the root suite.
       const rootSuite = mocha.suite.clone();
@@ -108,12 +109,17 @@ exports.watchParallelRun = (
  *   file collection. See `lib/cli/collect-files.cjs`.
  * @private
  */
-exports.watchRun = (mocha, { watchFiles, watchIgnore }, fileCollectParams) => {
+exports.watchRun = (
+  mocha,
+  { watchFiles, watchIgnore, clearScreen },
+  fileCollectParams,
+) => {
   debug("creating serial watcher");
 
   return createWatcher(mocha, {
     watchFiles,
     watchIgnore,
+    clearScreen,
     beforeRun({ mocha }) {
       mocha.unloadFiles();
 
@@ -397,6 +403,7 @@ function createPathMatcher(allowed, ignored, basePath) {
  *   `chokidar.watch`.
  * @param {string[]} [opts.watchIgnore] - List of paths and patterns to exclude
  *   from watching. See `ignored` option of `chokidar`.
+ * @param {boolean} [opts.clearScreen] - Clear the terminal before each run.
  * @param {FileCollectionOptions} opts.fileCollectParams - List of extensions to watch if `opts.watchFiles` is not given.
  * @returns {FSWatcher}
  * @ignore
@@ -404,7 +411,7 @@ function createPathMatcher(allowed, ignored, basePath) {
  */
 const createWatcher = (
   mocha,
-  { watchFiles, watchIgnore, beforeRun, fileCollectParams },
+  { watchFiles, watchIgnore, clearScreen, beforeRun, fileCollectParams },
 ) => {
   if (!watchFiles) {
     watchFiles = fileCollectParams.extension.map((ext) => `**/*.${ext}`);
@@ -436,6 +443,7 @@ const createWatcher = (
 
   const rerunner = createRerunner(mocha, watcher, {
     beforeRun,
+    clearScreen,
   });
 
   watcher.on("ready", async () => {
@@ -511,11 +519,12 @@ const createWatcher = (
  * @param {FSWatcher} watcher - Chokidar `FSWatcher` instance
  * @param {Object} [opts] - Options!
  * @param {BeforeWatchRun} [opts.beforeRun] - Function to call before `mocha.run()`
+ * @param {boolean} [opts.clearScreen] - Clear the terminal before each run
  * @returns {Rerunner}
  * @ignore
  * @private
  */
-const createRerunner = (mocha, watcher, { beforeRun } = {}) => {
+const createRerunner = (mocha, watcher, { beforeRun, clearScreen } = {}) => {
   // Set to a `Runner` when mocha is running. Set to `null` when mocha is not
   // running.
   let runner = null;
@@ -525,6 +534,9 @@ const createRerunner = (mocha, watcher, { beforeRun } = {}) => {
 
   const run = () => {
     try {
+      if (clearScreen) {
+        clearTerminal();
+      }
       mocha = beforeRun ? beforeRun({ mocha, watcher }) || mocha : mocha;
       runner = mocha.run(() => {
         debug("finished watch run");
@@ -609,6 +621,15 @@ const showCursor = () => {
  */
 const eraseLine = () => {
   process.stdout.write("\u001b[2K");
+};
+
+/**
+ * Clears the terminal and moves the cursor to the top-left corner.
+ * @private
+ */
+const clearTerminal = () => {
+  // "\u001b[2J" clears the screen. "\u001b[0f" moves the cursor to the home position
+  process.stdout.write("\u001b[2J\u001b[0f");
 };
 
 /**

--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -628,8 +628,8 @@ const eraseLine = () => {
  * @private
  */
 const clearTerminal = () => {
-  // "\u001b[2J" clears the screen. "\u001b[0f" moves the cursor to the home position
-  process.stdout.write("\u001b[2J\u001b[0f");
+  // "\u001b[2J" clears the screen. "\u001b[H" moves the cursor to the home position
+  process.stdout.write("\u001b[2J\u001b[H");
 };
 
 /**

--- a/test/integration/options/watch.spec.cjs
+++ b/test/integration/options/watch.spec.cjs
@@ -559,5 +559,31 @@ describe("--watch", function () {
         },
       );
     });
+
+    describe("--clear-screen", function () {
+      const CLEAR_SCREEN = String.fromCharCode(27) + "[2J";
+
+      it("clears the terminal before each run when enabled", function () {
+        const testFile = path.join(tempDir, "test.js");
+        copyFixture(DEFAULT_FIXTURE, testFile);
+
+        return runMochaWatchAsync([testFile, "--clear-screen"], tempDir, () => {
+          touchFile(testFile);
+        }).then((result) => {
+          expect(result.output, "to contain", CLEAR_SCREEN);
+        });
+      });
+
+      it("does not clear the terminal when disabled", function () {
+        const testFile = path.join(tempDir, "test.js");
+        copyFixture(DEFAULT_FIXTURE, testFile);
+
+        return runMochaWatchAsync([testFile], tempDir, () => {
+          touchFile(testFile);
+        }).then((result) => {
+          expect(result.output, "not to contain", CLEAR_SCREEN);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2312 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Added a --clear-screen flag that clears the terminal before each run under --watch. I took the name from Josh's suggestion in the issue. It clears before every run,including the first, to match the "min" reporter and "tsc --watch".
It's a no-op without --watch so it stays out of the way of single runs.

<img width="1930" height="510" alt="bild" src="https://github.com/user-attachments/assets/388decbd-e341-4877-8b08-bd1e4aaab8e1" />