### PR TITLE
chore(deps): bump unexpected to 13 and remove unused plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,11 +67,8 @@
         "semver": "^7.7.2",
         "sinon": "^22.0.0",
         "typescript": "^5.8.3",
-        "unexpected": "^11.14.0",
-        "unexpected-eventemitter": "^2.2.0",
-        "unexpected-map": "^3.0.0",
-        "unexpected-set": "^3.0.0",
-        "unexpected-sinon": "^11.0.0",
+        "unexpected": "^13.2.1",
+        "unexpected-sinon": "^11.1.0",
         "webpack": "^5.67.0",
         "webpack-cli": "^7.0.2"
       },
@@ -8954,10 +8951,14 @@
       }
     },
     "node_modules/ukkonen": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ukkonen/-/ukkonen-1.4.0.tgz",
-      "integrity": "sha512-g8SLGxflI0/VNH2C8j66KcfJXrU5StJglRQBYPNiChXFlOrqqYM1icOykOAAUgTeBpktaEuCm9hjpPinQ080PA==",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ukkonen/-/ukkonen-2.2.0.tgz",
+      "integrity": "sha512-tUad5tv8CxhXfA0xsogqXqiaZ1ldQdNni3iNOWOTXrf2/hnYa532Fg0fk6h+IyIEOPF324aLyovVAR/H/wR8rA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/unbash": {
       "version": "3.0.0",
@@ -8977,18 +8978,19 @@
       "license": "MIT"
     },
     "node_modules/unexpected": {
-      "version": "11.15.1",
-      "resolved": "https://registry.npmjs.org/unexpected/-/unexpected-11.15.1.tgz",
-      "integrity": "sha512-s3XfLMEKRPioyuC5cqOCl2oCgGEg4fLhIuFHcUf0IExkGXTafPlLrkcvWV76woFrXpdxWGShYpDDQXBA3lOUcA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/unexpected/-/unexpected-13.2.1.tgz",
+      "integrity": "sha512-6rWjexbMV4DICp8xeKHKql5JTC5No7Mz55wei2YcXGkqBAtAgfzIhFLzbDohRzN/lNtwG6+NuIvMI/0giQXOvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-changes": "3.0.1",
         "array-changes-async": "3.0.1",
         "detect-indent": "3.0.1",
-        "diff": "4.0.2",
+        "diff": "^5.0.0",
         "greedy-interval-packer": "1.2.0",
-        "magicpen": "^6.2.1",
-        "ukkonen": "^1.4.0",
+        "magicpen": "^6.2.4",
+        "ukkonen": "^2.1.0",
         "unexpected-bluebird": "2.9.34-longstack2"
       }
     },
@@ -8997,37 +8999,6 @@
       "resolved": "https://registry.npmjs.org/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz",
       "integrity": "sha512-lAgr5q+ToN4cO+mCus6h9VLcnl27fCiWiCuDyx7Pcvf9IoFOaTRv0bauvikXRkg9+78c/1nDBbQxP+Wk9+uOCA==",
       "dev": true
-    },
-    "node_modules/unexpected-eventemitter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/unexpected-eventemitter/-/unexpected-eventemitter-2.4.0.tgz",
-      "integrity": "sha512-RhqPmdrD9T62HVzIdild1gGL6bkwk6QNh52FJxEmPaHTLOZBXmBASRpjzpCkRlP+E137qduV7ePSBCF5pUyLnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "unexpected": "^10 || ^11 || ^12 || ^13"
-      }
-    },
-    "node_modules/unexpected-map": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unexpected-map/-/unexpected-map-3.1.0.tgz",
-      "integrity": "sha512-wOs3gRYRrt8jkxYUHU5sP28Z7haK+sRgqx9LU9xazxar0U6RcBoMZy/dULifvjKxCvfXJE19gp+QbWkAYZitTA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "unexpected": "^10.40.2 || ^11.0.0 || ^12.0.0"
-      }
-    },
-    "node_modules/unexpected-set": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/unexpected-set/-/unexpected-set-3.3.0.tgz",
-      "integrity": "sha512-TF6GG/ord4jfCyyiGq1BiNgqmRcuoAqqZ7oa2SAU33lpXNV61ZQNuBiI5TglSMasY0lrDi0O6FCE2d8lFuSG4A==",
-      "dev": true,
-      "peerDependencies": {
-        "unexpected": "^10.37.4 || ^11.0.0-4 || ^12.0.0"
-      }
     },
     "node_modules/unexpected-sinon": {
       "version": "11.1.0",
@@ -9041,10 +9012,11 @@
       }
     },
     "node_modules/unexpected/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "sinon": "^22.0.0",
         "typescript": "^5.8.3",
         "unexpected": "^13.2.1",
-        "unexpected-sinon": "^11.1.0",
         "webpack": "^5.67.0",
         "webpack-cli": "^7.0.2"
       },
@@ -8999,17 +8998,6 @@
       "resolved": "https://registry.npmjs.org/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz",
       "integrity": "sha512-lAgr5q+ToN4cO+mCus6h9VLcnl27fCiWiCuDyx7Pcvf9IoFOaTRv0bauvikXRkg9+78c/1nDBbQxP+Wk9+uOCA==",
       "dev": true
-    },
-    "node_modules/unexpected-sinon": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/unexpected-sinon/-/unexpected-sinon-11.1.0.tgz",
-      "integrity": "sha512-6de9CU85JJg/hNLQ1sL/ssg7wls2u9bBqKmCmv12HOdjpyIjMeYZEpRLL33OrfYTeaEj7x4oDm7a5I5vPsVgjw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "sinon": "*",
-        "unexpected": "^10.8.0 || ^11.0.0-4 || ^12.0.0 || ^13.0.0"
-      }
     },
     "node_modules/unexpected/node_modules/diff": {
       "version": "5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "sinon": "^22.0.0",
         "typescript": "^5.8.3",
         "unexpected": "^13.2.1",
+        "unexpected-eventemitter": "^2.4.0",
         "unexpected-sinon": "^11.1.0",
         "webpack": "^5.67.0",
         "webpack-cli": "^7.0.2"
@@ -8999,6 +9000,19 @@
       "resolved": "https://registry.npmjs.org/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz",
       "integrity": "sha512-lAgr5q+ToN4cO+mCus6h9VLcnl27fCiWiCuDyx7Pcvf9IoFOaTRv0bauvikXRkg9+78c/1nDBbQxP+Wk9+uOCA==",
       "dev": true
+    },
+    "node_modules/unexpected-eventemitter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/unexpected-eventemitter/-/unexpected-eventemitter-2.4.0.tgz",
+      "integrity": "sha512-RhqPmdrD9T62HVzIdild1gGL6bkwk6QNh52FJxEmPaHTLOZBXmBASRpjzpCkRlP+E137qduV7ePSBCF5pUyLnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "unexpected": "^10 || ^11 || ^12 || ^13"
+      }
     },
     "node_modules/unexpected-sinon": {
       "version": "11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "sinon": "^22.0.0",
         "typescript": "^5.8.3",
         "unexpected": "^13.2.1",
+        "unexpected-sinon": "^11.1.0",
         "webpack": "^5.67.0",
         "webpack-cli": "^7.0.2"
       },
@@ -8998,6 +8999,17 @@
       "resolved": "https://registry.npmjs.org/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz",
       "integrity": "sha512-lAgr5q+ToN4cO+mCus6h9VLcnl27fCiWiCuDyx7Pcvf9IoFOaTRv0bauvikXRkg9+78c/1nDBbQxP+Wk9+uOCA==",
       "dev": true
+    },
+    "node_modules/unexpected-sinon": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/unexpected-sinon/-/unexpected-sinon-11.1.0.tgz",
+      "integrity": "sha512-6de9CU85JJg/hNLQ1sL/ssg7wls2u9bBqKmCmv12HOdjpyIjMeYZEpRLL33OrfYTeaEj7x4oDm7a5I5vPsVgjw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "sinon": "*",
+        "unexpected": "^10.8.0 || ^11.0.0-4 || ^12.0.0 || ^13.0.0"
+      }
     },
     "node_modules/unexpected/node_modules/diff": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -142,11 +142,8 @@
     "semver": "^7.7.2",
     "sinon": "^22.0.0",
     "typescript": "^5.8.3",
-    "unexpected": "^11.14.0",
-    "unexpected-eventemitter": "^2.2.0",
-    "unexpected-map": "^3.0.0",
-    "unexpected-set": "^3.0.0",
-    "unexpected-sinon": "^11.0.0",
+    "unexpected": "^13.2.1",
+    "unexpected-sinon": "^11.1.0",
     "webpack": "^5.67.0",
     "webpack-cli": "^7.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "sinon": "^22.0.0",
     "typescript": "^5.8.3",
     "unexpected": "^13.2.1",
+    "unexpected-sinon": "^11.1.0",
     "webpack": "^5.67.0",
     "webpack-cli": "^7.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "sinon": "^22.0.0",
     "typescript": "^5.8.3",
     "unexpected": "^13.2.1",
+    "unexpected-eventemitter": "^2.4.0",
     "unexpected-sinon": "^11.1.0",
     "webpack": "^5.67.0",
     "webpack-cli": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "sinon": "^22.0.0",
     "typescript": "^5.8.3",
     "unexpected": "^13.2.1",
-    "unexpected-sinon": "^11.1.0",
     "webpack": "^5.67.0",
     "webpack-cli": "^7.0.2"
   },

--- a/test/browser-specific/setup.cjs
+++ b/test/browser-specific/setup.cjs
@@ -2,4 +2,4 @@
 
 process.stdout = require("browser-stdout")();
 
-global.expect = require("unexpected").clone().use(require("unexpected-sinon"));
+global.expect = require("unexpected").clone();

--- a/test/browser-specific/setup.cjs
+++ b/test/browser-specific/setup.cjs
@@ -2,4 +2,7 @@
 
 process.stdout = require("browser-stdout")();
 
-global.expect = require("unexpected").clone().use(require("unexpected-sinon"));
+global.expect = require("unexpected")
+  .clone()
+  .use(require("unexpected-eventemitter"))
+  .use(require("unexpected-sinon"));

--- a/test/browser-specific/setup.cjs
+++ b/test/browser-specific/setup.cjs
@@ -2,4 +2,4 @@
 
 process.stdout = require("browser-stdout")();
 
-global.expect = require("unexpected").clone();
+global.expect = require("unexpected").clone().use(require("unexpected-sinon"));

--- a/test/browser-specific/setup.cjs
+++ b/test/browser-specific/setup.cjs
@@ -4,5 +4,5 @@ process.stdout = require("browser-stdout")();
 
 global.expect = require("unexpected")
   .clone()
-  .use(require("unexpected-eventemitter"))
-  .use(require("unexpected-sinon"));
+  .use(require("unexpected-sinon"))
+  .use(require("unexpected-eventemitter"));

--- a/test/browser-specific/setup.cjs
+++ b/test/browser-specific/setup.cjs
@@ -2,9 +2,4 @@
 
 process.stdout = require("browser-stdout")();
 
-global.expect = require("unexpected")
-  .clone()
-  .use(require("unexpected-set"))
-  .use(require("unexpected-map"))
-  .use(require("unexpected-sinon"))
-  .use(require("unexpected-eventemitter"));
+global.expect = require("unexpected").clone().use(require("unexpected-sinon"));

--- a/test/integration/options/parallel.spec.cjs
+++ b/test/integration/options/parallel.spec.cjs
@@ -473,8 +473,8 @@ describe("--parallel", function () {
       });
     });
 
-    describe.only("when a single test file is run with --reporter=json", function () {
-      it.only("should have the same output as when run with --no-parallel", async function () {
+    describe("when a single test file is run with --reporter=json", function () {
+      it("should have the same output as when run with --no-parallel", async function () {
         // this one has some timings/durations that we can safely ignore
         const { expected, actual } = await compareReporters("json");
         expected.output = JSON.parse(expected.output);

--- a/test/integration/options/parallel.spec.cjs
+++ b/test/integration/options/parallel.spec.cjs
@@ -473,28 +473,28 @@ describe("--parallel", function () {
       });
     });
 
-    describe("when a single test file is run with --reporter=json", function () {
-      it("should have the same output as when run with --no-parallel", async function () {
+    describe.only("when a single test file is run with --reporter=json", function () {
+      it.only("should have the same output as when run with --no-parallel", async function () {
         // this one has some timings/durations that we can safely ignore
         const { expected, actual } = await compareReporters("json");
         expected.output = JSON.parse(expected.output);
         actual.output = JSON.parse(actual.output);
-        return expect(actual, "to satisfy", {
+        expect(actual, "to satisfy", {
           passing: expected.passing,
           failing: expected.failing,
           pending: expected.pending,
           code: expected.code,
-          output: {
-            stats: {
-              suites: expected.output.stats.suites,
-              tests: expected.output.stats.tests,
-              passes: expected.output.stats.passes,
-              pending: expected.output.stats.pending,
-              failures: expected.output.stats.failures,
-            },
-            tests: expected.tests,
+        });
+        expect(actual.output, "to satisfy", {
+          stats: {
+            suites: expected.output.stats.suites,
+            tests: expected.output.stats.tests,
+            passes: expected.output.stats.passes,
+            pending: expected.output.stats.pending,
+            failures: expected.output.stats.failures,
           },
         });
+        expect(actual.output.tests, "to satisfy", expected.output.tests);
       });
     });
 

--- a/test/setup.cjs
+++ b/test/setup.cjs
@@ -4,5 +4,4 @@ const unexpected = require("unexpected");
 
 global.expect = unexpected
   .clone()
-  .use(require("unexpected-sinon"))
   .use(require("./assertions.cjs"));

--- a/test/setup.cjs
+++ b/test/setup.cjs
@@ -4,5 +4,6 @@ const unexpected = require("unexpected");
 
 global.expect = unexpected
   .clone()
+  .use(require("unexpected-eventemitter"))
   .use(require("unexpected-sinon"))
   .use(require("./assertions.cjs"));

--- a/test/setup.cjs
+++ b/test/setup.cjs
@@ -4,4 +4,5 @@ const unexpected = require("unexpected");
 
 global.expect = unexpected
   .clone()
+  .use(require("unexpected-sinon"))
   .use(require("./assertions.cjs"));

--- a/test/setup.cjs
+++ b/test/setup.cjs
@@ -5,7 +5,4 @@ const unexpected = require("unexpected");
 global.expect = unexpected
   .clone()
   .use(require("unexpected-sinon"))
-  .use(require("unexpected-eventemitter"))
-  .use(require("unexpected-map"))
-  .use(require("unexpected-set"))
   .use(require("./assertions.cjs"));

--- a/test/setup.cjs
+++ b/test/setup.cjs
@@ -4,6 +4,6 @@ const unexpected = require("unexpected");
 
 global.expect = unexpected
   .clone()
-  .use(require("unexpected-eventemitter"))
   .use(require("unexpected-sinon"))
+  .use(require("unexpected-eventemitter"))
   .use(require("./assertions.cjs"));

--- a/test/unit/errors.spec.cjs
+++ b/test/unit/errors.spec.cjs
@@ -1,7 +1,7 @@
 "use strict";
 
 var errors = require("../../lib/errors.js");
-var constants = require("../../lib/error-constants.js");
+var { constants } = require("../../lib/error-constants.js");
 const sinon = require("sinon");
 const { createNoFilesMatchPatternError } = require("../../lib/errors.js");
 

--- a/test/unit/mocha.spec.cjs
+++ b/test/unit/mocha.spec.cjs
@@ -615,8 +615,7 @@ describe("Mocha", function () {
                 mocha.suite,
                 {
                   delay: mocha.options.delay,
-                  cleanReferencesAfterRun:
-                    mocha._cleanReferencesAfterRun,
+                  cleanReferencesAfterRun: mocha._cleanReferencesAfterRun,
                 },
               ],
             }).and("was called once");

--- a/test/unit/mocha.spec.cjs
+++ b/test/unit/mocha.spec.cjs
@@ -616,7 +616,7 @@ describe("Mocha", function () {
                 {
                   delay: mocha.options.delay,
                   cleanReferencesAfterRun:
-                    mocha.options.cleanReferencesAfterRun,
+                    mocha._cleanReferencesAfterRun,
                 },
               ],
             }).and("was called once");

--- a/test/unit/plugin-loader.spec.cjs
+++ b/test/unit/plugin-loader.spec.cjs
@@ -18,10 +18,9 @@ describe("plugin module", function () {
         it("should register the custom plugins", function () {
           const plugin = { exportName: "mochaBananaPhone" };
           expect(
-            new PluginLoader({ pluginDefs: [plugin] }).registered,
+            Object.fromEntries(new PluginLoader({ pluginDefs: [plugin] }).registered),
             "to satisfy",
-            new Map([["mochaBananaPhone", plugin]]),
-          );
+            { "mochaBananaPhone": plugin });
         });
       });
 
@@ -142,7 +141,7 @@ describe("plugin module", function () {
           it("should return false", function () {
             // also it should not throw
             expect(
-              pluginLoader.load({ mochaBananaPhone: () => {} }),
+              pluginLoader.load({ mochaBananaPhone: () => { } }),
               "to be false",
             );
           });
@@ -161,22 +160,21 @@ describe("plugin module", function () {
           });
 
           it("should return true", function () {
-            const func = () => {};
+            const func = () => { };
             expect(pluginLoader.load({ mochaBananaPhone: func }), "to be true");
           });
 
           it("should retain the value of any matching property in its mapping", function () {
-            const func = () => {};
+            const func = () => { };
             pluginLoader.load({ mochaBananaPhone: func });
             expect(
-              pluginLoader.loaded,
+              Object.fromEntries(pluginLoader.loaded),
               "to satisfy",
-              new Map([["mochaBananaPhone", [func]]]),
-            );
+              { mochaBananaPhone: [func] });
           });
 
           it("should call the associated validator, if present", function () {
-            const func = () => {};
+            const func = () => { };
             pluginLoader.load({ mochaBananaPhone: func });
             expect(plugin.validate, "was called once");
           });
@@ -220,7 +218,7 @@ describe("plugin module", function () {
             let retval;
 
             beforeEach(function () {
-              retval = pluginLoader.load({ butts: () => {} });
+              retval = pluginLoader.load({ butts: () => { } });
             });
 
             it("should return false", function () {
@@ -260,18 +258,16 @@ describe("plugin module", function () {
 
               it("should add the implementation to the internal mapping", function () {
                 expect(
-                  pluginLoader.loaded,
+                  Object.fromEntries(pluginLoader.loaded),
                   "to satisfy",
-                  new Map([["foo", expect.it("to have length", 1)]]),
-                );
+                  { "foo": expect.it("to have length", 1) });
               });
 
               it("should not add an implementation of plugins not present", function () {
                 expect(
-                  pluginLoader.loaded,
+                  Object.fromEntries(pluginLoader.loaded),
                   "to satisfy",
-                  new Map([["bar", expect.it("to be empty")]]),
-                );
+                  { "bar": expect.it("to be empty") });
               });
             });
 
@@ -386,11 +382,11 @@ describe("plugin module", function () {
 
     describe("when a loaded impl is finalized", function () {
       it("should flatten the implementations", async function () {
-        function a() {}
-        function b() {}
-        function d() {}
-        function g() {}
-        async function f() {}
+        function a() { }
+        function b() { }
+        function d() { }
+        function g() { }
+        async function f() { }
         function c() {
           return {
             beforeAll: d,

--- a/test/unit/plugin-loader.spec.cjs
+++ b/test/unit/plugin-loader.spec.cjs
@@ -18,9 +18,12 @@ describe("plugin module", function () {
         it("should register the custom plugins", function () {
           const plugin = { exportName: "mochaBananaPhone" };
           expect(
-            Object.fromEntries(new PluginLoader({ pluginDefs: [plugin] }).registered),
+            Object.fromEntries(
+              new PluginLoader({ pluginDefs: [plugin] }).registered,
+            ),
             "to satisfy",
-            { "mochaBananaPhone": plugin });
+            { mochaBananaPhone: plugin },
+          );
         });
       });
 
@@ -141,7 +144,7 @@ describe("plugin module", function () {
           it("should return false", function () {
             // also it should not throw
             expect(
-              pluginLoader.load({ mochaBananaPhone: () => { } }),
+              pluginLoader.load({ mochaBananaPhone: () => {} }),
               "to be false",
             );
           });
@@ -160,21 +163,20 @@ describe("plugin module", function () {
           });
 
           it("should return true", function () {
-            const func = () => { };
+            const func = () => {};
             expect(pluginLoader.load({ mochaBananaPhone: func }), "to be true");
           });
 
           it("should retain the value of any matching property in its mapping", function () {
-            const func = () => { };
+            const func = () => {};
             pluginLoader.load({ mochaBananaPhone: func });
-            expect(
-              Object.fromEntries(pluginLoader.loaded),
-              "to satisfy",
-              { mochaBananaPhone: [func] });
+            expect(Object.fromEntries(pluginLoader.loaded), "to satisfy", {
+              mochaBananaPhone: [func],
+            });
           });
 
           it("should call the associated validator, if present", function () {
-            const func = () => { };
+            const func = () => {};
             pluginLoader.load({ mochaBananaPhone: func });
             expect(plugin.validate, "was called once");
           });
@@ -218,7 +220,7 @@ describe("plugin module", function () {
             let retval;
 
             beforeEach(function () {
-              retval = pluginLoader.load({ butts: () => { } });
+              retval = pluginLoader.load({ butts: () => {} });
             });
 
             it("should return false", function () {
@@ -257,17 +259,15 @@ describe("plugin module", function () {
               });
 
               it("should add the implementation to the internal mapping", function () {
-                expect(
-                  Object.fromEntries(pluginLoader.loaded),
-                  "to satisfy",
-                  { "foo": expect.it("to have length", 1) });
+                expect(Object.fromEntries(pluginLoader.loaded), "to satisfy", {
+                  foo: expect.it("to have length", 1),
+                });
               });
 
               it("should not add an implementation of plugins not present", function () {
-                expect(
-                  Object.fromEntries(pluginLoader.loaded),
-                  "to satisfy",
-                  { "bar": expect.it("to be empty") });
+                expect(Object.fromEntries(pluginLoader.loaded), "to satisfy", {
+                  bar: expect.it("to be empty"),
+                });
               });
             });
 
@@ -382,11 +382,11 @@ describe("plugin module", function () {
 
     describe("when a loaded impl is finalized", function () {
       it("should flatten the implementations", async function () {
-        function a() { }
-        function b() { }
-        function d() { }
-        function g() { }
-        async function f() { }
+        function a() {}
+        function b() {}
+        function d() {}
+        function g() {}
+        async function f() {}
         function c() {
           return {
             beforeAll: d,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: ~fixes #000~ (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Supersedes #5730. The failures were from the old `unexpected-map` and `unexpected-set` packages not supporting `unexpected@13`:

```plaintext
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: mocha@12.0.0-rc.1
npm error Found: unexpected@13.2.1
npm error node_modules/unexpected
npm error   dev unexpected@"^13.2.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer unexpected@"^10.37.4 || ^11.0.0-4 || ^12.0.0" from unexpected-set@3.3.0
npm error node_modules/unexpected-set
npm error   dev unexpected-set@"^3.3.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry this command with --force or --legacy-peer-deps to accept an inc
```

But we only barely use those packages' additions. I was able to rewrite them all with just a few lines of code:

* `plugin-loader.spec.cjs`: using the nice new `Object.fromEntries()`
* `parallel.spec.cjs`: an odd side effect of the plugins that I rewrote to just use a couple more manual assertions.

Note that `unexpected-eventemitter` and `unexpected-sinon` _are_ used: search `"to emit from"` and `"was called`, respectively.