### PR TITLE
Guard prepare() against running after _uncaught already ended the run

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -1215,6 +1215,13 @@ Runner.prototype.run = function (fn, opts = {}) {
   };
 
   const prepare = () => {
+    // An uncaught exception may have already ended the run before this
+    // setImmediate fires (e.g. a setTimeout(throw) that races the first tick).
+    // Guard against the phantom second run that would otherwise occur.
+    if (this.state === constants.STATE_STOPPED) {
+      debug("run(): prepare() called after run already ended; aborting");
+      return;
+    }
     debug("run(): starting");
     // If there is an `only` filter
     if (rootSuite.hasOnly()) {


### PR DESCRIPTION
Fixes #6116

- [x] Addresses an existing open issue: fixes #6116
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Problem

A `setTimeout(() => { throw new Error() }, 0)` scheduled before Mocha's run starts causes nondeterministic test output. On Node.js 24, a zero-delay `setTimeout` can fire before the `setImmediate` that queues `prepare()`.

When the uncaught exception fires first, `_uncaught()` emits `EVENT_RUN_BEGIN` + `EVENT_RUN_END` and sets `state = STATE_STOPPED`. The already-queued `prepare` fires next, unconditionally resets `state = STATE_RUNNING`, and triggers a full phantom second run — emitting duplicate `EVENT_RUN_BEGIN`, suite events, and another `EVENT_RUN_END` **after** the reporter has already printed its summary.

## Fix

Add an early-return guard at the top of `prepare()`:

```js
const prepare = () => {
  if (this.state === constants.STATE_STOPPED) {
    debug("run(): prepare() called after run already ended; aborting");
    return;
  }
  // … rest unchanged
```

1 file, 4 lines added.