### PR TITLE
Guard prepare() against running after _uncaught already ended the run

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -1215,6 +1215,13 @@ Runner.prototype.run = function (fn, opts = {}) {
   };
 
   const prepare = () => {
+    // An uncaught exception may have already ended the run before this
+    // setImmediate fires (e.g. a setTimeout(throw) that races the first tick).
+    // Guard against the phantom second run that would otherwise occur.
+    if (this.state === constants.STATE_STOPPED) {
+      debug("run(): prepare() called after run already ended; aborting");
+      return;
+    }
     debug("run(): starting");
     // If there is an `only` filter
     if (rootSuite.hasOnly()) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1215,6 +1215,13 @@ Runner.prototype.run = function (fn, opts = {}) {
   };
 
   const prepare = () => {
+    // An uncaught exception may have already ended the run before this
+    // setImmediate fires (e.g. a setTimeout(throw) that races the first tick).
+    // Guard against the phantom second run that would otherwise occur.
+    if (this.state === constants.STATE_STOPPED) {
+      debug("run(): prepare() called after run already ended; aborting");
+      return;
+    }
     debug("run(): starting");
     // If there is an `only` filter
     if (rootSuite.hasOnly()) {

--- a/test/unit/runner.spec.cjs
+++ b/test/unit/runner.spec.cjs
@@ -754,6 +754,42 @@ describe("Runner", function () {
           });
         });
       });
+
+      describe("when _uncaught() ends the run before prepare() fires", function () {
+        it("should not reset state to STATE_RUNNING", function (done) {
+          // Simulate the race: _uncaught() fires synchronously and sets state
+          // to STATE_STOPPED before the Runner.immediately(prepare) callback runs.
+          runner.run();
+          // Force the runner into STATE_STOPPED as _uncaught() would after
+          // emitting EVENT_RUN_BEGIN + EVENT_RUN_END.
+          runner.state = STATE_STOPPED;
+
+          // Let the setImmediate / Runner.immediately tick fire.
+          setImmediate(function () {
+            expect(runner.state, "to be", STATE_STOPPED);
+            done();
+          });
+        });
+
+        it("should not emit EVENT_RUN_BEGIN a second time", function (done) {
+          var beginCount = 0;
+          runner.on("start", function () {
+            beginCount += 1;
+          });
+
+          runner.run();
+          // Simulate _uncaught() having already emitted start/end and stopped
+          // the run before our queued prepare() fires.
+          runner.emit("start");
+          runner.state = STATE_STOPPED;
+
+          setImmediate(function () {
+            // Only the one we emitted manually above should have fired.
+            expect(beginCount, "to be", 1);
+            done();
+          });
+        });
+      });
     });
 
     describe("runAsync()", function () {


### PR DESCRIPTION
## Problem

If a `setTimeout(throw, 0)` fires before `Runner.immediately(prepare)` runs, `_uncaught()` emits `EVENT_RUN_BEGIN` + `EVENT_RUN_END` and sets state to `STATE_STOPPED`. The queued `prepare()` then fires unconditionally, resets state to `STATE_RUNNING`, and triggers a phantom second run — emitting duplicate events after the reporter has already printed its summary.

## Fix

Add an early return at the top of `prepare()` when state is already `STATE_STOPPED`.

Fixes #6116

---

- [x] Addresses an existing open issue: fixes #6116
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken