### PR TITLE
docs: sync CLI docs with v12 options and defaults

### DIFF
--- a/docs/src/content/docs/declaring/exclusive-tests.mdx
+++ b/docs/src/content/docs/declaring/exclusive-tests.mdx
@@ -108,5 +108,6 @@ Hooks, if present, will still be executed.
 
 :::tip
 Be mindful not to commit usages of `.only()` to version control, unless you really mean it!
-To do so one can run mocha with the option `--forbid-only` in the continuous integration test command (or in a git precommit hook).
+Since v12, Mocha guards against this by default in continuous integration: [`--forbid-only`](/running/cli#--forbid-only) defaults to `true` when the `CI` environment variable is set.
+On older versions, or outside of CI (for example in a git precommit hook), pass `--forbid-only` explicitly.
 :::

--- a/docs/src/content/docs/declaring/exclusive-tests.mdx
+++ b/docs/src/content/docs/declaring/exclusive-tests.mdx
@@ -109,5 +109,5 @@ Hooks, if present, will still be executed.
 :::tip
 Be mindful not to commit usages of `.only()` to version control, unless you really mean it!
 Since v12, Mocha guards against this by default in continuous integration: [`--forbid-only`](/running/cli#--forbid-only) defaults to `true` when the `CI` environment variable is set.
-On older versions, or outside of CI (for example in a git precommit hook), pass `--forbid-only` explicitly.
+On older versions or outside of CI (for example in a git precommit hook), pass `--forbid-only` explicitly.
 :::

--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -35,7 +35,7 @@ Rules & Behavior
       --fail-zero                   Fail test run if no test(s) encountered
                                                                        [boolean]
       --forbid-only                 Fail if exclusive test(s) encountered
-                                                      [boolean] [default: false]
+                                                                       [boolean]
       --forbid-pending              Fail if pending test(s) encountered[boolean]
       --global, --globals           List of allowed global variables     [array]
   -j, --jobs                        Number of concurrent jobs for --parallel;

--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -30,16 +30,20 @@ Rules & Behavior
                                                                        [boolean]
       --pass-on-failing-test-suite  Not fail test run if tests were failed
                                                       [boolean] [default: false]
+      --fail-hook-affected-tests    Report tests as failed when affected by hook
+                                    failures (before/beforeEach)       [boolean]
       --fail-zero                   Fail test run if no test(s) encountered
                                                                        [boolean]
       --forbid-only                 Fail if exclusive test(s) encountered
-                                                                       [boolean]
+                                                      [boolean] [default: false]
       --forbid-pending              Fail if pending test(s) encountered[boolean]
       --global, --globals           List of allowed global variables     [array]
   -j, --jobs                        Number of concurrent jobs for --parallel;
                                     use 1 to run in serial
                                    [number] [default: (number of CPU cores - 1)]
   -p, --parallel                    Run tests in parallel              [boolean]
+      --posix-exit-codes            Use POSIX and UNIX shell exit codes as
+                                    Mocha's return value               [boolean]
       --retries                     Retry failed tests this many times  [number]
   -s, --slow                        Specify "slow" test threshold (in
                                     milliseconds)         [string] [default: 75]
@@ -183,6 +187,14 @@ To ensure your tests aren't leaving messes around, here are some ideas to get st
 
 If set to `true`, Mocha returns exit code `0` even if there are failed tests during the run.
 
+### `--fail-hook-affected-tests`
+
+:::note[New in v12.0.0]
+:::
+
+When a `before` or `beforeEach` hook fails, Mocha skips the tests affected by that hook; only the hook itself is reported as a failure.
+Use `--fail-hook-affected-tests` to also report each affected test as failed.
+
 ### `--fail-zero`
 
 :::note[New in v9.1.0]
@@ -195,6 +207,13 @@ Fail test run with `exit-code: 1` if no tests are encountered.
 Enforce a rule that tests may not be exclusive (use of e.g., `describe.only()` or `it.only()` is disallowed).
 
 `--forbid-only` causes Mocha to fail when an exclusive ("only'd") test or suite is encountered, and it will abort further test execution.
+
+:::note[Updated in v12.0.0]
+Before v12, `--forbid-only` defaulted to `false`.
+Since v12, it defaults to `true` when the `CI` environment variable is set, and `false` otherwise.
+Most CI providers, like GitHub Actions and GitLab, set `CI` automatically.
+Use `--no-forbid-only` to allow exclusive tests in CI.
+:::
 
 ### `--forbid-pending`
 
@@ -247,6 +266,21 @@ Each test file will be put into a queue and executed as workers become available
 `--parallel` has certain implications for Mocha's behavior which you must be aware of.
 Read more about [running tests in parallel](/features/parallel-mode).
 :::
+
+### `--posix-exit-codes`
+
+:::note[New in v11.3.0]
+:::
+
+Exits with standard POSIX exit codes instead of the number of failed tests.
+
+Those exit codes are:
+
+- `0`: if all tests passed
+- `1`: if any test failed
+- `128 + <signal>` if given a signal, such as:
+  - 134: `SIGABRT` (`128 + 6`)
+  - 143: `SIGTERM` (`128 + 15`)
 
 ### `--retries <n>`
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: works on #5528
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The CLI docs got out of sync with the actual `--help` output because a few changes either only made it into the old `docs/index.md` (which was removed in #5583) or never got documented at all.

I now added the the two missing option docs, update the `--forbid-only` docs to explain the new CI default, refreshed the `--help` snapshot so it match the actual output and fix the tip on the exclusive tests page that still tells people to manually add `--forbid-only` to their CI command.

One thing i want to say is that the snapshot still shows `--forbid-only` as `[default: false]` because that's what `--help` prints in a normal shell. The default is actually automatic so the option's docs now explain that it's enabled automatically in CI.