### PR TITLE
feat: add --order option to run tests in random order

### DIFF
--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -41,6 +41,9 @@ Rules & Behavior
   -j, --jobs                        Number of concurrent jobs for --parallel;
                                     use 1 to run in serial
                                    [number] [default: (number of CPU cores - 1)]
+      --order                       Run order of tests; "random" or
+                                    "random:<seed>" shuffles execution order
+                                                   [string] [default: "default"]
   -p, --parallel                    Run tests in parallel              [boolean]
       --posix-exit-codes            Use POSIX and UNIX shell exit codes as
                                     Mocha's return value               [boolean]
@@ -252,6 +255,32 @@ Use `--jobs 0` or `--jobs 1` to temporarily disable `--parallel`.
 :::
 
 Has no effect unless used with [`--parallel`](#--parallel--p).
+
+### `--order <order>`
+
+Set the order in which tests run.
+Accepted values are `default`, `random` and `random:<seed>`.
+
+Use `--order random` to shuffle the run order of tests.
+Sibling suites and sibling tests are shuffled ([Fisher-Yates](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)) within their parent suite; the suite hierarchy is preserved, so hooks run exactly as often as they otherwise would.
+Running in a random order helps to uncover accidental dependencies between tests.
+
+Each randomized run reports the seed it used.
+To reproduce a particular order (say, one that produced a failure), pass the reported seed back via `--order random:<seed>`:
+
+```bash
+mocha --order random
+# Mocha: test order randomized with seed 42; use --order random:42 to reproduce
+mocha --order random:42
+```
+
+The seed is reported on `STDERR`, so machine-readable reporter output on `STDOUT` (such as `json` or `xunit`) is unaffected.
+
+`--order random` is mutually exclusive with [`--sort`](#--sort--s).
+
+:::note
+In [parallel mode](/features/parallel-mode), test files are handed to workers in a nondeterministic order; `--order random` shuffles the run order of suites and tests within each file.
+:::
 
 ### `--parallel, -p`
 

--- a/lib/cli/run-option-metadata.cjs
+++ b/lib/cli/run-option-metadata.cjs
@@ -58,6 +58,7 @@ const types = {
     "config",
     "fgrep",
     "grep",
+    "order",
     "package",
     "reporter",
     "ui",
@@ -127,6 +128,8 @@ const descriptions = {
   "list-interfaces": "List built-in user interfaces & exit",
   "list-reporters": "List built-in reporters & exit",
   "no-colors": "Force-disable color output",
+  order:
+    'Run order of tests; "random" or "random:<seed>" shuffles execution order',
   "node-option": 'Node or V8 option (no leading "--")',
   package: "Path to package.json for config",
   parallel: "Run tests in parallel",

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -101,6 +101,23 @@ const validateRunOptions = (argv) => {
     );
   }
 
+  if (typeof argv.order !== "undefined") {
+    if (!/^(default|random(:\d{1,10})?)$/.test(argv.order)) {
+      throw createInvalidArgumentValueError(
+        `invalid order '${argv.order}'`,
+        "--order",
+        argv.order,
+        'expected "default", "random" or "random:<seed>"',
+      );
+    }
+
+    if (argv.sort && argv.order !== "default") {
+      throw createUnsupportedError(
+        "--sort and --order random are mutually exclusive",
+      );
+    }
+  }
+
   if (argv.parallel) {
     if (argv.file) {
       throw createUnsupportedError(

--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -12,9 +12,11 @@ var builtinReporters = require("./reporters/index.cjs");
 var utils = require("./utils.cjs");
 var mocharc = require("./mocharc.json");
 var { Suite } = require("./suite.js");
+var { ORDER_RANDOM, generateOrderSeed, parseOrder } = require("./order.js");
 var esmUtils = require("./nodejs/esm-utils.cjs");
 var createStatsCollector = require("./stats-collector.js").createStatsCollector;
 const {
+  createInvalidArgumentValueError,
   createInvalidReporterError,
   createInvalidInterfaceError,
   createMochaInstanceAlreadyDisposedError,
@@ -192,6 +194,10 @@ function Mocha(options = {}) {
 
   if ("retries" in options) {
     this.retries(options.retries);
+  }
+
+  if (typeof options.order !== "undefined") {
+    this.order(options.order);
   }
 
   [
@@ -760,6 +766,44 @@ Mocha.prototype.retries = function (retry) {
 };
 
 /**
+ * Sets the order in which tests are run.
+ *
+ * When set to `'random'`, sibling suites and sibling tests are shuffled
+ * (Fisher-Yates) before the run; the suite hierarchy and hooks are
+ * unaffected. A seed is generated if not supplied, and is reported so a
+ * given order can be reproduced with `'random:<seed>'`.
+ *
+ * @public
+ * @see [CLI option](../#-order-order)
+ * @param {string} order - One of `'default'`, `'random'` or `'random:<seed>'`.
+ * @return {Mocha} this
+ * @chainable
+ * @example
+ *
+ * // Run tests in random order, reproducible with seed `42`
+ * mocha.order('random:42');
+ */
+Mocha.prototype.order = function (order) {
+  const parsed = parseOrder(String(order));
+  if (!parsed) {
+    throw createInvalidArgumentValueError(
+      `invalid order '${order}'`,
+      "order",
+      order,
+      'expected "default", "random" or "random:<seed>"',
+    );
+  }
+  if (parsed.mode === ORDER_RANDOM && parsed.seed === null) {
+    parsed.seed = generateOrderSeed();
+  }
+  // normalize, so that a generated seed is shared with worker processes
+  // (parallel mode) and reported to the user
+  this.options.order =
+    parsed.mode === ORDER_RANDOM ? `random:${parsed.seed}` : parsed.mode;
+  return this;
+};
+
+/**
  * Sets slowness threshold value.
  *
  * @public
@@ -990,6 +1034,22 @@ Mocha.prototype.run = function (fn) {
   var suite = this.suite;
   var options = this.options;
   options.files = this.files;
+  const order = options.order ? parseOrder(String(options.order)) : null;
+  if (order && order.mode === ORDER_RANDOM) {
+    if (order.seed === null) {
+      // `options.order` was assigned directly instead of via `Mocha#order()`
+      order.seed = generateOrderSeed();
+      options.order = `random:${order.seed}`;
+    }
+    if (!this.isWorker) {
+      const orderMessage = `test order randomized with seed ${order.seed}; use --order random:${order.seed} to reproduce`;
+      if (utils.isBrowser()) {
+        console.log(`Mocha: ${orderMessage}`);
+      } else {
+        process.stderr.write(`Mocha: ${orderMessage}\n`);
+      }
+    }
+  }
   const runner = new this._runnerClass(suite, {
     cleanReferencesAfterRun: this._cleanReferencesAfterRun,
     delay: options.delay,

--- a/lib/order.js
+++ b/lib/order.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+/**
+ * Helpers for the `--order` option: parsing the option value and shuffling
+ * the suite tree with a seeded pseudo-random number generator, so that a
+ * randomized run can be reproduced by supplying the same seed.
+ *
+ * @module
+ * @private
+ */
+
+/**
+ * Run order constants.
+ */
+export const ORDER_DEFAULT = "default";
+export const ORDER_RANDOM = "random";
+
+/**
+ * A parsed `order` option value.
+ *
+ * @typedef {Object} ParsedOrder
+ * @property {string} mode - One of `"default"` or `"random"`.
+ * @property {number|null} seed - Seed for randomization; `null` if none given.
+ */
+
+/**
+ * Parses an `order` option value.
+ *
+ * Valid values are `default`, `random` and `random:<seed>`, where `<seed>`
+ * is a non-negative integer. Seeds are normalized to unsigned 32-bit
+ * integers; the normalized seed is what gets reported and reproduces a run.
+ *
+ * @param {string} value - Raw option value
+ * @returns {ParsedOrder|null} Parsed value, or `null` if invalid
+ */
+export function parseOrder(value) {
+  if (value === ORDER_DEFAULT) {
+    return { mode: ORDER_DEFAULT, seed: null };
+  }
+  if (value === ORDER_RANDOM) {
+    return { mode: ORDER_RANDOM, seed: null };
+  }
+  const match = /^random:(\d{1,10})$/.exec(value);
+  if (match) {
+    return { mode: ORDER_RANDOM, seed: Number(match[1]) >>> 0 };
+  }
+  return null;
+}
+
+/**
+ * Generates a random seed suitable for {@link randomizeOrder}.
+ *
+ * @returns {number} Unsigned 32-bit integer seed
+ */
+export function generateOrderSeed() {
+  return Math.floor(Math.random() * 0x100000000) >>> 0;
+}
+
+/**
+ * Creates a seeded pseudo-random number generator (mulberry32).
+ *
+ * Small and dependency-free; quality is more than sufficient for shuffling
+ * test order, and identical seeds yield identical sequences on any platform.
+ *
+ * @param {number} seed - Seed value
+ * @returns {function(): number} Function returning numbers in `[0, 1)`
+ */
+function createRandom(seed) {
+  let state = seed >>> 0;
+  return function random() {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+}
+
+/**
+ * Shuffles `array` in place using the Fisher-Yates algorithm.
+ *
+ * @param {Array<*>} array - Array to shuffle
+ * @param {function(): number} random - Function returning numbers in `[0, 1)`
+ */
+function shuffle(array, random) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    const tmp = array[i];
+    array[i] = array[j];
+    array[j] = tmp;
+  }
+}
+
+/**
+ * Randomizes the run order of `suite` and all of its descendants in place.
+ *
+ * Sibling suites and sibling tests are shuffled within their parent suite;
+ * the suite hierarchy itself is preserved, so hooks (`before`, `beforeEach`,
+ * etc.) run exactly as often as they would in a non-randomized run.
+ *
+ * @param {import('./suite.js').Suite} suite - Root of the (sub)tree to shuffle
+ * @param {number} seed - Seed for the pseudo-random number generator
+ */
+export function randomizeOrder(suite, seed) {
+  const random = createRandom(seed);
+  (function randomizeSuite(currentSuite) {
+    shuffle(currentSuite.suites, random);
+    shuffle(currentSuite.tests, random);
+    currentSuite.suites.forEach(randomizeSuite);
+  })(suite);
+}

--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -14,6 +14,12 @@ var utils = require("./utils.cjs");
 var debug = require("debug")("mocha:runner");
 var { Runnable } = require("./runnable.js");
 var { Suite } = require("./suite.js");
+var {
+  ORDER_RANDOM,
+  generateOrderSeed,
+  parseOrder,
+  randomizeOrder,
+} = require("./order.js");
 var HOOK_TYPE_BEFORE_EACH = Suite.constants.HOOK_TYPE_BEFORE_EACH;
 var HOOK_TYPE_AFTER_EACH = Suite.constants.HOOK_TYPE_AFTER_EACH;
 var HOOK_TYPE_AFTER_ALL = Suite.constants.HOOK_TYPE_AFTER_ALL;
@@ -1216,6 +1222,16 @@ Runner.prototype.run = function (fn, opts = {}) {
 
   const prepare = () => {
     debug("run(): starting");
+    const order = options.order ? parseOrder(String(options.order)) : null;
+    if (order && order.mode === ORDER_RANDOM) {
+      // the seed is expected to have been filled in (and reported) by
+      // `Mocha#order()`; the fallback covers direct `Runner` usage
+      randomizeOrder(
+        rootSuite,
+        order.seed === null ? generateOrderSeed() : order.seed,
+      );
+      debug("run(): randomized test order");
+    }
     // If there is an `only` filter
     if (rootSuite.hasOnly()) {
       rootSuite.filterOnly();

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -73,6 +73,9 @@ export interface MochaOptions {
   /** Disable syntax highlighting? */
   noHighlighting?: boolean;
 
+  /** Run order of tests: "default", "random" or "random:<seed>". */
+  order?: string;
+
   /** Reporter name or constructor. */
   reporter?: string | Reporter;
 

--- a/test/integration/fixtures/options/order.fixture.js
+++ b/test/integration/fixtures/options/order.fixture.js
@@ -1,0 +1,17 @@
+'use strict';
+
+it('root test', function () {});
+
+describe('alpha', function () {
+  it('one', function () {});
+  it('two', function () {});
+
+  describe('inner', function () {
+    it('three', function () {});
+  });
+});
+
+describe('beta', function () {
+  it('four', function () {});
+  it('five', function () {});
+});

--- a/test/integration/options/order.spec.cjs
+++ b/test/integration/options/order.spec.cjs
@@ -1,0 +1,157 @@
+"use strict";
+
+var path = require("node:path").posix;
+var helpers = require("../helpers.cjs");
+var invokeMochaAsync = helpers.invokeMochaAsync;
+var resolveFixturePath = helpers.resolveFixturePath;
+var runMochaJSON = helpers.runMochaJSON;
+var runMochaJSONAsync = helpers.runMochaJSONAsync;
+
+var FIXTURE = path.join("options", "order.fixture.js");
+
+// `STDERR` piped separately, so it does not corrupt the JSON reporter output
+var SEPARATE_STDERR = {
+  stdio: ["inherit", "pipe", "pipe"],
+  separateStderr: true,
+};
+
+describe("--order", function () {
+  it("should run tests in a reproducible shuffled order given a seed", function (done) {
+    runMochaJSON(
+      FIXTURE,
+      ["--order", "random:42"],
+      function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, "to have passed test count", 6).and(
+          "to have passed test order",
+          "root test",
+          "two",
+          "one",
+          "three",
+          "four",
+          "five",
+        );
+        done();
+      },
+      SEPARATE_STDERR,
+    );
+  });
+
+  it("should shuffle sibling suites as well as tests", function (done) {
+    runMochaJSON(
+      FIXTURE,
+      ["--order", "random:1337"],
+      function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res, "to have passed test count", 6).and(
+          "to have passed test order",
+          "root test",
+          "five",
+          "four",
+          "one",
+          "two",
+          "three",
+        );
+        done();
+      },
+      SEPARATE_STDERR,
+    );
+  });
+
+  it("should report the seed used", function (done) {
+    runMochaJSON(
+      FIXTURE,
+      ["--order", "random:42"],
+      function (err, res) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(res.stderr, "to match", /randomized with seed 42/);
+        done();
+      },
+      SEPARATE_STDERR,
+    );
+  });
+
+  it("should generate a seed which reproduces the order when given back", async function () {
+    var firstRun = await runMochaJSONAsync(
+      FIXTURE,
+      ["--order", "random"],
+      SEPARATE_STDERR,
+    );
+    var match = /randomized with seed (\d+)/.exec(firstRun.stderr);
+    expect(match, "to be truthy");
+    var seed = match[1];
+    var secondRun = await runMochaJSONAsync(
+      FIXTURE,
+      ["--order", "random:" + seed],
+      SEPARATE_STDERR,
+    );
+    expect(secondRun, "to have passed test count", 6).and(
+      "to have passed test order",
+      firstRun.passes.map(function (test) {
+        return test.title;
+      }),
+    );
+  });
+
+  it("should run tests in declaration order given 'default'", function (done) {
+    runMochaJSON(FIXTURE, ["--order", "default"], function (err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, "to have passed test count", 6).and(
+        "to have passed test order",
+        "root test",
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+      );
+      done();
+    });
+  });
+
+  describe("when used with --sort", function () {
+    it("should error out", function () {
+      return expect(
+        invokeMochaAsync(
+          ["--sort", "--order", "random", resolveFixturePath(FIXTURE)],
+          "pipe",
+        )[1],
+        "when fulfilled",
+        "to satisfy",
+        {
+          code: 1,
+          output: /--sort and --order random are mutually exclusive/,
+        },
+      );
+    });
+  });
+
+  describe("when given an invalid value", function () {
+    it("should error out", function () {
+      return expect(
+        invokeMochaAsync(
+          ["--order", "banana", resolveFixturePath(FIXTURE)],
+          "pipe",
+        )[1],
+        "when fulfilled",
+        "to satisfy",
+        {
+          code: 1,
+          output: /invalid order 'banana'/,
+        },
+      );
+    });
+  });
+});

--- a/test/node-unit/order.spec.cjs
+++ b/test/node-unit/order.spec.cjs
@@ -1,0 +1,140 @@
+"use strict";
+
+const {
+  generateOrderSeed,
+  parseOrder,
+  randomizeOrder,
+} = require("../../lib/order.js");
+const Mocha = require("../../lib/mocha.cjs");
+
+describe("order", function () {
+  describe("parseOrder()", function () {
+    it("should parse 'default'", function () {
+      expect(parseOrder("default"), "to equal", {
+        mode: "default",
+        seed: null,
+      });
+    });
+
+    it("should parse 'random' without a seed", function () {
+      expect(parseOrder("random"), "to equal", { mode: "random", seed: null });
+    });
+
+    it("should parse 'random' with a seed", function () {
+      expect(parseOrder("random:42"), "to equal", { mode: "random", seed: 42 });
+    });
+
+    it("should normalize seeds to unsigned 32-bit integers", function () {
+      expect(parseOrder("random:4294967296"), "to equal", {
+        mode: "random",
+        seed: 0,
+      });
+    });
+
+    it("should reject unknown values", function () {
+      expect(parseOrder("banana"), "to be null");
+      expect(parseOrder("random:"), "to be null");
+      expect(parseOrder("random:-1"), "to be null");
+      expect(parseOrder("random:1.5"), "to be null");
+    });
+  });
+
+  describe("generateOrderSeed()", function () {
+    it("should return an unsigned 32-bit integer", function () {
+      const seed = generateOrderSeed();
+      expect(Number.isInteger(seed), "to be true");
+      expect(seed, "to be within", 0, 4294967295);
+    });
+  });
+
+  describe("randomizeOrder()", function () {
+    function createSuiteTree() {
+      return {
+        suites: [
+          {
+            suites: [],
+            tests: ["one", "two", "three", "four"],
+          },
+          {
+            suites: [],
+            tests: ["five", "six", "seven"],
+          },
+        ],
+        tests: ["eight", "nine", "ten"],
+      };
+    }
+
+    it("should produce identical order for identical seeds", function () {
+      const a = createSuiteTree();
+      const b = createSuiteTree();
+      randomizeOrder(a, 42);
+      randomizeOrder(b, 42);
+      expect(a, "to equal", b);
+    });
+
+    it("should produce a different order for a different seed", function () {
+      const a = createSuiteTree();
+      const b = createSuiteTree();
+      randomizeOrder(a, 42);
+      randomizeOrder(b, 1337);
+      expect(a, "not to equal", b);
+    });
+
+    it("should keep every suite and test, shuffled within its parent", function () {
+      const tree = createSuiteTree();
+      randomizeOrder(tree, 42);
+      expect(tree.tests.slice().sort(), "to equal", ["eight", "nine", "ten"]);
+      expect(tree.suites, "to have length", 2);
+      const allNestedTests = tree.suites.flatMap((suite) => suite.tests).sort();
+      expect(allNestedTests, "to equal", [
+        "five",
+        "four",
+        "one",
+        "seven",
+        "six",
+        "three",
+        "two",
+      ]);
+    });
+  });
+
+  describe("Mocha#order()", function () {
+    it("should be chainable", function () {
+      const mocha = new Mocha({ reporter: function () {} });
+      expect(mocha.order("default"), "to be", mocha);
+    });
+
+    it("should store a normalized value", function () {
+      const mocha = new Mocha({ reporter: function () {} });
+      mocha.order("random:42");
+      expect(mocha.options.order, "to be", "random:42");
+    });
+
+    it("should fill in a generated seed when none given", function () {
+      const mocha = new Mocha({ reporter: function () {} });
+      mocha.order("random");
+      expect(mocha.options.order, "to match", /^random:\d+$/);
+    });
+
+    it("should be settable via constructor options", function () {
+      const mocha = new Mocha({
+        reporter: function () {},
+        order: "random:42",
+      });
+      expect(mocha.options.order, "to be", "random:42");
+    });
+
+    it("should throw on an invalid value", function () {
+      const mocha = new Mocha({ reporter: function () {} });
+      expect(
+        function () {
+          mocha.order("banana");
+        },
+        "to throw",
+        {
+          code: "ERR_MOCHA_INVALID_ARG_VALUE",
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #902
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This adds a `--order` CLI option (and a matching `Mocha#order()` API) to run tests in a shuffled order, closing #902.

`--order random` shuffles sibling suites and sibling tests within their parent using a seeded Fisher-Yates shuffle (mulberry32 PRNG). The suite hierarchy is preserved, so hooks still run exactly as often as they would in a normal run. Each randomized run reports the seed it used on STDERR, so it doesn't corrupt machine-readable reporter output on STDOUT, and the seed can be passed back via `--order random:<seed>` to reproduce a specific order (useful for pinning down order-dependent test failures).

Accepted values: `default`, `random`, `random:<seed>` (seed is a 1-10 digit non-negative integer, normalized to an unsigned 32-bit int).

`--order random` is mutually exclusive with `--sort`.

This was originally built against the old yargs-based CLI. Since then main moved 35 commits and dropped yargs for a hand-rolled parser on top of node:util's parseArgs, so the CLI wiring here was rewritten against that: `order` is now registered as a string option in `lib/cli/run-option-metadata.cjs` (both the type bucket and the help description), and the format/mutual-exclusion validation now lives in `validateRunOptions` in `lib/cli/run.cjs`, matching how the `--parallel`/`--file` check works there. The actual shuffling logic in `lib/order.js` and its wiring into `lib/mocha.cjs`/`lib/runner.cjs` didn't need any changes, since none of that touches CLI parsing.

Closes #902
