### PR TITLE
fix!: escape markdown special characters in markdown reporter

### DIFF
--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -24,6 +24,21 @@ var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 
 var SUITE_PREFIX = "$";
 
+/**
+ * Escape markdown special characters so that suite and test titles are
+ * rendered literally in the generated markdown.
+ *
+ * Backslash-escapes the characters that have special meaning in
+ * GitHub-Flavored Markdown: `\`, backtick, `*`, `_`, `{`, `}`, `[`, `]`,
+ * `(`, `)`, `#`, `+`, `-`, `.`, `!`, `>`, and `|`.
+ *
+ * @param {string} str - Raw text to escape
+ * @return {string} Escaped text safe for inline use in markdown
+ */
+function escapeMarkdown(str) {
+  return str.replace(/([\\`*_{}[\]()#+\-.!>|])/g, "\\$1");
+}
+
 class Markdown extends Base {
   static description = "GitHub Flavored Markdown";
 
@@ -43,7 +58,7 @@ class Markdown extends Base {
     var buf = "";
 
     function title(str) {
-      return Array(level).join("#") + " " + str;
+      return Array(level).join("#") + " " + escapeMarkdown(str);
     }
 
     function mapTOC(suite, obj) {
@@ -67,7 +82,7 @@ class Markdown extends Base {
           continue;
         }
         if (key !== SUITE_PREFIX) {
-          link = " - [" + key.substring(1) + "]";
+          link = " - [" + escapeMarkdown(key.substring(1)) + "]";
           link += "(#" + utils.slug(obj[key].suite.fullTitle()) + ")\n";
           buf += Array(level).join("  ") + link;
         }
@@ -96,7 +111,7 @@ class Markdown extends Base {
 
     runner.on(EVENT_TEST_PASS, function (test) {
       var code = utils.clean(test.body);
-      buf += test.title + ".\n";
+      buf += escapeMarkdown(test.title) + ".\n";
       buf += "\n```js\n";
       buf += code + "\n";
       buf += "```\n\n";

--- a/test/reporters/markdown.spec.cjs
+++ b/test/reporters/markdown.spec.cjs
@@ -111,5 +111,85 @@ describe("Markdown reporter", function () {
         expect(stdout, "to equal", expectedArray);
       });
     });
+
+    describe("escaping markdown special characters", function () {
+      it("should escape special characters in suite titles in the TOC and headings", async function () {
+        var specialTitle = "*** [test] (#1)";
+        var expectedSuite = {
+          title: specialTitle,
+          fullTitle: function () {
+            return specialTitle;
+          },
+          suites: [],
+        };
+        var runner = createMockRunner(
+          "suite suite end",
+          EVENT_SUITE_BEGIN,
+          EVENT_SUITE_END,
+          EVENT_RUN_END,
+          expectedSuite,
+        );
+        runner.suite = expectedSuite;
+        var options = {};
+        var { stdout } = await runReporter({}, runner, options);
+
+        // The slug strips all non-word chars, so the anchor name is empty
+        var slug = "";
+        var escapedTitle = "\\*\\*\\* \\[test\\] \\(#1\\)";
+
+        var expectedArray = [
+          "# TOC\n",
+          " - [" + escapedTitle + "](#" + slug + ")\n",
+          '<a name="' + slug + '"></a>\n ' + escapedTitle + "\n",
+        ];
+
+        expect(stdout, "to equal", expectedArray);
+      });
+
+      it("should escape special characters in test titles", async function () {
+        var specialTitle = ">>> should _work_ with *special* chars";
+        var expectedSuite = {
+          title: "suite",
+          fullTitle: function () {
+            return "suite";
+          },
+          suites: [],
+        };
+        var expectedBody = "some body";
+        var expectedTest = {
+          title: specialTitle,
+          fullTitle: function () {
+            return "suite " + specialTitle;
+          },
+          duration: 1000,
+          currentRetry: function () {
+            return 1;
+          },
+          slow: noop,
+          body: expectedBody,
+        };
+        var runner = createMockRunner(
+          "pass end",
+          EVENT_TEST_PASS,
+          EVENT_RUN_END,
+          null,
+          expectedTest,
+        );
+        runner.suite = expectedSuite;
+        var options = {};
+        var { stdout } = await runReporter({}, runner, options);
+
+        var escapedTitle =
+          "\\>\\>\\> should \\_work\\_ with \\*special\\* chars";
+
+        // Find the line that contains the test title (3rd element: the body output)
+        var bodyOutput = stdout[2];
+        expect(
+          bodyOutput,
+          "to contain",
+          escapedTitle + ".\n\n```js\n" + expectedBody + "\n```\n\n",
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2306
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The markdown reporter (`-R md`) inserts suite and test titles verbatim into the generated markdown. When a title contains characters that have special meaning in GitHub-Flavored Markdown (e.g. `*`, `_`, `#`, `[`, `]`, `(`, `)`, backticks), the output's semantics are broken — headings render incorrectly, links point to wrong anchors, and emphasis marks are misinterpreted.

This PR adds an `escapeMarkdown()` helper that backslash-escapes the full set of GFM special characters and applies it in three places:

1. **TOC link text** (`stringifyTOC`): suite titles in the table of contents are now escaped.
2. **Suite headings** (`title()` -> `EVENT_SUITE_BEGIN`): suite titles used as markdown headings are now escaped.
3. **Test titles** (`EVENT_TEST_PASS`): test titles in the body output are now escaped.

The `utils.slug()` function (used for anchor names) already strips all non-word characters, so anchor links remain unaffected — only the human-visible text is escaped.

### Example

Before:
```
# TOC
   - [***](#)
     - [\\](#-)
# ***
## \\
>>> should be escaped.
```

After:
```
# TOC
   - [\*\*\*](#)
     - [\\](#-)
# \*\*\*
## \\
\>\>\> should be escaped.
```

## AI Disclosure

Portions of this PR were generated with the assistance of AI tools. The code has been manually reviewed for correctness, security, and adherence to project conventions. I am responsible for understanding and maintaining this code.