### PR TITLE
fix(deps): update dependency serialize-javascript to ^7.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "minimatch": "^10.2.2",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^7.0.2",
+        "serialize-javascript": "^7.0.7",
         "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
         "workerpool": "^10.0.0",
@@ -8282,9 +8282,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.2.tgz",
-      "integrity": "sha512-Y/agDAqbUWRYFWLF5pMT9Rb8wN5ERPMbQH7oq6R+4YgFdMNO4+ELo4PjFCW3H+2CbXirPr/XUgYT+3iXJfTbZQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "minimatch": "^10.2.2",
     "ms": "^2.1.3",
     "picocolors": "^1.1.1",
-    "serialize-javascript": "^7.0.2",
+    "serialize-javascript": "^7.0.7",
     "strip-json-comments": "^5.0.3",
     "supports-color": "^8.1.1",
     "workerpool": "^10.0.0",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: this is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes) (dependency security update)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates `serialize-javascript` from `^7.0.2` to `^7.0.7` (latest), which resolves two known vulnerabilities affecting 7.0.2:

- **[GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)** (high): RCE via `RegExp.flags` and `Date.prototype.toISOString()` — affects `<= 7.0.2`, patched in 7.0.3
- **[GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v)** / CVE-2026-34043 (medium): CPU exhaustion DoS via crafted array-like objects — affects `>= 5.0.0, < 7.0.5`, patched in 7.0.5