### PR TITLE
feat!: replace yargs with Node.js util.parseArgs

### DIFF
--- a/bin/mocha.js
+++ b/bin/mocha.js
@@ -11,7 +11,7 @@
 import d from "debug";
 import { spawn } from "node:child_process";
 import os from "node:os";
-import unparse from "yargs-unparser";
+import { unparseMochaArgs } from "../lib/cli/unparse-args.js";
 
 import { main } from "../lib/cli/cli.js";
 import { loadOptions } from "../lib/cli/options.cjs";
@@ -20,7 +20,6 @@ import {
   isNodeFlag,
   impliesNoTimeouts,
 } from "../lib/cli/node-flags.cjs";
-import { aliases } from "../lib/cli/run-option-metadata.cjs";
 import { fileURLToPath } from "node:url";
 
 const debug = d.debug("mocha:cli:mocha");
@@ -99,7 +98,7 @@ if (mochaArgs["node-option"] || Object.keys(nodeArgs).length || hasInspect) {
   const args = [].concat(
     nodeArgv,
     mochaPath,
-    unparse(mochaArgs, { alias: aliases }),
+    unparseMochaArgs(mochaArgs),
   );
 
   debug(

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -127,9 +127,10 @@ export function main(argv = process.argv.slice(2), mochaArgs) {
       process.exit(0);
     }
 
-    const command = argv[0] || (args._ && args._[0]);
+    const command = (args._ && args._[0]) || argv[0];
     if (command === "init") {
-      const commandArgs = argv[0] === "init" ? argv.slice(1) : args._.slice(1);
+      const commandArgs =
+        args._ && args._[0] === "init" ? args._.slice(1) : argv.slice(1);
       return init.handler(init.parse(commandArgs));
     }
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -82,6 +82,7 @@ const runCommand = async (args) => {
   args.spec = args.spec || (args._ && args._.length ? args._ : ["test"]);
 
   try {
+    run.normalizeRunOptions(args);
     run.validateRunOptions(args);
   } catch (err) {
     fail(err && err.message, err);

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1,25 +1,100 @@
 /**
  * Contains CLI entry point and public API for programmatic usage in Node.js.
- * - Option parsing is handled by {@link https://npm.im/yargs yargs}.
+ * - Option parsing is handled by {@link module:lib/cli/parse-args}.
  * - If executed via `node`, this module will run {@linkcode module:lib/cli.main main()}.
  * @public
  * @module lib/cli
  */
 
 import debugModule from "debug";
-import yargs from "yargs";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
-import { loadOptions, YARGS_PARSER_CONFIG } from "./options.cjs";
+import { loadOptions } from "./options.cjs";
 import { run, init } from "./commands.js";
 import pc from "picocolors";
 import { logSymbols } from "../utils.cjs";
 
 import packageJson from "../../package.json" with { type: "json" };
 
+const require = createRequire(import.meta.url);
+const { getRunOptionDefinitions } = require("./run-option-metadata.cjs");
+
 const __filename = fileURLToPath(import.meta.url);
 
 const debug = debugModule("mocha:cli:cli");
+
+const hasFlag = (args, longName, shortName) =>
+  args.includes(`--${longName}`) || args.includes(`-${shortName}`);
+
+const formatOption = (option) => {
+  const aliases = option.aliases.map((alias) =>
+    alias.length === 1 ? `-${alias}` : `--${alias}`,
+  );
+  return [`--${option.name}`].concat(aliases).join(", ");
+};
+
+const printVersion = () => {
+  console.log(packageJson.version);
+};
+
+const printHelp = () => {
+  const options = getRunOptionDefinitions()
+    .filter((option) => option.description)
+    .map((option) => `  ${formatOption(option).padEnd(34)} ${option.description}`)
+    .join("\n");
+
+  console.log(`Usage: mocha [spec..]
+       mocha init <path>
+
+Commands:
+  init <path>  ${init.description}
+
+Options:
+${options}
+  --help, -h${"".padEnd(24)} Show usage information & exit
+  --version, -V${"".padEnd(21)} Show version number & exit
+
+Mocha Resources
+    Chat: ${packageJson.discord}
+  GitHub: ${packageJson.repository.url}
+    Docs: ${packageJson.homepage}`);
+};
+
+const fail = (msg, err) => {
+  debug("caught error before command handler: %O", err);
+  printHelp();
+  console.error(`\n${logSymbols.error} ${pc.red("ERROR:")} ${msg}`);
+  if (!msg && err) {
+    // Log raw error and stack when an unexpected error is encountered, to
+    // make debugging easier (instead of an inactionable "ERROR: null").
+    console.error(err);
+  }
+  process.exit(1);
+};
+
+const failRunPreparation = (err) => {
+  console.error(`\n${logSymbols.error} ${pc.red("ERROR:")}`, err);
+  process.exit(1);
+};
+
+const runCommand = async (args) => {
+  args.spec = args.spec || (args._ && args._.length ? args._ : ["test"]);
+
+  try {
+    run.validateRunOptions(args);
+  } catch (err) {
+    fail(err && err.message, err);
+  }
+
+  try {
+    await run.prepareRunOptions(args);
+  } catch (err) {
+    failRunPreparation(err);
+  }
+
+  return run.handler(args);
+};
 
 /**
  * - Accepts an `Array` of arguments
@@ -39,43 +114,28 @@ export function main(argv = process.argv.slice(2), mochaArgs) {
     debug("unable to set Error.stackTraceLimit = Infinity", err);
   }
 
-  const args = mochaArgs ?? loadOptions(argv);
+  try {
+    const args = mochaArgs ?? loadOptions(argv);
+    if (hasFlag(argv, "help", "h") || args.help || args.h) {
+      printHelp();
+      process.exit(0);
+    }
 
-  yargs()
-    .scriptName("mocha")
-    .command(run)
-    .command(init)
-    .updateStrings({
-      "Positionals:": "Positional Arguments",
-      "Options:": "Other Options",
-      "Commands:": "Commands",
-    })
-    .fail((msg, err, yargs) => {
-      debug("caught error sometime before command handler: %O", err);
-      yargs.showHelp();
-      console.error(`\n${logSymbols.error} ${pc.red("ERROR:")} ${msg}`);
-      if (!msg) {
-        // Log raw error and stack when an unexpected error is encountered, to
-        // make debugging easier (instead of an inactionable "ERROR: null").
-        console.error(err);
-      }
-      process.exit(1);
-    })
-    .help("help", "Show usage information & exit")
-    .alias("help", "h")
-    .version("version", "Show version number & exit", packageJson.version)
-    .alias("version", "V")
-    .wrap(process.stdout.columns ? Math.min(process.stdout.columns, 80) : 80)
-    .epilog(
-      `${pc.reset("Mocha Resources")}
-    Chat: ${pc.magenta(packageJson.discord)}
-  GitHub: ${pc.blue(packageJson.repository.url)}
-    Docs: ${pc.yellow(packageJson.homepage)}
-      `,
-    )
-    .parserConfiguration(YARGS_PARSER_CONFIG)
-    .config(args)
-    .parse(args._);
+    if (hasFlag(argv, "version", "V") || args.version || args.V) {
+      printVersion();
+      process.exit(0);
+    }
+
+    const command = argv[0] || (args._ && args._[0]);
+    if (command === "init") {
+      const commandArgs = argv[0] === "init" ? argv.slice(1) : args._.slice(1);
+      return init.handler(init.parse(commandArgs));
+    }
+
+    return runCommand(args);
+  } catch (err) {
+    fail(err && err.message, err);
+  }
 }
 
 // allow direct execution

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -7,7 +7,6 @@
  */
 
 import debugModule from "debug";
-import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 import { loadOptions } from "./options.cjs";
@@ -16,9 +15,7 @@ import pc from "picocolors";
 import { logSymbols } from "../utils.cjs";
 
 import packageJson from "../../package.json" with { type: "json" };
-
-const require = createRequire(import.meta.url);
-const { getRunOptionDefinitions } = require("./run-option-metadata.cjs");
+import { getRunOptionDefinitions } from "./run-option-metadata.cjs";
 
 const __filename = fileURLToPath(import.meta.url);
 

--- a/lib/cli/commands.js
+++ b/lib/cli/commands.js
@@ -1,6 +1,5 @@
 /**
- * Exports Yargs commands
- * @see https://github.com/yargs/yargs/blob/main/docs/advanced.md
+ * Exports Mocha CLI commands.
  * @private
  * @module
  */

--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -12,11 +12,13 @@ export const command = "init <path>";
 
 export const description = "create a client-side Mocha setup at <path>";
 
-export const builder = (yargs) =>
-  yargs.positional("path", {
-    type: "string",
-    normalize: true,
-  });
+export const parse = (args) => {
+  const [pathArg] = args;
+  if (!pathArg) {
+    throw new Error("Not enough non-option arguments: got 0, need at least 1");
+  }
+  return { _: [], path: path.normalize(pathArg) };
+};
 
 export const handler = (argv) => {
   const destdir = argv.path;

--- a/lib/cli/node-flags.cjs
+++ b/lib/cli/node-flags.cjs
@@ -8,7 +8,7 @@
 
 const nodeFlags = process.allowedNodeEnvironmentFlags;
 const { isMochaFlag } = require("./run-option-metadata.cjs");
-const unparse = require("yargs-unparser");
+const { unparseNodeFlags } = require("./unparse-args.js");
 
 /**
  * These flags are considered "debug" flags.
@@ -64,26 +64,6 @@ function isNodeFlag(flag, bareword = true) {
  */
 function impliesNoTimeouts(flag) {
   return debugFlags.has(flag);
-}
-
-/**
- * All non-strictly-boolean arguments to node--those with values--must specify those values using `=`, e.g., `--inspect=0.0.0.0`.
- * Unparse these arguments using `yargs-unparser` (which would result in `--inspect 0.0.0.0`), then supply `=` where we have values.
- * There's probably an easier or more robust way to do this; fixes welcome
- * @param {Object} opts - Arguments object
- * @returns {string[]} Unparsed arguments using `=` to specify values
- * @private
- */
-function unparseNodeFlags(opts) {
-  var args = unparse(opts);
-  return args.length
-    ? args
-        .join(" ")
-        .split(/\b/)
-        .map((arg) => (arg === " " ? "=" : arg))
-        .join("")
-        .split(" ")
-    : [];
 }
 
 exports.isNodeFlag = isNodeFlag;

--- a/lib/cli/options.cjs
+++ b/lib/cli/options.cjs
@@ -9,38 +9,25 @@
 
 const { readFileSync } = require("node:fs");
 const pc = require("picocolors");
-const yargsParser = require("yargs-parser");
-const {
-  types,
-  aliases,
-  isMochaFlag,
-  expectedTypeForFlag,
-} = require("./run-option-metadata.cjs");
+const { parseMochaArgs } = require("./parse-args.js");
 const { ONE_AND_DONE_ARGS } = require("./one-and-dones.js");
 const mocharc = require("../mocharc.json");
-const { list } = require("./run-helpers.cjs");
 const { loadConfig, findConfig } = require("./config.cjs");
 const { sync } = require("find-up");
 const debugModule = require("debug");
-const { isNodeFlag } = require("./node-flags.cjs");
-const {
-  createUnparsableFileError,
-  createInvalidArgumentTypeError,
-  createUnsupportedError,
-} = require("../errors.js");
-const { isNumeric } = require("../utils.cjs");
+const { createUnparsableFileError, isMochaError } = require("../errors.js");
 
 const debug = debugModule("mocha:cli:options");
 
 /**
- * The `yargs-parser` namespace
- * @external yargsParser
- * @see {@link https://npm.im/yargs-parser}
+ * The `parseArgs` function
+ * @external parseArgs
+ * @see {@link https://nodejs.org/api/util.html#utilparseargsconfig}
  */
 
 /**
- * An object returned by a configured `yargs-parser` representing arguments
- * @memberof external:yargsParser
+ * An object representing arguments parsed from the CLI
+ * @memberof external:parseArgs
  * @interface Arguments
  */
 
@@ -56,152 +43,23 @@ const YARGS_PARSER_CONFIG = {
 };
 
 /**
- * This is the config pulled from the `yargs` property of Mocha's
- * `package.json`, but it also disables camel case expansion as to
- * avoid outputting non-canonical keynames, as we need to do some
- * lookups.
- * @private
- * @ignore
- */
-const configuration = Object.assign({}, YARGS_PARSER_CONFIG, {
-  "camel-case-expansion": false,
-});
-
-/**
- * This is a really fancy way to:
- * - `array`-type options: ensure unique values and evtl. split comma-delimited lists
- * - `boolean`/`number`/`string`- options: use last element when given multiple times
- * This is passed as the `coerce` option to `yargs-parser`
- * @private
- * @ignore
- */
-const globOptions = ["spec", "ignore"];
-const coerceOpts = Object.assign(
-  types.array.reduce(
-    (acc, arg) =>
-      Object.assign(acc, {
-        [arg]: (v) =>
-          Array.from(new Set(globOptions.includes(arg) ? v : list(v))),
-      }),
-    {},
-  ),
-  types.boolean
-    .concat(types.string, types.number)
-    .reduce(
-      (acc, arg) =>
-        Object.assign(acc, { [arg]: (v) => (Array.isArray(v) ? v.pop() : v) }),
-      {},
-    ),
-);
-
-/**
- * We do not have a case when multiple arguments are ever allowed after a flag
- * (e.g., `--foo bar baz quux`), so we fix the number of arguments to 1 across
- * the board of non-boolean options.
- * This is passed as the `narg` option to `yargs-parser`
- * @private
- * @ignore
- */
-const nargOpts = types.array
-  .concat(types.string, types.number)
-  .reduce((acc, arg) => Object.assign(acc, { [arg]: 1 }), {});
-
-/**
- * Throws either "UNSUPPORTED" error or "INVALID_ARG_TYPE" error for numeric positional arguments.
- * @param {string[]} allArgs - Stringified args passed to mocha cli
- * @param {number} numericArg - Numeric positional arg for which error must be thrown
- * @param {Object} parsedResult - Result from `yargs-parser`
- * @private
- * @ignore
- */
-const createErrorForNumericPositionalArg = (
-  numericArg,
-  allArgs,
-  parsedResult,
-) => {
-  // A flag for `numericArg` exists if:
-  // 1. A mocha flag immediately preceeded the numericArg in `allArgs` array and
-  // 2. `numericArg` value could not be assigned to this flag by `yargs-parser` because of incompatible datatype.
-  const flag = allArgs.find((arg, index) => {
-    const normalizedArg = arg.replace(/^--?/, "");
-    return (
-      isMochaFlag(arg) &&
-      allArgs[index + 1] === String(numericArg) &&
-      parsedResult[normalizedArg] !== String(numericArg)
-    );
-  });
-
-  if (flag) {
-    throw createInvalidArgumentTypeError(
-      `Mocha flag '${flag}' given invalid option: '${numericArg}'`,
-      numericArg,
-      expectedTypeForFlag(flag),
-    );
-  } else {
-    throw createUnsupportedError(
-      `Option ${numericArg} is unsupported by the mocha cli`,
-    );
-  }
-};
-
-/**
- * Wrapper around `yargs-parser` which applies our settings
+ * Wrapper around `parseArgs` which applies our settings
  * @param {string|string[]} args - Arguments to parse
  * @param {Object} defaultValues - Default values of mocharc.json
- * @param  {...Object} configObjects - `configObjects` for yargs-parser
+ * @param  {...Object} configObjects - Objects to merge into parsed arguments
  * @private
  * @ignore
  */
 const parse = (args = [], defaultValues = {}, ...configObjects) => {
-  // save node-specific args for special handling.
-  // 1. when these args have a "=" they should be considered to have values
-  // 2. if they don't, they are just boolean flags
-  // 3. to avoid explicitly defining the set of them, we tell yargs-parser they
-  //    are ALL boolean flags.
-  // 4. we can then reapply the values after yargs-parser is done.
-  const allArgs = Array.isArray(args) ? args : args.split(" ");
-  const nodeArgs = allArgs.reduce((acc, arg) => {
-    const pair = arg.split("=");
-    let flag = pair[0];
-    if (isNodeFlag(flag, false)) {
-      flag = flag.replace(/^--?/, "");
-      return acc.concat([[flag, arg.includes("=") ? pair[1] : true]]);
+  try {
+    return parseMochaArgs(args, defaultValues, ...configObjects);
+  } catch (err) {
+    if (isMochaError(err)) {
+      throw err;
     }
-    return acc;
-  }, []);
-
-  const result = yargsParser.detailed(args, {
-    configuration,
-    configObjects,
-    default: defaultValues,
-    coerce: coerceOpts,
-    narg: nargOpts,
-    alias: aliases,
-    string: types.string,
-    array: types.array,
-    number: types.number,
-    boolean: types.boolean.concat(nodeArgs.map((pair) => pair[0])),
-  });
-  if (result.error) {
-    console.error(pc.red(`Error: ${result.error.message}`));
+    console.error(pc.red(`Error: ${err.message}`));
     process.exit(1);
   }
-
-  const numericPositionalArg = result.argv._.find((arg) => isNumeric(arg));
-  if (numericPositionalArg) {
-    createErrorForNumericPositionalArg(
-      numericPositionalArg,
-      allArgs,
-      result.argv,
-    );
-  }
-
-  // reapply "=" arg values from above
-  nodeArgs.forEach(([key, value]) => {
-    result.argv[key] = value;
-  });
-
-  return result.argv;
 };
 
 /**

--- a/lib/cli/options.cjs
+++ b/lib/cli/options.cjs
@@ -32,18 +32,7 @@ const debug = debugModule("mocha:cli:options");
  */
 
 /**
- * Base yargs parser configuration
- * @private
- */
-const YARGS_PARSER_CONFIG = {
-  "combine-arrays": true,
-  "short-option-groups": false,
-  "dot-notation": false,
-  "strip-aliased": true,
-};
-
-/**
- * Wrapper around `parseArgs` which applies our settings
+ * Wrapper around `parseMochaArgs` which applies Mocha's CLI parsing behavior.
  * @param {string|string[]} args - Arguments to parse
  * @param {Object} defaultValues - Default values of mocharc.json
  * @param  {...Object} configObjects - Objects to merge into parsed arguments
@@ -68,7 +57,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
  * @param {string|boolean} [args.config] - Path to config file or `false` to skip
  * @public
  * @alias module:lib/cli.loadRc
- * @returns {external:yargsParser.Arguments|void} Parsed config, or nothing if `args.config` is `false`
+ * @returns {external:parseArgs.Arguments|void} Parsed config, or nothing if `args.config` is `false`
  */
 const loadRc = (args = {}) => {
   if (args.config !== false) {
@@ -84,7 +73,7 @@ const loadRc = (args = {}) => {
  * @param {string|boolean} [args.config] - Path to `package.json` or `false` to use default
  * @public
  * @alias module:lib/cli.loadPkgRc
- * @returns {external:yargsParser.Arguments|void} Parsed config. Throws if unparsableF. Empty object if file not found.
+ * @returns {external:parseArgs.Arguments|void} Parsed config. Throws if unparsableF. Empty object if file not found.
  */
 const loadPkgRc = (args = {}) => {
   let result;
@@ -142,7 +131,7 @@ const loadPkgRc = (args = {}) => {
  * @param {string|string[]} [argv] - Arguments to parse
  * @public
  * @alias module:lib/cli.loadOptions
- * @returns {external:yargsParser.Arguments} Parsed args from everything
+ * @returns {external:parseArgs.Arguments} Parsed args from everything
  */
 const loadOptions = (argv = []) => {
   let args = parse(argv);
@@ -190,7 +179,6 @@ const loadOptions = (argv = []) => {
   return args;
 };
 
-exports.YARGS_PARSER_CONFIG = YARGS_PARSER_CONFIG;
 exports.loadRc = loadRc;
 exports.loadPkgRc = loadPkgRc;
 exports.loadOptions = loadOptions;

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -1,0 +1,306 @@
+import { parseArgs } from "node:util";
+import {
+  createInvalidArgumentTypeError,
+  createUnsupportedError,
+} from "../errors.js";
+import { isNumeric } from "../utils.cjs";
+import { list } from "./run-helpers.cjs";
+import {
+  aliases,
+  expectedTypeForFlag,
+  isMochaFlag,
+  types,
+} from "./run-option-metadata.cjs";
+import { isNodeFlag } from "./node-flags.cjs";
+
+const globOptions = ["spec", "ignore"];
+const aliasToCanonical = Object.entries(aliases).reduce(
+  (acc, [canonical, optionAliases]) => {
+    optionAliases.forEach((alias) => {
+      acc[alias] = canonical;
+    });
+    return acc;
+  },
+  {},
+);
+
+const canonicalOptionName = (name) => aliasToCanonical[name] || name;
+
+const optionTypeByName = Object.entries(types).reduce((acc, [type, names]) => {
+  names.forEach((name) => {
+    acc[name] = type;
+  });
+  return acc;
+}, {});
+
+const arrayOptions = new Set(types.array);
+const booleanOptions = new Set(types.boolean);
+const numberOptions = new Set(types.number);
+const scalarOptions = new Set(types.boolean.concat(types.string, types.number));
+
+/**
+ * Directly-passed Node/V8 flags are not a fixed list known to this parser. When
+ * we see them, define them as boolean options for parseArgs(), then reapply any
+ * values from equals-form flags after parsing.
+ */
+const createParseArgsOptions = (nodeArgs) => {
+  const options = {};
+
+  Object.entries(optionTypeByName).forEach(([name, type]) => {
+    const short = (aliases[name] || []).find((alias) => alias.length === 1);
+    options[name] = {
+      type: type === "boolean" ? "boolean" : "string",
+      multiple: type !== "boolean",
+    };
+    if (short) {
+      options[name].short = short;
+    }
+  });
+
+  nodeArgs.forEach(([name]) => {
+    options[name] = { type: "boolean" };
+  });
+
+  return options;
+};
+
+const toArray = (value) => {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+// Array-type options should have unique values, with comma-delimited values
+// split unless the option is a glob where commas can be part of the pattern.
+const coerceArrayOption = (name, value) => {
+  const values = toArray(value);
+  return Array.from(
+    new Set(globOptions.includes(name) ? values : list(values)),
+  );
+};
+
+// Boolean/string/number options use the last value when given multiple times.
+const coerceScalarOption = (name, value) => {
+  const scalar = Array.isArray(value) ? value[value.length - 1] : value;
+
+  if (booleanOptions.has(name)) {
+    if (scalar === "false") {
+      return false;
+    }
+    if (scalar === "true") {
+      return true;
+    }
+  }
+
+  return scalar;
+};
+
+const coerceNumberOption = (value) => {
+  const scalar = Array.isArray(value) ? value[value.length - 1] : value;
+  return scalar === undefined ? scalar : Number(scalar);
+};
+
+const mergeValue = (existing, next) => {
+  if (existing === undefined) {
+    return next;
+  }
+  return toArray(existing).concat(toArray(next));
+};
+
+const mergeConfigObjects = (defaultValues, configObjects) => {
+  const defaultArrayOptions = new Set();
+
+  return [defaultValues]
+    .concat(configObjects.slice().reverse())
+    .reduce((merged, config) => {
+      if (!config) {
+        return merged;
+      }
+
+      Object.entries(config).forEach(([rawName, value]) => {
+        const name = canonicalOptionName(rawName);
+        if (name === "_") {
+          merged._ = mergeValue(value, merged._);
+        } else if (arrayOptions.has(name)) {
+          if (config === defaultValues) {
+            defaultArrayOptions.add(name);
+            merged[name] = value;
+          } else if (defaultArrayOptions.has(name)) {
+            defaultArrayOptions.delete(name);
+            merged[name] = value;
+          } else {
+            merged[name] = mergeValue(value, merged[name]);
+          }
+        } else {
+          merged[name] = value;
+        }
+      });
+
+      return merged;
+    }, {});
+};
+
+const preprocessArgs = (allArgs) => {
+  return allArgs.map((arg) => {
+    const noPrefix = arg.replace(/^--?/, "");
+    const [name, ...rest] = noPrefix.split("=");
+    const canonical = canonicalOptionName(name.replace(/^no-/, ""));
+    const negated = name.startsWith("no-");
+    const prefix = arg.startsWith("--") ? "--" : arg.startsWith("-") ? "-" : "";
+
+    if (!prefix || name === canonical || name.length === 1) {
+      return arg;
+    }
+
+    const normalizedName = negated ? `no-${canonical}` : canonical;
+    return `${prefix}${normalizedName}${rest.length ? `=${rest.join("=")}` : ""}`;
+  });
+};
+
+const requiresValue = (name) => {
+  const canonical = canonicalOptionName(name);
+  return (
+    arrayOptions.has(canonical) ||
+    types.string.includes(canonical) ||
+    numberOptions.has(canonical)
+  );
+};
+
+/**
+ * Disallows multiple arguments after a single option, such as `--grep abc def`.
+ */
+const validateArgsBeforeParse = (allArgs) => {
+  allArgs.forEach((arg, index) => {
+    if (!arg.startsWith("-") || arg === "--" || arg.includes("=")) {
+      return;
+    }
+
+    const name = canonicalOptionName(arg.replace(/^--?/, ""));
+    const next = allArgs[index + 1];
+
+    if (requiresValue(name) && (next === undefined || next.startsWith("-"))) {
+      throw new Error(`Not enough arguments following: ${name}`);
+    }
+  });
+};
+
+const normalizeParsedValues = (values, positionals) => {
+  const normalized = Object.assign({ _: positionals }, values);
+
+  Object.keys(normalized).forEach((rawName) => {
+    if (rawName === "_") {
+      return;
+    }
+
+    const name = canonicalOptionName(rawName);
+    if (name !== rawName) {
+      normalized[name] = mergeValue(normalized[name], normalized[rawName]);
+      delete normalized[rawName];
+    }
+  });
+
+  arrayOptions.forEach((name) => {
+    if (normalized[name] !== undefined) {
+      normalized[name] = coerceArrayOption(name, normalized[name]);
+    }
+  });
+
+  scalarOptions.forEach((name) => {
+    if (normalized[name] !== undefined) {
+      normalized[name] = coerceScalarOption(name, normalized[name]);
+    }
+  });
+
+  numberOptions.forEach((name) => {
+    if (normalized[name] !== undefined) {
+      normalized[name] = coerceNumberOption(normalized[name]);
+    }
+  });
+
+  return normalized;
+};
+
+const createErrorForNumericPositionalArg = (
+  numericArg,
+  allArgs,
+  parsedResult,
+) => {
+  // A flag for `numericArg` exists if:
+  // 1. A Mocha flag immediately preceded the numericArg in `allArgs`, and
+  // 2. parseArgs() could not assign the numericArg to that flag because the
+  //    option has an incompatible datatype.
+  const flag = allArgs.find((arg, index) => {
+    const normalizedArg = arg.replace(/^--?/, "");
+    return (
+      isMochaFlag(arg) &&
+      allArgs[index + 1] === String(numericArg) &&
+      parsedResult[normalizedArg] !== String(numericArg)
+    );
+  });
+
+  if (flag) {
+    throw createInvalidArgumentTypeError(
+      `Mocha flag '${flag}' given invalid option: '${numericArg}'`,
+      numericArg,
+      expectedTypeForFlag(flag),
+    );
+  }
+
+  throw createUnsupportedError(
+    `Option ${numericArg} is unsupported by the mocha cli`,
+  );
+};
+
+export const parseMochaArgs = (
+  args = [],
+  defaultValues = {},
+  ...configObjects
+) => {
+  const allArgs = Array.isArray(args) ? args : args ? args.split(" ") : [];
+
+  // Save Node-specific args for special handling. Equals-form args have values;
+  // the rest are boolean flags.
+  const nodeArgs = allArgs.reduce((acc, arg) => {
+    const pair = arg.split("=");
+    let flag = pair[0];
+    if (isNodeFlag(flag, false)) {
+      flag = flag.replace(/^--?/, "");
+      return acc.concat([[flag, arg.includes("=") ? pair[1] : true]]);
+    }
+    return acc;
+  }, []);
+
+  validateArgsBeforeParse(allArgs);
+  const parsed = parseArgs({
+    args: preprocessArgs(allArgs),
+    options: createParseArgsOptions(nodeArgs),
+    allowNegative: true,
+    allowPositionals: true,
+    strict: false,
+  });
+
+  const result = normalizeParsedValues(
+    Object.assign(
+      mergeConfigObjects(defaultValues, configObjects),
+      parsed.values,
+    ),
+    parsed.positionals,
+  );
+
+  const numericPositionalArg = result._.find((arg) => isNumeric(arg));
+  if (numericPositionalArg) {
+    createErrorForNumericPositionalArg(
+      Number(numericPositionalArg),
+      allArgs,
+      result,
+    );
+  }
+
+  // Reapply equals-form Node/V8 flag values saved above.
+  nodeArgs.forEach(([key, value]) => {
+    result[key] = value;
+  });
+
+  return result;
+};

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -74,6 +74,23 @@ const toArray = (value) => {
 // Array-type options should have unique values, with comma-delimited values
 // split unless the option is a glob where commas can be part of the pattern.
 const coerceArrayOption = (name, value) => {
+  if (
+    name === "reporter-option" &&
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value)
+  ) {
+    return value;
+  }
+
+  if (
+    name === "reporter-option" &&
+    Array.isArray(value) &&
+    value.every((item) => item && typeof item === "object" && !Array.isArray(item))
+  ) {
+    return Object.assign({}, ...value);
+  }
+
   const values = toArray(value);
   return Array.from(
     new Set(globOptions.includes(name) ? values : list(values)),

--- a/lib/cli/run-option-metadata.cjs
+++ b/lib/cli/run-option-metadata.cjs
@@ -8,7 +8,7 @@
  */
 
 /**
- * Dictionary of yargs option types to list of options having said type
+ * Dictionary of option types to list of options having said type
  * @type {Record<string, string[]>}
  * @private
  */
@@ -94,6 +94,65 @@ const aliases = {
   watch: ["w"],
 };
 
+const descriptions = {
+  "allow-uncaught": "Allow uncaught errors to propagate",
+  "async-only": "Require all tests to use a callback (async) or return a Promise",
+  bail: 'Abort ("bail") after first test failure',
+  "check-leaks": "Check for global variable leaks",
+  color: "Force-enable color output",
+  config: "Path to config file",
+  delay: "Delay initial execution of root suite",
+  diff: "Show diff on failure",
+  "dry-run": "Report tests without executing them",
+  exit: "Force Mocha to quit after tests complete",
+  extension: "File extension(s) to load",
+  "fail-hook-affected-tests":
+    "Report tests as failed when affected by hook failures (before/beforeEach)",
+  "fail-zero": "Fail test run if no test(s) encountered",
+  "pass-on-failing-test-suite": "Not fail test run if tests were failed",
+  fgrep: "Only run tests containing this string",
+  file: "Specify file(s) to be loaded prior to root suite execution",
+  "forbid-only": "Fail if exclusive test(s) encountered",
+  "forbid-pending": "Fail if pending test(s) encountered",
+  "full-trace": "Display full stack traces",
+  global: "List of allowed global variables",
+  grep: "Only run tests matching this string or regexp",
+  ignore: "Ignore file(s) or glob pattern(s)",
+  "inline-diffs":
+    "Display actual/expected differences inline within each string",
+  invert: "Inverts --grep and --fgrep matches",
+  jobs: "Number of concurrent jobs for --parallel; use 1 to run in serial",
+  "list-interfaces": "List built-in user interfaces & exit",
+  "list-reporters": "List built-in reporters & exit",
+  "no-colors": "Force-disable color output",
+  "node-option": 'Node or V8 option (no leading "--")',
+  package: "Path to package.json for config",
+  parallel: "Run tests in parallel",
+  "posix-exit-codes": "Use POSIX and UNIX shell exit codes as Mocha's return value",
+  recursive: "Look for tests in subdirectories",
+  reporter: "Specify reporter to use",
+  "reporter-option": "Reporter-specific options (<k=v,[k1=v1,..]>)",
+  require: "Require module",
+  retries: "Retry failed tests this many times",
+  slow: 'Specify "slow" test threshold (in milliseconds)',
+  sort: "Sort test files",
+  timeout: "Specify test timeout threshold (in milliseconds)",
+  ui: "Specify user interface",
+  watch: "Watch files in the current working directory for changes",
+  "watch-files": "List of paths or globs to watch",
+  "watch-ignore": "List of paths or globs to exclude from watching",
+};
+
+const getRunOptionDefinitions = () =>
+  Object.entries(types).flatMap(([type, names]) =>
+    names.map((name) => ({
+      name,
+      type,
+      aliases: aliases[name] || [],
+      description: descriptions[name] || "",
+    })),
+  );
+
 const ALL_MOCHA_FLAGS = Object.keys(types).reduce((acc, key) => {
   // gets all flags from each of the fields in `types`, adds those,
   // then adds aliases of each flag (if any)
@@ -139,5 +198,6 @@ const expectedTypeForFlag = (flag) => {
 
 exports.types = types;
 exports.aliases = aliases;
+exports.getRunOptionDefinitions = getRunOptionDefinitions;
 exports.isMochaFlag = isMochaFlag;
 exports.expectedTypeForFlag = expectedTypeForFlag;

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -10,10 +10,12 @@
 const Mocha = require("../mocha.cjs");
 const {
   createUnsupportedError,
+  createInvalidArgumentValueError,
   createMissingArgumentError,
 } = require("../errors.js");
 
 const {
+  list,
   handleRequires,
   validateLegacyPlugin,
   runMocha,
@@ -24,6 +26,43 @@ const debug = require("debug")("mocha:cli:run");
 exports.command = ["$0 [spec..]", "inspect"];
 
 exports.describe = "Run tests with Mocha";
+
+const camelCase = (name) =>
+  name.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+
+const coerceReporterOption = (opts) =>
+  list(opts).reduce((acc, opt) => {
+    const pair = opt.split("=");
+
+    if (pair.length > 2 || !pair.length) {
+      throw createInvalidArgumentValueError(
+        `invalid reporter option '${opt}'`,
+        "--reporter-option",
+        opt,
+        'expected "key=value" format',
+      );
+    }
+
+    acc[pair[0]] = pair.length === 2 ? pair[1] : true;
+    return acc;
+  }, {});
+
+const normalizeRunOptions = (argv) => {
+  Object.keys(argv).forEach((name) => {
+    if (name.includes("-")) {
+      const normalizedName = camelCase(name);
+      if (!(normalizedName in argv)) {
+        argv[normalizedName] = argv[name];
+      }
+    }
+  });
+
+  if (Array.isArray(argv["reporter-option"])) {
+    argv["reporter-option"] = coerceReporterOption(argv["reporter-option"]);
+  }
+
+  return argv;
+};
 
 const validateRunOptions = (argv) => {
   // "one-and-dones"; help and version are handled by the top-level CLI.
@@ -39,6 +78,12 @@ const validateRunOptions = (argv) => {
       '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
       "--fgrep|--grep",
       "string|regexp",
+    );
+  }
+
+  if (argv.fgrep && argv.grep) {
+    throw createUnsupportedError(
+      "Arguments fgrep and grep are mutually exclusive",
     );
   }
 
@@ -73,8 +118,10 @@ const prepareRunOptions = async (argv) => {
 
 exports.validateRunOptions = validateRunOptions;
 exports.prepareRunOptions = prepareRunOptions;
+exports.normalizeRunOptions = normalizeRunOptions;
 
 exports.handler = async function (argv) {
+  normalizeRunOptions(argv);
   debug("running with config", argv);
   const mocha = new Mocha(argv);
 

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -7,38 +7,19 @@
  * @private
  */
 
-const pc = require("picocolors");
 const Mocha = require("../mocha.cjs");
 const {
   createUnsupportedError,
-  createInvalidArgumentValueError,
   createMissingArgumentError,
 } = require("../errors.js");
 
 const {
-  list,
   handleRequires,
   validateLegacyPlugin,
   runMocha,
 } = require("./run-helpers.cjs");
-const { ONE_AND_DONES, ONE_AND_DONE_ARGS } = require("./one-and-dones.js");
+const { ONE_AND_DONES } = require("./one-and-dones.js");
 const debug = require("debug")("mocha:cli:run");
-const defaults = require("../mocharc.json");
-const { types, aliases } = require("./run-option-metadata.cjs");
-const { isCI, logSymbols } = require("../utils.cjs");
-
-/**
- * Logical option groups
- * @constant
- */
-const GROUPS = {
-  FILES: "File Handling",
-  FILTERS: "Test Filters",
-  NODEJS: "Node.js & V8",
-  OUTPUT: "Reporting & Output",
-  RULES: "Rules & Behavior",
-  CONFIG: "Configuration",
-};
 
 exports.command = ["$0 [spec..]", "inspect"];
 
@@ -53,7 +34,6 @@ const validateRunOptions = (argv) => {
     }
   });
 
-  // yargs.implies() isn't flexible enough to handle this
   if (argv.invert && !("fgrep" in argv || "grep" in argv)) {
     throw createMissingArgumentError(
       '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
@@ -63,14 +43,12 @@ const validateRunOptions = (argv) => {
   }
 
   if (argv.parallel) {
-    // yargs.conflicts() can't deal with `--file foo.js --no-parallel`, either
     if (argv.file) {
       throw createUnsupportedError(
         "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --file",
       );
     }
 
-    // or this
     if (argv.sort) {
       throw createUnsupportedError(
         "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --sort",
@@ -93,282 +71,11 @@ const prepareRunOptions = async (argv) => {
   return argv;
 };
 
-exports.builder = (yargs) =>
-  yargs
-    .options({
-      "allow-uncaught": {
-        description: "Allow uncaught errors to propagate",
-        group: GROUPS.RULES,
-      },
-      "async-only": {
-        description:
-          "Require all tests to use a callback (async) or return a Promise",
-        group: GROUPS.RULES,
-      },
-      bail: {
-        description: 'Abort ("bail") after first test failure',
-        group: GROUPS.RULES,
-      },
-      "check-leaks": {
-        description: "Check for global variable leaks",
-        group: GROUPS.RULES,
-      },
-      color: {
-        description: "Force-enable color output",
-        group: GROUPS.OUTPUT,
-      },
-      config: {
-        config: true,
-        defaultDescription: "(nearest rc file)",
-        description: "Path to config file",
-        group: GROUPS.CONFIG,
-      },
-      delay: {
-        description: "Delay initial execution of root suite",
-        group: GROUPS.RULES,
-      },
-      diff: {
-        default: true,
-        description: "Show diff on failure",
-        group: GROUPS.OUTPUT,
-      },
-      "dry-run": {
-        description: "Report tests without executing them",
-        group: GROUPS.RULES,
-      },
-      exit: {
-        description: "Force Mocha to quit after tests complete",
-        group: GROUPS.RULES,
-      },
-      extension: {
-        default: defaults.extension,
-        description: "File extension(s) to load",
-        group: GROUPS.FILES,
-        requiresArg: true,
-        coerce: list,
-      },
-      "pass-on-failing-test-suite": {
-        default: false,
-        description: "Not fail test run if tests were failed",
-        group: GROUPS.RULES,
-      },
-      "fail-hook-affected-tests": {
-        description:
-          "Report tests as failed when affected by hook failures (before/beforeEach)",
-        group: GROUPS.RULES,
-      },
-      "fail-zero": {
-        description: "Fail test run if no test(s) encountered",
-        group: GROUPS.RULES,
-      },
-      fgrep: {
-        conflicts: "grep",
-        description: "Only run tests containing this string",
-        group: GROUPS.FILTERS,
-        requiresArg: true,
-      },
-      file: {
-        defaultDescription: "(none)",
-        description:
-          "Specify file(s) to be loaded prior to root suite execution",
-        group: GROUPS.FILES,
-        normalize: true,
-        requiresArg: true,
-      },
-      "forbid-only": {
-        description: "Fail if exclusive test(s) encountered",
-        group: GROUPS.RULES,
-        default: isCI(),
-      },
-      "forbid-pending": {
-        description: "Fail if pending test(s) encountered",
-        group: GROUPS.RULES,
-      },
-      "full-trace": {
-        description: "Display full stack traces",
-        group: GROUPS.OUTPUT,
-      },
-      global: {
-        coerce: list,
-        description: "List of allowed global variables",
-        group: GROUPS.RULES,
-        requiresArg: true,
-      },
-      grep: {
-        coerce: (value) => (!value ? null : value),
-        conflicts: "fgrep",
-        description: "Only run tests matching this string or regexp",
-        group: GROUPS.FILTERS,
-        requiresArg: true,
-      },
-      ignore: {
-        defaultDescription: "(none)",
-        description: "Ignore file(s) or glob pattern(s)",
-        group: GROUPS.FILES,
-        requiresArg: true,
-      },
-      "inline-diffs": {
-        description:
-          "Display actual/expected differences inline within each string",
-        group: GROUPS.OUTPUT,
-      },
-      invert: {
-        description: "Inverts --grep and --fgrep matches",
-        group: GROUPS.FILTERS,
-      },
-      jobs: {
-        description:
-          "Number of concurrent jobs for --parallel; use 1 to run in serial",
-        defaultDescription: "(number of CPU cores - 1)",
-        requiresArg: true,
-        group: GROUPS.RULES,
-      },
-      "list-interfaces": {
-        conflicts: Array.from(ONE_AND_DONE_ARGS).filter(
-          (arg) => arg !== "list-interfaces",
-        ),
-        description: "List built-in user interfaces & exit",
-      },
-      "list-reporters": {
-        conflicts: Array.from(ONE_AND_DONE_ARGS).filter(
-          (arg) => arg !== "list-reporters",
-        ),
-        description: "List built-in reporters & exit",
-      },
-      "no-colors": {
-        description: "Force-disable color output",
-        group: GROUPS.OUTPUT,
-        hidden: true,
-      },
-      "node-option": {
-        description: 'Node or V8 option (no leading "--")',
-        group: GROUPS.CONFIG,
-      },
-      package: {
-        description: "Path to package.json for config",
-        group: GROUPS.CONFIG,
-        normalize: true,
-        requiresArg: true,
-      },
-      parallel: {
-        description: "Run tests in parallel",
-        group: GROUPS.RULES,
-      },
-      "posix-exit-codes": {
-        description:
-          "Use POSIX and UNIX shell exit codes as Mocha's return value",
-        group: GROUPS.RULES,
-      },
-      recursive: {
-        description: "Look for tests in subdirectories",
-        group: GROUPS.FILES,
-      },
-      reporter: {
-        default: defaults.reporter,
-        description: "Specify reporter to use",
-        group: GROUPS.OUTPUT,
-        requiresArg: true,
-      },
-      "reporter-option": {
-        coerce: (opts) =>
-          list(opts).reduce((acc, opt) => {
-            const pair = opt.split("=");
-
-            if (pair.length > 2 || !pair.length) {
-              throw createInvalidArgumentValueError(
-                `invalid reporter option '${opt}'`,
-                "--reporter-option",
-                opt,
-                'expected "key=value" format',
-              );
-            }
-
-            acc[pair[0]] = pair.length === 2 ? pair[1] : true;
-            return acc;
-          }, {}),
-        description: "Reporter-specific options (<k=v,[k1=v1,..]>)",
-        group: GROUPS.OUTPUT,
-        requiresArg: true,
-      },
-      require: {
-        defaultDescription: "(none)",
-        description: "Require module",
-        group: GROUPS.FILES,
-        requiresArg: true,
-      },
-      retries: {
-        description: "Retry failed tests this many times",
-        group: GROUPS.RULES,
-      },
-      slow: {
-        default: defaults.slow,
-        description: 'Specify "slow" test threshold (in milliseconds)',
-        group: GROUPS.RULES,
-      },
-      sort: {
-        description: "Sort test files",
-        group: GROUPS.FILES,
-      },
-      timeout: {
-        default: defaults.timeout,
-        description: "Specify test timeout threshold (in milliseconds)",
-        group: GROUPS.RULES,
-      },
-      ui: {
-        default: defaults.ui,
-        description: "Specify user interface",
-        group: GROUPS.RULES,
-        requiresArg: true,
-      },
-      watch: {
-        description: "Watch files in the current working directory for changes",
-        group: GROUPS.FILES,
-      },
-      "watch-files": {
-        description: "List of paths or globs to watch",
-        group: GROUPS.FILES,
-        requiresArg: true,
-        coerce: list,
-      },
-      "watch-ignore": {
-        description: "List of paths or globs to exclude from watching",
-        group: GROUPS.FILES,
-        requiresArg: true,
-        coerce: list,
-        default: defaults["watch-ignore"],
-      },
-    })
-    .positional("spec", {
-      default: ["test"],
-      description: "One or more files, directories, or globs to test",
-      type: "array",
-    })
-    .check((argv) => {
-      validateRunOptions(argv);
-      return true;
-    })
-    .middleware(async (argv, yargs) => {
-      // currently a failing middleware does not work nicely with yargs' `fail()`.
-      try {
-        // load requires first, because it can impact "plugin" validation
-        await prepareRunOptions(argv);
-      } catch (err) {
-        // this could be a bad --require, bad reporter, ui, etc.
-        console.error(`\n${logSymbols.error} ${pc.red("ERROR:")}`, err);
-        yargs.exit(1);
-      }
-    })
-    .array(types.array)
-    .boolean(types.boolean)
-    .string(types.string)
-    .number(types.number)
-    .alias(aliases);
-
 exports.validateRunOptions = validateRunOptions;
 exports.prepareRunOptions = prepareRunOptions;
 
 exports.handler = async function (argv) {
-  debug("post-yargs config", argv);
+  debug("running with config", argv);
   const mocha = new Mocha(argv);
 
   try {

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -44,6 +44,55 @@ exports.command = ["$0 [spec..]", "inspect"];
 
 exports.describe = "Run tests with Mocha";
 
+const validateRunOptions = (argv) => {
+  // "one-and-dones"; help and version are handled by the top-level CLI.
+  Object.keys(ONE_AND_DONES).forEach((opt) => {
+    if (argv[opt]) {
+      ONE_AND_DONES[opt].call(null);
+      process.exit(0);
+    }
+  });
+
+  // yargs.implies() isn't flexible enough to handle this
+  if (argv.invert && !("fgrep" in argv || "grep" in argv)) {
+    throw createMissingArgumentError(
+      '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
+      "--fgrep|--grep",
+      "string|regexp",
+    );
+  }
+
+  if (argv.parallel) {
+    // yargs.conflicts() can't deal with `--file foo.js --no-parallel`, either
+    if (argv.file) {
+      throw createUnsupportedError(
+        "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --file",
+      );
+    }
+
+    // or this
+    if (argv.sort) {
+      throw createUnsupportedError(
+        "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --sort",
+      );
+    }
+
+    if (["progress", "markdown", "json-stream"].includes(argv.reporter)) {
+      throw createUnsupportedError(
+        `--reporter=${argv.reporter} is mutually exclusive with --parallel`,
+      );
+    }
+  }
+};
+
+const prepareRunOptions = async (argv) => {
+  const plugins = await handleRequires(argv.require);
+  validateLegacyPlugin(argv, "reporter", Mocha.reporters);
+  validateLegacyPlugin(argv, "ui", Mocha.interfaces);
+  Object.assign(argv, plugins);
+  return argv;
+};
+
 exports.builder = (yargs) =>
   yargs
     .options({
@@ -295,67 +344,14 @@ exports.builder = (yargs) =>
       type: "array",
     })
     .check((argv) => {
-      // "one-and-dones"; let yargs handle help and version
-      Object.keys(ONE_AND_DONES).forEach((opt) => {
-        if (argv[opt]) {
-          ONE_AND_DONES[opt].call(null, yargs);
-          process.exit();
-        }
-      });
-
-      // yargs.implies() isn't flexible enough to handle this
-      if (argv.invert && !("fgrep" in argv || "grep" in argv)) {
-        throw createMissingArgumentError(
-          '"--invert" requires one of "--fgrep <str>" or "--grep <regexp>"',
-          "--fgrep|--grep",
-          "string|regexp",
-        );
-      }
-
-      if (argv.parallel) {
-        // yargs.conflicts() can't deal with `--file foo.js --no-parallel`, either
-        if (argv.file) {
-          throw createUnsupportedError(
-            "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --file",
-          );
-        }
-
-        // or this
-        if (argv.sort) {
-          throw createUnsupportedError(
-            "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --sort",
-          );
-        }
-
-        if (argv.reporter === "progress") {
-          throw createUnsupportedError(
-            "--reporter=progress is mutually exclusive with --parallel",
-          );
-        }
-
-        if (argv.reporter === "markdown") {
-          throw createUnsupportedError(
-            "--reporter=markdown is mutually exclusive with --parallel",
-          );
-        }
-
-        if (argv.reporter === "json-stream") {
-          throw createUnsupportedError(
-            "--reporter=json-stream is mutually exclusive with --parallel",
-          );
-        }
-      }
-
+      validateRunOptions(argv);
       return true;
     })
     .middleware(async (argv, yargs) => {
       // currently a failing middleware does not work nicely with yargs' `fail()`.
       try {
         // load requires first, because it can impact "plugin" validation
-        const plugins = await handleRequires(argv.require);
-        validateLegacyPlugin(argv, "reporter", Mocha.reporters);
-        validateLegacyPlugin(argv, "ui", Mocha.interfaces);
-        Object.assign(argv, plugins);
+        await prepareRunOptions(argv);
       } catch (err) {
         // this could be a bad --require, bad reporter, ui, etc.
         console.error(`\n${logSymbols.error} ${pc.red("ERROR:")}`, err);
@@ -367,6 +363,9 @@ exports.builder = (yargs) =>
     .string(types.string)
     .number(types.number)
     .alias(aliases);
+
+exports.validateRunOptions = validateRunOptions;
+exports.prepareRunOptions = prepareRunOptions;
 
 exports.handler = async function (argv) {
   debug("post-yargs config", argv);

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -66,6 +66,15 @@ const normalizeRunOptions = (argv) => {
 
 const validateRunOptions = (argv) => {
   // "one-and-dones"; help and version are handled by the top-level CLI.
+  const oneAndDoneOptions = Object.keys(ONE_AND_DONES).filter((opt) =>
+    Boolean(argv[opt]),
+  );
+  if (oneAndDoneOptions.length > 1) {
+    throw createUnsupportedError(
+      `Arguments ${oneAndDoneOptions.join(" and ")} are mutually exclusive`,
+    );
+  }
+
   Object.keys(ONE_AND_DONES).forEach((opt) => {
     if (argv[opt]) {
       ONE_AND_DONES[opt].call(null);

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -49,6 +49,13 @@ const coerceReporterOption = (opts) =>
 
 const normalizeRunOptions = (argv) => {
   Object.keys(argv).forEach((name) => {
+    const reporterOptionMatch = name.match(/^reporter-options?\.(.+)$/);
+    if (reporterOptionMatch) {
+      argv["reporter-option"] = Object.assign({}, argv["reporter-option"], {
+        [reporterOptionMatch[1]]: argv[name],
+      });
+    }
+
     if (name.includes("-")) {
       const normalizedName = camelCase(name);
       if (!(normalizedName in argv)) {

--- a/lib/cli/unparse-args.js
+++ b/lib/cli/unparse-args.js
@@ -1,0 +1,52 @@
+const toArray = (value) => (Array.isArray(value) ? value : [value]);
+
+const unparseOption = (name, value) => {
+  if (value === false) {
+    return [`--no-${name}`];
+  }
+
+  if (value === true) {
+    return [`--${name}`];
+  }
+
+  if (value == null) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => unparseOption(name, item));
+  }
+
+  if (typeof value === "object") {
+    return Object.entries(value).flatMap(([key, item]) =>
+      unparseOption(`${name}.${key}`, item),
+    );
+  }
+
+  return [`--${name}`, String(value)];
+};
+
+const unparseMochaArgs = (opts) => {
+  const positionals = opts._ == null ? [] : toArray(opts._).map(String);
+  const options = Object.entries(opts).flatMap(([name, value]) =>
+    name === "_" ? [] : unparseOption(name, value),
+  );
+
+  return positionals.concat(options);
+};
+
+const unparseNodeFlags = (opts) => {
+  return Object.entries(opts).flatMap(([name, value]) => {
+    if (value === true) {
+      return [`--${name}`];
+    }
+
+    if (value === false || value == null) {
+      return [];
+    }
+
+    return toArray(value).map((item) => `--${name}=${item}`);
+  });
+};
+
+export { unparseMochaArgs, unparseNodeFlags };

--- a/lib/cli/unparse-args.js
+++ b/lib/cli/unparse-args.js
@@ -23,6 +23,10 @@ const unparseOption = (name, value) => {
     );
   }
 
+  if (name.includes(".")) {
+    return [`--${name}=${String(value)}`];
+  }
+
   return [`--${name}`, String(value)];
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
         "serialize-javascript": "^7.0.2",
         "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
-        "workerpool": "^10.0.0",
-        "yargs": "^17.7.2"
+        "workerpool": "^10.0.0"
       },
       "bin": {
         "mocha": "bin/mocha.js"
@@ -41,7 +40,6 @@
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@test/esm-only-loader": "./test/compiler-fixtures/esm-only-loader",
         "@types/node": "^24.0.0",
-        "@types/yargs": "^17.0.33",
         "chai": "^6.0.0",
         "coffeescript": "^2.6.1",
         "cross-env": "^10.0.0",
@@ -2459,23 +2457,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@voxpelli/semver-set": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@voxpelli/semver-set/-/semver-set-6.0.0.tgz",
@@ -2799,6 +2780,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2807,6 +2789,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3397,6 +3380,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3413,7 +3397,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -3805,7 +3790,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.0",
@@ -3884,6 +3870,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4519,6 +4506,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5068,6 +5056,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7943,6 +7932,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8547,6 +8537,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8576,6 +8567,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9545,6 +9537,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9601,6 +9594,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -9632,6 +9626,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -9650,6 +9645,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -9659,6 +9655,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "supports-color": "^8.1.1",
         "workerpool": "^10.0.0",
         "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
         "workerpool": "^10.0.0",
-        "yargs": "^17.7.2",
-        "yargs-unparser": "^2.0.0"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "mocha": "bin/mocha.js"
@@ -4365,6 +4364,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -9653,50 +9653,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yargs/node_modules/cliui": {

--- a/package.json
+++ b/package.json
@@ -103,8 +103,7 @@
     "serialize-javascript": "^7.0.2",
     "strip-json-comments": "^5.0.3",
     "supports-color": "^8.1.1",
-    "workerpool": "^10.0.0",
-    "yargs": "^17.7.2"
+    "workerpool": "^10.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
@@ -116,7 +115,6 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@test/esm-only-loader": "./test/compiler-fixtures/esm-only-loader",
     "@types/node": "^24.0.0",
-    "@types/yargs": "^17.0.33",
     "chai": "^6.0.0",
     "coffeescript": "^2.6.1",
     "cross-env": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
     "strip-json-comments": "^5.0.3",
     "supports-color": "^8.1.1",
     "workerpool": "^10.0.0",
-    "yargs": "^17.7.2",
-    "yargs-unparser": "^2.0.0"
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "supports-color": "^8.1.1",
     "workerpool": "^10.0.0",
     "yargs": "^17.7.2",
-    "yargs-parser": "^21.1.1",
     "yargs-unparser": "^2.0.0"
   },
   "devDependencies": {

--- a/test/integration/help.spec.cjs
+++ b/test/integration/help.spec.cjs
@@ -1,6 +1,25 @@
 "use strict";
 
 var invokeMocha = require("./helpers.cjs").invokeMocha;
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var rimraf = require("rimraf");
+
+function expectSuccessfulOutput(args, matcher, done) {
+  invokeMocha(
+    args,
+    function (err, result) {
+      if (err) {
+        return done(err);
+      }
+      expect(result, "to have succeeded");
+      expect(result.output, "to match", matcher);
+      done();
+    },
+    { stdio: "pipe" },
+  );
+}
 
 describe("help", function () {
   it("prints usage, commands and common options", function (done) {
@@ -18,6 +37,48 @@ describe("help", function () {
         done();
       },
       { stdio: "pipe" },
+    );
+  });
+
+  it("prints usage for -h", function (done) {
+    expectSuccessfulOutput(["-h"], /Usage: mocha \[spec\.\.\]/, done);
+  });
+
+  it("prints help for init --help without writing files", function (done) {
+    var tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-init-help-"));
+
+    invokeMocha(
+      ["init", tmpdir, "--help"],
+      function (err, result) {
+        var files = fs.readdirSync(tmpdir);
+        rimraf.sync(tmpdir);
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have succeeded");
+        expect(result.output, "to contain", "Usage: mocha [spec..]");
+        expect(files, "to be empty");
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
+});
+
+describe("version", function () {
+  it("prints version for --version", function (done) {
+    expectSuccessfulOutput(["--version"], /^\d+\.\d+\.\d+/, done);
+  });
+
+  it("prints version for -V", function (done) {
+    expectSuccessfulOutput(["-V"], /^\d+\.\d+\.\d+/, done);
+  });
+
+  it("prints version without loading required modules", function (done) {
+    expectSuccessfulOutput(
+      ["--version", "--require", "definitely-missing-module"],
+      /^\d+\.\d+\.\d+/,
+      done,
     );
   });
 });

--- a/test/integration/help.spec.cjs
+++ b/test/integration/help.spec.cjs
@@ -1,0 +1,23 @@
+"use strict";
+
+var invokeMocha = require("./helpers.cjs").invokeMocha;
+
+describe("help", function () {
+  it("prints usage, commands and common options", function (done) {
+    invokeMocha(
+      ["--help"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have succeeded");
+        expect(result.output, "to contain", "Usage: mocha [spec..]");
+        expect(result.output, "to contain", "mocha init <path>");
+        expect(result.output, "to contain", "--reporter");
+        expect(result.output, "to contain", "--timeout");
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
+});

--- a/test/integration/help.spec.js
+++ b/test/integration/help.spec.js
@@ -1,10 +1,8 @@
-"use strict";
-
-var invokeMocha = require("./helpers.cjs").invokeMocha;
-var fs = require("node:fs");
-var os = require("node:os");
-var path = require("node:path");
-var rimraf = require("rimraf");
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { sync as rimrafSync } from "rimraf";
+import { invokeMocha } from "./helpers.cjs";
 
 function expectSuccessfulOutput(args, matcher, done) {
   invokeMocha(
@@ -45,13 +43,13 @@ describe("help", function () {
   });
 
   it("prints help for init --help without writing files", function (done) {
-    var tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-init-help-"));
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-init-help-"));
 
     invokeMocha(
       ["init", tmpdir, "--help"],
       function (err, result) {
-        var files = fs.readdirSync(tmpdir);
-        rimraf.sync(tmpdir);
+        const files = fs.readdirSync(tmpdir);
+        rimrafSync(tmpdir);
         if (err) {
           return done(err);
         }

--- a/test/integration/init.spec.cjs
+++ b/test/integration/init.spec.cjs
@@ -2,9 +2,20 @@
 
 var fs = require("node:fs");
 var rimraf = require("rimraf");
-var invokeMocha = require("./helpers.cjs").invokeMocha;
+var helpers = require("./helpers.cjs");
+var invokeMocha = helpers.invokeMocha;
+var invokeNode = helpers.invokeNode;
 var path = require("node:path");
 var os = require("node:os");
+
+var CLI_EXECUTABLE = require.resolve("../../lib/cli/cli.js");
+
+function expectInitFiles(tmpdir) {
+  expect(fs.existsSync(path.join(tmpdir, "mocha.css")), "to be true");
+  expect(fs.existsSync(path.join(tmpdir, "mocha.js")), "to be true");
+  expect(fs.existsSync(path.join(tmpdir, "tests.spec.js")), "to be true");
+  expect(fs.existsSync(path.join(tmpdir, "index.html")), "to be true");
+}
 
 describe("init command", function () {
   var tmpdir;
@@ -70,10 +81,37 @@ describe("init command", function () {
           return done(err);
         }
         expect(result, "to have succeeded");
-        expect(fs.existsSync(path.join(tmpdir, "mocha.css")), "to be true");
-        expect(fs.existsSync(path.join(tmpdir, "mocha.js")), "to be true");
-        expect(fs.existsSync(path.join(tmpdir, "tests.spec.js")), "to be true");
-        expect(fs.existsSync(path.join(tmpdir, "index.html")), "to be true");
+        expectInitFiles(tmpdir);
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
+
+  it("should create files when init follows a top-level option", function (done) {
+    invokeNode(
+      [CLI_EXECUTABLE, "--no-config", "init", tmpdir],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have succeeded");
+        expectInitFiles(tmpdir);
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
+
+  it("should create files when init is respawned with a Node option", function (done) {
+    invokeMocha(
+      ["--node-option", "trace-warnings", "init", tmpdir],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have succeeded");
+        expectInitFiles(tmpdir);
         done();
       },
       { stdio: "pipe" },

--- a/test/integration/options/listInterfaces.spec.cjs
+++ b/test/integration/options/listInterfaces.spec.cjs
@@ -35,4 +35,18 @@ describe("--list-interfaces", function () {
       done();
     });
   });
+
+  it("should fail when combined with another one-and-done option", function (done) {
+    invokeMocha(
+      ["--list-interfaces", "--list-reporters"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have failed with output", /mutually exclusive/i);
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
 });

--- a/test/integration/options/listReporters.spec.cjs
+++ b/test/integration/options/listReporters.spec.cjs
@@ -37,4 +37,18 @@ describe("--list-reporters", function () {
       done();
     });
   });
+
+  it("should fail when combined with another one-and-done option", function (done) {
+    invokeMocha(
+      ["--list-reporters", "--list-interfaces"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have failed with output", /mutually exclusive/i);
+        done();
+      },
+      { stdio: "pipe" },
+    );
+  });
 });

--- a/test/integration/options/reporter-option.spec.cjs
+++ b/test/integration/options/reporter-option.spec.cjs
@@ -1,7 +1,19 @@
 "use strict";
 
 var runMocha = require("../helpers.cjs").runMocha;
+var invokeMocha = require("../helpers.cjs").invokeMocha;
 var path = require("node:path");
+var fs = require("node:fs");
+var os = require("node:os");
+var rimraf = require("rimraf");
+
+var customReporter = path.join(
+  __dirname,
+  "..",
+  "fixtures",
+  "options",
+  "reporter-with-options.fixture.cjs",
+);
 
 describe("--reporter-option", function () {
   describe("when given options w/ invalid format", function () {
@@ -28,13 +40,7 @@ describe("--reporter-option", function () {
         "passing.fixture.cjs",
         [
           "--reporter",
-          path.join(
-            __dirname,
-            "..",
-            "fixtures",
-            "options",
-            "reporter-with-options.fixture.cjs",
-          ),
+          customReporter,
           "--reporter-option",
           "foo=bar,baz=quux",
         ],
@@ -57,13 +63,7 @@ describe("--reporter-option", function () {
         "passing.fixture.cjs",
         [
           "--reporter",
-          path.join(
-            __dirname,
-            "..",
-            "fixtures",
-            "options",
-            "reporter-with-options.fixture.cjs",
-          ),
+          customReporter,
           "--reporter-option",
           "foo=bar",
           "--reporter-option",
@@ -80,6 +80,90 @@ describe("--reporter-option", function () {
           done();
         },
         "pipe",
+      );
+    });
+
+    it("should allow key-only boolean values", function (done) {
+      runMocha(
+        "passing.fixture.cjs",
+        ["--reporter", customReporter, "--reporter-option", "foo"],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have passed").and(
+            "to contain output",
+            /{"foo":true}/,
+          );
+          done();
+        },
+        "pipe",
+      );
+    });
+
+    it("should allow the short alias", function (done) {
+      runMocha(
+        "passing.fixture.cjs",
+        ["--reporter", customReporter, "-O", "foo=bar"],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have passed").and(
+            "to contain output",
+            /{"foo":"bar"}/,
+          );
+          done();
+        },
+        "pipe",
+      );
+    });
+
+    it("should allow the long alias", function (done) {
+      runMocha(
+        "passing.fixture.cjs",
+        ["--reporter", customReporter, "--reporter-options", "foo=bar"],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have passed").and(
+            "to contain output",
+            /{"foo":"bar"}/,
+          );
+          done();
+        },
+        "pipe",
+      );
+    });
+
+    it("should preserve package config reporter options after respawning with a Node option", function (done) {
+      var tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-reporter-option-"));
+      fs.writeFileSync(
+        path.join(tmpdir, "package.json"),
+        JSON.stringify({
+          mocha: {
+            reporter: customReporter,
+            "reporter-option": ["foo=bar"],
+            spec: [path.join(__dirname, "..", "fixtures", "passing.fixture.cjs")],
+          },
+        }),
+      );
+
+      invokeMocha(
+        ["--node-option", "trace-warnings"],
+        function (err, res) {
+          rimraf.sync(tmpdir);
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have passed").and(
+            "to contain output",
+            /{"foo":"bar"}/,
+          );
+          done();
+        },
+        { cwd: tmpdir, stdio: "pipe" },
       );
     });
   });

--- a/test/integration/options/reporter-option.spec.cjs
+++ b/test/integration/options/reporter-option.spec.cjs
@@ -166,5 +166,38 @@ describe("--reporter-option", function () {
         { cwd: tmpdir, stdio: "pipe" },
       );
     });
+
+    it("should preserve package config reporter option objects after respawning with a Node option", function (done) {
+      var tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-reporter-option-"));
+      fs.writeFileSync(
+        path.join(tmpdir, "package.json"),
+        JSON.stringify({
+          mocha: {
+            reporter: customReporter,
+            "reporter-option": {
+              foo: "bar",
+              baz: true,
+            },
+            spec: [path.join(__dirname, "..", "fixtures", "passing.fixture.cjs")],
+          },
+        }),
+      );
+
+      invokeMocha(
+        ["--node-option", "trace-warnings"],
+        function (err, res) {
+          rimraf.sync(tmpdir);
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have passed").and(
+            "to contain output",
+            /{"foo":"bar","baz":true}/,
+          );
+          done();
+        },
+        { cwd: tmpdir, stdio: "pipe" },
+      );
+    });
   });
 });

--- a/test/integration/options/run-preparation.spec.cjs
+++ b/test/integration/options/run-preparation.spec.cjs
@@ -1,0 +1,39 @@
+"use strict";
+
+var runMocha = require("../helpers.cjs").runMocha;
+
+describe("run preparation", function () {
+  it("should fail when a required module cannot be loaded", function (done) {
+    runMocha(
+      "passing.fixture.cjs",
+      ["--require", "definitely-missing-module"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have failed");
+        expect(result.output, "to contain", "ERROR:");
+        expect(result.output, "to contain", "definitely-missing-module");
+        done();
+      },
+      "pipe",
+    );
+  });
+
+  it("should fail when a reporter cannot be loaded", function (done) {
+    runMocha(
+      "passing.fixture.cjs",
+      ["--reporter", "definitely-missing-reporter"],
+      function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result, "to have failed");
+        expect(result.output, "to contain", "ERROR:");
+        expect(result.output, "to contain", "definitely-missing-reporter");
+        done();
+      },
+      "pipe",
+    );
+  });
+});

--- a/test/integration/options/run-preparation.spec.js
+++ b/test/integration/options/run-preparation.spec.js
@@ -1,6 +1,4 @@
-"use strict";
-
-var runMocha = require("../helpers.cjs").runMocha;
+import { runMocha } from "../helpers.cjs";
 
 describe("run preparation", function () {
   it("should fail when a required module cannot be loaded", function (done) {

--- a/test/node-unit/cli/cli.spec.js
+++ b/test/node-unit/cli/cli.spec.js
@@ -1,4 +1,5 @@
 import { main } from "../../../lib/cli/cli.js";
+import sinon from "sinon";
 
 describe("cli", function () {
   describe("main()", function () {
@@ -14,12 +15,12 @@ describe("cli", function () {
 
     it("prints version and exits for --version", function () {
       expect(() => main(["--version"]), "to throw", /process\.exit/);
-      expect(process.exit, "was called with", 0);
+      expect(process.exit, "to have a call satisfying", [0]);
     });
 
     it("prints help and exits for --help", function () {
       expect(() => main(["--help"]), "to throw", /process\.exit/);
-      expect(process.exit, "was called with", 0);
+      expect(process.exit, "to have a call satisfying", [0]);
     });
   });
 });

--- a/test/node-unit/cli/cli.spec.js
+++ b/test/node-unit/cli/cli.spec.js
@@ -1,0 +1,25 @@
+import { main } from "../../../lib/cli/cli.js";
+
+describe("cli", function () {
+  describe("main()", function () {
+    beforeEach(function () {
+      sinon.stub(console, "error");
+      sinon.stub(console, "log");
+      sinon.stub(process, "exit").throws(new Error("process.exit"));
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it("prints version and exits for --version", function () {
+      expect(() => main(["--version"]), "to throw", /process\.exit/);
+      expect(process.exit, "was called with", 0);
+    });
+
+    it("prints help and exits for --help", function () {
+      expect(() => main(["--help"]), "to throw", /process\.exit/);
+      expect(process.exit, "was called with", 0);
+    });
+  });
+});

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -1,0 +1,292 @@
+import { constants } from "../../../lib/error-constants.js";
+import { parseMochaArgs } from "../../../lib/cli/parse-args.js";
+
+const defaults = {
+  timeout: 1000,
+  extension: ["js"],
+};
+
+describe("parse-args", function () {
+  it("canonicalizes aliases and strips alias keys", function () {
+    const result = parseMochaArgs(
+      [
+        "-R",
+        "json",
+        "-t",
+        "123",
+        "-A",
+        "-b",
+        "-g",
+        "foo",
+        "-r",
+        "./x.js",
+        "-O",
+        "a=b",
+        "test/a.js",
+      ],
+      defaults,
+    );
+
+    expect(result, "to satisfy", {
+      _: ["test/a.js"],
+      reporter: "json",
+      timeout: "123",
+      "async-only": true,
+      bail: true,
+      grep: "foo",
+      require: ["./x.js"],
+      "reporter-option": ["a=b"],
+    });
+    ["R", "t", "A", "b", "g", "r", "O"].forEach((alias) => {
+      expect(result, "not to have property", alias);
+    });
+  });
+
+  it("uses the last value for repeated scalar options across aliases", function () {
+    expect(
+      parseMochaArgs(["--timeout", "100", "-t", "10"], defaults),
+      "to satisfy",
+      {
+        timeout: "10",
+      },
+    );
+  });
+
+  it("canonicalizes long aliases in equals form", function () {
+    const result = parseMochaArgs(
+      ["--reporter-options=a=b", "--timeouts=200"],
+      defaults,
+    );
+
+    expect(result, "to satisfy", {
+      "reporter-option": ["a=b"],
+      timeout: "200",
+    });
+    expect(result, "not to have property", "reporter-options");
+    expect(result, "not to have property", "timeouts");
+  });
+
+  it("splits, deduplicates, and preserves order for repeated array options", function () {
+    expect(
+      parseMochaArgs(
+        [
+          "--require",
+          "a",
+          "--require",
+          "a,b",
+          "--extension",
+          "js,ts",
+          "--extension",
+          "ts",
+        ],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        require: ["a", "b"],
+        extension: ["js", "ts"],
+      },
+    );
+  });
+
+  it("does not split glob array options on commas", function () {
+    expect(
+      parseMochaArgs(
+        [
+          "--spec",
+          "{dirA,dirB}/**/*.spec.js",
+          "--ignore",
+          "fixtures/{one,two}.js",
+        ],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        spec: ["{dirA,dirB}/**/*.spec.js"],
+        ignore: ["fixtures/{one,two}.js"],
+      },
+    );
+  });
+
+  it("replaces default array options before merging user config arrays", function () {
+    expect(
+      parseMochaArgs(
+        [],
+        defaults,
+        { extension: ["ts"] },
+        { extension: ["tsx"] },
+      ),
+      "to satisfy",
+      {
+        extension: ["ts", "tsx"],
+      },
+    );
+  });
+
+  it("canonicalizes aliases from config objects", function () {
+    const result = parseMochaArgs([], defaults, {
+      R: "json",
+      r: ["./setup.js"],
+      timeouts: "200",
+    });
+
+    expect(result, "to satisfy", {
+      reporter: "json",
+      require: ["./setup.js"],
+      timeout: "200",
+    });
+    expect(result, "not to have property", "R");
+    expect(result, "not to have property", "r");
+    expect(result, "not to have property", "timeouts");
+  });
+
+  it("gives parsed args precedence over config objects", function () {
+    expect(
+      parseMochaArgs(["--require", "./cli.js", "--timeout", "100"], defaults, {
+        require: ["./config.js"],
+        timeout: "200",
+      }),
+      "to satisfy",
+      {
+        require: ["./cli.js"],
+        timeout: "100",
+      },
+    );
+  });
+
+  it("preserves boolean negation including long alias negation", function () {
+    expect(
+      parseMochaArgs(
+        [
+          "--color",
+          "--no-color",
+          "--no-colors",
+          "--parallel",
+          "--no-parallel",
+          "--no-timeouts",
+        ],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        color: false,
+        parallel: false,
+        timeout: false,
+      },
+    );
+  });
+
+  it("coerces known boolean options in equals form", function () {
+    expect(
+      parseMochaArgs(["--color=false", "--parallel=true"], defaults),
+      "to satisfy",
+      {
+        color: false,
+        parallel: true,
+      },
+    );
+  });
+
+  it("coerces repeated number options to the last numeric value", function () {
+    expect(
+      parseMochaArgs(["--jobs", "2", "-j", "4", "--retries=3"], defaults),
+      "to satisfy",
+      {
+        jobs: 4,
+        retries: 3,
+      },
+    );
+  });
+
+  it("preserves unknown option negation", function () {
+    expect(parseMochaArgs(["--no-foo"], defaults), "to satisfy", {
+      foo: false,
+    });
+  });
+
+  it("keeps unknown options accepted in equals form", function () {
+    expect(parseMochaArgs(["--foo=bar"], defaults), "to satisfy", {
+      _: [],
+      foo: "bar",
+    });
+  });
+
+  it("treats separated unknown option values as positionals", function () {
+    expect(
+      parseMochaArgs(["--foo", "bar", "-x", "baz"], defaults),
+      "to satisfy",
+      {
+        _: ["bar", "baz"],
+        foo: true,
+        x: true,
+      },
+    );
+  });
+
+  it("treats the option terminator as the start of positionals", function () {
+    expect(
+      parseMochaArgs(["--", "--not-an-option", "test.js"], defaults),
+      "to satisfy",
+      {
+        _: ["--not-an-option", "test.js"],
+      },
+    );
+  });
+
+  it("accepts dash-prefixed option values in equals form", function () {
+    expect(parseMochaArgs(["--grep=-foo"], defaults), "to satisfy", {
+      grep: "-foo",
+    });
+  });
+
+  it("rejects dash-prefixed option values in separated form", function () {
+    expect(
+      () => parseMochaArgs(["--grep", "-foo"], defaults),
+      "to throw",
+      /Not enough arguments following: grep/,
+    );
+  });
+
+  it("preserves directly-passed Node and V8 flags", function () {
+    expect(
+      parseMochaArgs(
+        ["--trace-warnings", "--max-old-space-size=4096", "--conditions=dev"],
+        defaults,
+      ),
+      "to satisfy",
+      {
+        "trace-warnings": true,
+        "max-old-space-size": "4096",
+        conditions: "dev",
+      },
+    );
+  });
+
+  it("uses the last value for repeated directly-passed Node and V8 flags", function () {
+    expect(
+      parseMochaArgs(["--conditions=dev", "--conditions=test"], defaults),
+      "to satisfy",
+      {
+        conditions: "test",
+      },
+    );
+  });
+
+  it("uses native short option grouping behavior", function () {
+    expect(parseMochaArgs(["-bc"], defaults), "to satisfy", {
+      _: [],
+      bail: true,
+      color: true,
+    });
+  });
+
+  it("preserves numeric positional argument errors", function () {
+    expect(() => parseMochaArgs(["--delay", "123"], defaults), "to throw", {
+      message: "Mocha flag '--delay' given invalid option: '123'",
+      code: constants.INVALID_ARG_TYPE,
+      argument: 123,
+      actual: "number",
+      expected: "boolean",
+    });
+  });
+});

--- a/test/node-unit/cli/run.spec.cjs
+++ b/test/node-unit/cli/run.spec.cjs
@@ -1,22 +1,22 @@
 "use strict";
 
-const { builder } = require("../../../lib/cli/run.cjs");
-const { types } = require("../../../lib/cli/run-option-metadata.cjs");
+const {
+  getRunOptionDefinitions,
+  types,
+} = require("../../../lib/cli/run-option-metadata.cjs");
 
 describe("command", function () {
   describe("run", function () {
-    describe("builder", function () {
-      const IGNORED_OPTIONS = new Set(["help", "version"]);
-      const options = builder(require("yargs")()).getOptions();
+    describe("option metadata", function () {
       ["number", "string", "boolean", "array"].forEach((type) => {
         describe(`${type} type`, function () {
-          Array.from(new Set(options[type])).forEach((option) => {
-            if (!IGNORED_OPTIONS.has(option)) {
-              it(`should include option ${option}`, function () {
-                expect(types[type], "to contain", option);
+          getRunOptionDefinitions()
+            .filter((option) => option.type === type)
+            .forEach((option) => {
+              it(`should include option ${option.name}`, function () {
+                expect(types[type], "to contain", option.name);
               });
-            }
-          });
+            });
         });
       });
     });

--- a/test/node-unit/cli/unparse-args.spec.js
+++ b/test/node-unit/cli/unparse-args.spec.js
@@ -1,0 +1,101 @@
+import {
+  unparseMochaArgs,
+  unparseNodeFlags,
+} from "../../../lib/cli/unparse-args.js";
+
+describe("unparse-args", function () {
+  describe("unparseNodeFlags()", function () {
+    it("unparses Node and V8 flags using equals for values", function () {
+      expect(
+        unparseNodeFlags({
+          "trace-warnings": true,
+          "max-old-space-size": "4096",
+          inspect: "0.0.0.0:9229",
+        }),
+        "to equal",
+        [
+          "--trace-warnings",
+          "--max-old-space-size=4096",
+          "--inspect=0.0.0.0:9229",
+        ],
+      );
+    });
+
+    it("omits false and nullish Node and V8 flag values", function () {
+      expect(
+        unparseNodeFlags({
+          "trace-warnings": false,
+          conditions: undefined,
+          "zero-fill-buffers": null,
+        }),
+        "to equal",
+        [],
+      );
+    });
+  });
+
+  describe("unparseMochaArgs()", function () {
+    it("unparses positionals, booleans, scalars, and repeated arrays", function () {
+      expect(
+        unparseMochaArgs({
+          _: ["test/a.spec.js", "test/b.spec.js"],
+          require: ["tsx", "./setup.js"],
+          reporter: "json",
+          timeout: "0",
+          color: false,
+          bail: true,
+        }),
+        "to equal",
+        [
+          "test/a.spec.js",
+          "test/b.spec.js",
+          "--require",
+          "tsx",
+          "--require",
+          "./setup.js",
+          "--reporter",
+          "json",
+          "--timeout",
+          "0",
+          "--no-color",
+          "--bail",
+        ],
+      );
+    });
+
+    it("emits positionals first regardless of object insertion order", function () {
+      expect(
+        unparseMochaArgs({
+          reporter: "json",
+          _: ["test/a.spec.js"],
+        }),
+        "to equal",
+        ["test/a.spec.js", "--reporter", "json"],
+      );
+    });
+
+    it("omits absent positionals", function () {
+      expect(
+        unparseMochaArgs({
+          _: undefined,
+          reporter: "json",
+        }),
+        "to equal",
+        ["--reporter", "json"],
+      );
+    });
+
+    it("unparses reporter-option object values in yargs-unparser-compatible dotted form", function () {
+      expect(
+        unparseMochaArgs({
+          "reporter-option": {
+            foo: "bar",
+            baz: true,
+          },
+        }),
+        "to equal",
+        ["--reporter-option.foo", "bar", "--reporter-option.baz"],
+      );
+    });
+  });
+});

--- a/test/node-unit/cli/unparse-args.spec.js
+++ b/test/node-unit/cli/unparse-args.spec.js
@@ -85,7 +85,7 @@ describe("unparse-args", function () {
       );
     });
 
-    it("unparses reporter-option object values in legacy dotted form", function () {
+    it("unparses reporter-option object values in dotted form", function () {
       expect(
         unparseMochaArgs({
           "reporter-option": {
@@ -94,7 +94,7 @@ describe("unparse-args", function () {
           },
         }),
         "to equal",
-        ["--reporter-option.foo", "bar", "--reporter-option.baz"],
+        ["--reporter-option.foo=bar", "--reporter-option.baz"],
       );
     });
   });

--- a/test/node-unit/cli/unparse-args.spec.js
+++ b/test/node-unit/cli/unparse-args.spec.js
@@ -85,7 +85,7 @@ describe("unparse-args", function () {
       );
     });
 
-    it("unparses reporter-option object values in yargs-unparser-compatible dotted form", function () {
+    it("unparses reporter-option object values in legacy dotted form", function () {
       expect(
         unparseMochaArgs({
           "reporter-option": {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6122 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Replaces `yargs` command dispatching with [Node.js-native `util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig).

Stacked on:
- #6124
- #6125

This PR is actually a net reduction in lines of code. Ignoring test files, the PR total is +298/-397. Combined with those two stacked PRs, the total prod lines change comes out to +673/-577. Not bad!

### Behavior Changes

- `--help` output is now generated by Mocha instead of yargs, so exact formatting, grouping, and wrapping may differ while preserving the same user-facing information.
- `--version` / `-V` and `--help` / `-h` are handled before run preparation, so they print version/help output even when other options such as `--require` point to modules that cannot be loaded.

---

(Ref #6128 for paperwork issues)