### PR TITLE
docs: clarify CLI option help and parallel errors

### DIFF
--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -28,7 +28,7 @@ Rules & Behavior
       --dry-run                     Report tests without executing them[boolean]
       --exit                        Force Mocha to quit after tests complete
                                                                        [boolean]
-      --pass-on-failing-test-suite  Not fail test run if tests were failed
+      --pass-on-failing-test-suite  Pass test run if only error is test failures
                                                       [boolean] [default: false]
       --fail-hook-affected-tests    Report tests as failed when affected by hook
                                     failures (before/beforeEach)       [boolean]
@@ -37,7 +37,7 @@ Rules & Behavior
       --forbid-only                 Fail if exclusive test(s) encountered
                                                                        [boolean]
       --forbid-pending              Fail if pending test(s) encountered[boolean]
-      --global, --globals           List of allowed global variables     [array]
+      --global, --globals           List allowed global variables        [array]
   -j, --jobs                        Number of concurrent jobs for --parallel;
                                     use 1 to run in serial
                                    [number] [default: (number of CPU cores - 1)]

--- a/lib/cli/run-option-metadata.cjs
+++ b/lib/cli/run-option-metadata.cjs
@@ -111,13 +111,13 @@ const descriptions = {
   "fail-hook-affected-tests":
     "Report tests as failed when affected by hook failures (before/beforeEach)",
   "fail-zero": "Fail test run if no test(s) encountered",
-  "pass-on-failing-test-suite": "Not fail test run if tests were failed",
+  "pass-on-failing-test-suite": "Pass test run if only error is test failures",
   fgrep: "Only run tests containing this string",
   file: "Specify file(s) to be loaded prior to root suite execution",
   "forbid-only": "Fail if exclusive test(s) encountered",
   "forbid-pending": "Fail if pending test(s) encountered",
   "full-trace": "Display full stack traces",
-  global: "List of allowed global variables",
+  global: "List allowed global variables",
   grep: "Only run tests matching this string or regexp",
   ignore: "Ignore file(s) or glob pattern(s)",
   "inline-diffs":

--- a/lib/cli/run.cjs
+++ b/lib/cli/run.cjs
@@ -104,13 +104,13 @@ const validateRunOptions = (argv) => {
   if (argv.parallel) {
     if (argv.file) {
       throw createUnsupportedError(
-        "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --file",
+        "--parallel is mutually exclusive with --file",
       );
     }
 
     if (argv.sort) {
       throw createUnsupportedError(
-        "--parallel runs test files in a non-deterministic order, and is mutually exclusive with --sort",
+        "--parallel is mutually exclusive with --sort",
       );
     }
 


### PR DESCRIPTION
## Overview

Clarifies Mocha CLI help text and shortens `--parallel` conflict errors per #6165.

## Checklist

- [x] Addresses an existing open issue: fixes #6165
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Summary

- Clarify `--pass-on-failing-test-suite` and `--global` help text wording
- Shorten `--parallel` conflict errors with `--file` / `--sort`
- Keep the CLI docs help excerpt in sync

## Test plan

- [ ] Confirm `mocha --help` shows the updated descriptions
- [ ] Confirm `--parallel --file` and `--parallel --sort` still error with the shorter messages
- [ ] Existing parallel integration tests still match `/mutually exclusive with --file|sort/`