### PR TITLE
fix: add package.json exports to avoid DEP0151 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
   "homepage": "https://mochajs.org/",
   "logo": "https://cldup.com/S9uQ-cOLYz.svg",
   "notifyLogo": "https://ibin.co/4QuRuGjXvl36.png",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*"
+  },
   "bin": {
     "mocha": "./bin/mocha.js"
   },

--- a/test/integration/package-entrypoint.spec.cjs
+++ b/test/integration/package-entrypoint.spec.cjs
@@ -1,0 +1,48 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { invokeNode } = require("./helpers.cjs");
+
+describe("package entrypoint", function () {
+  it("should resolve the package root without DEP0151 warnings", async function () {
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-package-root-"));
+    const packageDir = path.join(tempDir, "node_modules", "mocha");
+
+    fs.mkdirSync(path.dirname(packageDir), { recursive: true });
+
+    try {
+      if (process.platform === "win32") {
+        fs.symlinkSync(repoRoot, packageDir, "junction");
+      } else {
+        fs.symlinkSync(repoRoot, packageDir);
+      }
+
+      const result = await new Promise((resolve, reject) => {
+        invokeNode(
+          [
+            "--input-type=module",
+            "-e",
+            "import {describe, it} from 'mocha'; console.log(typeof describe, typeof it);",
+          ],
+          (err, res) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve(res);
+          },
+          { cwd: tempDir, stdio: ["ignore", "pipe", "pipe"] },
+        );
+      });
+
+      expect(result.code, "to be", 0);
+      expect(result.output, "to contain", "function function");
+      expect(result.output, "not to contain", "DEP0151");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/integration/package-entrypoint.spec.cjs
+++ b/test/integration/package-entrypoint.spec.cjs
@@ -8,7 +8,9 @@ const { invokeNode } = require("./helpers.cjs");
 describe("package entrypoint", function () {
   it("should resolve the package root without DEP0151 warnings", async function () {
     const repoRoot = path.resolve(__dirname, "..", "..");
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-package-root-"));
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "mocha-package-root-"),
+    );
     const packageDir = path.join(tempDir, "node_modules", "mocha");
 
     fs.mkdirSync(path.dirname(packageDir), { recursive: true });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6147 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an `exports` map that points the package root to the existing `./index.js` entry point and keeps a wildcard subpath export so existing deep imports (e.g. `mocha/lib/reporters/*`) and browser bundle files remain reachable.

Node 22+ emits a `[DEP0151] DeprecationWarning` when an ES module package is resolved without an explicit `"main"` or `"exports"` field. Mocha 12 is now `"type": "module"`, so importing the package root triggered the warning.

`exports` is the modern alternative to `main`, supporting advanced features like pattern-matching and conditional exports. `main` is still supported. Because our project did not have either `exports` or `main` before this, we were implicitly exporting everything, and we must continue to do so to avoid a breaking change. Ref https://nodejs.org/api/packages.html#package-entry-points.

In the future, we can restrict what we export for future major versions of Mocha.