### PR TITLE
chore(repo): change stale threshold from 2+2 to 1+1

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,23 +16,23 @@ jobs:
       - uses: actions/stale@v10
         with:
           close-issue-message: >
-            This issue has been automatically closed after waiting 4 weeks with no response from the author.
+            This issue has been automatically closed after waiting 2 weeks with no response from the author.
             If you have more information to provide, please feel free to reopen this issue or open a new one.
           close-pr-message: >
-            This pull request has been automatically closed after waiting 4 weeks with no response from the author.
+            This pull request has been automatically closed after waiting 2 weeks with no response from the author.
             If you have more information to provide, please feel free to reopen this pull request or open a new one.
-          days-before-close: 14
-          days-before-stale: 14
+          days-before-close: 7
+          days-before-stale: 7
           only-labels: "status: waiting for author"
           operations-per-run: 100
           remove-stale-when-updated: true
           stale-issue-label: "status: stale"
           stale-issue-message: >
-            This issue has been waiting for a response from the author for 2 weeks with no activity.
-            If there is no further activity in the next 2 weeks, this issue will be automatically closed.
+            This issue has been waiting for a response from the author for 1 week with no activity.
+            If there is no further activity in the next 1 week, this issue will be automatically closed.
             Maintainers: to keep this issue open indefinitely, remove the "status: waiting for author" label.
           stale-pr-label: "status: stale"
           stale-pr-message: >
-            This pull request has been waiting for a response from the author for 2 weeks with no activity.
-            If there is no further activity in the next 2 weeks, this pull request will be automatically closed.
+            This pull request has been waiting for a response from the author for 1 week with no activity.
+            If there is no further activity in the next 1 week, this pull request will be automatically closed.
             Maintainers: to keep this pull request open indefinitely, remove the "status: waiting for author" label.


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes)
~- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)~
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Waiting 2 weeks per update was overkill, we've decided to wait 1 week per update instead.