### PR TITLE
fix(docs): restore homepage logo

### DIFF
--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -1,12 +1,9 @@
 ---
 import Default from "@astrojs/starlight/components/PageTitle.astro";
-import type { ComponentProps } from "astro/types";
 
 import HomepagePageTitle from "./HomepagePageTitle.astro";
 
-type Props = ComponentProps<typeof Default>;
-
-const isHomepage = Astro.props.slug === "";
+const isHomepage = Astro.locals.starlightRoute.id === "";
 ---
 
-{isHomepage ? <HomepagePageTitle /> : <Default {...Astro.props} />}
+{isHomepage ? <HomepagePageTitle /> : <Default />}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6182 
- [x]  That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Restore logo by reading the current route from Astro.locals.starlightRoute instead of Astro.props so the homepage gets its logo back.

To give background, the old check was Astro.props.slug === "". Starlight 0.32 stopped handing route data to component overrides so that's been undefined since we went from Starlight 0.28 to 0.37 in #5574. isHomepage was never true and the logo branch just never ran. What is honestly even more problematic is that literally nothing complained either because ComponentProps on a starlight component with no declared Props widens to Record<string, any> and astro check is happy either way.

I also dropped the dead Props type and the {...Astro.props} spread since starlight's migration guide says to remove them.

One other thing i noticed in that file: the "Last updated" "<time>" still has a Jekyll leftover as its `datetime`, `datetime="{{ 'now' | date: '%Y-%m-%dT%H:%M:%SZ' }}".` That is not a valid datetime.