### PR TITLE
fix(docs): restore spacing around footer links

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -3,6 +3,7 @@ import starlight from "@astrojs/starlight";
 import starlightBlog from "starlight-blog";
 
 export default defineConfig({
+  compressHTML: true,
   integrations: [
     starlight({
       components: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6184 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I decided to fix this one by pinning `compressHTML: true` which puts the spaces back around the footer links.

As you might have researched from my backing issue, astro 7 flipped the compressHTML default from true to "jsx". Under the new default, whitespace that touches a tag boundary gets deleted rather than collapsed so the line breaks in Footer.astro that used to render as spaces now render as nothing. Also why the footer has said "CopyrightOpenJS Foundationand Mocha contributors" on all 71 pages.

went with the config option instead of sprinkling `{" "}` through the footer prose. It gets back exactly the output we had from launch through Astro 6 and nobody has to redo it the next time they edit that file.
