### PR TITLE
test: keep stderr out of the JSON parsed by the FIFO test

### DIFF
--- a/test/integration/fifo.spec.cjs
+++ b/test/integration/fifo.spec.cjs
@@ -60,7 +60,7 @@ describe("FIFO support", function () {
           done(err);
         }
       },
-      { stdio: "pipe" },
+      { separateStderr: true, stdio: "pipe" },
     );
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6186 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fix by passing `separateStderr: true` in the FIFO test so warnings on stderr stop ending up in the JSON we parse.

This just makes the test robust. Mocha still prints that warning when you run it on 22.12.x which is the engines question in the issue.

$env:NODE_OPTIONS="--trace-require-module=all"; node bin/mocha.js test/integration/fifo.spec.cjs

Run that on main to see it fail then on this branch to see it pass. On bash it should be NODE_OPTIONS=--trace-require-module=all node bin/mocha.js test/integration/fifo.spec.cjs