### PR TITLE
refactor: convert lib/nodejs/file-unloader to ESM (#6010)

### DIFF
--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -467,7 +467,8 @@ Mocha.unloadFile = function (file) {
       "unloadFile() is only supported in a Node.js environment",
     );
   }
-  return require("./nodejs/file-unloader.cjs").unloadFile(file);
+  const { unloadFile } = require("./nodejs/file-unloader.js");
+  return unloadFile(file);
 };
 
 /**

--- a/lib/nodejs/file-unloader.js
+++ b/lib/nodejs/file-unloader.js
@@ -1,15 +1,17 @@
-"use strict";
-
 /**
  * This module should not be in the browser bundle, so it's here.
  * @private
  * @module
  */
 
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
 /**
  * Deletes a file from the `require` cache.
  * @param {string} file - File
  */
-exports.unloadFile = (file) => {
+export function unloadFile(file) {
   delete require.cache[require.resolve(file)];
-};
+}

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "supports-color": false,
     "./lib/nodejs/buffered-worker-pool.cjs": false,
     "./lib/nodejs/esm-utils.cjs": false,
-    "./lib/nodejs/file-unloader.cjs": false,
+    "./lib/nodejs/file-unloader.js": false,
     "./lib/nodejs/parallel-buffered-runner.cjs": false,
     "./lib/nodejs/serializer.js": false,
     "./lib/nodejs/worker.cjs": false,


### PR DESCRIPTION
<!-- PR title: refactor: convert lib/nodejs/file-unloader to ESM (#6010) -->

**You set the work.** #6010 (`status: accepting prs`): convert `lib/nodejs/file-unloader` to ESM, handling the `require.cache` interop that blocks a naive conversion.

**It's done.** Converted to `.js` ESM — not the `.mjs` the earlier attempt used, because #6078's flip to `"type": "module"` inverted the extension convention since this issue was filed (your own `serializer.mjs` → `serializer.js` rename in that sweep set the precedent). The `require.cache` interop is preserved via `createRequire(import.meta.url)` — the same idiom already used in `test/node-unit/cli/options.spec.js` — and verified with standalone CJS and ESM callers plus the existing `unloadFile()` regression test.

**Here's the evidence.**

- Fresh clone at `7cb26783`, patch applied, `npm ci --ignore-scripts`, then the network was disconnected.
- Unit suite in a clean `node:22-bookworm` container: **1,218 passing / 3 pending, 0 failing**.
- Locally beyond the container: integration, interfaces, jsapi, requires, reporters, only, smoke suites all passing; `format:check`, `lint`, `tsc`, and the Rollup build clean — with the browser bundle confirmed to contain zero `file-unloader` references (the `browser` field exclusion still works).
- Builds on closed PR #6026 (which stalled on CLA, not on review): same core approach, updated to current house style.

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `7cb267830c51d0b9a851086eb8d87013ee7663bd` |
| Container | `node:22-bookworm@sha256:5647be70…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f015512207f64e07efda20e880f38a437f6e7df4c70ed7bbc05f387d44dc0928c44807a10) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f0155122026a00c314e67cb1e851be4ccf7881ec2cda29e5e6f8c59825ff9871612f19aaf) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0x9cd36052a2eaa743597671f7a2eefa945e6cd003ec3673e640feac3a1f8eaec3) → [work delivered](https://sepolia.basescan.org/tx/0x28b0adcf91d5d736617fcb59adef08053e8bd78e87dcf14130e5d0c8a0ec1fc9) → [checks passed](https://sepolia.basescan.org/tx/0x53fc9f9777ea87743fffcb3f49073762655bd903e4535a5633147fb47c9bb6d2) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the change is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Closes #6010.

Changes: `lib/nodejs/file-unloader.cjs` → `lib/nodejs/file-unloader.js` with `export function unloadFile`; `import { createRequire } from "node:module"` for the cache interop (`require.cache` is process-global and backed by `Module._cache`, so a `createRequire`-derived `require` correctly deletes entries populated by unrelated CJS callers); `lib/mocha.cjs` call site destructures the named import (matching how `worker.cjs` consumes `serializer.js`); `package.json` `browser` field entry updated. `"use strict"` dropped — ESM is always strict, matching the merged `serializer.js` conversion.

### Notes for the reviewer

- The Playwright browser suite wasn't run locally; the file is excluded from the browser bundle via the `browser` field, and the built `mocha.js` was confirmed to contain no `file-unloader` references, so browser behaviour is unaffected by construction.
- `AGENTS.md`'s "CJS to ESM migration conventions" section still says `.mjs` — stale relative to post-#6078 practice; flagging rather than fixing, as it's out of scope here.
