### PR TITLE
docs: credit non-OpenCollective sponsors and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Also, your company's logo will show [on GitHub](https://github.com/mochajs/mocha
 [![MochaJS Sponsor](https://opencollective.com/mochajs/tiers/sponsors/2/avatar)](https://opencollective.com/mochajs/tiers/sponsors/2/website)
 [![MochaJS Sponsor](https://opencollective.com/mochajs/tiers/sponsors/3/avatar)](https://opencollective.com/mochajs/tiers/sponsors/3/website)
 
+### Tools & Services
+
+The Mocha project gratefully acknowledges the following organizations for providing tools and services that help us build, test, and host the project:
+
+- [JetBrains](https://www.jetbrains.com/) — WebStorm licenses for maintainers
+- [WallabyJS](https://wallabyjs.com/) — WallabyJS licenses for maintainers
+- [SauceLabs](https://saucelabs.com/) — cross-browser testing credits
+- [Travis CI](https://www.travis-ci.com/) — Linux/macOS CI
+- [AppVeyor](https://www.appveyor.com/) — Windows CI
+- [Coveralls](https://coveralls.io/) — code-coverage reporting
+- [Netlify](https://www.netlify.com/) — documentation site hosting
+
 ## Development
 
 You might want to know that:


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3627 (trivial docs change)
- [x] That issue was marked as \`status: accepting prs\`
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a new **Tools & Services** subsection under the existing **Sponsors** section of `README.md` so that organisations currently donating tools and services — but not surfaced by the OpenCollective backers/sponsors shields — are publicly credited.

It lists:

- **License donors**: JetBrains (WebStorm), WallabyJS
- **Cross-browser testing**: SauceLabs
- **CI**: Travis CI, AppVeyor
- **Coverage reporting**: Coveralls
- **Docs hosting**: Netlify

These were called out in #3627 as needed but not yet credited. The README is the only source for the sponsors listing consumed by both GitHub and mochajs.org.

## Links

- Issue: #3627

## Notes

- Documentation-only change; no code, tests, or build steps affected.
- I left the existing OpenCollective section untouched so sponsor tiers continue to render.
- Trimmed/service list per #3627. If maintainers prefer a logo grid instead of text links, let me know and I can replace this with sponsor logo assets (mocha already ships sponsor logo SVGs in `docs/`).