### PR TITLE
fix: report test error when afterEach fails before retry

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -979,7 +979,16 @@ Runner.prototype.runTests = function (suite, fn) {
 
             // Early return + hook trigger so that it doesn't
             // increment the count wrong
-            return self.hookUp(HOOK_TYPE_AFTER_EACH, next);
+            return self.hookUp(
+              HOOK_TYPE_AFTER_EACH,
+              function (hookErr, errSuite) {
+                if (hookErr) {
+                  self.fail(test, err);
+                  self.emit(constants.EVENT_TEST_END, test);
+                }
+                next(hookErr, errSuite);
+              },
+            );
           } else {
             self.fail(test, err);
           }

--- a/test/unit/runner.spec.cjs
+++ b/test/unit/runner.spec.cjs
@@ -528,6 +528,43 @@ describe("Runner", function () {
         });
       });
 
+      it("should report test failure when afterEach fails before a retry", function (done) {
+        var testErr = new Error("test error");
+        var hookErr = new Error("hook error");
+        var failed = [];
+
+        suite.retries(1);
+        suite.afterEach(function () {
+          throw hookErr;
+        });
+        suite.addTest(
+          new Test("im a test about bears", function () {
+            throw testErr;
+          }),
+        );
+
+        runner.on(EVENT_TEST_FAIL, function (runnable, err) {
+          failed.push({ runnable, err });
+        });
+
+        runner.run(function (failures) {
+          expect(failures, "to be", 2);
+          expect(
+            failed.some(function (failure) {
+              return failure.runnable instanceof Test && failure.err === testErr;
+            }),
+            "to be true",
+          );
+          expect(
+            failed.some(function (failure) {
+              return failure.runnable instanceof Hook && failure.err === hookErr;
+            }),
+            "to be true",
+          );
+          done();
+        });
+      });
+
       it("should not throw an exception if something emits EVENT_TEST_END with a non-Test object", function () {
         expect(function () {
           runner.emit(EVENT_TEST_END, {});


### PR DESCRIPTION
When a retryable test failed and its afterEach hook also failed, Mocha only reported the hook failure and hid the original test error.

The retry path ran afterEach before marking the test failed; this now reports the test error if afterEach aborts the retry.

Fixes #5007

Validation: npm run lint; npm run test-node:unit (1222 passing, 6 pending); npm run test-smoke (1 passing).