### PR TITLE
fix: align .browserslistrc node target with supported Node versions

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
-node >= 14
+node >= 20.19
 last 2 Chrome versions
 last 2 Edge versions
 last 2 Firefox versions


### PR DESCRIPTION
Node 14 reached EOL April 2023. Mocha's supported matrix is ^20.19.0 || >=22.12.0 (.github/DEVELOPMENT.md:8, AGENTS.md), but .browserslistrc still declared 'node >= 14'. This aligns the published bundle JS target to the minimum supported Node version (Node 20.19).