### PR TITLE
test: use a junction to link the config fixture on Windows

### DIFF
--- a/test/integration/config.spec.cjs
+++ b/test/integration/config.spec.cjs
@@ -75,12 +75,13 @@ describe("config", function () {
       var pkgName = "mocha-config";
       var installedLocally = false;
       var symlinkedPkg = false;
+      var linkType = process.platform === "win32" ? "junction" : "dir";
 
       before(function () {
         try {
           var srcPath = path.join(configDir, pkgName);
           var targetPath = path.join(nodeModulesDir, pkgName);
-          fs.symlinkSync(srcPath, targetPath, "dir");
+          fs.symlinkSync(srcPath, targetPath, linkType);
           symlinkedPkg = true;
           installedLocally = true;
         } catch (err) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5989
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fix by using a junction for the mocha-config fixture on Windows instead of a `"dir"` symlink.

Windows needs extra permissions for `"dir"` symlinks so `fs.symlinkSync` can fail with EPERM on normal setups. Junctions don't need those permissions so the test can actually run.

I looked at those 2 possibly AI-authored PRs to see what they done but they just ignored EPERM which would leave the test skipped on most devices. I used the same approach as package-entrypoint.spec.cjs.

Now i was not sure about this specific part if i should have removed but i left the EEXIST handling and console.error fallback so real setup errors still show up