### PR TITLE
fix: only reject positional args that are entirely numeric

### DIFF
--- a/lib/utils.cjs
+++ b/lib/utils.cjs
@@ -732,7 +732,7 @@ exports.breakCircularDeps = (inputObj) => {
  * Checks if provided input can be parsed as a JavaScript Number.
  */
 exports.isNumeric = (input) => {
-  return !isNaN(parseFloat(input));
+  return String(input).trim() !== "" && !isNaN(Number(input));
 };
 
 /**

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -787,6 +787,10 @@ describe("options", function () {
       it("does not throw error if numeric value is passed to an array flag", function () {
         expect(() => loadOptions(`--spec ${numericArg}`), "not to throw");
       });
+
+      it("does not throw error if a positional file name begins with a number", function () {
+        expect(() => loadOptions("1-spec.js"), "not to throw");
+      });
     });
 
     describe("when parsing throws a non-Mocha error", function () {

--- a/test/node-unit/utils.spec.cjs
+++ b/test/node-unit/utils.spec.cjs
@@ -55,6 +55,9 @@ describe("utils", function () {
       it("returns false for a string that cannot be parsed as a number", function () {
         expect(utils.isNumeric("foo"), "to equal", false);
       });
+      it("returns false for a string that only begins with a number", function () {
+        expect(utils.isNumeric("1-spec.js"), "to equal", false);
+      });
       it("returns false for empty string", function () {
         expect(utils.isNumeric(""), "to equal", false);
       });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6283
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`isNumeric` checks its input with `parseFloat`, which stops at the first character that cannot be part of a number. A spec file whose name starts with a digit, like `npx mocha 1-spec.js`, therefore counts as a numeric positional and the CLI bails out with `Option NaN is unsupported by the mocha cli`.

Comparing against `Number` instead makes the check look at the whole string, so bare numbers such as `mocha 123` still error while file names that merely begin with a digit run as before.

Note that #6221 is still in triage rather than labelled accepting prs, so feel free to close this if you want to discuss it first.