### PR TITLE
fix: fail nested tests when a beforeEach hook fails

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -651,27 +651,12 @@ Runner.prototype.hook = function (name, fn) {
         }
       } else if (err) {
         self.fail(hook, err);
-        // If failHookAffectedTests is enabled, mark affected tests as failed
-        if (self._opts.failHookAffectedTests) {
-          if (name === HOOK_TYPE_BEFORE_ALL) {
-            self.failAffectedTests(self.suite, err, hook.title);
-          } else if (name === HOOK_TYPE_BEFORE_EACH) {
-            // Fail the current test
-            if (self.test && !self.test.state) {
-              var testError = createHookSkipError(hook.title, err);
-
-              self.test.state = STATE_FAILED;
-              self.failures++;
-              self.emit(constants.EVENT_TEST_BEGIN, self.test);
-              self.emit(constants.EVENT_TEST_FAIL, self.test, testError);
-              self.emit(constants.EVENT_TEST_END, self.test);
-            }
-            // Store the hook error info for remaining tests
-            self._failedBeforeEachHook = {
-              error: err,
-              title: hook.title,
-            };
-          }
+        // before / beforeEach skip the rest of this suite tree; report those tests as failed
+        if (
+          self._opts.failHookAffectedTests &&
+          (name === HOOK_TYPE_BEFORE_ALL || name === HOOK_TYPE_BEFORE_EACH)
+        ) {
+          self.failAffectedTests(self.suite, err, hook.title);
         }
         // stop executing hooks, notify callee of hook err
         return fn(err);
@@ -827,33 +812,6 @@ Runner.prototype.runTests = function (suite, fn) {
   function hookErr(err, errSuite, after) {
     // before/after Each hook for errSuite failed:
     var orig = self.suite;
-
-    // If failHookAffectedTests is enabled and this is a beforeEach failure,
-    // mark remaining tests as failed
-    if (
-      self._opts.failHookAffectedTests &&
-      !after &&
-      self._failedBeforeEachHook
-    ) {
-      // Fail all remaining tests in the suite
-      var remainingTests = tests.slice();
-      remainingTests.forEach(function (t) {
-        if (!t.state) {
-          var testError = createHookSkipError(
-            self._failedBeforeEachHook.title,
-            self._failedBeforeEachHook.error,
-          );
-
-          t.state = STATE_FAILED;
-          self.failures++;
-          self.emit(constants.EVENT_TEST_BEGIN, t);
-          self.emit(constants.EVENT_TEST_FAIL, t, testError);
-          self.emit(constants.EVENT_TEST_END, t);
-        }
-      });
-      // Clear the stored hook info
-      delete self._failedBeforeEachHook;
-    }
 
     // for failed 'after each' hook start from errSuite parent,
     // otherwise start from errSuite itself

--- a/test/integration/fixtures/hooks/before-each-hook-error-with-fail-affected-nested.fixture.js
+++ b/test/integration/fixtures/hooks/before-each-hook-error-with-fail-affected-nested.fixture.js
@@ -1,0 +1,23 @@
+'use strict';
+
+describe('fails `beforeEach` hook', function () {
+  beforeEach(function () {
+    throw new Error('error in `beforeEach` hook');
+  });
+  it('direct test', function () {
+    // This should be reported as failed due to beforeEach hook failure
+  });
+  describe('nested suite', function () {
+    it('nested test 1', function () {
+      // This should be reported as failed due to the parent beforeEach hook failure
+    });
+    it('nested test 2', function () {
+      // This should be reported as failed due to the parent beforeEach hook failure
+    });
+  });
+});
+describe('passes normally', function () {
+  it('unaffected test', function () {
+    // This should pass normally
+  });
+});

--- a/test/integration/hook-err.spec.cjs
+++ b/test/integration/hook-err.spec.cjs
@@ -332,6 +332,32 @@ describe("hook error handling", function () {
       });
     });
 
+    describe("error in `beforeEach` hook with nested suites", function () {
+      it("should fail affected tests in nested suites", function (done) {
+        runMochaJSON(
+          "hooks/before-each-hook-error-with-fail-affected-nested.fixture.js",
+          ["--fail-hook-affected-tests"],
+          (err, res) => {
+            if (err) {
+              return done(err);
+            }
+            expect(res, "to have failed")
+              .and("to have failed test count", 4)
+              .and(
+                "to have failed test",
+                '"before each" hook for "direct test"',
+              )
+              .and("to have failed test", "direct test")
+              .and("to have failed test", "nested test 1")
+              .and("to have failed test", "nested test 2")
+              .and("to have passed test count", 1)
+              .and("to have passed test", "unaffected test");
+            done();
+          },
+        );
+      });
+    });
+
     describe("non-Error thrown in `before` hook", function () {
       it("should handle null, undefined, and other non-Error values", function (done) {
         runMochaJSON(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6132
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--fail-hook-affected-tests` already reports every remaining test under a failed `before` hook, including nested `describe`s. A failed `beforeEach` only marked leftover tests in the current suite, so nested tests disappeared from the run.

Route `beforeEach` through the same `failAffectedTests` walk as `before`. Added an integration fixture for the nested case.

Fixes #6132