### PR TITLE
fix: stringify cyclic objects with custom @@toStringTag

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -293,9 +293,10 @@ function estimateSize(val, maxDepth, seen) {
   if (type === "number" || type === "boolean") return 8;
   if (val === null || val === undefined) return 4;
 
-  // Avoid circular references
+  // Circular refs stringify to "[Circular]"; count them instead of
+  // treating the whole value as too complex to diff.
   if (type === "object") {
-    if (seen.has(val)) return -1;
+    if (seen.has(val)) return 12;
     seen.add(val);
 
     // Special handling for Buffers - they can be massive

--- a/lib/utils.cjs
+++ b/lib/utils.cjs
@@ -202,6 +202,96 @@ var canonicalType = (exports.canonicalType = function canonicalType(value) {
 });
 
 /**
+ * Built-in `Object.prototype.toString` tags (lowercased) plus Mocha's own
+ * `canonicalType` results. Custom `@@toStringTag` values are not listed.
+ */
+var knownTypeHints = {
+  arguments: true,
+  array: true,
+  arraybuffer: true,
+  asyncfunction: true,
+  asyncgenerator: true,
+  asyncgeneratorfunction: true,
+  bigint: true,
+  bigint64array: true,
+  biguint64array: true,
+  boolean: true,
+  buffer: true,
+  dataview: true,
+  date: true,
+  domwindow: true,
+  error: true,
+  finalizationregistry: true,
+  float16array: true,
+  float32array: true,
+  float64array: true,
+  function: true,
+  generator: true,
+  generatorfunction: true,
+  global: true,
+  int16array: true,
+  int32array: true,
+  int8array: true,
+  map: true,
+  module: true,
+  null: true,
+  "null-prototype": true,
+  number: true,
+  object: true,
+  promise: true,
+  regexp: true,
+  set: true,
+  sharedarraybuffer: true,
+  string: true,
+  symbol: true,
+  uint16array: true,
+  uint32array: true,
+  uint8array: true,
+  uint8clampedarray: true,
+  undefined: true,
+  weakmap: true,
+  weakref: true,
+  weakset: true,
+  window: true,
+};
+
+/**
+ * Remap a custom `@@toStringTag` (and fake `Date` tags) to a structured type
+ * so stringify/canonicalize walk properties instead of calling JSON.stringify.
+ *
+ * @param {*} value
+ * @param {string} typeHint
+ * @returns {string}
+ */
+function asStructuredTypeHint(value, typeHint) {
+  if (
+    typeHint === "date" &&
+    (value == null || typeof value.getTime !== "function")
+  ) {
+    return "object";
+  }
+
+  if (
+    knownTypeHints[typeHint] ||
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  ) {
+    return typeHint;
+  }
+
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (typeof value === "function") {
+    return "function";
+  }
+  if (Object.getPrototypeOf(value) === null) {
+    return "null-prototype";
+  }
+  return "object";
+}
+
+/**
  *
  * Returns a general type or data structure of a variable
  * @private
@@ -258,7 +348,7 @@ exports.type = function type(value) {
  * @return {string}
  */
 exports.stringify = function (value) {
-  var typeHint = canonicalType(value);
+  var typeHint = asStructuredTypeHint(value, canonicalType(value));
 
   if (!~["object", "array", "function", "null-prototype"].indexOf(typeHint)) {
     if (typeHint === "buffer") {
@@ -350,10 +440,27 @@ function jsonStringify(object, spaces, depth) {
         val = "[Buffer: " + jsonStringify(json, 2, depth + 1) + "]";
         break;
       default:
-        val =
-          val === "[Function]" || val === "[Circular]"
-            ? val
-            : JSON.stringify(val); // string
+        if (val === "[Function]" || val === "[Circular]") {
+          break;
+        }
+        try {
+          val = JSON.stringify(val);
+        } catch (err) {
+          // Built-in tagged objects (Map/Set/etc.) with circular own
+          // properties still hit this path; do not let the reporter throw.
+          if (
+            err instanceof TypeError &&
+            /circular|cyclic/i.test(err.message)
+          ) {
+            val = jsonStringify(
+              exports.canonicalize(val, null, "object"),
+              typeof spaces === "undefined" ? 2 : spaces,
+              (depth || 1) + 1,
+            );
+          } else {
+            throw err;
+          }
+        }
     }
     return val;
   }
@@ -402,7 +509,7 @@ exports.canonicalize = function canonicalize(value, stack, typeHint) {
 
   var prop;
 
-  typeHint = typeHint || canonicalType(value);
+  typeHint = asStructuredTypeHint(value, typeHint || canonicalType(value));
   function withStack(value, fn) {
     stack.push(value);
     fn();

--- a/test/reporters/base.spec.cjs
+++ b/test/reporters/base.spec.cjs
@@ -367,6 +367,28 @@ describe("Base reporter", function () {
     expect(errOut, "to match", /\+ expected/);
   });
 
+  it("should stringify circular objects with a custom @@toStringTag", function () {
+    var err = new Error("test");
+    var actual = { x: 1, [Symbol.toStringTag]: "CustomTag" };
+    actual.self = actual;
+    var expected = { x: 2, [Symbol.toStringTag]: "CustomTag" };
+    expected.self = expected;
+    err.actual = actual;
+    err.expected = expected;
+    err.showDiff = true;
+    var test = makeTest(err);
+
+    expect(function () {
+      list([test]);
+    }, "not to throw");
+
+    var errOut = stdout.join("\n");
+    expect(errOut, "to match", /\[Circular]/);
+    expect(errOut, "to match", /"x"/);
+    expect(errOut, "to match", /- actual/);
+    expect(errOut, "to match", /\+ expected/);
+  });
+
   it("should handle error messages that are not strings", function () {
     try {
       assert(false, true);

--- a/test/unit/reporters/base-diff-protection.spec.cjs
+++ b/test/unit/reporters/base-diff-protection.spec.cjs
@@ -126,5 +126,19 @@ describe("Base reporter diff hang protection", function () {
       var output = stdout.join("");
       chaiExpect(output).to.not.contain("too large to diff");
     });
+
+    it("should still produce a valid diff for small circular objects", function () {
+      var actual = { x: 1 };
+      actual.self = actual;
+      var expected = { x: 2 };
+      expected.self = expected;
+      var test = makeFailedTest("small circular test", actual, expected);
+
+      list([test]);
+
+      var output = stdout.join("");
+      chaiExpect(output).to.not.contain("too large to diff");
+      chaiExpect(output).to.contain("[Circular]");
+    });
   });
 });

--- a/test/unit/utils.spec.cjs
+++ b/test/unit/utils.spec.cjs
@@ -368,6 +368,58 @@ describe("lib/utils", function () {
       expect(stringify(travis), "to be", '{\n  "fn": [Circular]\n}');
     });
 
+    it("should stringify objects with a custom @@toStringTag", function () {
+      var obj = { x: 1, [Symbol.toStringTag]: "CustomTag" };
+
+      expect(stringify(obj), "to be", '{\n  "x": 1\n}');
+    });
+
+    it("should handle circular objects with a custom @@toStringTag", function () {
+      var obj = { x: 1, [Symbol.toStringTag]: "CustomTag" };
+      obj.self = obj;
+
+      expect(stringify(obj), "to be", '{\n  "self": [Circular]\n  "x": 1\n}');
+    });
+
+    it("should handle circular objects whose prototype defines @@toStringTag", function () {
+      function Custom() {
+        this.x = 1;
+      }
+      Custom.prototype[Symbol.toStringTag] = "CustomTag";
+      var obj = new Custom();
+      obj.self = obj;
+
+      expect(stringify(obj), "to be", '{\n  "self": [Circular]\n  "x": 1\n}');
+    });
+
+    it("should handle nested circular objects with a custom @@toStringTag", function () {
+      var inner = { x: 1, [Symbol.toStringTag]: "CustomTag" };
+      inner.self = inner;
+
+      expect(
+        stringify({ inner: inner }),
+        "to be",
+        '{\n  "inner": {\n    "self": [Circular]\n    "x": 1\n  }\n}',
+      );
+    });
+
+    it("should not treat a non-Date with @@toStringTag Date as a Date", function () {
+      var obj = { x: 1, [Symbol.toStringTag]: "Date" };
+      obj.self = obj;
+
+      expect(stringify(obj), "to be", '{\n  "self": [Circular]\n  "x": 1\n}');
+    });
+
+    it("should not throw on a circular Map with extra properties", function () {
+      var map = new Map();
+      map.self = map;
+
+      expect(function () {
+        stringify(map);
+      }, "not to throw");
+      expect(stringify(map), "to contain", "[Circular]");
+    });
+
     it("should handle various non-undefined, non-null, non-object, non-array, non-date, and non-function values", function () {
       var regexp = /(?:)/;
       var regExpObj = { regexp };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5641
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`canonicalType()` uses `Object.prototype.toString`, so a custom `@@toStringTag` becomes a type name that stringify does not handle. The diff reporter then called `JSON.stringify` on the raw object and threw `TypeError: Converting circular structure to JSON`.

Remap unknown tags (and fake `Date` tags) to object so canonicalize walks properties and emits `[Circular]`. Also count cycles in the reporter size estimate instead of treating them as too large to diff.

Fixes #5641