### PR TITLE
fix: stringify empty null-prototype objects without crashing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,6 +108,7 @@ function emptyRepresentation(value, typeHint) {
   switch (typeHint) {
     case "function":
       return "[Function]";
+    case "null-prototype":
     case "object":
       return "{}";
     case "array":

--- a/test/integration/fixtures/regression/issue-5507.fixture.js
+++ b/test/integration/fixtures/regression/issue-5507.fixture.js
@@ -1,0 +1,5 @@
+"use strict";
+
+it("t", async function () {
+  require("node:assert").deepEqual(Object.create(null), { a: 1 });
+});

--- a/test/integration/regression.spec.js
+++ b/test/integration/regression.spec.js
@@ -75,4 +75,18 @@ describe("regressions", function () {
       done();
     });
   });
+
+  it("issue-5507: null-prototype assertion diffs should exit non-zero", function (done) {
+    run("regression/issue-5507.fixture.js", [], function (err, res) {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(res, "to have failed")
+        .and("to have failed test count", 1)
+        .and("to have passed test count", 0);
+      expect(res.output, "not to contain", "toString is not a function");
+      done();
+    });
+  });
 });

--- a/test/reporters/base.spec.js
+++ b/test/reporters/base.spec.js
@@ -367,6 +367,22 @@ describe("Base reporter", function () {
     expect(errOut, "to match", /\+ expected/);
   });
 
+  it("should stringify empty Object.create(null)", function () {
+    var err = new Error("test");
+    err.actual = Object.create(null);
+    err.expected = { a: 1 };
+    err.showDiff = true;
+    var test = makeTest(err);
+
+    list([test]);
+
+    var errOut = stdout.join("\n");
+    expect(errOut, "to match", /test/);
+    expect(errOut, "to match", /- actual/);
+    expect(errOut, "to match", /\+ expected/);
+    expect(errOut, "not to match", /toString is not a function/);
+  });
+
   it("should handle error messages that are not strings", function () {
     try {
       assert(false, true);

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -538,6 +538,10 @@ describe("lib/utils", function () {
       expect(stringify(a), "to be", '{\n  "foo": 1\n}');
     });
 
+    it("should stringify an empty object without an Object prototype", function () {
+      expect(stringify(Object.create(null)), "to be", "{}");
+    });
+
     // In old version node.js, Symbol is not available by default.
     if (typeof global.Symbol === "function") {
       it("should handle Symbol", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5507
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

On v11, stringifying an empty `Object.create(null)` for a reporter diff called `value.toString()`, which throws. That error escaped the default reporter's `fail` handler as an `unhandledRejection` and Mocha exited 0 with no failure output.

This backports the v12 `emptyRepresentation` handling: empty null-prototype objects stringify as `{}`. The original assertion failure is reported and the process exits non-zero.

Fixes #5507