### PR TITLE
fix: show skipped instead of pending for this.skip()

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -20,6 +20,7 @@ import Runner from "../runner.cjs";
 const { constants } = Runner;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
+var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
 
 const isBrowser = utils.isBrowser();
 
@@ -65,6 +66,9 @@ export class Base {
     this.options = options || {};
     this.runner = runner;
     this.stats = runner.stats; // assigned so Reporters keep a closer reference
+    this._skipped = 0;
+    this._pendingOnly = 0;
+    var self = this;
 
     var maxDiffSizeOpt =
       this.options.reporterOption && this.options.reporterOption.maxDiffSize;
@@ -94,6 +98,14 @@ export class Base {
       }
       failures.push(test);
     });
+
+    runner.on(EVENT_TEST_PENDING, function (test) {
+      if (test && test.skipped) {
+        self._skipped++;
+      } else {
+        self._pendingOnly++;
+      }
+    });
   }
 
   /**
@@ -116,8 +128,20 @@ export class Base {
 
     Base.consoleLog(fmt, stats.passes || 0, milliseconds(stats.duration));
 
-    // pending
-    if (stats.pending) {
+    // pending / skipped (this.skip() is skipped; empty it() stays pending)
+    if (this._pendingOnly) {
+      fmt = Base.color("pending", " ") + Base.color("pending", " %d pending");
+
+      Base.consoleLog(fmt, this._pendingOnly);
+    }
+
+    if (this._skipped) {
+      fmt = Base.color("pending", " ") + Base.color("pending", " %d skipped");
+
+      Base.consoleLog(fmt, this._skipped);
+    }
+
+    if (!this._pendingOnly && !this._skipped && stats.pending) {
       fmt = Base.color("pending", " ") + Base.color("pending", " %d pending");
 
       Base.consoleLog(fmt, stats.pending);

--- a/lib/reporters/github-actions.js
+++ b/lib/reporters/github-actions.js
@@ -135,7 +135,13 @@ class GithubActions extends Spec {
             ms(this.stats.duration) +
             ")",
         );
-        if (this.stats.pending) {
+        if (this._pendingOnly) {
+          lines.push(":pause_button: " + this._pendingOnly + " pending");
+        }
+        if (this._skipped) {
+          lines.push(":fast_forward: " + this._skipped + " skipped");
+        }
+        if (!this._pendingOnly && !this._skipped && this.stats.pending) {
           lines.push(":pause_button: " + this.stats.pending + " pending");
         }
         if (this.stats.failures) {

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -226,10 +226,15 @@ class HTML extends Base {
     });
 
     runner.on(EVENT_TEST_PENDING, function (test) {
+      var kind = test.skipped ? "skipped" : "pending";
       var el = fragment(
-        '<li class="test pass pending"><h2>%e</h2></li>',
+        '<li class="test pass %s"><h2>%e</h2></li>',
+        kind,
         test.title,
       );
+      if (test.skipped && test.body) {
+        self.addCodeToggle(el, test.body);
+      }
       appendToStack(el);
       updateStats();
     });

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -48,7 +48,11 @@ class List extends Base {
     });
 
     runner.on(EVENT_TEST_PENDING, function (test) {
-      var fmt = color("checkmark", "  -") + color("pending", " %s");
+      var fmt = test.skipped
+        ? color("checkmark", "  -") +
+          color("pending", " %s") +
+          color("pending", " (skipped)")
+        : color("checkmark", "  -") + color("pending", " %s");
       Base.consoleLog(fmt, test.fullTitle());
     });
 

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -61,7 +61,9 @@ class Spec extends Base {
     });
 
     runner.on(EVENT_TEST_PENDING, function (test) {
-      var fmt = indent() + color("pending", "  - %s");
+      var fmt = test.skipped
+        ? indent() + color("pending", "  - %s") + color("pending", " (skipped)")
+        : indent() + color("pending", "  - %s");
       Base.consoleLog(fmt, test.title);
     });
 

--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -59,6 +59,7 @@ class Runnable extends EventEmitter {
     this.timedOut = false;
     this._currentRetry = 0;
     this.pending = false;
+    this.skipped = false;
     delete this.state;
     delete this.err;
   }
@@ -137,6 +138,7 @@ class Runnable extends EventEmitter {
    */
   skip() {
     this.pending = true;
+    this.skipped = true;
     throw new PendingError("sync skip; aborting execution");
   }
 
@@ -323,6 +325,7 @@ class Runnable extends EventEmitter {
       // allows skip() to be used in an explicit async context
       this.skip = function asyncSkip() {
         this.pending = true;
+        this.skipped = true;
         done();
         // halt execution, the uncaught handler will ignore the failure.
         throw new PendingError("async skip; aborting execution");

--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -627,10 +627,12 @@ Runner.prototype.hook = function (name, fn) {
           // TODO define and implement use case
           if (self.test) {
             self.test.pending = true;
+            self.test.skipped = true;
           }
         } else if (name === HOOK_TYPE_BEFORE_EACH) {
           if (self.test) {
             self.test.pending = true;
+            self.test.skipped = true;
           }
           self.emit(constants.EVENT_HOOK_END, hook);
           hook.pending = false; // activates hook for next test
@@ -638,6 +640,7 @@ Runner.prototype.hook = function (name, fn) {
         } else if (name === HOOK_TYPE_BEFORE_ALL) {
           suite.tests.forEach(function (test) {
             test.pending = true;
+            test.skipped = true;
           });
           suite.suites.forEach(function (suite) {
             suite.pending = true;

--- a/lib/test.js
+++ b/lib/test.js
@@ -94,6 +94,7 @@ class Test extends Runnable {
         $$fullTitle: this.parent.fullTitle(),
         [MOCHA_ID_PROP_NAME]: this.parent.id,
       },
+      skipped: Boolean(this.skipped),
       speed: this.speed,
       state: this.state,
       title: this.title,

--- a/mocha.css
+++ b/mocha.css
@@ -144,6 +144,11 @@ body {
   font-family: arial, sans-serif;
 }
 
+#mocha .test.skipped:hover h2::after {
+  content: "(skipped)";
+  font-family: arial, sans-serif;
+}
+
 #mocha .test.pass.medium .duration {
   background: var(--mocha-test-pass-mediump-color);
 }
@@ -180,11 +185,13 @@ body {
   display: none;
 }
 
-#mocha .test.pending {
+#mocha .test.pending,
+#mocha .test.skipped {
   color: var(--mocha-test-pending-color);
 }
 
-#mocha .test.pending::before {
+#mocha .test.pending::before,
+#mocha .test.skipped::before {
   content: "◦";
   color: var(--mocha-test-pending-icon-color);
 }
@@ -327,7 +334,8 @@ body {
 #mocha-report.pending .test.fail {
   display: none;
 }
-#mocha-report.pending .test.pass.pending {
+#mocha-report.pending .test.pass.pending,
+#mocha-report.pending .test.pass.skipped {
   display: block;
 }
 

--- a/test/integration/reporters.spec.cjs
+++ b/test/integration/reporters.spec.cjs
@@ -7,6 +7,43 @@ var path = require("node:path");
 var run = require("./helpers.cjs").runMocha;
 
 describe("reporters", function () {
+  describe("spec", function () {
+    it("labels this.skip() as skipped instead of pending", function (done) {
+      run(
+        "pending/skip-sync-spec.fixture.cjs",
+        ["--reporter", "spec"],
+        function (err, res) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(res.output, "to contain", "should skip immediately (skipped)");
+          expect(res.output, "to contain", "1 skipped");
+          expect(res.output, "not to contain", "1 pending");
+          done();
+        },
+      );
+    });
+
+    it("still labels unimplemented tests as pending", function (done) {
+      run(
+        "pending/spec.fixture.js",
+        ["--reporter", "spec"],
+        function (err, res) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(res.output, "to contain", "pending spec");
+          expect(res.output, "to contain", "1 pending");
+          expect(res.output, "not to contain", "(skipped)");
+          expect(res.output, "not to contain", "1 skipped");
+          done();
+        },
+      );
+    });
+  });
+
   describe("markdown", function () {
     var res;
 

--- a/test/reporters/list.spec.cjs
+++ b/test/reporters/list.spec.cjs
@@ -80,6 +80,30 @@ describe("List reporter", function () {
 
         expect(stdout[0], "to equal", "  - " + expectedTitle + "\n");
       });
+
+      it("should label this.skip() as skipped instead of pending", async function () {
+        var skippedTest = {
+          fullTitle: function () {
+            return expectedTitle;
+          },
+          skipped: true,
+        };
+        var runner = createMockRunner(
+          "pending test",
+          EVENT_TEST_PENDING,
+          null,
+          null,
+          skippedTest,
+        );
+        var options = {};
+        var fakeThis = {
+          epilogue: noop,
+        };
+        var { stdout } = await runReporter(fakeThis, runner, options);
+        sinon.restore();
+
+        expect(stdout[0], "to equal", "  - " + expectedTitle + " (skipped)\n");
+      });
     });
 
     describe("on 'pass' event", function () {

--- a/test/reporters/spec.spec.cjs
+++ b/test/reporters/spec.spec.cjs
@@ -69,6 +69,26 @@ describe("Spec reporter", function () {
         var expectedArray = ["  - " + expectedTitle + "\n"];
         expect(stdout, "to equal", expectedArray);
       });
+
+      it("should label this.skip() as skipped instead of pending", async function () {
+        var test = {
+          title: expectedTitle,
+          skipped: true,
+        };
+        var runner = createMockRunner(
+          "pending test",
+          EVENT_TEST_PENDING,
+          null,
+          null,
+          test,
+        );
+        var options = {};
+        var { stdout } = await runReporter({ epilogue: noop }, runner, options);
+        sinon.restore();
+
+        var expectedArray = ["  - " + expectedTitle + " (skipped)\n"];
+        expect(stdout, "to equal", expectedArray);
+      });
     });
 
     describe("on 'pass' event", function () {

--- a/test/unit/runnable.spec.cjs
+++ b/test/unit/runnable.spec.cjs
@@ -237,6 +237,18 @@ describe("Runnable(title, fn)", function () {
     });
 
     describe("when sync", function () {
+      it("this.skip() should mark the runnable as skipped", function (done) {
+        var runnable = new Runnable("foo", function () {
+          runnable.skip();
+        });
+        runnable.run(function (err) {
+          expect(err, "to be undefined");
+          expect(runnable.pending, "to be true");
+          expect(runnable.skipped, "to be true");
+          done();
+        });
+      });
+
       describe("without error", function () {
         it("should invoke the callback", function (done) {
           var spy = sinon.spy();
@@ -634,6 +646,7 @@ describe("Runnable(title, fn)", function () {
         runnable.run(function (err) {
           expect(err, "to be undefined");
           expect(runnable.pending, "to be true");
+          expect(runnable.skipped, "to be true");
           done();
         });
       });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5138
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`this.skip()` was reported as pending, the same label used for unimplemented tests (`it('title')` with no callback). That made skipped tests look unfinished.

This keeps the pending event and stats as they are, and only changes the displayed text:

- `this.skip()` is marked `skipped` and reporters show "skipped"
- unimplemented tests still show "pending"

HTML hover text is `(skipped)` for `this.skip()` and `(pending)` otherwise. Spec/list append `(skipped)` for skipped tests, and the epilogue reports skipped vs pending separately.

Fixes #5138