### PR TITLE
fix: keep running tests when a file has a syntax error

### DIFF
--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -387,12 +387,35 @@ Mocha.prototype.ui = function (ui) {
 };
 
 /**
+ * Records a syntax error while loading a test file as a failing test so
+ * remaining files still run. Other load errors are rethrown.
+ *
+ * @param {import("./suite.js").Suite} suite - Suite that would have received the file's tests
+ * @param {string} file - File that failed to load
+ * @param {Error} err - Load error
+ * @private
+ */
+function handleFileLoadError(suite, file, err) {
+  if (!(err instanceof SyntaxError)) {
+    throw err;
+  }
+  var Test = require("./test.js").Test;
+  var filename = path.resolve(file);
+  var test = new Test(file, function () {
+    throw err;
+  });
+  test.file = filename;
+  suite.addTest(test);
+}
+
+/**
  * Loads `files` prior to execution. Does not support ES Modules.
  *
  * @description
  * The implementation relies on Node's `require` to execute
  * the test interface functions and will be subject to its cache.
  * Supports only CommonJS modules. To load ES modules, use Mocha#loadFilesAsync.
+ * If a file has a syntax error, a failing test is added and remaining files are still loaded.
  *
  * @private
  * @see {@link Mocha#addFile}
@@ -407,8 +430,12 @@ Mocha.prototype.loadFiles = function (fn) {
   this.files.forEach(function (file) {
     file = path.resolve(file);
     suite.emit(EVENT_FILE_PRE_REQUIRE, global, file, self);
-    suite.emit(EVENT_FILE_REQUIRE, require(file), file, self);
-    suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
+    try {
+      suite.emit(EVENT_FILE_REQUIRE, require(file), file, self);
+      suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
+    } catch (err) {
+      handleFileLoadError(suite, file, err);
+    }
   });
   fn && fn();
 };
@@ -420,6 +447,7 @@ Mocha.prototype.loadFiles = function (fn) {
  * The implementation relies on Node's `require` and `import` to execute
  * the test interface functions and will be subject to its cache.
  * Supports both CJS and ESM modules.
+ * If a file has a syntax error, a failing test is added and remaining files are still loaded.
  *
  * @public
  * @see {@link Mocha#addFile}
@@ -450,6 +478,9 @@ Mocha.prototype.loadFilesAsync = function ({ esmDecorator } = {}) {
       suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
     },
     esmDecorator,
+    function (file, err) {
+      handleFileLoadError(suite, file, err);
+    },
   );
 };
 

--- a/lib/nodejs/esm-utils.cjs
+++ b/lib/nodejs/esm-utils.cjs
@@ -169,13 +169,22 @@ exports.loadFilesAsync = async (
   preLoadFunc,
   postLoadFunc,
   esmDecorator,
+  onLoadError,
 ) => {
   for (const file of files) {
     preLoadFunc(file);
-    const result = await exports.requireOrImport(
-      resolveFile(file),
-      esmDecorator,
-    );
-    postLoadFunc(file, result);
+    try {
+      const result = await exports.requireOrImport(
+        resolveFile(file),
+        esmDecorator,
+      );
+      postLoadFunc(file, result);
+    } catch (err) {
+      if (typeof onLoadError === "function") {
+        onLoadError(file, err);
+      } else {
+        throw err;
+      }
+    }
   }
 };

--- a/test/integration/fixtures/regression/issue-5288-syntax-error.fixture.js
+++ b/test/integration/fixtures/regression/issue-5288-syntax-error.fixture.js
@@ -1,0 +1,3 @@
+// Intentionally invalid so Mocha reports this file as a failed test
+it("should never run because of a syntax error here", => {
+});

--- a/test/integration/options/watch.spec.cjs
+++ b/test/integration/options/watch.spec.cjs
@@ -56,14 +56,18 @@ describe("--watch", function () {
 
       replaceFileContents(testFile, "done();", "done((;");
 
-      return runMochaWatchJSONAsync(
-        [testFile],
-        { cwd: tempDir, firstRunCrashPattern: /SyntaxError/, expectedRuns: 1 },
-        () => {
-          replaceFileContents(testFile, "done((;", "done();");
-        },
-      ).then((results) => {
-        expect(results, "to have length", 1);
+      return runMochaWatchJSONAsync([testFile], tempDir, () => {
+        replaceFileContents(testFile, "done((;", "done();");
+      }).then((results) => {
+        expect(results, "to have length", 2);
+        expect(results[0].stats.failures, "to be", 1);
+        expect(
+          results[0].failures[0].err.stack ||
+            results[0].failures[0].err.message,
+          "to match",
+          /SyntaxError/,
+        );
+        expect(results[1].stats.failures, "to be", 0);
       });
     });
 

--- a/test/integration/regression.spec.cjs
+++ b/test/integration/regression.spec.cjs
@@ -2,6 +2,7 @@
 
 var run = require("./helpers.cjs").runMocha;
 var runJSON = require("./helpers.cjs").runMochaJSON;
+var { resolveFixturePath, runMochaJSONAsync } = require("./helpers.cjs");
 
 describe("regressions", function () {
   it("issue-1991: Declarations do not get cleaned up unless you set them to `null` - Memory Leak", function (done) {
@@ -81,6 +82,24 @@ describe("regressions", function () {
           .and("to have passed test count", 1);
         done();
       },
+    );
+  });
+
+  it("issue-5288: should continue running tests after a file with a syntax error", async function () {
+    const res = await runMochaJSONAsync("passing.fixture.cjs", [
+      resolveFixturePath("regression/issue-5288-syntax-error.fixture.js"),
+    ]);
+
+    expect(res, "to have failed")
+      .and("to have passed test count", 2)
+      .and("to have failed test count", 1)
+      .and("to have passed test", "test1")
+      .and("to have passed test", "test2");
+    expect(res.failures[0].file, "to contain", "issue-5288-syntax-error");
+    expect(
+      res.failures[0].err.stack || res.failures[0].err.message,
+      "to match",
+      /SyntaxError/,
     );
   });
 });

--- a/test/node-unit/esm-utils.spec.cjs
+++ b/test/node-unit/esm-utils.spec.cjs
@@ -144,5 +144,44 @@ describe("esm-utils", function () {
         },
       );
     });
+
+    it("should invoke onLoadError and continue loading remaining files", async function () {
+      const syntaxError = new SyntaxError("Unexpected token");
+      esmUtils.doImport.onFirstCall().rejects(syntaxError);
+      esmUtils.doImport.onSecondCall().resolves({});
+      const onLoadError = sinon.spy();
+      const loaded = [];
+
+      await esmUtils.loadFilesAsync(
+        ["/foo/bad.mjs", "/foo/good.mjs"],
+        () => {},
+        (file) => {
+          loaded.push(file);
+        },
+        undefined,
+        onLoadError,
+      );
+
+      expect(onLoadError, "to have a call satisfying", [
+        "/foo/bad.mjs",
+        syntaxError,
+      ]).and("was called once");
+      expect(loaded, "to equal", ["/foo/good.mjs"]);
+    });
+
+    it("should still reject when a file fails to load without onLoadError", async function () {
+      esmUtils.doImport.rejects(new SyntaxError("Unexpected token"));
+
+      return expect(
+        () =>
+          esmUtils.loadFilesAsync(
+            ["/foo/bad.mjs"],
+            () => {},
+            () => {},
+          ),
+        "to be rejected with error satisfying",
+        { name: "SyntaxError" },
+      );
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5288
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

A syntax error in one test file currently aborts the whole run (`Exception during run: SyntaxError...`) before remaining files load, so reporters never see the failure and valid files never run.

This treats a `SyntaxError` while loading a file as a failing test and continues loading the rest. Other load-time errors (including Mocha policy errors such as `--forbid-only`) still abort as before.

Fixes #5288