### PR TITLE
fix: keep nested-suite failure when parent teardown also fails

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -196,6 +196,13 @@ class Runner extends EventEmitter {
     this.total = suite.total();
     this.failures = 0;
     /**
+     * Primary failures already reported. Used so an ancestor teardown
+     * error can be attached to a nested-suite failure instead of
+     * replacing or independently counting it.
+     * @type {Array<{runnable: Runnable, err: Error}>}
+     */
+    this._reportedFailures = [];
+    /**
      * @type {Map<EventEmitter,Map<string,Set<EventListener>>>}
      */
     this._eventListeners = new Map();
@@ -545,32 +552,30 @@ Runner.prototype.fail = function (test, err, force) {
     );
   }
 
-  ++this.failures;
-  debug("total number of failures: %d", this.failures);
-  test.state = STATE_FAILED;
-
   if (!isError(err)) {
     err = thrown2Error(err);
   }
 
-  // Filter the stack traces
-  if (!this.fullStackTrace) {
-    const alreadyFiltered = new Set();
-    let currentErr = err;
+  filterErrorStacks(err, this.fullStackTrace);
 
-    while (currentErr && currentErr.stack && !alreadyFiltered.has(currentErr)) {
-      alreadyFiltered.add(currentErr);
-
-      try {
-        currentErr.stack = stackFilter(currentErr.stack);
-      } catch {
-        // Ignore error as some environments do not take kindly to monkeying with the stack
-      }
-
-      currentErr = currentErr.cause;
+  // Parent after/afterEach/afterAll after a nested-suite failure:
+  // keep the original nested error as the primary report.
+  if (isTeardownHook(test) && this._reportedFailures.length) {
+    var origin = findDescendantFailure(this._reportedFailures, test.parent);
+    if (origin && attachSecondaryError(origin.err, err)) {
+      debug(
+        "fail(): attached parent teardown error to nested failure %s",
+        origin.runnable.title,
+      );
+      return;
     }
   }
 
+  ++this.failures;
+  debug("total number of failures: %d", this.failures);
+  test.state = STATE_FAILED;
+
+  this._reportedFailures.push({ runnable: test, err: err });
   this.emit(constants.EVENT_TEST_FAIL, test, err);
 };
 
@@ -1383,6 +1388,123 @@ function filterLeaks(ok, globals) {
     });
     return !matched.length && (!global.navigator || key !== "onerror");
   });
+}
+
+/**
+ * Whether `runnable` is an after/afterEach hook registered on its suite.
+ *
+ * @private
+ * @param {Runnable} runnable
+ * @returns {boolean}
+ */
+function isTeardownHook(runnable) {
+  if (!runnable || runnable.type !== "hook" || !runnable.parent) {
+    return false;
+  }
+  var parent = runnable.parent;
+  return (
+    (Array.isArray(parent._afterAll) &&
+      parent._afterAll.indexOf(runnable) !== -1) ||
+    (Array.isArray(parent._afterEach) &&
+      parent._afterEach.indexOf(runnable) !== -1)
+  );
+}
+
+/**
+ * Whether `suite` is a strict descendant of `ancestor`.
+ *
+ * @private
+ * @param {Suite} suite
+ * @param {Suite} ancestor
+ * @returns {boolean}
+ */
+function isStrictDescendantOf(suite, ancestor) {
+  var current = suite;
+  while (current && current.parent) {
+    if (current.parent === ancestor) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+/**
+ * First reported failure whose runnable lives in a descendant of `ancestor`.
+ *
+ * @private
+ * @param {Array<{runnable: Runnable, err: Error}>} reportedFailures
+ * @param {Suite} ancestor
+ * @returns {{runnable: Runnable, err: Error}|null}
+ */
+function findDescendantFailure(reportedFailures, ancestor) {
+  if (!ancestor) {
+    return null;
+  }
+  for (var i = 0; i < reportedFailures.length; i++) {
+    var item = reportedFailures[i];
+    var suite = item.runnable && item.runnable.parent;
+    if (suite && isStrictDescendantOf(suite, ancestor)) {
+      return item;
+    }
+  }
+  return null;
+}
+
+/**
+ * Attach `secondaryErr` to the end of `primaryErr`'s `cause` chain.
+ *
+ * @private
+ * @param {Error} primaryErr
+ * @param {Error} secondaryErr
+ * @returns {boolean} whether the error was attached
+ */
+function attachSecondaryError(primaryErr, secondaryErr) {
+  if (!primaryErr || !secondaryErr || primaryErr === secondaryErr) {
+    return false;
+  }
+  try {
+    var tail = primaryErr;
+    var seen = new Set();
+    while (tail.cause && !seen.has(tail)) {
+      seen.add(tail);
+      tail = tail.cause;
+    }
+    if (tail.cause) {
+      return false;
+    }
+    tail.cause = secondaryErr;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Filter mocha frames out of `err` and its `cause` trail.
+ *
+ * @private
+ * @param {Error} err
+ * @param {boolean} fullStackTrace
+ */
+function filterErrorStacks(err, fullStackTrace) {
+  if (fullStackTrace) {
+    return;
+  }
+  const alreadyFiltered = new Set();
+  let currentErr = err;
+
+  while (currentErr && currentErr.stack && !alreadyFiltered.has(currentErr)) {
+    alreadyFiltered.add(currentErr);
+
+    try {
+      currentErr.stack = stackFilter(currentErr.stack);
+    } catch {
+      // Ignore error as some environments do not take kindly to monkeying with the stack
+    }
+
+    currentErr = currentErr.cause;
+  }
 }
 
 /**

--- a/test/integration/fixtures/hooks/parent-after-all-nested-failure.fixture.js
+++ b/test/integration/fixtures/hooks/parent-after-all-nested-failure.fixture.js
@@ -1,0 +1,13 @@
+"use strict";
+
+describe("outer suite", function () {
+  after(function () {
+    throw new Error("outer cleanup failed");
+  });
+
+  describe("inner suite", function () {
+    it("fails for the real reason", function () {
+      throw new Error("inner test failed");
+    });
+  });
+});

--- a/test/integration/fixtures/hooks/parent-after-each-nested-failure.fixture.js
+++ b/test/integration/fixtures/hooks/parent-after-each-nested-failure.fixture.js
@@ -1,0 +1,15 @@
+"use strict";
+
+describe("outer suite", function () {
+  afterEach(function () {
+    throw new Error("outer cleanup failed");
+  });
+
+  describe("inner suite", function () {
+    beforeEach(function () {
+      throw new Error("inner setup failed");
+    });
+
+    it("does something", function () {});
+  });
+});

--- a/test/integration/hook-err.spec.cjs
+++ b/test/integration/hook-err.spec.cjs
@@ -273,6 +273,68 @@ describe("hook error handling", function () {
     });
   });
 
+  describe("parent teardown after nested-suite failure", function () {
+    it("should keep a nested beforeEach error as the primary failure when parent afterEach also throws", function (done) {
+      runMochaJSON(
+        "hooks/parent-after-each-nested-failure.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "inner setup failed")
+            .and("to have failed test count", 1)
+            .and(
+              "to have failed test",
+              '"before each" hook for "does something"',
+            )
+            .and(
+              "not to have failed test",
+              '"after each" hook for "does something"',
+            );
+          done();
+        },
+      );
+    });
+
+    it("should keep a nested test error as the primary failure when parent afterAll also throws", function (done) {
+      runMochaJSON(
+        "hooks/parent-after-all-nested-failure.fixture.js",
+        [],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed with error", "inner test failed")
+            .and("to have failed test count", 1)
+            .and("to have failed test", "fails for the real reason")
+            .and(
+              "not to have failed test",
+              '"after all" hook in "outer suite"',
+            );
+          done();
+        },
+      );
+    });
+
+    it("should surface the parent afterEach error as a cause of the nested failure", function (done) {
+      runMocha(
+        "hooks/parent-after-each-nested-failure.fixture.js",
+        ["--reporter", "spec"],
+        (err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res, "to have failed").and("to have failed test count", 1);
+          expect(res.output, "to contain", "Error: inner setup failed")
+            .and("to contain", "Caused by: Error: outer cleanup failed")
+            .and("not to contain", "2 failing");
+          done();
+        },
+      );
+    });
+  });
+
   describe('"this.test.error()-style failure', function () {
     it("should fail the associated test", async function () {
       return expect(

--- a/test/unit/runner.spec.cjs
+++ b/test/unit/runner.spec.cjs
@@ -497,6 +497,58 @@ describe("Runner", function () {
         );
         done();
       });
+
+      describe("when a parent teardown fails after a nested-suite failure", function () {
+        it("should keep the nested failure primary and attach the parent afterEach error", function () {
+          var inner = Suite.create(suite, "inner");
+          var innerTest = new Test("nested fail", noop);
+          inner.addTest(innerTest);
+          var afterEachHook = suite.afterEach(function () {});
+          var original = new Error("inner test failed");
+          var teardownErr = new Error("outer cleanup failed");
+          var failEvents = [];
+
+          runner.on(EVENT_TEST_FAIL, function (runnable, err) {
+            failEvents.push({ runnable: runnable, err: err });
+          });
+
+          runner.fail(innerTest, original);
+          runner.fail(afterEachHook, teardownErr);
+
+          expect(runner.failures, "to be", 1);
+          expect(failEvents, "to have length", 1);
+          expect(failEvents[0].runnable, "to be", innerTest);
+          expect(failEvents[0].err, "to be", original);
+          expect(original.cause, "to be", teardownErr);
+          expect(afterEachHook.state, "to be undefined");
+        });
+
+        it("should keep the nested failure primary and attach the parent afterAll error", function () {
+          var inner = Suite.create(suite, "inner");
+          var innerTest = new Test("nested fail", noop);
+          inner.addTest(innerTest);
+          var afterAllHook = suite.afterAll(function () {});
+          var original = new Error("inner test failed");
+          var teardownErr = new Error("outer cleanup failed");
+
+          runner.fail(innerTest, original);
+          runner.fail(afterAllHook, teardownErr);
+
+          expect(runner.failures, "to be", 1);
+          expect(original.cause, "to be", teardownErr);
+        });
+
+        it("should still report a same-suite afterEach failure independently", function () {
+          var test = new Test("failing test", noop);
+          suite.addTest(test);
+          var afterEachHook = suite.afterEach(function () {});
+
+          runner.fail(test, new Error("test failed"));
+          runner.fail(afterEachHook, new Error("after each failed"));
+
+          expect(runner.failures, "to be", 2);
+        });
+      });
     });
 
     describe("run()", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5925
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When a nested test or hook fails and a parent `after`/`afterEach` also throws, Mocha reported both as independent failures. In large CI logs the teardown cascade looked like a separate root cause.

If the teardown hook belongs to an ancestor of the already-failed suite, attach the teardown error as `cause` on the original nested failure instead of incrementing a second failure. Same-suite teardown errors are unchanged.

Fixes #5925