### PR TITLE
fix: apply require root hooks in programmatic serial runs

### DIFF
--- a/lib/cli/run-helpers.cjs
+++ b/lib/cli/run-helpers.cjs
@@ -14,7 +14,6 @@
  * @typedef {import('../runner.cjs')} Runner
  */
 
-const fs = require("node:fs");
 const path = require("node:path");
 const pc = require("picocolors");
 const debug = require("debug")("mocha:cli:run:helpers");
@@ -22,8 +21,7 @@ const { watchRun, watchParallelRun } = require("./watch-run.cjs");
 const collectFiles = require("./collect-files.cjs");
 const { format } = require("node:util");
 const { createInvalidLegacyPluginError } = require("../errors.js");
-const { requireOrImport } = require("../nodejs/esm-utils.cjs");
-const { PluginLoader } = require("../plugin-loader.js");
+const { handleRequires } = require("../nodejs/handle-requires.cjs");
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
@@ -94,32 +92,7 @@ exports.list = (str) =>
  * @returns {Promise<object>} Plugin implementations
  * @private
  */
-exports.handleRequires = async (
-  requires = [],
-  { ignoredPlugins = [] } = {},
-) => {
-  const pluginLoader = PluginLoader.create({ ignore: ignoredPlugins });
-  for await (const mod of requires) {
-    let modpath = mod;
-    // this is relative to cwd
-    if (fs.existsSync(mod) || fs.existsSync(`${mod}.js`)) {
-      modpath = path.resolve(mod);
-      debug("resolved required file %s to %s", mod, modpath);
-    }
-    const requiredModule = await requireOrImport(modpath);
-    if (requiredModule && typeof requiredModule === "object") {
-      if (pluginLoader.load(requiredModule)) {
-        debug("found one or more plugin implementations in %s", modpath);
-      }
-    }
-    debug('loaded required module "%s"', mod);
-  }
-  const plugins = await pluginLoader.finalize();
-  if (Object.keys(plugins).length) {
-    debug("finalized plugin implementations: %O", plugins);
-  }
-  return plugins;
-};
+exports.handleRequires = handleRequires;
 
 /**
  * Logs errors and exits the app if unmatched files exist

--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -923,6 +923,40 @@ Mocha.prototype.forbidPending = function (forbidPending) {
 };
 
 /**
+ * Load plugins exported by `options.require` (root hooks, global fixtures).
+ *
+ * CLI and worker startup already call {@link handleRequires} and pass the
+ * result into the Mocha constructor. Programmatic serial runs do not, so
+ * do that work here unless `rootHooks` was already supplied.
+ * @private
+ * @returns {Promise<void>}
+ */
+Mocha.prototype._applyRequirePlugins = async function _applyRequirePlugins() {
+  const requires = utils.castArray(this.options.require).filter(Boolean);
+  if (
+    !requires.length ||
+    this.options.rootHooks ||
+    this.isWorker ||
+    this.options.parallel ||
+    utils.isBrowser()
+  ) {
+    return;
+  }
+
+  const { handleRequires } = require("./nodejs/handle-requires.cjs");
+  const plugins = await handleRequires(requires);
+  if (plugins.rootHooks) {
+    this.rootHooks(plugins.rootHooks);
+  }
+  if (plugins.globalSetup) {
+    this.globalSetup(plugins.globalSetup);
+  }
+  if (plugins.globalTeardown) {
+    this.globalTeardown(plugins.globalTeardown);
+  }
+};
+
+/**
  * Throws an error if mocha is in the wrong state to be able to transition to a "running" state.
  * @private
  */
@@ -1037,6 +1071,13 @@ Mocha.prototype.run = function (fn) {
   };
 
   const runAsync = async (runner) => {
+    try {
+      await this._applyRequirePlugins();
+    } catch (err) {
+      reportFixtureError("require", err);
+      return 1;
+    }
+
     let context = {};
     if (this.options.enableGlobalSetup && this.hasGlobalSetupFixtures()) {
       try {

--- a/lib/nodejs/handle-requires.cjs
+++ b/lib/nodejs/handle-requires.cjs
@@ -1,0 +1,50 @@
+"use strict";
+
+/**
+ * Load `--require` modules and collect plugin implementations.
+ * @module
+ * @private
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const debug = require("debug")("mocha:nodejs:handle-requires");
+const { requireOrImport } = require("./esm-utils.cjs");
+const { PluginLoader } = require("../plugin-loader.js");
+
+/**
+ * `require()` the modules as required by `--require <require>`.
+ *
+ * Returns plugin implementations such as `rootHooks`, if any.
+ * @param {string[]} requires - Modules to require
+ * @param {Object} [options]
+ * @param {string[]} [options.ignoredPlugins] - Plugin export names to ignore
+ * @returns {Promise<object>} Plugin implementations
+ * @private
+ */
+exports.handleRequires = async (
+  requires = [],
+  { ignoredPlugins = [] } = {},
+) => {
+  const pluginLoader = PluginLoader.create({ ignore: ignoredPlugins });
+  for await (const mod of requires) {
+    let modpath = mod;
+    // this is relative to cwd
+    if (fs.existsSync(mod) || fs.existsSync(`${mod}.js`)) {
+      modpath = path.resolve(mod);
+      debug("resolved required file %s to %s", mod, modpath);
+    }
+    const requiredModule = await requireOrImport(modpath);
+    if (requiredModule && typeof requiredModule === "object") {
+      if (pluginLoader.load(requiredModule)) {
+        debug("found one or more plugin implementations in %s", modpath);
+      }
+    }
+    debug('loaded required module "%s"', mod);
+  }
+  const plugins = await pluginLoader.finalize();
+  if (Object.keys(plugins).length) {
+    debug("finalized plugin implementations: %O", plugins);
+  }
+  return plugins;
+};

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -100,7 +100,7 @@ export interface MochaOptions {
   /** Hooks to bootstrap the root suite with. */
   rootHooks?: MochaRootHookObject;
 
-  /** Pathname of `rootHooks` plugin for parallel runs. */
+  /** Module(s) to require, including `rootHooks` plugins. */
   require?: string[];
 
   /** Should be `true` if `Mocha` process is running in a worker process. */

--- a/test/integration/fixtures/plugins/root-hooks/programmatic-serial.fixture.cjs
+++ b/test/integration/fixtures/plugins/root-hooks/programmatic-serial.fixture.cjs
@@ -1,0 +1,14 @@
+"use strict";
+
+const path = require("node:path");
+const Mocha = require("../../../../../lib/mocha.cjs");
+
+const mocha = new Mocha({
+  require: [path.join(__dirname, "root-hook-defs-a.fixture.js")],
+});
+
+mocha.addFile(path.join(__dirname, "root-hook-test.fixture.js"));
+
+mocha.run((failures) => {
+  process.exitCode = failures ? 1 : 0;
+});

--- a/test/integration/plugins/root-hooks.spec.cjs
+++ b/test/integration/plugins/root-hooks.spec.cjs
@@ -1,6 +1,8 @@
 "use strict";
 
-var invokeMochaAsync = require("../helpers.cjs").invokeMochaAsync;
+var helpers = require("../helpers.cjs");
+var invokeMochaAsync = helpers.invokeMochaAsync;
+var invokeNode = helpers.invokeNode;
 
 /**
  * Extracts root hook log messages from run results
@@ -82,6 +84,27 @@ describe("root hooks", function () {
           "beforeEach array 1",
           "beforeEach array 2",
         ],
+      );
+    });
+
+    it("should run root hooks when provided via require in programmatic API", function (done) {
+      invokeNode(
+        [
+          require.resolve("../fixtures/plugins/root-hooks/programmatic-serial.fixture.cjs"),
+        ],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(extractHookOutputFromResult(res), "to equal", [
+            "afterAll",
+            "afterEach",
+            "beforeAll",
+            "beforeEach",
+          ]);
+          done();
+        },
       );
     });
 

--- a/test/unit/mocha.spec.cjs
+++ b/test/unit/mocha.spec.cjs
@@ -995,6 +995,32 @@ describe("Mocha", function () {
           });
         });
       });
+
+      describe("when `require` option exports mochaHooks", function () {
+        it("should apply those root hooks in serial mode", function (done) {
+          mocha.options.require = [
+            require.resolve("../integration/fixtures/plugins/root-hooks/root-hook-defs-a.fixture.js"),
+          ];
+          mocha.run(function () {
+            expect(suite.beforeAll, "was called");
+            expect(suite.beforeEach, "was called");
+            expect(suite.afterAll, "was called");
+            expect(suite.afterEach, "was called");
+            done();
+          });
+        });
+
+        it("should not load require plugins when rootHooks was already supplied", function (done) {
+          mocha.options.require = [
+            require.resolve("../integration/fixtures/plugins/root-hooks/root-hook-defs-a.fixture.js"),
+          ];
+          mocha.options.rootHooks = { beforeAll() {} };
+          mocha.run(function () {
+            expect(suite.beforeAll, "was not called");
+            done();
+          });
+        });
+      });
     });
 
     describe("parallelMode()", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5006
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--require` files that export `mochaHooks` already run under the CLI and in parallel workers, because both call `handleRequires` before constructing `Mocha`. A programmatic serial run (`new Mocha({ require })`) never did that, so the root hooks were skipped.

`Mocha#run` now loads those plugins when `rootHooks` was not already supplied. `handleRequires` lives in `lib/nodejs` so the Mocha class does not import CLI helpers.

Fixes #5006