### PR TITLE
fix: fail parallel runs on worker unhandledRejection

### DIFF
--- a/lib/nodejs/parallel-buffered-runner.cjs
+++ b/lib/nodejs/parallel-buffered-runner.cjs
@@ -14,7 +14,7 @@
  */
 
 const Runner = require("../runner.cjs");
-const { EVENT_RUN_BEGIN, EVENT_RUN_END } = Runner.constants;
+const { EVENT_RUN_BEGIN, EVENT_RUN_END, STATE_RUNNING } = Runner.constants;
 const debug = require("debug")("mocha:parallel:parallel-buffered-runner");
 const { BufferedWorkerPool } = require("./buffered-worker-pool.cjs");
 const { setInterval, clearInterval } = global;
@@ -316,6 +316,7 @@ class ParallelBufferedRunner extends Runner {
         // this is set for uncaught exception handling in `Runner#uncaught`
         // TODO: `Runner` should be using a state machine instead.
         this.started = true;
+        this.state = STATE_RUNNING;
         this._state = RUNNING;
 
         this.emit(EVENT_RUN_BEGIN);
@@ -330,7 +331,11 @@ class ParallelBufferedRunner extends Runner {
         );
 
         // note that pool may already be terminated due to --bail
-        await pool.terminate();
+        try {
+          await pool.terminate();
+        } catch (err) {
+          debug("run(): error terminating worker pool: %O", err);
+        }
 
         results
           .filter(({ status }) => status === "rejected")

--- a/lib/nodejs/worker.cjs
+++ b/lib/nodejs/worker.cjs
@@ -25,7 +25,7 @@ const d = require("debug");
 const debug = d.debug(`mocha:parallel:worker:${process.pid}`);
 const isDebugEnabled = d.enabled(`mocha:parallel:worker:${process.pid}`);
 const { serialize } = require("./serializer.js");
-const { setInterval, clearInterval } = global;
+const { setInterval, clearInterval, setImmediate } = global;
 
 let rootHooks;
 
@@ -129,25 +129,86 @@ async function run(filepath, serializedOptions = "{}") {
       // Runner adds these; if we don't remove them, we'll get a leak.
       process.removeAllListeners("uncaughtException");
       process.removeAllListeners("unhandledRejection");
+      clearInterval(debugInterval);
+
+      let settled = false;
+      const finish = (cb, value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        process.removeListener("uncaughtException", onFatal);
+        process.removeListener("unhandledRejection", onFatal);
+        cb(value);
+      };
+
+      const onFatal = (reason) => {
+        const err =
+          reason instanceof Error ? reason : new Error(String(reason));
+        debug("run(): captured unhandled error after suite completed: %O", err);
+        finish(reject, err);
+      };
+
+      // Mocha detaches its listeners when the suite ends. Keep listening until
+      // this file's pending timers drain so a late unhandledRejection still
+      // fails the worker (and therefore the parallel run).
+      process.on("uncaughtException", onFatal);
+      process.on("unhandledRejection", onFatal);
 
       try {
         const serialized = serialize(result);
         debug(
           "run(): completed run with %d test failures; returning to main process",
-          typeof result.failures === "number" ? result.failures : 0,
+          typeof result.failureCount === "number" ? result.failureCount : 0,
         );
-        resolve(serialized);
+        whenNoPendingTimers(() => {
+          finish(resolve, serialized);
+        });
       } catch (err) {
         // TODO: figure out exactly what the sad path looks like here.
         // rejection should only happen if an error is "unrecoverable"
         debug("run(): serialization failed; rejecting: %O", err);
-        reject(err);
-      } finally {
-        clearInterval(debugInterval);
+        finish(reject, err);
       }
     });
   });
 }
+
+/**
+ * True when this process is a forked worker (has IPC). Unit tests load this
+ * file in-process, where draining would wait on Mocha's own test timeouts.
+ * @returns {boolean}
+ */
+const isForkedWorker = () => typeof process.send === "function";
+
+/**
+ * Whether the event loop still has a timer/immediate that might throw or reject.
+ * @returns {boolean}
+ */
+const hasPendingTimers = () =>
+  process
+    .getActiveResourcesInfo()
+    .some((type) => type === "Timeout" || type === "Immediate");
+
+/**
+ * Invoke `cb` once there are no pending timeouts/immediates (or immediately
+ * when not running as a forked worker).
+ * @param {Function} cb
+ */
+const whenNoPendingTimers = (cb) => {
+  if (!isForkedWorker() || !hasPendingTimers()) {
+    cb();
+    return;
+  }
+  const check = () => {
+    if (hasPendingTimers()) {
+      setImmediate(check);
+      return;
+    }
+    cb();
+  };
+  setImmediate(check);
+};
 
 // this registers the `run` function.
 workerpool.worker({ run });

--- a/test/integration/fixtures/parallel/delayed-fail.fixture.js
+++ b/test/integration/fixtures/parallel/delayed-fail.fixture.js
@@ -1,0 +1,8 @@
+"use strict";
+
+describe("issue-5184 delayed failure", function () {
+  it("fails after a delay", async function () {
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    throw new Error("delayed failure");
+  });
+});

--- a/test/integration/fixtures/parallel/unhandled-rejection.fixture.js
+++ b/test/integration/fixtures/parallel/unhandled-rejection.fixture.js
@@ -1,0 +1,9 @@
+"use strict";
+
+describe("issue-5184 unhandled rejection", function () {
+  it("passes then rejects", function () {
+    setTimeout(() => {
+      Promise.reject(new Error("late unhandled rejection"));
+    }, 50);
+  });
+});

--- a/test/integration/parallel.spec.cjs
+++ b/test/integration/parallel.spec.cjs
@@ -1,7 +1,11 @@
 "use strict";
 
 const assert = require("node:assert");
-const { runMochaJSONAsync } = require("./helpers.cjs");
+const {
+  invokeMochaAsync,
+  resolveFixturePath,
+  runMochaJSONAsync,
+} = require("./helpers.cjs");
 
 describe("parallel run", () => {
   /**
@@ -75,6 +79,43 @@ describe("parallel run", () => {
     assert.deepStrictEqual(result.failures[0].err.values, [
       { toB: { toA: "[Circular]" } },
     ]);
+  });
+
+  /**
+   * @see https://github.com/mochajs/mocha/issues/5184
+   */
+  describe("issue-5184: unhandled rejection after a test passes", function () {
+    it("should fail the run", async function () {
+      const [, promise] = invokeMochaAsync(
+        [
+          "--parallel",
+          "--jobs",
+          "2",
+          resolveFixturePath("parallel/unhandled-rejection.fixture.js"),
+        ],
+        { stdio: "pipe" },
+      );
+      return expect(
+        promise,
+        "when fulfilled",
+        "to have failed with output",
+        /late unhandled rejection/,
+      );
+    });
+
+    it("should fail the run when another file also fails", async function () {
+      const [, promise] = invokeMochaAsync(
+        [
+          "--parallel",
+          "--jobs",
+          "2",
+          resolveFixturePath("parallel/unhandled-rejection.fixture.js"),
+          resolveFixturePath("parallel/delayed-fail.fixture.js"),
+        ],
+        { stdio: "pipe" },
+      );
+      return expect(promise, "when fulfilled", "to have failed");
+    });
   });
 
   it("should correctly handle a non-writable getter reference in an exception", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5184
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In parallel mode, a worker reported success as soon as its suite finished, then dropped `unhandledRejection` / `uncaughtException` listeners. A later rejection crashed the worker after results were already sent, so the parent exited `0` (and could even skip the final summary when another file failed).

Workers now keep those listeners until pending timers drain and reject the file run if one fires. The parent records that as an uncaught failure, so the process exits non-zero. Serial mode is unchanged.

Fixes #5184