### PR TITLE
fix: flush V8 coverage before parallel workers are killed

### DIFF
--- a/docs/src/content/docs/features/parallel-mode.mdx
+++ b/docs/src/content/docs/features/parallel-mode.mdx
@@ -161,6 +161,12 @@ Mocha does **not** provide an option to spawn a fresh process for each test file
 - Invoking `mocha` separately for each test file and merging results externally.
 - Using a test runner that provides process-level isolation per test file.
 
+## Code Coverage
+
+V8 coverage (`c8`, or `nyc` in V8 mode) is written when each worker process exits. Mocha asks workers to exit cleanly and flushes coverage over that shutdown path. If a worker is still exiting when the terminate grace period elapses, workerpool force-kills it and that worker's coverage dump is dropped.
+
+When `NODE_V8_COVERAGE` is set, Mocha automatically allows workers up to 60 seconds to exit. Override this with [`--worker-terminate-timeout`](/running/cli#--worker-terminate-timeout-ms) if a run still drops coverage.
+
 ## Parallel Mode Worker IDs
 
 :::note[New in v9.2.0]

--- a/docs/src/content/docs/running/cli.mdx
+++ b/docs/src/content/docs/running/cli.mdx
@@ -42,6 +42,9 @@ Rules & Behavior
                                     use 1 to run in serial
                                    [number] [default: (number of CPU cores - 1)]
   -p, --parallel                    Run tests in parallel              [boolean]
+      --worker-terminate-timeout    Milliseconds a --parallel worker may take
+                                    to exit before it is force-killed
+                                                        [number] [default: 1000]
       --posix-exit-codes            Use POSIX and UNIX shell exit codes as
                                     Mocha's return value               [boolean]
       --retries                     Retry failed tests this many times  [number]
@@ -250,6 +253,14 @@ The default value is the _number of CPU cores_ less 1.
 :::tip
 Use `--jobs 0` or `--jobs 1` to temporarily disable `--parallel`.
 :::
+
+Has no effect unless used with [`--parallel`](#--parallel--p).
+
+### `--worker-terminate-timeout <ms>`
+
+When Mocha shuts down a [`--parallel`](#--parallel--p) worker, it first asks the process to exit so Node can flush `NODE_V8_COVERAGE` data. If the worker is still alive after this timeout, it is force-killed and that flush is lost.
+
+The default is `1000` (workerpool's default). When `NODE_V8_COVERAGE` is set and this option is omitted, Mocha raises the grace period to `60000` so coverage tools such as `c8` can finish writing large profiles.
 
 Has no effect unless used with [`--parallel`](#--parallel--p).
 

--- a/lib/cli/run-option-metadata.cjs
+++ b/lib/cli/run-option-metadata.cjs
@@ -53,7 +53,7 @@ const types = {
     "sort",
     "watch",
   ],
-  number: ["retries", "jobs"],
+  number: ["retries", "jobs", "worker-terminate-timeout"],
   string: [
     "config",
     "fgrep",
@@ -124,6 +124,8 @@ const descriptions = {
     "Display actual/expected differences inline within each string",
   invert: "Inverts --grep and --fgrep matches",
   jobs: "Number of concurrent jobs for --parallel; use 1 to run in serial",
+  "worker-terminate-timeout":
+    "Milliseconds a --parallel worker may take to exit before it is force-killed",
   "list-interfaces": "List built-in user interfaces & exit",
   "list-reporters": "List built-in reporters & exit",
   "no-colors": "Force-disable color output",

--- a/lib/nodejs/buffered-worker-pool.cjs
+++ b/lib/nodejs/buffered-worker-pool.cjs
@@ -22,6 +22,19 @@ const { createInvalidArgumentTypeError } = require("../errors.js");
 const WORKER_PATH = require.resolve("./worker.cjs");
 
 /**
+ * workerpool's own default when `workerTerminateTimeout` is omitted.
+ * @type {number}
+ */
+const DEFAULT_WORKER_TERMINATE_TIMEOUT_MS = 1000;
+
+/**
+ * Grace period while a worker writes `NODE_V8_COVERAGE` output on exit.
+ * Large profiles routinely exceed workerpool's 1s default.
+ * @type {number}
+ */
+const COVERAGE_WORKER_TERMINATE_TIMEOUT_MS = 60000;
+
+/**
  * A mapping of Mocha `Options` objects to serialized values.
  *
  * This is helpful because we tend to same the same options over and over
@@ -29,6 +42,22 @@ const WORKER_PATH = require.resolve("./worker.cjs");
  * @type {WeakMap<MochaOptions,string>}
  */
 let optionsCache = new WeakMap();
+
+/**
+ * Resolves how long workerpool should wait for a worker to exit before
+ * force-killing it. An explicit value wins; otherwise coverage collection
+ * needs a longer window than workerpool's 1s default.
+ * @param {unknown} timeout - Caller-supplied timeout in milliseconds
+ * @returns {number}
+ */
+const resolveWorkerTerminateTimeout = (timeout) => {
+  if (typeof timeout === "number" && Number.isFinite(timeout) && timeout > 0) {
+    return timeout;
+  }
+  return process.env.NODE_V8_COVERAGE
+    ? COVERAGE_WORKER_TERMINATE_TIMEOUT_MS
+    : DEFAULT_WORKER_TERMINATE_TIMEOUT_MS;
+};
 
 /**
  * These options are passed into the [workerpool](https://npm.im/workerpool) module.
@@ -41,6 +70,7 @@ const WORKER_POOL_DEFAULT_OPTS = {
   // along to children
   forkOpts: { execArgv: process.execArgv },
   maxWorkers: workerpool.cpus - 1,
+  workerTerminateTimeout: DEFAULT_WORKER_TERMINATE_TIMEOUT_MS,
 };
 
 /**
@@ -59,6 +89,9 @@ class BufferedWorkerPool {
         ? WORKER_POOL_DEFAULT_OPTS.maxWorkers
         : opts.maxWorkers,
     );
+    const workerTerminateTimeout = resolveWorkerTerminateTimeout(
+      opts.workerTerminateTimeout,
+    );
 
     /* istanbul ignore next */
     if (workerpool.cpus < 2) {
@@ -76,8 +109,9 @@ class BufferedWorkerPool {
     }
     /* istanbul ignore next */
     debug(
-      "run(): starting worker pool of max size %d, using node args: %s",
+      "run(): starting worker pool of max size %d, terminate timeout %d ms, using node args: %s",
       maxWorkers,
+      workerTerminateTimeout,
       process.execArgv.join(" "),
     );
 
@@ -96,6 +130,7 @@ class BufferedWorkerPool {
       ...WORKER_POOL_DEFAULT_OPTS,
       ...opts,
       maxWorkers,
+      workerTerminateTimeout,
       onCreateWorker,
     };
     this._pool = workerpool.pool(WORKER_PATH, this.options);

--- a/lib/nodejs/parallel-buffered-runner.cjs
+++ b/lib/nodejs/parallel-buffered-runner.cjs
@@ -35,6 +35,8 @@ const DENY_OPTIONS = [
   "p",
   "jobs",
   "j",
+  "workerTerminateTimeout",
+  "worker-terminate-timeout",
 ];
 
 /**
@@ -303,7 +305,10 @@ class ParallelBufferedRunner extends Runner {
       let pool;
 
       try {
-        pool = BufferedWorkerPool.create({ maxWorkers: options.jobs });
+        pool = BufferedWorkerPool.create({
+          maxWorkers: options.jobs,
+          workerTerminateTimeout: options.workerTerminateTimeout,
+        });
 
         sigIntListener = this._bindSigIntListener(pool);
 

--- a/lib/nodejs/worker.cjs
+++ b/lib/nodejs/worker.cjs
@@ -25,6 +25,7 @@ const d = require("debug");
 const debug = d.debug(`mocha:parallel:worker:${process.pid}`);
 const isDebugEnabled = d.enabled(`mocha:parallel:worker:${process.pid}`);
 const { serialize } = require("./serializer.js");
+const v8 = require("node:v8");
 const { setInterval, clearInterval } = global;
 
 let rootHooks;
@@ -149,10 +150,30 @@ async function run(filepath, serializedOptions = "{}") {
   });
 }
 
+/**
+ * Writes the worker's V8 coverage profile before workerpool force-kills the
+ * process. Node also dumps coverage on `process.exit()`, but that write is
+ * raced against workerpool's terminate timeout.
+ * @returns {void|unknown}
+ */
+const flushV8Coverage = () => {
+  if (!process.env.NODE_V8_COVERAGE) {
+    return;
+  }
+  try {
+    if (typeof v8.takeCoverage === "function") {
+      return v8.takeCoverage();
+    }
+  } catch {
+    // Coverage tools should not fail the worker.
+  }
+};
+
 // this registers the `run` function.
-workerpool.worker({ run });
+workerpool.worker({ run }, { onTerminate: flushV8Coverage });
 
 debug("started worker process");
 
 // for testing
 exports.run = run;
+exports.flushV8Coverage = flushV8Coverage;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -97,6 +97,9 @@ export interface MochaOptions {
   /** Max number of worker processes for parallel runs. */
   jobs?: number;
 
+  /** Grace period (ms) for a --parallel worker to exit before force-kill. */
+  workerTerminateTimeout?: number;
+
   /** Hooks to bootstrap the root suite with. */
   rootHooks?: MochaRootHookObject;
 

--- a/test/integration/fixtures/options/parallel/slow-coverage-flush.fixture.cjs
+++ b/test/integration/fixtures/options/parallel/slow-coverage-flush.fixture.cjs
@@ -1,0 +1,28 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * Delays v8.takeCoverage() in worker processes so a 1s terminate timeout
+ * would kill the worker before the flush finishes.
+ */
+if (process.env.MOCHA_WORKER_ID !== undefined && process.env.NODE_V8_COVERAGE) {
+  const v8 = require("node:v8");
+  const takeCoverage = v8.takeCoverage.bind(v8);
+  v8.takeCoverage = function delayedTakeCoverage() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        takeCoverage();
+        fs.writeFileSync(
+          path.join(
+            process.env.NODE_V8_COVERAGE,
+            `mocha-worker-flush-${process.pid}.ok`,
+          ),
+          "",
+        );
+        resolve();
+      }, 2000);
+    });
+  };
+}

--- a/test/integration/help.spec.js
+++ b/test/integration/help.spec.js
@@ -32,6 +32,7 @@ describe("help", function () {
         expect(result.output, "to contain", "mocha init <path>");
         expect(result.output, "to contain", "--reporter");
         expect(result.output, "to contain", "--timeout");
+        expect(result.output, "to contain", "--worker-terminate-timeout");
         done();
       },
       { stdio: "pipe" },

--- a/test/integration/options/worker-terminate-timeout.spec.cjs
+++ b/test/integration/options/worker-terminate-timeout.spec.cjs
@@ -1,0 +1,64 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { sync: rimrafSync } = require("rimraf");
+const { invokeMochaAsync, resolveFixturePath } = require("../helpers.cjs");
+
+describe("--worker-terminate-timeout", function () {
+  this.timeout(20000);
+
+  it("should appear in --help", async function () {
+    const [, promise] = invokeMochaAsync(["--help"], "pipe");
+    return expect(
+      promise,
+      "when fulfilled",
+      "to contain output",
+      /--worker-terminate-timeout/,
+    );
+  });
+
+  describe("when collecting V8 coverage in parallel mode", function () {
+    let coverageDir;
+
+    beforeEach(function () {
+      coverageDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "mocha-worker-coverage-"),
+      );
+    });
+
+    afterEach(function () {
+      rimrafSync(coverageDir);
+    });
+
+    it("should let workers finish flushing coverage before they are killed", async function () {
+      const [, promise] = invokeMochaAsync(
+        [
+          "--parallel",
+          "--jobs",
+          "2",
+          "--require",
+          resolveFixturePath(
+            "options/parallel/slow-coverage-flush.fixture.cjs",
+          ),
+          resolveFixturePath("options/parallel/test-a.fixture.js"),
+          resolveFixturePath("passing.fixture.cjs"),
+        ],
+        {
+          env: {
+            ...process.env,
+            NODE_V8_COVERAGE: coverageDir,
+          },
+        },
+      );
+
+      await expect(promise, "when fulfilled", "to have succeeded");
+
+      const flushed = fs
+        .readdirSync(coverageDir)
+        .filter((name) => name.startsWith("mocha-worker-flush-"));
+      expect(flushed.length, "to be greater than", 0);
+    });
+  });
+});

--- a/test/node-unit/buffered-worker-pool.spec.cjs
+++ b/test/node-unit/buffered-worker-pool.spec.cjs
@@ -108,7 +108,52 @@ describe("class BufferedWorkerPool", function () {
           workerType: "process",
           forkOpts: { execArgv: process.execArgv },
           maxWorkers: expect.it("to be greater than or equal to", 1),
+          workerTerminateTimeout: expect.it("to be a number"),
         },
+      });
+    });
+
+    describe("workerTerminateTimeout", function () {
+      const previousCoverage = process.env.NODE_V8_COVERAGE;
+
+      afterEach(function () {
+        if (previousCoverage === undefined) {
+          delete process.env.NODE_V8_COVERAGE;
+        } else {
+          process.env.NODE_V8_COVERAGE = previousCoverage;
+        }
+      });
+
+      it("should honor an explicit timeout", function () {
+        delete process.env.NODE_V8_COVERAGE;
+        expect(
+          new BufferedWorkerPool({ workerTerminateTimeout: 5000 }),
+          "to satisfy",
+          { options: { workerTerminateTimeout: 5000 } },
+        );
+      });
+
+      it("should raise the timeout when NODE_V8_COVERAGE is set", function () {
+        process.env.NODE_V8_COVERAGE = "/tmp/coverage";
+        expect(new BufferedWorkerPool(), "to satisfy", {
+          options: { workerTerminateTimeout: 60000 },
+        });
+      });
+
+      it("should keep the default timeout when NODE_V8_COVERAGE is unset", function () {
+        delete process.env.NODE_V8_COVERAGE;
+        expect(new BufferedWorkerPool(), "to satisfy", {
+          options: { workerTerminateTimeout: 1000 },
+        });
+      });
+
+      it("should let an explicit timeout override NODE_V8_COVERAGE", function () {
+        process.env.NODE_V8_COVERAGE = "/tmp/coverage";
+        expect(
+          new BufferedWorkerPool({ workerTerminateTimeout: 2500 }),
+          "to satisfy",
+          { options: { workerTerminateTimeout: 2500 } },
+        );
       });
     });
   });

--- a/test/node-unit/parallel-buffered-runner.spec.cjs
+++ b/test/node-unit/parallel-buffered-runner.spec.cjs
@@ -120,6 +120,24 @@ describe("parallel-buffered-runner", function () {
           expect(runner.run(done, { files: [], options: {} }), "to be", runner);
         });
 
+        it("should pass workerTerminateTimeout to the worker pool", function (done) {
+          runner.run(
+            () => {
+              expect(BufferedWorkerPool.create, "to have a call satisfying", [
+                {
+                  maxWorkers: 3,
+                  workerTerminateTimeout: 5000,
+                },
+              ]);
+              done();
+            },
+            {
+              files: [],
+              options: { jobs: 3, workerTerminateTimeout: 5000 },
+            },
+          );
+        });
+
         it("should emit `EVENT_RUN_BEGIN`", async function () {
           return expect(
             () =>

--- a/test/node-unit/worker.spec.cjs
+++ b/test/node-unit/worker.spec.cjs
@@ -74,6 +74,7 @@ describe("worker", function () {
     it("should register itself with workerpool", function () {
       expect(stubs.workerpool.worker, "to have a call satisfying", [
         { run: worker.run },
+        { onTerminate: worker.flushV8Coverage },
       ]);
     });
 
@@ -222,6 +223,32 @@ describe("worker", function () {
               });
             });
           });
+        });
+      });
+
+      describe("flushV8Coverage()", function () {
+        const previousCoverage = process.env.NODE_V8_COVERAGE;
+
+        afterEach(function () {
+          if (previousCoverage === undefined) {
+            delete process.env.NODE_V8_COVERAGE;
+          } else {
+            process.env.NODE_V8_COVERAGE = previousCoverage;
+          }
+        });
+
+        it("should take coverage when NODE_V8_COVERAGE is set", function () {
+          const takeCoverage = sinon.stub(require("node:v8"), "takeCoverage");
+          process.env.NODE_V8_COVERAGE = "/tmp/coverage";
+          worker.flushV8Coverage();
+          expect(takeCoverage, "was called once");
+        });
+
+        it("should not take coverage when NODE_V8_COVERAGE is unset", function () {
+          const takeCoverage = sinon.stub(require("node:v8"), "takeCoverage");
+          delete process.env.NODE_V8_COVERAGE;
+          worker.flushV8Coverage();
+          expect(takeCoverage, "was not called");
         });
       });
     });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6219
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--parallel` workers were force-killed after workerpool's 1s terminate timeout, which cuts off Node's `NODE_V8_COVERAGE` write. Coverage from those workers is silently dropped.

Workers now flush V8 coverage from workerpool's `onTerminate` hook. When `NODE_V8_COVERAGE` is set, the terminate grace period is raised to 60s. `--worker-terminate-timeout` can override that.

Fixes #6219