### PR TITLE
fix: reload mochaHooks on serial watch reruns

### DIFF
--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const debug = require("debug")("mocha:cli:watch");
+const fs = require("node:fs");
 const path = require("node:path");
 const chokidar = require("chokidar");
 const glob = require("glob");
@@ -116,12 +117,23 @@ exports.watchRun = (
 ) => {
   debug("creating serial watcher");
 
+  // First run already loaded `--require` via prepareRunOptions(). Later
+  // reruns must reload mochaHooks so they close over the same module
+  // instances as the freshly required test files (issue #5149).
+  let reloadRootHooks = false;
+
   return createWatcher(mocha, {
     watchFiles,
     watchIgnore,
     clearScreen,
-    beforeRun({ mocha }) {
+    async beforeRun({ mocha }) {
       mocha.unloadFiles();
+
+      if (reloadRootHooks) {
+        await reloadWatchRootHooks(mocha);
+      } else {
+        reloadRootHooks = true;
+      }
 
       // I don't know why we're cloning the root suite.
       const rootSuite = mocha.suite.clone();
@@ -532,24 +544,36 @@ const createRerunner = (mocha, watcher, { beforeRun, clearScreen } = {}) => {
   // true if a file has changed during a test run
   let rerunScheduled = false;
 
-  const run = () => {
+  // Includes async `beforeRun` work, when `runner` is still null.
+  let inFlight = false;
+
+  const run = async () => {
+    inFlight = true;
     try {
       if (clearScreen) {
         clearTerminal();
       }
-      mocha = beforeRun ? beforeRun({ mocha, watcher }) || mocha : mocha;
-      runner = mocha.run(() => {
-        debug("finished watch run");
-        runner = null;
-        blastCache(watcher);
-        if (rerunScheduled) {
-          rerun();
-        } else {
-          console.error(`${logSymbols.info} [mocha] waiting for changes...`);
-        }
+      mocha = beforeRun
+        ? (await beforeRun({ mocha, watcher })) || mocha
+        : mocha;
+      await new Promise((resolve) => {
+        runner = mocha.run(() => {
+          debug("finished watch run");
+          runner = null;
+          blastCache(watcher);
+          resolve();
+        });
       });
     } catch (err) {
       console.error(err.stack);
+      runner = null;
+    }
+
+    if (rerunScheduled) {
+      rerun();
+    } else {
+      inFlight = false;
+      console.error(`${logSymbols.info} [mocha] waiting for changes...`);
     }
   };
 
@@ -561,7 +585,7 @@ const createRerunner = (mocha, watcher, { beforeRun, clearScreen } = {}) => {
     rerunScheduled = true;
     if (runner) {
       runner.abort();
-    } else {
+    } else if (!inFlight) {
       rerun();
     }
   };
@@ -644,4 +668,46 @@ const blastCache = (watcher) => {
     delete require.cache[file];
   });
   debug("deleted %d file(s) from the require cache", files.length);
+};
+
+/**
+ * Drop `--require` modules from `require.cache` so a later `handleRequires()`
+ * re-evaluates mochaHooks instead of returning the first-run closures.
+ * @param {string|string[]} [requires]
+ * @ignore
+ * @private
+ */
+const blastRequiredModules = (requires = []) => {
+  const list = Array.isArray(requires) ? requires : [requires];
+  list.forEach((mod) => {
+    try {
+      let id = mod;
+      if (fs.existsSync(mod) || fs.existsSync(`${mod}.js`)) {
+        id = path.resolve(mod);
+      }
+      delete require.cache[require.resolve(id)];
+    } catch {
+      // ESM-only or unresolvable; requireOrImport will load it again.
+    }
+  });
+};
+
+/**
+ * Reload mochaHooks after a watch-mode cache blast.
+ * @param {Mocha} mocha
+ * @ignore
+ * @private
+ */
+const reloadWatchRootHooks = async (mocha) => {
+  const requires = mocha.options.require;
+  if (!requires || !requires.length) {
+    return;
+  }
+  blastRequiredModules(requires);
+  // Lazy require avoids a cycle: run-helpers.cjs loads this file.
+  const { handleRequires } = require("./run-helpers.cjs");
+  const plugins = await handleRequires(requires);
+  if (plugins.rootHooks) {
+    mocha.options.rootHooks = plugins.rootHooks;
+  }
 };

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -241,7 +241,9 @@ export interface BeforeWatchRunOptions {
  * Optionally, it can return a new `Mocha` instance.
  * @private
  */
-export type BeforeWatchRun = (options: BeforeWatchRunOptions) => Mocha;
+export type BeforeWatchRun = (
+  options: BeforeWatchRunOptions,
+) => Mocha | void | Promise<Mocha | void>;
 
 /**
  * Object containing run control methods

--- a/test/integration/fixtures/options/watch/hook-init-store.fixture.cjs
+++ b/test/integration/fixtures/options/watch/hook-init-store.fixture.cjs
@@ -1,0 +1,9 @@
+"use strict";
+
+const { store } = require("./lib/store");
+
+exports.mochaHooks = {
+  beforeEach() {
+    store.initialize(["testItem1", "testItem2"]);
+  },
+};

--- a/test/integration/fixtures/options/watch/stateful-store.fixture.cjs
+++ b/test/integration/fixtures/options/watch/stateful-store.fixture.cjs
@@ -1,0 +1,17 @@
+"use strict";
+
+class Store {
+  constructor() {
+    this._items = [];
+  }
+
+  initialize(items) {
+    this._items = items;
+  }
+
+  getItems() {
+    return this._items;
+  }
+}
+
+exports.store = new Store();

--- a/test/integration/fixtures/options/watch/test-via-wrapper.fixture.cjs
+++ b/test/integration/fixtures/options/watch/test-via-wrapper.fixture.cjs
@@ -1,0 +1,10 @@
+"use strict";
+
+const assert = require("node:assert");
+const { getItems } = require("./lib/wrapper");
+
+describe("mochaHooks watch state", function () {
+  it("should see items initialized by mochaHooks", function () {
+    assert.deepStrictEqual(getItems(), ["testItem1", "testItem2"]);
+  });
+});

--- a/test/integration/fixtures/options/watch/wrapper.fixture.cjs
+++ b/test/integration/fixtures/options/watch/wrapper.fixture.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+const { store } = require("./store");
+
+exports.getItems = () => store.getItems();

--- a/test/integration/options/watch.spec.cjs
+++ b/test/integration/options/watch.spec.cjs
@@ -529,6 +529,55 @@ describe("--watch", function () {
       it("mochaHooks.beforeEach runs as expected", setupHookTest("beforeEach"));
       it("mochaHooks.afterAll runs as expected", setupHookTest("afterAll"));
       it("mochaHooks.afterEach runs as expected", setupHookTest("afterEach"));
+
+      /**
+       * Layout used by https://github.com/mochajs/mocha/issues/5149:
+       * mochaHooks mutates a singleton; the test reads it through a wrapper
+       * so a stale hook closure and a reloaded test module disagree.
+       */
+      function setupMochaHooksStateTest(extraArgs) {
+        return function () {
+          const testFile = path.join(tempDir, "test.js");
+          const hookFile = path.join(tempDir, "hooks.js");
+          const storeFile = path.join(tempDir, "lib/store.js");
+          const wrapperFile = path.join(tempDir, "lib/wrapper.js");
+
+          copyFixture("options/watch/test-via-wrapper.fixture.cjs", testFile);
+          copyFixture("options/watch/hook-init-store.fixture.cjs", hookFile);
+          copyFixture("options/watch/stateful-store.fixture.cjs", storeFile);
+          copyFixture("options/watch/wrapper.fixture.cjs", wrapperFile);
+
+          return runMochaWatchJSONAsync(
+            [testFile, "--require", hookFile, ...extraArgs],
+            tempDir,
+            () => {
+              touchFile(testFile);
+            },
+          ).then((results) => {
+            expect(results, "to have length", 2);
+            expect(results[0].passes, "to have length", 1);
+            expect(results[0].failures, "to have length", 0);
+            expect(results[1].passes, "to have length", 1);
+            expect(results[1].failures, "to have length", 0);
+          });
+        };
+      }
+
+      // Regression test for https://github.com/mochajs/mocha/issues/5149
+      it(
+        "shares mochaHooks module state with tests on re-runs",
+        setupMochaHooksStateTest([]),
+      );
+
+      it(
+        "shares mochaHooks module state when hooks are unwatched",
+        setupMochaHooksStateTest([
+          "--watch-files",
+          "test.js",
+          "--watch-files",
+          "lib/**/*.js",
+        ]),
+      );
     });
 
     it("should not leak event listeners", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5149
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Serial `--watch` kept the first-run `mochaHooks` closures on `mocha.options` after blasting watched files from `require.cache`. Tests then loaded a new module instance, so hook mutations no longer applied.

On each watch rerun, drop `--require` modules from the cache and reload `mochaHooks` so hooks and tests share the same instances. Overlapping reruns wait for async `beforeRun` to finish, avoiding a double-dispose.

Fixes #5149

This change was written with AI assistance.