### PR TITLE
fix: count delayed tests before applying --fail-zero

### DIFF
--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -1223,6 +1223,8 @@ Runner.prototype.run = function (fn, opts = {}) {
     }
     this.state = constants.STATE_RUNNING;
     if (this._opts.delay) {
+      // Delayed tests are registered after the Runner is constructed.
+      this.total = this.grepTotal(this.suite);
       this.emit(constants.EVENT_DELAY_END);
       debug('run(): "delay" ended');
     }

--- a/test/integration/options/failZero.spec.cjs
+++ b/test/integration/options/failZero.spec.cjs
@@ -1,5 +1,6 @@
 "use strict";
 
+var path = require("node:path").posix;
 var helpers = require("../helpers.cjs");
 var runMochaJSON = helpers.runMochaJSON;
 
@@ -17,6 +18,44 @@ describe("--fail-zero", function () {
         .and("to have test count", 0)
         .and("to have exit code", 1);
       done();
+    });
+  });
+
+  describe("with --delay", function () {
+    it("should pass when delayed tests are registered", function (done) {
+      var fixture = path.join("options", "delay.fixture.cjs");
+      runMochaJSON(
+        fixture,
+        ["--fail-zero", "--delay", "--no-forbid-only"],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res, "to have passed")
+            .and("to have passed test count", 1)
+            .and("to have exit code", 0);
+          done();
+        },
+      );
+    });
+
+    it("should fail when delayed tests do not match grep", function (done) {
+      var fixture = path.join("options", "delay.fixture.cjs");
+      runMochaJSON(
+        fixture,
+        ["--fail-zero", "--delay", "--no-forbid-only", "--grep", "yyyyyy"],
+        function (err, res) {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res, "to have passed test count", 0)
+            .and("to have test count", 0)
+            .and("to have exit code", 1);
+          done();
+        },
+      );
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4950
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--fail-zero` with `--delay` always exited 1, even when delayed tests ran and passed.

`Runner` sets `this.total` in the constructor, before delayed suites register tests via `run()`. `--fail-zero` then treated that stale `0` as "no tests".

Recount `this.total` with `grepTotal()` after delayed registration, so grep/invert still apply.

Fixes #4950