### PR TITLE
fix: apply --fail-zero to the whole parallel run

### DIFF
--- a/lib/nodejs/parallel-buffered-runner.cjs
+++ b/lib/nodejs/parallel-buffered-runner.cjs
@@ -348,6 +348,11 @@ class ParallelBufferedRunner extends Runner {
           return;
         }
 
+        // --fail-zero applies to the aggregate run, not each worker/file
+        if (this._opts.failZero && !(this.stats && this.stats.tests)) {
+          this.failures = 1;
+        }
+
         this.emit(EVENT_RUN_END);
         debug("run(): completing with failure count %d", this.failures);
         callback(this.failures);

--- a/lib/nodejs/worker.cjs
+++ b/lib/nodejs/worker.cjs
@@ -102,6 +102,8 @@ async function run(filepath, serializedOptions = "{}") {
     forbidOnly: true,
     // it's useful for a Mocha instance to know if it's running in a worker process.
     isWorker: true,
+    // --fail-zero is a whole-run check; a worker file with no grep matches is not a failure
+    failZero: false,
   });
 
   await bootstrap(opts);

--- a/test/integration/options/failZero.spec.cjs
+++ b/test/integration/options/failZero.spec.cjs
@@ -2,6 +2,8 @@
 
 var helpers = require("../helpers.cjs");
 var runMochaJSON = helpers.runMochaJSON;
+var runMochaJSONAsync = helpers.runMochaJSONAsync;
+var resolveFixturePath = helpers.resolveFixturePath;
 
 describe("--fail-zero", function () {
   var args = ["--fail-zero", "--grep", "yyyyyy"];
@@ -17,6 +19,45 @@ describe("--fail-zero", function () {
         .and("to have test count", 0)
         .and("to have exit code", 1);
       done();
+    });
+  });
+
+  describe("when used with --parallel and --grep", function () {
+    var extraFiles = [
+      resolveFixturePath("options/parallel/test-a.fixture.js"),
+      resolveFixturePath("passing.fixture.cjs"),
+    ];
+
+    it("should pass when matching tests ran in other files", async function () {
+      var result = await runMochaJSONAsync(
+        "__default__.fixture.js",
+        [
+          "--fail-zero",
+          "--parallel",
+          "--jobs",
+          "2",
+          "--grep",
+          "should pass",
+        ].concat(extraFiles),
+      );
+
+      expect(result, "to have passed")
+        .and("to have passed test count", 1)
+        .and("to have test count", 1)
+        .and("to have exit code", 0);
+    });
+
+    it("should fail when no tests match across files", async function () {
+      var result = await runMochaJSONAsync(
+        "__default__.fixture.js",
+        ["--fail-zero", "--parallel", "--jobs", "2", "--grep", "yyyyyy"].concat(
+          extraFiles,
+        ),
+      );
+
+      expect(result, "to have passed test count", 0)
+        .and("to have test count", 0)
+        .and("to have exit code", 1);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4969
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--fail-zero` should fail only when the whole run encounters no tests. In parallel mode each worker applied it to its own file, so `--grep` files with zero matches incremented the exit code even when other files passed.

Workers no longer apply `--fail-zero`. The parent runner applies it to the aggregate test count.

Fixes #4969