### PR TITLE
fix: print load errors through the reporter

### DIFF
--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -387,12 +387,32 @@ Mocha.prototype.ui = function (ui) {
 };
 
 /**
+ * Records a test-file load failure as a failing test so the reporter
+ * prints it. Otherwise Mocha exits before the reporter starts.
+ * @see https://github.com/mochajs/mocha/issues/4948
+ * @param {import("./suite.js").Suite} suite
+ * @param {string} [file]
+ * @param {Error} err
+ * @private
+ */
+function reportFileLoadError(suite, file, err) {
+  var Test = require("./test.js").Test;
+  var filename = file ? path.resolve(file) : "<unknown>";
+  var test = new Test(filename, function () {
+    throw err;
+  });
+  test.file = filename;
+  suite.addTest(test);
+}
+
+/**
  * Loads `files` prior to execution. Does not support ES Modules.
  *
  * @description
  * The implementation relies on Node's `require` to execute
  * the test interface functions and will be subject to its cache.
  * Supports only CommonJS modules. To load ES modules, use Mocha#loadFilesAsync.
+ * Load errors are recorded as failing tests so they appear in reporter output.
  *
  * @private
  * @see {@link Mocha#addFile}
@@ -404,12 +424,17 @@ Mocha.prototype.ui = function (ui) {
 Mocha.prototype.loadFiles = function (fn) {
   var self = this;
   var suite = this.suite;
-  this.files.forEach(function (file) {
-    file = path.resolve(file);
+  for (var i = 0; i < this.files.length; i++) {
+    var file = path.resolve(this.files[i]);
     suite.emit(EVENT_FILE_PRE_REQUIRE, global, file, self);
-    suite.emit(EVENT_FILE_REQUIRE, require(file), file, self);
-    suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
-  });
+    try {
+      suite.emit(EVENT_FILE_REQUIRE, require(file), file, self);
+      suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
+    } catch (err) {
+      reportFileLoadError(suite, file, err);
+      break;
+    }
+  }
   fn && fn();
 };
 
@@ -420,6 +445,7 @@ Mocha.prototype.loadFiles = function (fn) {
  * The implementation relies on Node's `require` and `import` to execute
  * the test interface functions and will be subject to its cache.
  * Supports both CJS and ESM modules.
+ * Load errors are recorded as failing tests so they appear in reporter output.
  *
  * @public
  * @see {@link Mocha#addFile}
@@ -439,18 +465,24 @@ Mocha.prototype.loadFilesAsync = function ({ esmDecorator } = {}) {
   var self = this;
   var suite = this.suite;
   this.lazyLoadFiles(true);
+  var currentFile;
 
-  return esmUtils.loadFilesAsync(
-    this.files,
-    function (file) {
-      suite.emit(EVENT_FILE_PRE_REQUIRE, global, file, self);
-    },
-    function (file, resultModule) {
-      suite.emit(EVENT_FILE_REQUIRE, resultModule, file, self);
-      suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
-    },
-    esmDecorator,
-  );
+  return Promise.resolve(
+    esmUtils.loadFilesAsync(
+      this.files,
+      function (file) {
+        currentFile = file;
+        suite.emit(EVENT_FILE_PRE_REQUIRE, global, file, self);
+      },
+      function (file, resultModule) {
+        suite.emit(EVENT_FILE_REQUIRE, resultModule, file, self);
+        suite.emit(EVENT_FILE_POST_REQUIRE, global, file, self);
+      },
+      esmDecorator,
+    ),
+  ).catch(function (err) {
+    reportFileLoadError(suite, currentFile, err);
+  });
 };
 
 /**

--- a/test/integration/fixtures/regression/issue-4948-load-error.fixture.js
+++ b/test/integration/fixtures/regression/issue-4948-load-error.fixture.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Thrown during load (not inside a test) so Mocha must surface the error
+// instead of exiting with no reporter output. See issue #4948.
+throw new Error("intentional load failure from issue 4948");

--- a/test/integration/regression.spec.cjs
+++ b/test/integration/regression.spec.cjs
@@ -2,6 +2,7 @@
 
 var run = require("./helpers.cjs").runMocha;
 var runJSON = require("./helpers.cjs").runMochaJSON;
+var runMochaJSONAsync = require("./helpers.cjs").runMochaJSONAsync;
 
 describe("regressions", function () {
   it("issue-1991: Declarations do not get cleaned up unless you set them to `null` - Memory Leak", function (done) {
@@ -81,6 +82,20 @@ describe("regressions", function () {
           .and("to have passed test count", 1);
         done();
       },
+    );
+  });
+
+  it("issue-4948: should print an error when a test file fails to load", async function () {
+    const res = await runMochaJSONAsync(
+      "regression/issue-4948-load-error.fixture.js",
+    );
+
+    expect(res, "to have failed").and("to have failed test count", 1);
+    expect(res.failures[0].file, "to contain", "issue-4948-load-error");
+    expect(
+      res.failures[0].err.message || res.failures[0].err.stack,
+      "to contain",
+      "intentional load failure from issue 4948",
     );
   });
 });

--- a/test/node-unit/mocha.spec.cjs
+++ b/test/node-unit/mocha.spec.cjs
@@ -45,6 +45,7 @@ describe("Mocha", function () {
       bail: sinon.stub(),
       reset: sinon.stub(),
       dispose: sinon.stub(),
+      addTest: sinon.stub(),
     });
     stubs.Suite = sinon.stub().returns(stubs.suite);
     stubs.Suite.constants = {};
@@ -236,6 +237,22 @@ describe("Mocha", function () {
           "to be",
           esmDecorator,
         );
+      });
+
+      it("should record a failing test when loading a file throws", async function () {
+        const loadErr = new Error("could not import suite");
+        mocha.files = ["/tmp/broken.spec.js"];
+        stubs.esmUtils.loadFilesAsync.callsFake(async (files, preLoad) => {
+          preLoad(files[0]);
+          throw loadErr;
+        });
+
+        await mocha.loadFilesAsync();
+
+        expect(stubs.suite.addTest, "was called once");
+        const test = stubs.suite.addTest.firstCall.args[0];
+        expect(test.file, "to contain", "broken.spec.js");
+        expect(() => test.fn(), "to throw", loadErr);
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4948
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

When `Mocha#loadFiles` / `Mocha#loadFilesAsync` throws, the CLI never starts a reporter, so a load failure can exit with no user-facing output unless `DEBUG` is set.

This records the thrown error as a failing test on the root suite so the reporter prints the file and exception, then exits non-zero.

Fixes #4948