### PR TITLE
docs: fix minor API documentation issue

### DIFF
--- a/lib/cli/options.cjs
+++ b/lib/cli/options.cjs
@@ -122,7 +122,7 @@ const loadPkgRc = (args = {}) => {
  *
  * 1. Command-line args
  * 2. `MOCHA_OPTIONS` environment variable.
- * 3. RC file (`.mocharc.c?js`, `.mocharc.ya?ml`, `mocharc.json`)
+ * 3. RC file (`.mocharc.c?js`, `.mocharc.ya?ml`, `mocharc.jsonc?`)
  * 4. `mocha` prop of `package.json`
  * 5. default configuration (`lib/mocharc.json`)
  *


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`loadOptions` calls `loadRc`, which in turn calls `loadConfig`. This calls `parsers.json`, which strips comments from JSON. Ultimately, this implies `loadOptions` supports `.jsonc` RC files. This change trivially changes part of the jsdoc comment from `json` to `jsonc?` in order to reflect this support.
