### PR TITLE
fix: keep unknown config values from becoming test specs

### DIFF
--- a/lib/cli/unparse-args.js
+++ b/lib/cli/unparse-args.js
@@ -23,10 +23,7 @@ const unparseOption = (name, value) => {
     );
   }
 
-  if (name.includes(".")) {
-    return [`--${name}=${String(value)}`];
-  }
-  return [`--${name}`, String(value)];
+  return [`--${name}=${String(value)}`];
 };
 
 const unparseMochaArgs = (opts) => {

--- a/test/node-unit/cli/unparse-args.spec.js
+++ b/test/node-unit/cli/unparse-args.spec.js
@@ -49,14 +49,10 @@ describe("unparse-args", function () {
         [
           "test/a.spec.js",
           "test/b.spec.js",
-          "--require",
-          "tsx",
-          "--require",
-          "./setup.js",
-          "--reporter",
-          "json",
-          "--timeout",
-          "0",
+          "--require=tsx",
+          "--require=./setup.js",
+          "--reporter=json",
+          "--timeout=0",
           "--no-color",
           "--bail",
         ],
@@ -70,7 +66,7 @@ describe("unparse-args", function () {
           _: ["test/a.spec.js"],
         }),
         "to equal",
-        ["test/a.spec.js", "--reporter", "json"],
+        ["test/a.spec.js", "--reporter=json"],
       );
     });
 
@@ -81,7 +77,17 @@ describe("unparse-args", function () {
           reporter: "json",
         }),
         "to equal",
-        ["--reporter", "json"],
+        ["--reporter=json"],
+      );
+    });
+
+    it("keeps the value of an unrecognized option attached to its flag", function () {
+      expect(
+        unparseMochaArgs({
+          $schema: "https://json.schemastore.org/mocharc.json",
+        }),
+        "to equal",
+        ["--$schema=https://json.schemastore.org/mocharc.json"],
       );
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6242
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

A `$schema` key in `.mocharc.json` ends up in the spec list, so Mocha warns that it cannot match the pattern `https://json.schemastore.org/mocharc.json`, or fails with `No test files found` when nothing else matches.

When `bin/mocha.js` respawns Node it unparses the loaded options back into argv as `--name value`. The child re-parses that with `util.parseArgs`, which only knows the types of Mocha's own flags, so the value following an unknown flag like `--$schema` stays a positional and joins the specs. Writing values as `--name=value` keeps each one attached to its flag, the same way `unparseNodeFlags` already does it.

One note on the checklist above: #6242 is still in triage, so it does not carry the `status: accepting prs` label yet.
