### PR TITLE
chore: add dependency conflict detection workflow

### DIFF
--- a/.github/workflows/npm-script.yml
+++ b/.github/workflows/npm-script.yml
@@ -46,6 +46,26 @@ jobs:
         if: inputs.os
         run: echo "splitted=$(echo '${{ inputs.os }}' | jq -R -c 'split(",")')" >> $GITHUB_OUTPUT
 
+  find-conflicts:
+    permissions:
+      id-token: none
+    runs-on: ${{ matrix.os }}
+    needs:
+      - resolve-inputs
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: ${{ fromJson(needs.resolve-inputs.outputs.nodeVersions || '["22"]') }}
+        os: ${{ fromJson(needs.resolve-inputs.outputs.os || '["ubuntu-latest"]') }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node_version }}
+      - name: Check dependency tree
+        run: npm i --no-fund --package-lock-only --dry-run
+
   script:
     name: ${{ inputs.npm-script }}${{ needs.resolve-inputs.outputs.browsers && format('[{0}]', matrix.browser) }}${{ needs.resolve-inputs.outputs.nodeVersions && format(' with node.js {0}', matrix.node_version) }}${{ needs.resolve-inputs.outputs.os && format(' on {0}', matrix.os) }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6039 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a workflow that performs a dry run of installing dependencies and devDependencies. By using `npm i` instead of `npm ci`, this workflow will check `package-lock.json` and fail if there's a dependency conflict.