### PR TITLE
fix: fixup parsing negative numbers and quoted strings

### DIFF
--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -14,6 +14,9 @@ import {
 } from "./run-option-metadata.cjs";
 import { isNodeFlag } from "./node-flags.cjs";
 
+import debugModule from "debug";
+const debug = debugModule("mocha:cli:parse-args");
+
 const globOptions = ["spec", "ignore"];
 const aliasToCanonical = Object.entries(aliases).reduce(
   (acc, [canonical, optionAliases]) => {
@@ -200,11 +203,14 @@ const requiresValue = (name) => {
  * ```
  */
 const splitArgs = (args) => {
+  debug(`starting splitArgs(${args})`);
   if (!args) {
+    debug("splitArgs took in falsy value, returning empty array");
     return [];
   }
 
   if (Array.isArray(args)) {
+    debug("splitArgs took in array, returning argument unchanged");
     return args;
   }
 
@@ -247,7 +253,7 @@ const splitArgs = (args) => {
 
     // Using newlines in CLI in this way is difficult.
     // We do not handle it for now to keep tests simple.
-    if (/\t| /.test(char)) { 
+    if (/\t| /.test(char)) {
       if (tokenStarted) {
         result.push(current);
         current = "";
@@ -264,14 +270,19 @@ const splitArgs = (args) => {
     current += "\\";
   }
 
+  // Unterminated is OK, usually passed via MOCHA_OPTIONS
   if (quote) {
-    throw new Error(`Unterminated quote in arguments: ${args}`);
+    debug("unterminated quoted token, prepending quote");
+    current = quote + current;
+    debug(`updated token: ${current}`);
   }
 
   if (tokenStarted) {
     result.push(current);
   }
 
+  debug(`finishing splitArgs(${args})`);
+  debug(`returning ${result}`);
   return result;
 };
 
@@ -372,9 +383,9 @@ const createErrorForNumericPositionalArg = (
  * normalizes,
  * validates numerical args,
  * and returns resulting config object.
- * @param {string|string[]} args 
- * @param {object} defaultValues 
- * @param  {...any} configObjects 
+ * @param {string|string[]} args
+ * @param {object} defaultValues
+ * @param  {...any} configObjects
  */
 export const parseMochaArgs = (
   args = [],

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -13,10 +13,9 @@ import {
   types,
 } from "./run-option-metadata.cjs";
 import { isNodeFlag } from "./node-flags.cjs";
-
 import debugModule from "debug";
-const debug = debugModule("mocha:cli:parse-args");
 
+const debug = debugModule("mocha:cli:parse-args");
 const globOptions = ["spec", "ignore"];
 const aliasToCanonical = Object.entries(aliases).reduce(
   (acc, [canonical, optionAliases]) => {

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -186,6 +186,79 @@ const requiresValue = (name) => {
   );
 };
 
+const splitArgs = (args) => {
+  if (!args) {
+    return [];
+  }
+
+  if (Array.isArray(args)) {
+    return args;
+  }
+
+  const result = [];
+  let current = "";
+  let tokenStarted = false;
+  let quote = null;
+  let escaped = false;
+
+  for (const char of args) {
+    if (escaped) {
+      current += char;
+      tokenStarted = true;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      tokenStarted = true;
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+        tokenStarted = true;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      tokenStarted = true;
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (tokenStarted) {
+        result.push(current);
+        current = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+
+    current += char;
+    tokenStarted = true;
+  }
+
+  if (escaped) {
+    current += "\\";
+  }
+
+  if (quote) {
+    throw new Error(`Unterminated quote in arguments: ${args}`);
+  }
+
+  if (tokenStarted) {
+    result.push(current);
+  }
+
+  return result;
+};
+
 /**
  * Disallows multiple arguments after a single option, such as `--grep abc def`.
  */
@@ -198,7 +271,11 @@ const validateArgsBeforeParse = (allArgs) => {
     const name = canonicalOptionName(stripLeadingDashes(arg));
     const next = allArgs[index + 1];
 
-    if (requiresValue(name) && (next === undefined || next.startsWith("-"))) {
+    if (
+      requiresValue(name) &&
+      (next === undefined ||
+        (next.startsWith("-") && !isNumeric(next)))
+    ) {
       throw new Error(`Not enough arguments following: ${name}`);
     }
   });
@@ -276,7 +353,7 @@ export const parseMochaArgs = (
   defaultValues = {},
   ...configObjects
 ) => {
-  const allArgs = Array.isArray(args) ? args : args ? args.split(" ") : [];
+  const allArgs = splitArgs(args);
 
   // Save Node-specific args for special handling. Equals-form args have values;
   // the rest are boolean flags.

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -273,8 +273,7 @@ const validateArgsBeforeParse = (allArgs) => {
 
     if (
       requiresValue(name) &&
-      (next === undefined ||
-        (next.startsWith("-") && !isNumeric(next)))
+      (next === undefined || (next.startsWith("-") && !isNumeric(next)))
     ) {
       throw new Error(`Not enough arguments following: ${name}`);
     }

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -186,6 +186,19 @@ const requiresValue = (name) => {
   );
 };
 
+/**
+ * Splits for downstream handling.
+ * Does not apply Mocha-specific logic.
+ * If arg is already string array, returns arg.
+ * Respects escaped chars and quoted strings.
+ * @param {string|string[]} args Input to be split, e.g. `"--grep -1"`
+ * @returns {string[]} One entry per CLI arg-equivalent
+ * @sample
+ * ```js
+ * const x = splitArgs("--timeout -1 --grep 'foo \' bar' --color");
+ * x === ["--timeout", "-1", "--grep", "foo ' bar", "--color"]; // true
+ * ```
+ */
 const splitArgs = (args) => {
   if (!args) {
     return [];
@@ -230,8 +243,11 @@ const splitArgs = (args) => {
       quote = char;
       continue;
     }
+    // At this point, we are not in quoted mode
 
-    if (/\s/.test(char)) {
+    // Using newlines in CLI in this way is difficult.
+    // We do not handle it for now to keep tests simple.
+    if (/\t| /.test(char)) { 
       if (tokenStarted) {
         result.push(current);
         current = "";
@@ -347,6 +363,19 @@ const createErrorForNumericPositionalArg = (
   );
 };
 
+/**
+ * Parse the args into a config object.
+ * Splits,
+ * handles Node args,
+ * validates general args,
+ * parses into config object,
+ * normalizes,
+ * validates numerical args,
+ * and returns resulting config object.
+ * @param {string|string[]} args 
+ * @param {object} defaultValues 
+ * @param  {...any} configObjects 
+ */
 export const parseMochaArgs = (
   args = [],
   defaultValues = {},

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -494,9 +494,7 @@ describe("options", function () {
         findConfig = sinon.stub().returns("/some/.mocharc.json");
         loadConfig = sinon.stub().returns({});
         findupSync = sinon.stub().returns("/some/package.json");
-        sinon
-          .stub(process, "env")
-          .value({ MOCHA_OPTIONS: "--timeout -1" });
+        sinon.stub(process, "env").value({ MOCHA_OPTIONS: "--timeout -1" });
 
         loadOptions = proxyLoadOptions({
           readFileSync,

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -506,7 +506,7 @@ describe("options", function () {
         expect(loadOptions(), "to have property", "timeout", "-1");
       });
 
-      it("should allow strings starting with hyphen in MOCHA_OPTIONS", function () {
+      it("should allow dash-prefixed option values in MOCHA_OPTIONS", function () {
         readFileSync = sinon.stub().onFirstCall().returns("{}");
         findConfig = sinon.stub().returns("/some/.mocharc.json");
         loadConfig = sinon.stub().returns({});
@@ -521,8 +521,7 @@ describe("options", function () {
         });
 
         expect(loadOptions(), "to have property", "grep", "-1");
-
-      })
+      });
     });
 
     describe("config priority", function () {

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -466,6 +466,47 @@ describe("options", function () {
           color: true,
         });
       });
+
+      it("should parse quoted flags from MOCHA_OPTIONS", function () {
+        readFileSync = sinon.stub().onFirstCall().returns("{}");
+        findConfig = sinon.stub().returns("/some/.mocharc.json");
+        loadConfig = sinon.stub().returns({});
+        findupSync = sinon.stub().returns("/some/package.json");
+        sinon
+          .stub(process, "env")
+          .value({ MOCHA_OPTIONS: "--grep 'foo bar' --color" });
+
+        loadOptions = proxyLoadOptions({
+          readFileSync,
+          findConfig,
+          loadConfig,
+          findupSync,
+        });
+
+        expect(loadOptions(), "to satisfy", {
+          grep: "foo bar",
+          color: true,
+        });
+      });
+
+      it("should allow negative numeric values in MOCHA_OPTIONS", function () {
+        readFileSync = sinon.stub().onFirstCall().returns("{}");
+        findConfig = sinon.stub().returns("/some/.mocharc.json");
+        loadConfig = sinon.stub().returns({});
+        findupSync = sinon.stub().returns("/some/package.json");
+        sinon
+          .stub(process, "env")
+          .value({ MOCHA_OPTIONS: "--timeout -1" });
+
+        loadOptions = proxyLoadOptions({
+          readFileSync,
+          findConfig,
+          loadConfig,
+          findupSync,
+        });
+
+        expect(loadOptions(), "to have property", "timeout", "-1");
+      });
     });
 
     describe("config priority", function () {

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -505,6 +505,24 @@ describe("options", function () {
 
         expect(loadOptions(), "to have property", "timeout", "-1");
       });
+
+      it("should allow strings starting with hyphen in MOCHA_OPTIONS", function () {
+        readFileSync = sinon.stub().onFirstCall().returns("{}");
+        findConfig = sinon.stub().returns("/some/.mocharc.json");
+        loadConfig = sinon.stub().returns({});
+        findupSync = sinon.stub().returns("/some/package.json");
+        sinon.stub(process, "env").value({ MOCHA_OPTIONS: "--grep -1" });
+
+        loadOptions = proxyLoadOptions({
+          readFileSync,
+          findConfig,
+          loadConfig,
+          findupSync,
+        });
+
+        expect(loadOptions(), "to have property", "grep", "-1");
+
+      })
     });
 
     describe("config priority", function () {

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -318,11 +318,13 @@ describe("parse-args", function () {
     );
   });
 
-  it("rejects unterminated quoted arguments", function () {
+  it("accepts unterminated quoted arguments", function () {
     expect(
-      () => parseMochaArgs('--grep "foo', defaults),
-      "to throw",
-      /Unterminated quote in arguments/,
+      parseMochaArgs('--grep "foo', defaults),
+      "to satisfy",
+      {
+        grep: '"foo',
+      },
     );
   });
 

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -307,9 +307,9 @@ describe("parse-args", function () {
     });
   });
 
-  it("splits arguments on all whitespace", function () {
+  it("splits arguments on all spaces and tabs", function () {
     expect(
-      parseMochaArgs("\t--grep\nfoo\r\n--color  ", defaults),
+      parseMochaArgs("\t--grep  \t foo   --color", defaults),
       "to satisfy",
       {
         grep: "foo",

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -319,13 +319,9 @@ describe("parse-args", function () {
   });
 
   it("accepts unterminated quoted arguments", function () {
-    expect(
-      parseMochaArgs('--grep "foo', defaults),
-      "to satisfy",
-      {
-        grep: '"foo',
-      },
-    );
+    expect(parseMochaArgs('--grep "foo', defaults), "to satisfy", {
+      grep: '"foo',
+    });
   });
 
   it("rejects dash-prefixed option values in separated form", function () {

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -239,6 +239,14 @@ describe("parse-args", function () {
     });
   });
 
+  it("rejects dash-prefixed option values in separated form", function () {
+    expect(
+      () => parseMochaArgs(["--grep", "-foo"], defaults),
+      "to throw",
+      /Not enough arguments following: grep/,
+    );
+  });
+
   it("accepts negative numeric option values in separated form", function () {
     expect(parseMochaArgs(["--timeout", "-1"], defaults), "to satisfy", {
       timeout: "-1",
@@ -316,14 +324,6 @@ describe("parse-args", function () {
     expect(parseMochaArgs('--grep "foo', defaults), "to satisfy", {
       grep: '"foo',
     });
-  });
-
-  it("rejects dash-prefixed option values in separated form", function () {
-    expect(
-      () => parseMochaArgs(["--grep", "-foo"], defaults),
-      "to throw",
-      /Not enough arguments following: grep/,
-    );
   });
 
   it("preserves directly-passed Node and V8 flags", function () {

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -272,14 +272,10 @@ describe("parse-args", function () {
   });
 
   it("parses single-quoted arguments from strings", function () {
-    expect(
-      parseMochaArgs("--grep 'foo bar' --color", defaults),
-      "to satisfy",
-      {
-        grep: "foo bar",
-        color: true,
-      },
-    );
+    expect(parseMochaArgs("--grep 'foo bar' --color", defaults), "to satisfy", {
+      grep: "foo bar",
+      color: true,
+    });
   });
 
   it("parses quoted values attached to options from strings", function () {

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -239,6 +239,97 @@ describe("parse-args", function () {
     });
   });
 
+  it("accepts negative numeric option values in separated form", function () {
+    expect(parseMochaArgs(["--timeout", "-1"], defaults), "to satisfy", {
+      timeout: "-1",
+    });
+  });
+
+  it("accepts negative numeric option values from strings", function () {
+    expect(parseMochaArgs("--timeout -1", defaults), "to satisfy", {
+      timeout: "-1",
+    });
+  });
+
+  it("accepts decimal and exponential negative numeric option values", function () {
+    ["-1.5", "-.5", "-1e3"].forEach((timeout) => {
+      expect(parseMochaArgs(["--timeout", timeout], defaults), "to satisfy", {
+        timeout,
+      });
+    });
+  });
+
+  it("parses double-quoted arguments from strings", function () {
+    expect(
+      parseMochaArgs('--grep "foo bar" --retries 3 --color', defaults),
+      "to satisfy",
+      {
+        grep: "foo bar",
+        retries: 3,
+        color: true,
+      },
+    );
+  });
+
+  it("parses single-quoted arguments from strings", function () {
+    expect(
+      parseMochaArgs("--grep 'foo bar' --color", defaults),
+      "to satisfy",
+      {
+        grep: "foo bar",
+        color: true,
+      },
+    );
+  });
+
+  it("parses quoted values attached to options from strings", function () {
+    expect(parseMochaArgs('--grep="foo bar"', defaults), "to satisfy", {
+      grep: "foo bar",
+    });
+  });
+
+  it("preserves empty quoted option values from strings", function () {
+    expect(parseMochaArgs('--grep ""', defaults), "to satisfy", {
+      grep: "",
+    });
+  });
+
+  it("parses escaped spaces and quotes from strings", function () {
+    expect(
+      parseMochaArgs('--grep foo\\ bar --fgrep "a \\"quote\\""', defaults),
+      "to satisfy",
+      {
+        grep: "foo bar",
+        fgrep: 'a "quote"',
+      },
+    );
+  });
+
+  it("preserves trailing backslashes in unquoted arguments", function () {
+    expect(parseMochaArgs("--grep foo\\", defaults), "to satisfy", {
+      grep: "foo\\",
+    });
+  });
+
+  it("splits arguments on all whitespace", function () {
+    expect(
+      parseMochaArgs("\t--grep\nfoo\r\n--color  ", defaults),
+      "to satisfy",
+      {
+        grep: "foo",
+        color: true,
+      },
+    );
+  });
+
+  it("rejects unterminated quoted arguments", function () {
+    expect(
+      () => parseMochaArgs('--grep "foo', defaults),
+      "to throw",
+      /Unterminated quote in arguments/,
+    );
+  });
+
   it("rejects dash-prefixed option values in separated form", function () {
     expect(
       () => parseMochaArgs(["--grep", "-foo"], defaults),

--- a/test/node-unit/cli/parse-args.spec.js
+++ b/test/node-unit/cli/parse-args.spec.js
@@ -301,12 +301,6 @@ describe("parse-args", function () {
     );
   });
 
-  it("preserves trailing backslashes in unquoted arguments", function () {
-    expect(parseMochaArgs("--grep foo\\", defaults), "to satisfy", {
-      grep: "foo\\",
-    });
-  });
-
   it("splits arguments on all spaces and tabs", function () {
     expect(
       parseMochaArgs("\t--grep  \t foo   --color", defaults),


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to mocha! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6252
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

We naively split args on single spaces earlier, which ignored cases like quoted strings, tabs, and more.

We also rejected negative numbers and dash-prefixed option values (`--grep -foo` is rejected in 12 RC 6), where Mocha 11 does not reject these cases.

This PR adds a `splitArgs` helper to handle these cases better and the same as Mocha 11.