### PR TITLE
fix: preserve FIFO descriptors when respawning

### DIFF
--- a/bin/mocha.js
+++ b/bin/mocha.js
@@ -10,6 +10,7 @@
 
 import d from "debug";
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import os from "node:os";
 import { unparseMochaArgs } from "../lib/cli/unparse-args.js";
 
@@ -95,6 +96,17 @@ if (mochaArgs["node-option"] || Object.keys(nodeArgs).length || hasInspect) {
 
   debug("final node argv", nodeArgv);
 
+  const stdio = ["inherit", "inherit", "inherit"];
+  mochaArgs._ = mochaArgs._?.map((arg) => {
+    const match = /^\/dev\/fd\/(\d+)$/.exec(arg);
+    if (!match || !fs.existsSync(arg)) {
+      return arg;
+    }
+
+    stdio.push(Number(match[1]));
+    return `/dev/fd/${stdio.length - 1}`;
+  });
+
   const args = [].concat(
     nodeArgv,
     mochaPath,
@@ -108,7 +120,7 @@ if (mochaArgs["node-option"] || Object.keys(nodeArgs).length || hasInspect) {
   );
 
   const proc = spawn(process.execPath, args, {
-    stdio: "inherit",
+    stdio,
   });
 
   proc.on("exit", (code, signal) => {

--- a/test/integration/fifo.spec.cjs
+++ b/test/integration/fifo.spec.cjs
@@ -1,7 +1,8 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const { execSync } = require("node:child_process");
+const { execFile, execSync } = require("node:child_process");
+const { promisify } = require("node:util");
 const {
   createReadStream,
   createWriteStream,
@@ -12,8 +13,30 @@ const { join } = require("node:path");
 const { tmpdir } = require("node:os");
 
 const { invokeMocha, toJSONResult } = require("./helpers.cjs");
+const execFileAsync = promisify(execFile);
+const itPosix = process.platform === "win32" ? it.skip : it;
 
 describe("FIFO support", function () {
+  itPosix(
+    "should accept a test passed using process substitution when respawning",
+    async function () {
+      const source = "it('should pass', () => true);";
+      const mochaPath = require.resolve("../../bin/mocha.js");
+
+      const { stdout } = await execFileAsync("/bin/bash", [
+        "-c",
+        '"$1" --no-config --reporter json --preserve-symlinks <(printf %s "$2")',
+        "bash",
+        mochaPath,
+        source,
+      ]);
+
+      const result = JSON.parse(stdout);
+      assert.equal(result.stats.tests, 1);
+      assert.equal(result.stats.passes, 1);
+    },
+  );
+
   it("should accept a test passed as a FIFO", function (done) {
     const dir = mkdtempSync(join(tmpdir(), "mocha-test-fifo-"));
     const fifoPath = join(dir, "fifo-1");


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6253
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies a filter to `mochaArgs._` to capture `/dev/fd/*` inputs. If one is found, we append its number and repam to `/dev/fd/` + that number.

I really, really didn't want to have to do things this way - it's super spooky to remap strings. But I couldn't figure out another approach. 🤷 
