### PR TITLE
feat: add escapeSpecialCharacters option to markdown reporter

### DIFF
--- a/docs/src/content/docs/reporters/markdown.mdx
+++ b/docs/src/content/docs/reporters/markdown.mdx
@@ -8,3 +8,6 @@ Alias: `Markdown`, `markdown`
 The Markdown reporter generates a markdown TOC and body for your test suite.
 This is great if you want to use the tests as documentation within a GitHub wiki page, or a markdown file in the repository that GitHub can render.
 For example, here is the Connect [test output](https://github.com/senchalabs/connect/blob/90a725343c2945aaee637e799b1cd11e065b2bff/tests.md).
+
+By default, suite and test titles are inserted into the markdown verbatim, so titles containing markdown special characters (such as `*`, `_`, backticks, or `#`) can break the rendered output.
+To backslash-escape special characters in titles instead, use `--reporter-option escapeSpecialCharacters=true`.

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -24,6 +24,20 @@ var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 
 var SUITE_PREFIX = "$";
 
+var MARKDOWN_SPECIAL_CHARACTERS = /([\\`*_{}[\]()#+\-.!<>|])/g;
+
+/**
+ * Backslash-escapes characters that have special meaning in markdown so that
+ * titles are rendered literally.
+ *
+ * @private
+ * @param {string} str - Raw title text.
+ * @return {string} Escaped text safe for inline use in markdown.
+ */
+function escapeSpecialCharacters(str) {
+  return str.replace(MARKDOWN_SPECIAL_CHARACTERS, "\\$1");
+}
+
 class Markdown extends Base {
   static description = "GitHub Flavored Markdown";
 
@@ -42,8 +56,17 @@ class Markdown extends Base {
     var level = 0;
     var buf = "";
 
+    var escapeTitle =
+      options &&
+      options.reporterOptions &&
+      options.reporterOptions.escapeSpecialCharacters
+        ? escapeSpecialCharacters
+        : function (str) {
+            return str;
+          };
+
     function title(str) {
-      return Array(level).join("#") + " " + str;
+      return Array(level).join("#") + " " + escapeTitle(str);
     }
 
     function mapTOC(suite, obj) {
@@ -67,7 +90,7 @@ class Markdown extends Base {
           continue;
         }
         if (key !== SUITE_PREFIX) {
-          link = " - [" + key.substring(1) + "]";
+          link = " - [" + escapeTitle(key.substring(1)) + "]";
           link += "(#" + utils.slug(obj[key].suite.fullTitle()) + ")\n";
           buf += Array(level).join("  ") + link;
         }
@@ -96,7 +119,7 @@ class Markdown extends Base {
 
     runner.on(EVENT_TEST_PASS, function (test) {
       var code = utils.clean(test.body);
-      buf += test.title + ".\n";
+      buf += escapeTitle(test.title) + ".\n";
       buf += "\n```js\n";
       buf += code + "\n";
       buf += "```\n\n";

--- a/test/reporters/markdown.spec.cjs
+++ b/test/reporters/markdown.spec.cjs
@@ -112,4 +112,131 @@ describe("Markdown reporter", function () {
       });
     });
   });
+
+  describe("'escapeSpecialCharacters' reporter option", function () {
+    var expectedBody = "some body";
+
+    function createSuite(title) {
+      return {
+        title,
+        fullTitle: function () {
+          return expectedFullTitle;
+        },
+        suites: [],
+      };
+    }
+
+    function createTest(title) {
+      return {
+        title,
+        fullTitle: function () {
+          return expectedFullTitle;
+        },
+        duration: 1000,
+        currentRetry: function () {
+          return 1;
+        },
+        slow: noop,
+        body: expectedBody,
+      };
+    }
+
+    describe("when enabled", function () {
+      var options = { reporterOptions: { escapeSpecialCharacters: true } };
+      var specialCharacters = [
+        "\\",
+        "`",
+        "*",
+        "_",
+        "{",
+        "}",
+        "[",
+        "]",
+        "(",
+        ")",
+        "#",
+        "+",
+        "-",
+        ".",
+        "!",
+        "<",
+        ">",
+        "|",
+      ];
+
+      specialCharacters.forEach(function (character) {
+        it(
+          "should escape '" + character + "' in TOC and test titles",
+          async function () {
+            var title = "title with " + character + " character";
+            var escapedTitle = "title with \\" + character + " character";
+            var test = createTest(title);
+            var runner = createMockRunner(
+              "pass end",
+              EVENT_TEST_PASS,
+              EVENT_RUN_END,
+              null,
+              test,
+            );
+            runner.suite = createSuite(title);
+            var { stdout } = await runReporter({}, runner, options);
+
+            var expectedArray = [
+              "# TOC\n",
+              " - [" + escapedTitle + "](#" + sluggedFullTitle + ")\n",
+              escapedTitle + ".\n\n```js\n" + expectedBody + "\n```\n\n",
+            ];
+
+            expect(stdout, "to equal", expectedArray);
+          },
+        );
+      });
+
+      it("should escape special characters in suite headings", async function () {
+        var expectedSuite = createSuite("*** [markdown] `titles`");
+        var runner = createMockRunner(
+          "suite suite end",
+          EVENT_SUITE_BEGIN,
+          EVENT_SUITE_END,
+          EVENT_RUN_END,
+          expectedSuite,
+        );
+        runner.suite = expectedSuite;
+        var { stdout } = await runReporter({}, runner, options);
+
+        var escapedTitle = "\\*\\*\\* \\[markdown\\] \\`titles\\`";
+        var expectedArray = [
+          "# TOC\n",
+          " - [" + escapedTitle + "](#" + sluggedFullTitle + ")\n",
+          '<a name="' + sluggedFullTitle + '"></a>\n ' + escapedTitle + "\n",
+        ];
+
+        expect(stdout, "to equal", expectedArray);
+      });
+    });
+
+    describe("when disabled", function () {
+      it("should write titles verbatim", async function () {
+        var title = "*** _title_ with `special` #characters";
+        var test = createTest(title);
+        var runner = createMockRunner(
+          "pass end",
+          EVENT_TEST_PASS,
+          EVENT_RUN_END,
+          null,
+          test,
+        );
+        runner.suite = createSuite(title);
+        var { stdout } = await runReporter({}, runner, {});
+
+        var expectedArray = [
+          "# TOC\n",
+          " - [" + title + "](#" + sluggedFullTitle + ")\n",
+          title + ".\n\n```js\n" + expectedBody + "\n```\n\n",
+        ];
+
+        expect(stdout, "to equal", expectedArray);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2306
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Test and suite titles containing markdown-special characters (backticks, `|`, `*`, `_`, `#`, `<`, …) currently break the markdown reporter's output — they get interpreted as markup in the TOC links, headings, and test-title lines.

Following the direction in #2306 (an option first, default flip in a future major), this adds an opt-in reporter option:

```
mocha -R markdown --reporter-option escapeSpecialCharacters=true
```

When enabled, `\` `` ` `` `*` `_` `{` `}` `[` `]` `(` `)` `#` `+` `-` `.` `!` `<` `>` `|` in titles are backslash-escaped at the three sites that render titles (TOC link text, suite headings, test-title lines). Anchors (`utils.slug`) and code fences are untouched. With the option off, output is byte-identical to today.

The option is read via `options.reporterOptions` the same way `xunit` and `tap` read theirs, and it's documented in `docs/src/content/docs/reporters/markdown.mdx` following the xunit page's "use `--reporter-option`" precedent.

Tests: one case per special character (18) plus suite-heading coverage and an option-off case asserting titles are written verbatim — written before the implementation (19 failing → 22 passing). `npm run test-node:reporters`, `test-node:unit`, `test-browser`, eslint, prettier, and `tsc` all pass.

Compared to the earlier attempts: #6155 was declined for making escaping the default and lacking per-character tests; both are addressed here, and this PR is scoped to the single issue.
