### PR TITLE
fix: resolve unloadFile paths from cwd

### DIFF
--- a/lib/nodejs/file-unloader.cjs
+++ b/lib/nodejs/file-unloader.cjs
@@ -1,5 +1,7 @@
 "use strict";
 
+const path = require("node:path");
+
 /**
  * This module should not be in the browser bundle, so it's here.
  * @private
@@ -11,5 +13,5 @@
  * @param {string} file - File
  */
 exports.unloadFile = (file) => {
-  delete require.cache[require.resolve(file)];
+  delete require.cache[require.resolve(path.resolve(file))];
 };

--- a/test/node-unit/mocha.spec.cjs
+++ b/test/node-unit/mocha.spec.cjs
@@ -254,6 +254,19 @@ describe("Mocha", function () {
       it("should be chainable", function () {
         expect(mocha.unloadFiles(), "to be", mocha);
       });
+
+      it("should unload files added with paths relative to the current working directory", function () {
+        const relativeFixturePath = path.relative(
+          process.cwd(),
+          DUMB_FIXTURE_PATH,
+        );
+
+        require(DUMB_FIXTURE_PATH);
+        mocha.addFile(relativeFixturePath);
+        mocha.unloadFiles();
+
+        expect(require.cache, "not to have key", DUMB_FIXTURE_PATH);
+      });
     });
 
     describe("reporter()", function () {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4548
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`addFile()` keeps paths exactly as supplied, and Mocha loads relative paths from the current working directory. `unloadFile()` instead passed those paths directly to `require.resolve()`, which resolved them relative to `lib/nodejs/file-unloader.cjs` and threw `MODULE_NOT_FOUND`.

Resolve the file path from the current working directory before looking up its cache key. The regression test loads a fixture, adds it using a cwd-relative path, and verifies that `unloadFiles()` removes it from `require.cache`.

The commit includes co-author attribution for the original implementation in #4549.

### Validation

- `npm run test-node:unit` — 1220 passing, 3 pending
- integration suite — 374 passing, 1 pending
- remaining Node interface, JS API, only, reporter, and require suites — passing
- Playwright browser suite — 4 passing
- Webpack compatibility build — passing
- formatting, ESLint, Knip, TypeScript, and smoke checks — passing

Fixes #4548
