### PR TITLE
chore: convert lib/runner.js to ESM

### DIFF
--- a/docs/src/content/docs/explainers/programmatic-usage.mdx
+++ b/docs/src/content/docs/explainers/programmatic-usage.mdx
@@ -33,7 +33,7 @@ mocha.run(function (failures) {
 });
 ```
 
-`mocha.run()` returns a `Runner` instance which emits many [events](https://github.com/mochajs/mocha/blob/main/lib/runner.cjs) of interest, exposed as `Mocha.Runner.constants` (e.g. `EVENT_TEST_PASS`, `EVENT_TEST_FAIL`, `EVENT_RUN_END`).
+`mocha.run()` returns a `Runner` instance which emits many [events](https://github.com/mochajs/mocha/blob/main/lib/runner.js) of interest, exposed as `Mocha.Runner.constants` (e.g. `EVENT_TEST_PASS`, `EVENT_TEST_FAIL`, `EVENT_RUN_END`).
 
 Note that `run` (via `loadFiles`, which it calls) relies on Node's `require` to execute the test interface functions. Thus, files loaded by Mocha will be stored in Node's `require` cache and therefore tests in these files will not be re-run if `mocha.run()` is called again. If you want to run tests multiple times, you may need to clear Node's `require` cache before subsequent calls in whichever manner best suits your needs. `Mocha#unloadFiles` is also available and will remove all files loaded by `Mocha#loadFiles`.
 

--- a/lib/cli/run-helpers.cjs
+++ b/lib/cli/run-helpers.cjs
@@ -11,7 +11,7 @@
  * @typedef {import('../mocha.cjs')} Mocha
  * @typedef {import('../types.d.ts').MochaOptions} MochaOptions
  * @typedef {import('../types.d.ts').UnmatchedFile} UnmatchedFile
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 const fs = require("node:fs");

--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -97,7 +97,7 @@ exports.Context = require("./context.js").Context;
  *
  * @memberof Mocha
  */
-exports.Runner = require("./runner.cjs");
+exports.Runner = require("./runner.js").Runner;
 exports.Suite = Suite;
 exports.Hook = require("./hook.js").Hook;
 exports.Test = require("./test.js").Test;
@@ -971,7 +971,7 @@ Object.defineProperty(Mocha.prototype, "version", {
  * @see {@link Mocha#unloadFiles}
  * @see {@link Runner#run}
  * @param {DoneCB} [fn] - Callback invoked when test execution completed.
- * @returns {import("./runner.cjs")} runner instance
+ * @returns {import("./runner.js").Runner} runner instance
  * @example
  *
  * // exit with non-zero status if there were test failures

--- a/lib/nodejs/parallel-buffered-runner.cjs
+++ b/lib/nodejs/parallel-buffered-runner.cjs
@@ -13,7 +13,7 @@
  * @typedef {import('../types.d.ts').SigIntListener} SigIntListener
  */
 
-const Runner = require("../runner.cjs");
+const { Runner } = require("../runner.js");
 const { EVENT_RUN_BEGIN, EVENT_RUN_END } = Runner.constants;
 const debug = require("debug")("mocha:parallel:parallel-buffered-runner");
 const { BufferedWorkerPool } = require("./buffered-worker-pool.cjs");

--- a/lib/nodejs/reporters/parallel-buffered.cjs
+++ b/lib/nodejs/reporters/parallel-buffered.cjs
@@ -8,7 +8,7 @@
 
 /**
  * @typedef {import('../../types.d.ts').BufferedEvent} BufferedEvent
- * @typedef {import('../../runner.cjs')} Runner
+ * @typedef {import('../../runner.js').Runner} Runner
  */
 
 /**
@@ -29,7 +29,7 @@ const {
   EVENT_HOOK_BEGIN,
   EVENT_HOOK_END,
   EVENT_RUN_END,
-} = require("../../runner.cjs").constants;
+} = require("../../runner.js").Runner.constants;
 const {
   SerializableEvent,
   SerializableWorkerResult,

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  * @typedef {import('../test.js')} Test
  * @typedef {import('../types.d.ts').FullErrorStack} FullErrorStack
  */
@@ -15,7 +15,7 @@ import * as diff from "diff";
 import milliseconds from "ms";
 import utils from "../utils.cjs";
 import supportsColor from "supports-color";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 
 const { constants } = Runner;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;

--- a/lib/reporters/doc.js
+++ b/lib/reporters/doc.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -11,7 +11,7 @@
 
 import { Base } from "./base.js";
 import utils from "../utils.cjs";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 
 var { constants } = Runner;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;

--- a/lib/reporters/github-actions.js
+++ b/lib/reporters/github-actions.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  * @typedef {import('../test.js')} Test
  */
 
@@ -13,7 +13,7 @@
 import fs from "node:fs";
 import ms from "ms";
 import { Spec } from "./spec.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 
 const { constants } = Runner;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -12,7 +12,7 @@
 import { Base } from "./base.js";
 import utils from "../utils.cjs";
 import { escapeRegExp } from "../utils/regexp.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  * @typedef {import('../test.js')} Test
  */
 
@@ -11,7 +11,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -14,7 +14,7 @@ import fs from "node:fs";
 import path from "node:path";
 import * as errors from "../errors.js";
 import utils from "../utils.cjs";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 const createUnsupportedError = errors.createUnsupportedError;
 var constants = Runner.constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 import { Runnable } from "../runnable.js";
 var constants = Runner.constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 
 var { constants } = Runner;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -11,7 +11,7 @@
 
 import { Base } from "./base.js";
 import utils from "../utils.cjs";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_RUN_END = constants.EVENT_RUN_END;
 var EVENT_SUITE_BEGIN = constants.EVENT_SUITE_BEGIN;

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 
 var { constants } = Runner;
 var EVENT_RUN_END = constants.EVENT_RUN_END;

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_TEST_END = constants.EVENT_TEST_END;

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  * @typedef {import('../test.js')} Test
  */
 
@@ -11,7 +11,7 @@
  */
 
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_RUN_BEGIN = constants.EVENT_RUN_BEGIN;
 var EVENT_RUN_END = constants.EVENT_RUN_END;

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  * @typedef {import('../test.js')} Test
  */
 
@@ -12,7 +12,7 @@
 
 import util from "node:util";
 import { Base } from "./base.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 var constants = Runner.constants;
 var EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
 var EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../runner.cjs')} Runner
+ * @typedef {import('../runner.js').Runner} Runner
  * @typedef {import('../test.js')} Test
  */
 
@@ -15,7 +15,7 @@ import utils from "../utils.cjs";
 import fs from "node:fs";
 import path from "node:path";
 import * as errors from "../errors.js";
-import Runner from "../runner.cjs";
+import { Runner } from "../runner.js";
 import { Runnable } from "../runnable.js";
 var createUnsupportedError = errors.createUnsupportedError;
 var constants = Runner.constants;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * @typedef {import('./types.d.ts').RunnerOptions} RunnerOptions
  */
@@ -8,12 +6,22 @@
  * Module dependencies.
  * @private
  */
-var EventEmitter = require("node:events").EventEmitter;
-var { PendingError } = require("./pending.js");
-var utils = require("./utils.cjs");
-var debug = require("debug")("mocha:runner");
-var { Runnable } = require("./runnable.js");
-var { Suite } = require("./suite.js");
+import { EventEmitter } from "node:events";
+import debugModule from "debug";
+import { PendingError } from "./pending.js";
+import utils from "./utils.cjs";
+import { Runnable } from "./runnable.js";
+import { Suite } from "./suite.js";
+import {
+  createInvalidExceptionError,
+  createUnsupportedError,
+  createFatalError,
+  isMochaError,
+} from "./errors.js";
+import { constants as errorConstants } from "./error-constants.js";
+
+const debug = debugModule("mocha:runner");
+
 var HOOK_TYPE_BEFORE_EACH = Suite.constants.HOOK_TYPE_BEFORE_EACH;
 var HOOK_TYPE_AFTER_EACH = Suite.constants.HOOK_TYPE_AFTER_EACH;
 var HOOK_TYPE_AFTER_ALL = Suite.constants.HOOK_TYPE_AFTER_ALL;
@@ -24,14 +32,6 @@ var STATE_PASSED = Runnable.constants.STATE_PASSED;
 var STATE_PENDING = Runnable.constants.STATE_PENDING;
 var stackFilter = utils.stackTraceFilter();
 var stringify = utils.stringify;
-
-const {
-  createInvalidExceptionError,
-  createUnsupportedError,
-  createFatalError,
-  isMochaError,
-} = require("./errors.js");
-const { constants: errorConstants } = require("./error-constants.js");
 
 /**
  * Non-enumerable globals.
@@ -1421,4 +1421,4 @@ Runner.constants = constants;
  * @see {@link https://nodejs.org/api/events.html#events_class_eventemitter}
  */
 
-module.exports = Runner;
+export { Runner };

--- a/lib/stats-collector.js
+++ b/lib/stats-collector.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import('./types.d.ts').StatsCollector} StatsCollector
- * @typedef {import('./runner.cjs')} Runner
+ * @typedef {import('./runner.js').Runner} Runner
  */
 
 /**
@@ -8,7 +8,7 @@
  * @module
  */
 
-import Runner from "./runner.cjs";
+import { Runner } from "./runner.js";
 
 const {
   EVENT_TEST_PASS,

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -10,7 +10,7 @@ import type { FSWatcher, MatchFunction } from "chokidar" with {
 
 import type { constants } from "./error-constants.js";
 import type Mocha from "./mocha.cjs";
-import Runner from "./runner.cjs";
+import { Runner } from "./runner.js";
 
 /**
  * Command-line options

--- a/test/integration/fixtures/runner/events-bail-retries.fixture.cjs
+++ b/test/integration/fixtures/runner/events-bail-retries.fixture.cjs
@@ -1,5 +1,5 @@
 'use strict';
-var Runner = require('../../../../lib/runner.cjs');
+var { Runner } = require('../../../../lib/runner.js');
 var assert = require('assert');
 var constants = Runner.constants;
 var EVENT_HOOK_BEGIN = constants.EVENT_HOOK_BEGIN;

--- a/test/integration/fixtures/runner/events-bail.fixture.cjs
+++ b/test/integration/fixtures/runner/events-bail.fixture.cjs
@@ -1,5 +1,5 @@
 'use strict';
-var Runner = require('../../../../lib/runner.cjs');
+var { Runner } = require('../../../../lib/runner.js');
 var assert = require('assert');
 var constants = Runner.constants;
 var EVENT_HOOK_BEGIN = constants.EVENT_HOOK_BEGIN;

--- a/test/integration/fixtures/runner/events-basic.fixture.cjs
+++ b/test/integration/fixtures/runner/events-basic.fixture.cjs
@@ -1,5 +1,5 @@
 'use strict';
-var Runner = require('../../../../lib/runner.cjs');
+var { Runner } = require('../../../../lib/runner.js');
 var assert = require('assert');
 var constants = Runner.constants;
 var EVENT_DELAY_BEGIN = constants.EVENT_DELAY_BEGIN;

--- a/test/integration/fixtures/runner/events-delay.fixture.cjs
+++ b/test/integration/fixtures/runner/events-delay.fixture.cjs
@@ -1,5 +1,5 @@
 'use strict';
-var Runner = require('../../../../lib/runner.cjs');
+var { Runner } = require('../../../../lib/runner.js');
 var assert = require('assert');
 var constants = Runner.constants;
 var EVENT_DELAY_BEGIN = constants.EVENT_DELAY_BEGIN;

--- a/test/integration/fixtures/runner/events-retries.fixture.cjs
+++ b/test/integration/fixtures/runner/events-retries.fixture.cjs
@@ -1,5 +1,5 @@
 'use strict';
-var Runner = require('../../../../lib/runner.cjs');
+var { Runner } = require('../../../../lib/runner.js');
 var assert = require('assert');
 var constants = Runner.constants;
 var EVENT_HOOK_BEGIN = constants.EVENT_HOOK_BEGIN;

--- a/test/node-unit/mocha.spec.cjs
+++ b/test/node-unit/mocha.spec.cjs
@@ -71,7 +71,7 @@ describe("Mocha", function () {
         "../../lib/nodejs/parallel-buffered-runner.cjs":
           stubs.ParallelBufferedRunner,
         "../../lib/nodejs/esm-utils.cjs": stubs.esmUtils,
-        "../../lib/runner.cjs": stubs.Runner,
+        "../../lib/runner.js": { Runner: stubs.Runner },
         "../../lib/errors.js": stubs.errors,
       }),
     );

--- a/test/node-unit/parallel-buffered-runner.spec.cjs
+++ b/test/node-unit/parallel-buffered-runner.spec.cjs
@@ -6,10 +6,10 @@ const {
   EVENT_TEST_FAIL,
   EVENT_SUITE_END,
   EVENT_SUITE_BEGIN,
-} = require("../../lib/runner.cjs").constants;
+} = require("../../lib/runner.js").Runner.constants;
 const rewiremock = require("rewiremock/node");
 const { Suite } = require("../../lib/suite.js");
-const Runner = require("../../lib/runner.cjs");
+const { Runner } = require("../../lib/runner.js");
 const sinon = require("sinon");
 const { constants } = require("../../lib/utils.cjs");
 const { MOCHA_ID_PROP_NAME } = constants;

--- a/test/node-unit/reporters/parallel-buffered.spec.cjs
+++ b/test/node-unit/reporters/parallel-buffered.spec.cjs
@@ -17,7 +17,7 @@ const {
   EVENT_HOOK_BEGIN,
   EVENT_HOOK_END,
   EVENT_RUN_END,
-} = require("../../../lib/runner.cjs").constants;
+} = require("../../../lib/runner.js").Runner.constants;
 const { EventEmitter } = require("node:events");
 const sinon = require("sinon");
 const rewiremock = require("rewiremock/node");


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5965 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Rename lib/runner.cjs to lib/runner.js and converts it to ESM with a named Runner export.


@mark-wiemer Also: It says to rename to `runner.mjs` but you and Josh agreed on js for ESM and cjs for CJS in https://github.com/mochajs/mocha/issues/5400#issuecomment-4730579332 so i went with `runner.js`. Also on to do #5964 first, i dont think thats needed. Runner just does import utils from "./utils.cjs", same as runnable.js and reporters/base.js already do so it works any way and not have to wait on #6071.