### PR TITLE
ci: only run coverage steps when the tests actually ran

### DIFF
--- a/.github/workflows/npm-script.yml
+++ b/.github/workflows/npm-script.yml
@@ -67,19 +67,19 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: "npm"
       - run: npm ci --ignore-scripts
-      - run: npm run ${{ inputs.npm-script }}
+      - id: npm-script
+        run: npm run ${{ inputs.npm-script }}
         env:
           BROWSER: ${{ matrix.browser }}
           COVERAGE: ${{ inputs.coverage && '1'}}
           NODE_OPTIONS: "--trace-warnings"
-      # Generate and upload coverage, even if tests fail
       - name: Generate coverage report
-        if: always() && inputs.coverage
+        if: ${{ !cancelled() && inputs.coverage && (steps.npm-script.conclusion == 'success' || steps.npm-script.conclusion == 'failure') }}
         run: npm run test-coverage-generate
       # https://github.com/marketplace/actions/codecov
       # https://app.codecov.io/gh/mochajs/mocha
       - name: Upload coverage reports
-        if: always() && inputs.coverage
+        if: ${{ !cancelled() && inputs.coverage && (steps.npm-script.conclusion == 'success' || steps.npm-script.conclusion == 'failure') }}
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5361
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Change the coverage steps to only run if the test script actually ran while keeping the existing behavior when tests genuinely fail.

Sometimes a job goes red with a test name even though the tests never ran. In #5986, `actions/setup-node` failed after a second so `npm ci` and the tests were skipped.
The coverage steps use `if: always()`, though, so they still ran and failed with `'nyc' is not recognized`. This then showed up as `test-node:requires failed` sending you looking in the wrong place.

Also making codecov/project and codecov/patch fail too.