### PR TITLE
fix: watch existing dirs so first run starts armed

### DIFF
--- a/lib/cli/watch-run.cjs
+++ b/lib/cli/watch-run.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const debug = require("debug")("mocha:cli:watch");
+const fs = require("node:fs");
 const path = require("node:path");
 const chokidar = require("chokidar");
 const glob = require("glob");
@@ -9,6 +10,8 @@ const { minimatch } = require("minimatch");
 const Context = require("../context.js").Context;
 const collectFiles = require("./collect-files.cjs");
 const { logSymbols } = require("../utils.cjs");
+
+const setTimeout = global.setTimeout;
 
 /**
  * @typedef {import('chokidar').FSWatcher} FSWatcher
@@ -391,6 +394,21 @@ function createPathMatcher(allowed, ignored, basePath) {
   return matcher;
 }
 
+async function whenWatching(watcher, dirPaths, attempts = 400) {
+  if (dirPaths.length === 0) {
+    return;
+  }
+  const expected = dirPaths.map((dirPath) => path.dirname(dirPath));
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const watched = Object.keys(watcher.getWatched());
+    if (expected.every((dirPath) => watched.includes(dirPath))) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  debug("gave up waiting for watchers on %o", expected);
+}
+
 /**
  * Bootstraps a Chokidar watcher. Handles keyboard input & signals
  * @param {Mocha} mocha - Mocha instance
@@ -436,7 +454,9 @@ const createWatcher = (
   const matcher = createPathMatcher(allowed, ignored, basePath);
 
   // Chokidar has to watch the directory paths in case new files are created
-  const watcher = chokidar.watch(Array.from(allowed.dir.paths), {
+  const watchPaths = Array.from(allowed.dir.paths);
+  const missingPaths = watchPaths.filter((dirPath) => !fs.existsSync(dirPath));
+  const watcher = chokidar.watch(watchPaths, {
     ignoreInitial: true,
     ignored: matcher.ignore,
   });
@@ -448,6 +468,7 @@ const createWatcher = (
 
   watcher.on("ready", async () => {
     debug("watcher ready");
+    await whenWatching(watcher, missingPaths);
     if (!globalFixtureContext) {
       debug("triggering global setup");
       globalFixtureContext = await mocha.runGlobalSetup();


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6297 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fix --watch-files test timing out on Windows CI by making sure the directory is watched before the first run finishes.

test was watching lib before it existed so chokidar only started watching it after "ready". On busy CI runners the second run could happen in that tiny gap and get missed leading to a 50s timeout.

Now we give chokidar the closest directory that already exists so it starts watching in time. I left retry from #6119 alone because it cover the separate nested lib/dir case.