### PR TITLE
fix: propagate spec file path on parallel worker death

### DIFF
--- a/lib/nodejs/parallel-buffered-runner.cjs
+++ b/lib/nodejs/parallel-buffered-runner.cjs
@@ -222,6 +222,9 @@ class ParallelBufferedRunner extends Runner {
             this._state = ABORTING;
             await pool.terminate(true);
           }
+          if (err && typeof err === 'object') {
+            try { err.file = file; } catch { /* frozen or non-writable */ }
+          }
           throw err;
         }
       } finally {

--- a/lib/runner.cjs
+++ b/lib/runner.cjs
@@ -1142,6 +1142,9 @@ Runner.prototype._uncaught = function (err) {
     runnable = new Runnable("Uncaught error outside test suite");
     debug("uncaught(): no current Runnable; created a phony one");
     runnable.parent = this.suite;
+    if (err.file) {
+      runnable.file = err.file;
+    }
 
     if (this.state === constants.STATE_RUNNING) {
       debug("uncaught(): failing gracefully");

--- a/test/integration/fixtures/parallel/worker-death.js
+++ b/test/integration/fixtures/parallel/worker-death.js
@@ -1,0 +1,5 @@
+// Fixture: a spec whose worker dies via process.exit in after()
+describe('worker death', () => {
+  it('passes before crash', () => {});
+  after(() => process.exit(1));
+});

--- a/test/integration/parallel.spec.cjs
+++ b/test/integration/parallel.spec.cjs
@@ -77,6 +77,20 @@ describe("parallel run", () => {
     ]);
   });
 
+  it("should report the crashing spec file when a worker dies", async () => {
+    const result = await runMochaJSONAsync("parallel/worker-death.js", [
+      "--parallel",
+      "--jobs",
+      "2",
+      require.resolve("./fixtures/parallel/test1.js"),
+    ]);
+    assert.strictEqual(result.stats.failures, 1);
+    assert.strictEqual(result.stats.passes, 1);
+    const failure = result.failures[0];
+    assert.strictEqual(failure.title, "Uncaught error outside test suite");
+    assert.match(failure.file, /worker-death\.js$/);
+  });
+
   it("should correctly handle a non-writable getter reference in an exception", async () => {
     const result = await runMochaJSONAsync("parallel/getter-error-object.js", [
       "--parallel",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6265
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) (or change is trivial)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`_createFileRunner` closes over `file` but the catch block re-throws without attaching it. `_uncaught` then creates a phony Runnable with no `.file`, so every reporter sees `undefined` for worker-death failures.

Tag the Error with the spec path before re-throwing and propagate it to the synthetic Runnable in `Runner#_uncaught`.

**Two changes, 6 lines:**

1. `parallel-buffered-runner.cjs` — `err.file = file` before re-throw (guarded for frozen errors)
2. `runner.cjs` — `runnable.file = err.file` on the phony Runnable

No API changes — `file` is already a standard Runnable property, so every existing reporter picks it up automatically.

Related: #6233 is complementary (fixes exit code / `STATE_RUNNING`), does not touch file attribution.