### PR TITLE
fix: bump serialize-javascript to ^7.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "minimatch": "^10.2.2",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^7.0.2",
+        "serialize-javascript": "^7.1.1",
         "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
         "workerpool": "^10.0.0"
@@ -8182,9 +8182,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
-      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "minimatch": "^10.2.2",
     "ms": "^2.1.3",
     "picocolors": "^1.1.1",
-    "serialize-javascript": "^7.0.2",
+    "serialize-javascript": "^7.1.1",
     "strip-json-comments": "^5.0.3",
     "supports-color": "^8.1.1",
     "workerpool": "^10.0.0"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: ~fixes #000 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))~ follow up to #6239, which only bumped the internal lockfile
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

🤷 