### PR TITLE
docs: add the Qualflare reporter to the third-party examples

### DIFF
--- a/docs/src/content/docs/reporters/third-party.mdx
+++ b/docs/src/content/docs/reporters/third-party.mdx
@@ -9,4 +9,5 @@ For more information see [Third party reporters](/explainers/third-party-reporte
 Examples:
 
 - the [TeamCity reporter](https://github.com/travisjeffery/mocha-teamcity-reporter)
+- the [Qualflare reporter](https://github.com/Qualflare/qualflare-mocha), which shows one way to keep a reporter working under `--parallel`
 - our [working example](https://github.com/mochajs/mocha-examples/tree/main/packages/third-party-reporter)


### PR DESCRIPTION
Adds one line to the Third-Party Reporters examples.

**Disclosure up front:** Qualflare is my SaaS. [`@qualflare/mocha`](https://github.com/Qualflare/qualflare-mocha) is the reporter, and it is open source (Apache-2.0) — happy for this to be closed if a vendor link is not wanted on this page.

The reason I think it earns a place next to the TeamCity reporter and the working example is `--parallel`. That page's existing example is serial-only, and the surrounding docs say a third-party reporter "may encounter issues when attempting to access non-existent properties within `Test`, `Suite`, and `Hook` objects" without showing what to do about it — which is what mochajs/mocha#4453 was about.

This reporter is built around that constraint and reads only allowlisted `Test.prototype.serialize()` fields, so it is a worked reference for the parallel-safe case:

- per-attempt retry history from `EVENT_TEST_RETRY`, which fires in parallel mode too and carries each attempt's error;
- metadata that crosses the worker boundary out of band, because a property set on a test object does not survive serialization;
- CI that asserts a run produces the **same report** with and without `--parallel`, across Mocha 8, 10 and 12.

If a link is fine but the framing is not, I am glad to shorten it to just the name.
