### PR TITLE
fix: only reject positional args that are entirely numeric

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -694,5 +694,5 @@ exports.breakCircularDeps = (inputObj) => {
  * Checks if provided input can be parsed as a JavaScript Number.
  */
 exports.isNumeric = (input) => {
-  return !isNaN(parseFloat(input));
+  return String(input).trim() !== "" && !isNaN(Number(input));
 };

--- a/test/node-unit/cli/options.spec.js
+++ b/test/node-unit/cli/options.spec.js
@@ -781,6 +781,10 @@ describe("options", function () {
       it("does not throw error if numeric value is passed to an array flag", function () {
         expect(() => loadOptions(`--spec ${numericArg}`), "not to throw");
       });
+
+      it("does not throw error if a positional file name begins with a number", function () {
+        expect(() => loadOptions("1-spec.js"), "not to throw");
+      });
     });
   });
 });

--- a/test/node-unit/utils.spec.js
+++ b/test/node-unit/utils.spec.js
@@ -55,6 +55,9 @@ describe("utils", function () {
       it("returns false for a string that cannot be parsed as a number", function () {
         expect(utils.isNumeric("foo"), "to equal", false);
       });
+      it("returns false for a string that only begins with a number", function () {
+        expect(utils.isNumeric("1-spec.js"), "to equal", false);
+      });
       it("returns false for empty string", function () {
         expect(utils.isNumeric(""), "to equal", false);
       });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6221
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies the fix from #6222 to v11 :)