### PR TITLE
fix: fail nested tests on beforeEach failure

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -835,9 +835,11 @@ Runner.prototype.runTests = function (suite, fn) {
       !after &&
       self._failedBeforeEachHook
     ) {
-      // Fail all remaining tests in the suite
-      var remainingTests = tests.slice();
-      remainingTests.forEach(function (t) {
+      // Fail all remaining tests in the suite and its nested suites.
+      // Sub-suites are skipped after a beforeEach failure (see
+      // `runSuite`), so without this their tests would be dropped
+      // instead of reported as failed (mochajs/mocha#6132).
+      function failTest(t) {
         if (!t.state) {
           var testError = createHookSkipError(
             self._failedBeforeEachHook.title,
@@ -850,7 +852,13 @@ Runner.prototype.runTests = function (suite, fn) {
           self.emit(constants.EVENT_TEST_FAIL, t, testError);
           self.emit(constants.EVENT_TEST_END, t);
         }
-      });
+      }
+      function failTestsInSuite(s) {
+        s.tests.forEach(failTest);
+        s.suites.forEach(failTestsInSuite);
+      }
+      tests.slice().forEach(failTest);
+      suite.suites.forEach(failTestsInSuite);
       // Clear the stored hook info
       delete self._failedBeforeEachHook;
     }

--- a/test/integration/fixtures/hooks/before-each-hook-error-with-fail-affected-nested.fixture.js
+++ b/test/integration/fixtures/hooks/before-each-hook-error-with-fail-affected-nested.fixture.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('outer', function () {
+  beforeEach(function () {
+    throw new Error('error in `beforeEach` hook');
+  });
+  it('direct test', function () {
+    // This should be reported as failed due to beforeEach hook failure
+  });
+  describe('nested', function () {
+    it('nested test 1', function () {
+      // This should be reported as failed due to beforeEach hook failure
+    });
+    it('nested test 2', function () {
+      // This should be reported as failed due to beforeEach hook failure
+    });
+  });
+});

--- a/test/integration/hook-err.spec.cjs
+++ b/test/integration/hook-err.spec.cjs
@@ -332,6 +332,31 @@ describe("hook error handling", function () {
       });
     });
 
+    describe("error in `beforeEach` hook with nested suites", function () {
+      it("should fail tests in nested suites", function (done) {
+        runMochaJSON(
+          "hooks/before-each-hook-error-with-fail-affected-nested.fixture.js",
+          ["--fail-hook-affected-tests"],
+          (err, res) => {
+            if (err) {
+              return done(err);
+            }
+            expect(res, "to have failed")
+              .and("to have failed test count", 4)
+              .and(
+                "to have failed test",
+                '"before each" hook for "direct test"',
+              )
+              .and("to have failed test", "direct test")
+              .and("to have failed test", "nested test 1")
+              .and("to have failed test", "nested test 2")
+              .and("to have passed test count", 0);
+            done();
+          },
+        );
+      });
+    });
+
     describe("non-Error thrown in `before` hook", function () {
       it("should handle null, undefined, and other non-Error values", function (done) {
         runMochaJSON(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6132 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Closes #6132.

A failing `beforeEach` with `--fail-hook-affected-tests` only failed the remaining tests of the immediate suite; tests in nested `describe` blocks were dropped entirely (not failed, not pending), under-reporting failure/total counts in every reporter.

This change mirrors the existing `before`/`beforeAll` path: in `runTests` -> `hookErr`, after failing the remaining direct tests, recursively mark not-yet-run tests in `suite.suites` as failed (same TEST_BEGIN/FAIL/END emission, `!state` guard so already-run tests are never double-counted).

Repro from the issue (`repro.mjs`):
- Before fix: `node ./bin/mocha.js --fail-hook-affected-tests repro.mjs --reporter json` -> 2 failing (hook + `direct test`), nested tests dropped, `stats.tests: 1`.
- After fix: 4 failing (hook + `direct test` + `nested test 1` + `nested test 2`), `stats.tests: 3` — identical to the `before` variant. Also verified consistent counts with `spec` (4 failing) and `tap` (# fail 4) reporters.

Tests (all with `--timeout 10000`; the 1s default is too short for spawned child processes on Windows — pre-existing env quirk, fails on clean main too):
- `test/integration/hook-err.spec.cjs`: 23 passing (includes new `error in beforeEach hook with nested suites` regression using `hooks/before-each-hook-error-with-fail-affected-nested.fixture.js`)
- `test/reporters/*.spec.{cjs,js}`: 158 passing
- `test/unit/**/*.spec.cjs` + `test/node-unit/**`: 1234 passing
- `eslint` on changed source/spec: 0 errors
