### PR TITLE
test: widen --exit detection window

### DIFF
--- a/test/integration/options/exit.spec.cjs
+++ b/test/integration/options/exit.spec.cjs
@@ -52,11 +52,13 @@ describe("--exit", function () {
         done();
       });
 
+      var waitForExitMs = shouldExit ? 30000 : timeout - 500;
+
       // If this callback happens, then Mocha didn't automatically exit.
       timeoutObj = setTimeout(function () {
         didExit = false;
         killSubprocess();
-      }, timeout - 500);
+      }, waitForExitMs);
     };
   };
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6060 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

Fixes #6060

## Overview

Replicates the author-abandoned #6101 approach verbatim: the "should exit" case now waits up to 30s for the subprocess to exit before force-killing it (`shouldExit ? 30000 : timeout - 500`). The extra time is only consumed when Mocha never exits, so passing runs are not slowed down; the no-exit tests keep their existing `timeout - 500` window. Timeout value only -- no logic changes, no new helpers, `mocha.js` untouched.

## Test evidence

- Targeted: `npx mocha test/integration/options/exit.spec.cjs --timeout 10000 --reporter spec` -> 3 passing (20s: two no-exit cases each wait out their 9.5s window by design).
- Targeted on unmodified main (default timeout): 3 passing (2s) -- no Windows default-timeout failure on this machine, so no workaround needed.
- Full `npm test` (per CONTRIBUTING): 362 passing, 3 pending, 1 failing -- the single failure is pre-existing/environmental (`FIFO support should accept a test passed as a FIFO`: `mkfifo` not recognized on Windows at `test/integration/fifo.spec.cjs:43`, a file this PR does not touch).
