### PR TITLE
refactor: convert file-unloader to ESM

### DIFF
--- a/lib/mocha.cjs
+++ b/lib/mocha.cjs
@@ -467,7 +467,8 @@ Mocha.unloadFile = function (file) {
       "unloadFile() is only supported in a Node.js environment",
     );
   }
-  return require("./nodejs/file-unloader.cjs").unloadFile(file);
+  const { unloadFile } = require("./nodejs/file-unloader.js");
+  return unloadFile(file);
 };
 
 /**

--- a/lib/nodejs/file-unloader.js
+++ b/lib/nodejs/file-unloader.js
@@ -1,15 +1,17 @@
-"use strict";
-
 /**
  * This module should not be in the browser bundle, so it's here.
  * @private
  * @module
  */
 
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
 /**
  * Deletes a file from the `require` cache.
  * @param {string} file - File
  */
-exports.unloadFile = (file) => {
+export function unloadFile(file) {
   delete require.cache[require.resolve(file)];
-};
+}

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "supports-color": false,
     "./lib/nodejs/buffered-worker-pool.cjs": false,
     "./lib/nodejs/esm-utils.cjs": false,
-    "./lib/nodejs/file-unloader.cjs": false,
+    "./lib/nodejs/file-unloader.js": false,
     "./lib/nodejs/parallel-buffered-runner.cjs": false,
     "./lib/nodejs/serializer.js": false,
     "./lib/nodejs/worker.cjs": false,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6010 (or is a [trivial change](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md#trivial-changes))
- [x] That issue was marked as [`status: accepting prs`](https://github.com/mochajs/mocha/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/mochajs/mocha/blob/main/.github/CONTRIBUTING.md) were taken

Fixes #6010

## Overview

Converts `lib/nodejs/file-unloader.cjs` to ESM (`lib/nodejs/file-unloader.js`) with a named `unloadFile` export, following the merged #6260 (`runner.js`) pattern and the AGENTS.md CJS->ESM conventions. The module keeps its `require.cache` interop via `createRequire(import.meta.url)`. The single runtime consumer (`Mocha.unloadFile` in `lib/mocha.cjs`) now destructures the named binding, and the `package.json` browser field points at the new path so the file stays out of the browser bundle. No logic changes; root `mocha.js` untouched. This supersedes the unmerged attempts #6026 (stale `.mjs` approach) and #6190 (closed over an unsigned CLA, no technical objection).

## Test evidence

- `npx eslint lib/nodejs/file-unloader.js lib/mocha.cjs` -> clean; `npx prettier --check` on changed files -> clean; `npm run tsc` -> clean; full `npm run lint` -> green.
- Targeted: `test/node-unit/mocha.spec.cjs --grep unloadFile` -> 5 passing; `test/unit/mocha.spec.cjs --grep unloadFile` -> 1 passing; `test/smoke/smoke.spec.cjs` -> 1 passing.
- Functional check: named export loads via both `import()` and `require()` destructuring, and `unloadFile()` removes the entry from `require.cache` (verified true -> false).
- `npm run test-node`: unit 1234 passing / 0 failing; integration 362 passing with 1 failing that is pre-existing and environmental (`FIFO support should accept a test passed as a FIFO`: `mkfifo` is not recognized on Windows at `test/integration/fifo.spec.cjs:43`); confirmed identical failure on unmodified main. interfaces / reporters (158) / requires / only / jsapi (220) all passing.
- `npm run test-browser`: 4 passed, webpack compat build compiled successfully (rollup browser bundle rebuilds fine with the renamed file).
